### PR TITLE
fix typo in 10.5 from Bugzilla

### DIFF
--- a/test/suite/ch10/10.5/10.5-7-b-3-s.js
+++ b/test/suite/ch10/10.5/10.5-7-b-3-s.js
@@ -15,7 +15,7 @@ function testcase() {
 
         function _10_5_7_b_3_fun() {
             arguments[1] = 12;
-            return arguments[0] = 30 && arguments[1] === 12;
+            return arguments[0] === 30 && arguments[1] === 12;
         };
 
         return _10_5_7_b_3_fun(30);


### PR DESCRIPTION
From [Bugzilla](https://bugs.ecmascript.org/show_bug.cgi?id=1795)
