### PR TITLE
Remove the alert call from test file

### DIFF
--- a/test/suite/intl402/ch09/9.2/9.2.6_4_b.js
+++ b/test/suite/intl402/ch09/9.2/9.2.6_4_b.js
@@ -29,7 +29,6 @@ testWithIntlConstructors(function (Constructor) {
                         locale + " is considered supported with matcher " + matcher + ".");
                 }
                 if (supported2[0] !== locale + validExtension || supported3[0] !== locale + invalidExtension) {
-                    alert(locale + "; " + supported2[0] + "; " + supported3[0]);
                     $ERROR("Unicode locale extension sequence is not correctly returned for locale " +
                         locale + " with matcher " + matcher + ".");
                 }


### PR DESCRIPTION
One of the intl test files had an alert call in it (intl402\ch09\9.2\9.2.6_4_b.js), removed the call.
