### PR TITLE
Correct shadow behavior in 12.6.4-2 (bugzilla #1450)

### DIFF
--- a/test/suite/ch12/12.6/12.6.4/12.6.4-2.js
+++ b/test/suite/ch12/12.6/12.6.4/12.6.4-2.js
@@ -10,43 +10,27 @@
 
 
 function testcase() {
-        var obj = {};
-
-        var proto = {};
-
-        Object.defineProperty(proto, "prop", {
-            value: "inheritedValue",
-            enumerable: false,
-            configurable: true,
-            writable: true
-        });
+        var proto = {
+            prop: "enumerableValue"
+        };
 
         var ConstructFun = function () { };
         ConstructFun.prototype = proto;
 
         var child = new ConstructFun();
 
-        Object.defineProperty(child, "prop1", {
-            value: "overridedValue1",
+        Object.defineProperty(child, "prop", {
+            value: "nonEnumerableValue",
             enumerable: false
         });
-        Object.defineProperty(child, "prop2", {
-            value: "overridedValue2",
-            enumerable: true
-        });
-        var accessedProp1 = false;
-        var accessedProp2 = false;
+
+        var accessedProp = false;
 
         for (var p in child) {
-            if (child.hasOwnProperty(p)) {
-                if (p === "prop1") {
-                    accessedProp1 = true;
-                }
-                if (p === "prop2") {
-                    accessedProp2 = true;
-                }
+            if (p === "prop") {
+                accessedProp = true;
             }
         }
-        return !accessedProp1 && accessedProp2 && child.prop1 === "overridedValue1" && child.prop2 === "overridedValue2";
+        return !accessedProp;
     }
 runTestCase(testcase);


### PR DESCRIPTION
Fixes [Bugzilla #1450](https://bugs.ecmascript.org/show_bug.cgi?id=1450).

The test was not checking the appropriate shadowing behavior. If I understand correctly, a non-enumerable property `obj.prop` must shadow an enumerable property in the [[prototype]], `obj.[[proto]].prop`, preventing `prop` from being included in the `for-in` loop.

It passes in FF 26, it does not pass in Chrome 32.
