### PR TITLE
Use `target='_blank'` to open links in new window

### DIFF
--- a/website/default.html
+++ b/website/default.html
@@ -48,7 +48,7 @@
         <!-- This Container holds the main header -->
         <div class="mainHeader"> 
             <p><span id="ECMAscript">ECMA</span><span id="ecmaSCRIPT">Script</span> <strong>Language</strong> test262
-            <a id="ecmascriptbacklink" href='javascript:void(window.open("http://www.ecmascript.org/"));'>ECMAScript.org</a></p>
+            <a id="ecmascriptbacklink" href='http://www.ecmascript.org/'>ECMAScript.org</a></p>
         </div>
         <!-- This Container holds the Navigation -->
         <div class="navBar">
@@ -66,32 +66,32 @@
                 <p class="content">test262 is a test suite intended to check agreement between JavaScript implementations and ECMA-262, the ECMAScript Language Specification (currently 5.1 Edition).
                     The test suite contains thousands of individual tests, each of which tests some specific requirements of the ECMAScript Language Specification.</p>
                 <p class="headers">What is ECMAScript?</p>
-                <p class="content">"ECMAScript" is the name under which the language more commonly known as "JavaScript" is standardized. Development of the ECMAScript standard is the responsibility of <a href='javascript:void(window.open("http://www.ecma-international.org/memento/TC39.htm"));'>Technical Committee 39 (TC39)</a> of <a href='javascript:void(window.open("http://www.ecma-international.org/"));'>Ecma International</a>.
+                <p class="content">"ECMAScript" is the name under which the language more commonly known as "JavaScript" is standardized. Development of the ECMAScript standard is the responsibility of <a href='http://www.ecma-international.org/memento/TC39.htm'>Technical Committee 39 (TC39)</a> of <a href='http://www.ecma-international.org/'>Ecma International</a>.
                     The ECMAScript Language Specification standard is officially known as ECMA-262.
                     ECMAScript 5.1 (or just ES5.1) is short hand for the "ECMA-262, 5.1 Edition ECMAScript Language Specification" the official name of the current edition of the standard.
                     ECMAScript 5.1 was approved as an official Ecma standard by the Ecma General Assembly in June 2011.
-                    The ECMAScript 5.1 standard is available in <a href='javascript:void(window.open("http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-262.pdf"));'>PDF</a> and <a href='javascript:void(window.open("http://ecma-international.org/ecma-262/5.1/"));'>HTML</a> versions from the Ecma International web site.</p>
+                    The ECMAScript 5.1 standard is available in <a href='http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-262.pdf'>PDF</a> and <a href='http://ecma-international.org/ecma-262/5.1/'>HTML</a> versions from the Ecma International web site.</p>
                 <p class="headers">Who creates and maintains test262?</p>
                 <p class="content">Development of test262 is a project of Ecma TC39.  The testing framework and individual tests are created by member organizations of TC39 and contributed to Ecma for use in test262. For more information about how test262 is developed and maintained click the “Development” tab at the top of this page.</p>
                 <p class="headers">What is the status of test262?</p>
                 <p class="content"><strong>test262 is not yet complete.  It is still undergoing active development.</strong> Some portions of the ES5 specification have very complete test coverage while other portions of the specification have only partial test coverage.  Some tests may be invalid or may yield false positive or false negative results. A perfect passing score on test262 does not guarantee that a JavaScript implementation perfectly supports ES5. Because tests are being actively added and modified, tests results from different days or times may not be directly comparable. Click the “Development” tab at the top of this page for instructions for reporting test262 bugs.</p>
                 <p class="headers">Where can I find out more?</p>
-                <p class="content">Please visit our <a href='javascript:void(window.open("http://wiki.ecmascript.org/doku.php?id=test262:faq"));'>Frequently Asked Questions</a> section on the <a href='javascript:void(window.open("http://wiki.ecmascript.org/doku.php?id="));'>ECMAScript Wiki</a>.</p>       
+                <p class="content">Please visit our <a href='http://wiki.ecmascript.org/doku.php?id=test262:faq'>Frequently Asked Questions</a> section on the <a href='http://wiki.ecmascript.org/doku.php?id='>ECMAScript Wiki</a>.</p>       
                 
                 <p class="headers">Running the Tests</p>
                 <p class="content">Click the “Run” tab at the top of this page for instructions and follow the instructions to run the tests.</p> 
                 
-                <a href='javascript:void(window.open("http://www.ecma-international.org/memento/TC39.htm"));'></a>
+                <a href='http://www.ecma-international.org/memento/TC39.htm'></a>
                          
             </div>
 
             <div class="content-dev">
                 <p class="headers">Development</p>
                 <p class="content">Test262 is being developed by the members of Ecma TC39. Ecma's intellectual property policies permit only Ecma 
-                    members to directly contribute code to the project. However, a <a href='javascript:void(window.open("http://mail.mozilla.org/pipermail/test262-discuss/"));'>public mailing list</a> is used to coordinate development of test262.  If you wish to participate in the discussion please <a href='javascript:void(window.open("http://mail.mozilla.org/listinfo/test262-discuss"));'>subscribe</a>.  Bug reports and suggestions should be sent to the mailing list.
+                    members to directly contribute code to the project. However, a <a href='http://mail.mozilla.org/pipermail/test262-discuss/'>public mailing list</a> is used to coordinate development of test262.  If you wish to participate in the discussion please <a href='http://mail.mozilla.org/listinfo/test262-discuss'>subscribe</a>.  Bug reports and suggestions should be sent to the mailing list.
                 </p>
                 <p class="content">
-                    Ecma members can find detailed instructions on Test262 development procedures at the <a href='javascript:void(window.open("http://wiki.ecmascript.org/doku.php?id=test262:test262"));'>Test262 Wiki</a>.
+                    Ecma members can find detailed instructions on Test262 development procedures at the <a href='http://wiki.ecmascript.org/doku.php?id=test262:test262'>Test262 Wiki</a>.
                 </p>
             </div>
 
@@ -176,7 +176,7 @@
     <!-- This is the Footer -->
     <div class="footer">
         <!--<div class="Links"> <a href="">Privacy</a> | <a href="">Terms of Use</a> </div>-->
-        <div class="copyright"> &copy; <a href='javascript:void(window.open("http://www.ecma-international.org"));'>Ecma International</a> </div>
+        <div class="copyright"> &copy; <a href='http://www.ecma-international.org'>Ecma International</a> </div>
     </div>
     <iframe id="scriptLoader" class="hide"></iframe>
 </body>


### PR DESCRIPTION
Opening links in new window/tab is implemented in HTML and using
JavaScript to do that is unnecessary. It also renders the page unusable
for users with JavaScript turned off by default.

Additionally, when trying to open a link like that in a new tab, Firefox
blocks it with its pop up detection.
