### PR TITLE
Initial promise tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.d8_history
+*~
+*.pyc
+console/TestCases

--- a/console/harness/PromiseHelper.js
+++ b/console/harness/PromiseHelper.js
@@ -1,0 +1,9 @@
+//-----------------------------------------------------------------------------
+function checkSequence(arr, message) {
+    arr.forEach(function(e, i) {
+        if (e !== (i+1)) {
+            $ERROR((message ? message : "Steps in unexpected sequence:") +
+                   " '" + arr.join(',') + "'");
+        }
+    });
+}

--- a/console/harness/doneprintHandle.js
+++ b/console/harness/doneprintHandle.js
@@ -3,7 +3,7 @@ function __consolePrintHandle__(msg){
 }
 
 function $DONE(){
-	if(arguments.length === 0)
+	if(!arguments[0])
 		__consolePrintHandle__('Test262:AsyncTestComplete');
 	else
 		__consolePrintHandle__('Error: ' + arguments[0]);

--- a/test/harness/PromiseHelper.js
+++ b/test/harness/PromiseHelper.js
@@ -1,0 +1,9 @@
+//-----------------------------------------------------------------------------
+function checkSequence(arr, message) {
+    arr.forEach(function(e, i) {
+        if (e !== (i+1)) {
+            $ERROR((message ? message : "Steps in unexpected sequence:") +
+                   " '" + arr.join(',') + "'");
+        }
+    });
+}

--- a/test/harness/doneprintHandle.js
+++ b/test/harness/doneprintHandle.js
@@ -3,7 +3,7 @@ function __consolePrintHandle__(msg){
 }
 
 function $DONE(){
-	if(arguments.length === 0)
+	if(!arguments[0])
 		__consolePrintHandle__('Test262:AsyncTestComplete');
 	else
 		__consolePrintHandle__('Error: ' + arguments[0]);

--- a/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A1.1_T1.js
+++ b/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A1.1_T1.js
@@ -1,0 +1,17 @@
+// Copyright 2014 Ecma International.  All rights reserved.
+/// Ecma International makes this code available under the terms and conditions set
+/// forth on http://hg.ecmascript.org/tests/test262/raw-file/tip/LICENSE (the
+/// "Use Terms").   Any redistribution of this code must retain the above
+/// copyright and this notice and otherwise comply with the Use Terms.
+
+/**
+ * Promise.all is callable
+ *
+ * @author Sam Mikes
+ */
+
+// CHECK#1
+var x = typeof Promise.all;
+if (x !== "function") {
+    $ERROR('#1: x = typeof Promise.all; x === "function". Actual: ' + (x));
+}

--- a/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A1.2_T1.js
+++ b/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A1.2_T1.js
@@ -1,0 +1,17 @@
+/// Copyright 2012 Ecma International.  All rights reserved.
+/// Ecma International makes this code available under the terms and conditions set
+/// forth on http://hg.ecmascript.org/tests/test262/raw-file/tip/LICENSE (the
+/// "Use Terms").   Any redistribution of this code must retain the above
+/// copyright and this notice and otherwise comply with the Use Terms.
+
+/**
+ * Promise.all expects 1 argument
+ *
+ * @author Sam Mikes
+ */
+
+// CHECK#1
+var x = Promise.all.length;
+if (x !== 1) {
+    $ERROR('#1: x = Promise.all.length; x === 1. Actual: ' + (x));
+}

--- a/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A2.1_T1.js
+++ b/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A2.1_T1.js
@@ -1,0 +1,17 @@
+// Copyright 2014 Ecma International.  All rights reserved.
+/// Ecma International makes this code available under the terms and conditions set
+/// forth on http://hg.ecmascript.org/tests/test262/raw-file/tip/LICENSE (the
+/// "Use Terms").   Any redistribution of this code must retain the above
+/// copyright and this notice and otherwise comply with the Use Terms.
+
+/**
+ * Promise.all([]) is a Promise
+ *
+ * @author Sam Mikes
+ */
+
+// CHECK#1
+var x = (Promise.all([]) instanceof Promise);
+if (x !== true) {
+    $ERROR('#1: x (Promise.all([]) instanceof Promise); x === true. Actual: ' + (x));
+}

--- a/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A2.2_T1.js
+++ b/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A2.2_T1.js
@@ -1,0 +1,25 @@
+// Copyright 2014 Ecma International.  All rights reserved.
+/// Ecma International makes this code available under the terms and conditions set
+/// forth on http://hg.ecmascript.org/tests/test262/raw-file/tip/LICENSE (the
+/// "Use Terms").   Any redistribution of this code must retain the above
+/// copyright and this notice and otherwise comply with the Use Terms.
+
+/**
+ * Promise.all([]) is resolved immediately
+ *
+ * @author Sam Mikes
+ */
+
+$INCLUDE("PromiseHelper.js");
+var sequence = [];
+
+Promise.all([]).then(function () {
+    sequence.push(1);
+}).catch($DONE);
+
+Promise.resolve().then(function() {
+    sequence.push(2);
+}).then(function () {
+    sequence.push(3);
+    checkSequence(sequence, "Promises resolved in unexpected sequence");
+}).then($DONE,$DONE);

--- a/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A2.3_T1.js
+++ b/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A2.3_T1.js
@@ -1,0 +1,20 @@
+
+// Copyright 2014 Ecma International.  All rights reserved.
+/// Ecma International makes this code available under the terms and conditions set
+/// forth on http://hg.ecmascript.org/tests/test262/raw-file/tip/LICENSE (the
+/// "Use Terms").   Any redistribution of this code must retain the above
+/// copyright and this notice and otherwise comply with the Use Terms.
+
+/**
+ * Promise.all is resolved with a new empty array
+ *
+ * @author Sam Mikes
+ */
+
+var arg = [];
+
+Promise.all(arg).then(function (result) {
+    if((result instanceof Array) !== true) {
+        $ERROR("expected an array from Promise.all, got " + result);
+    }
+}).then($DONE,$DONE);

--- a/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A2.3_T2.js
+++ b/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A2.3_T2.js
@@ -1,0 +1,20 @@
+
+// Copyright 2014 Ecma International.  All rights reserved.
+/// Ecma International makes this code available under the terms and conditions set
+/// forth on http://hg.ecmascript.org/tests/test262/raw-file/tip/LICENSE (the
+/// "Use Terms").   Any redistribution of this code must retain the above
+/// copyright and this notice and otherwise comply with the Use Terms.
+
+/**
+ * Promise.all is resolved with a new empty array
+ *
+ * @author Sam Mikes
+ */
+
+var arg = [];
+
+Promise.all(arg).then(function (result) {
+    if(result.length !== 0) {
+        $ERROR("expected an empty array from Promise.all([]), got " + result);
+    }
+}).then($DONE,$DONE);

--- a/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A2.3_T3.js
+++ b/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A2.3_T3.js
@@ -1,0 +1,20 @@
+
+// Copyright 2014 Ecma International.  All rights reserved.
+/// Ecma International makes this code available under the terms and conditions set
+/// forth on http://hg.ecmascript.org/tests/test262/raw-file/tip/LICENSE (the
+/// "Use Terms").   Any redistribution of this code must retain the above
+/// copyright and this notice and otherwise comply with the Use Terms.
+
+/**
+ * Promise.all is resolved with a new empty array
+ *
+ * @author Sam Mikes
+ */
+
+var arg = [];
+
+Promise.all(arg).then(function (result) {
+    if(result === arg) {
+        $ERROR("expected a new array from Promise.all but argument was re-used");
+    }
+}).then($DONE,$DONE);

--- a/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A3.1_T1.js
+++ b/test/suite/es6/ch25/25.4/25.4.4/25.4.4.1/S25.4.4.1_A3.1_T1.js
@@ -1,0 +1,23 @@
+// Copyright 2014 Ecma International.  All rights reserved.
+/// Ecma International makes this code available under the terms and conditions set
+/// forth on http://hg.ecmascript.org/tests/test262/raw-file/tip/LICENSE (the
+/// "Use Terms").   Any redistribution of this code must retain the above
+/// copyright and this notice and otherwise comply with the Use Terms.
+
+/**
+ * Promise.all expects an iterable argument; 
+ * ref 7.4.1 non-Object fails CheckIterable
+ * ref 7.4.2 GetIterator throws TypeError if CheckIterable fails
+ *
+ * @author Sam Mikes
+ */
+
+var nonIterable = 3;
+
+Promise.all(nonIterable).then(function () {
+    $ERROR('Promise unexpectedly resolved: Promise.all(nonIterable) should throw TypeError');
+},function (err) {
+    if (!(err instanceof TypeError)) {
+        $ERROR('Expected TypeError, got ' + err);
+    }
+}).then($DONE,$DONE);

--- a/tools/packaging/test262.py
+++ b/tools/packaging/test262.py
@@ -250,6 +250,12 @@ class TestCase(object):
   def IsAsyncTest(self):	
 	return '$DONE' in self.test
 
+  def GetIncludeList(self):
+    return re.findall('\$INCLUDE\([\'"]([^\)]+)[\'"]\)' ,self.test)
+
+  def GetAdditionalIncludes(self):
+    return '\n'.join([self.suite.GetInclude(include) for include in self.GetIncludeList()])
+
   def GetSource(self):
     # "var testDescrip = " + str(self.testRecord) + ';\n\n' + \
     source = self.suite.GetInclude("cth.js") + \
@@ -259,6 +265,7 @@ class TestCase(object):
         self.suite.GetInclude("testIntl.js") + \
 	self.suite.GetInclude("timer.js") + \
 	self.suite.GetInclude("doneprintHandle.js").replace('print', self.suite.print_handle) + \
+        self.GetAdditionalIncludes() + \
         self.test + '\n'
 
     if self.strict_mode:


### PR DESCRIPTION
Manually created some Promise tests.

I  believe the semantics of the $DONE() function should be changed.  At present $DONE(undefined) is       reported as an error.  A standard testing idiom is to do this:

```
Promise.resolve().then(function delayed() {
      // assertions

      return;
 }).then($DONE,$DONE);
```

this idiom results in a call to `$DONE(some_error_object)` if any assertion throws, and `$DONE(undefined)` if none throws.  (The `undefined` comes from the return value of function `delayed`)

This PR consists of two patches; one to commit the Promise tests, and one to change the behavior of $DONE.
