### PR TITLE
packager: make packager runnable

### DIFF
--- a/test/suite/es6/ch22/22.1/22.1.2/S22.1.2.1_T1.js
+++ b/test/suite/es6/ch22/22.1/22.1.2/S22.1.2.1_T1.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2014 Hank Yates. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-/*
+/**
  * @description Testing Array.from when passed a String
  * @author Hank Yates (hankyates@gmail.com)
  */

--- a/test/suite/es6/ch22/22.1/22.1.2/S22.1.2.1_T2.js
+++ b/test/suite/es6/ch22/22.1/22.1.2/S22.1.2.1_T2.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2014 Hank Yates. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-/*
+/**
  * @description Testing Array.from when passed an Object is passed
  * @author Hank Yates (hankyates@gmail.com)
  */

--- a/test/suite/es6/ch22/22.1/22.1.2/S22.1.2.1_T3.js
+++ b/test/suite/es6/ch22/22.1/22.1.2/S22.1.2.1_T3.js
@@ -1,10 +1,10 @@
 // Copyright (c) 2014 Hank Yates. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-/*
+/**
  * @description Testing Array.from when passed an undefined
  * @author Hank Yates (hankyates@gmail.com)
- * /
+ */
 
 runTestCase(function () {
   try {

--- a/tools/packaging/packagerConfig.py
+++ b/tools/packaging/packagerConfig.py
@@ -117,6 +117,6 @@ class SCAbstraction(object):
         '''
         Source control add of a file.
         '''
-        subprocess.call(["hg", "add", filename])
+        subprocess.call(["git", "add", filename])
         
 SC_HELPER = SCAbstraction()

--- a/tools/packaging/test262.py
+++ b/tools/packaging/test262.py
@@ -222,7 +222,7 @@ class TestCase(object):
     self.test = testRecord["test"]
     del testRecord["test"]
     del testRecord["header"]
-    del testRecord["commentary"]
+    testRecord.pop("commentary", None)    # do not throw if missing
     self.testRecord = testRecord;
     
 


### PR DESCRIPTION
packager.py cannot run due to syntax errors in a few script files

packagerConfig: use git instead of hg
test262: use pop instead of delete to avoid throw if property missing
S22.1.2.1_T_: fix docString header comment: should be /_*
S22.1.2.1_T3: fix docString header comment: should be /**, fix end of docstring \* / => */
