### PR TITLE
runner: support "includes" from YAML frontmatter

### DIFF
--- a/test/harness/sth.js
+++ b/test/harness/sth.js
@@ -160,8 +160,14 @@ function BrowserRunner() {
         iwin.testFinished = testFinished;
 
         //TODO: these should be moved to sta.js
-        var includes = code.match(/\$INCLUDE\(([^\)]+)\)/g), // find all of the $INCLUDE statements
+        var includes,
             include;
+        
+        includes = test.includes;
+        if (!includes || !(includes.length)) {
+            // includes not specified via frontmatter;  find all of the $INCLUDE statements
+            includes = code.match(/\$INCLUDE\(([^\)]+)\)/g);
+        }
 
         if (includes !== null) {
             // We have some includes, so loop through each include and

--- a/tools/packaging/test262.py
+++ b/tools/packaging/test262.py
@@ -251,7 +251,9 @@ class TestCase(object):
 	return '$DONE' in self.test
 
   def GetIncludeList(self):
-    return re.findall('\$INCLUDE\([\'"]([^\)]+)[\'"]\)' ,self.test)
+    if self.testRecord['includes']:
+      return self.testRecord['includes']
+    return re.findall('\$INCLUDE\([\'"]([^\)]+)[\'"]\)', self.test)
 
   def GetAdditionalIncludes(self):
     return '\n'.join([self.suite.GetInclude(include) for include in self.GetIncludeList()])


### PR DESCRIPTION
support frontmatter "includes" in python runner
use test.includes if present instead of scanning test code with regex

This PR adds **theoretical** support for the `includes` YAML.  No tests currently use it, so it is untested.

I will add some test fixtures later and inspect the packaging code to make sure the `includes` is passed from the test frontmatter into the generated JSON, where the browser runner can read it.

In both the python and in-browser runners, this patch falls back to scanning for `$INCLUDE("")` directives if the `test.includes` member is absent.
