### PR TITLE
test262.py: only include helper scripts when needed

### DIFF
--- a/test/harness/sth.js
+++ b/test/harness/sth.js
@@ -91,6 +91,9 @@ function BrowserRunner() {
         currentTest.code = codeString;
     }
 
+    function isAsyncTest(code) {
+        return /\$DONE()/.test(code));
+    }
 
     /* Run the test. */
     this.run = function (test, code) {
@@ -208,8 +211,8 @@ function BrowserRunner() {
 
         //this is mainly applicable for consoles that do not have setTimeout support
 		//idoc.writeln("<script type='text/javascript' src='harness/timer.js' defer>" + "</script>");
-        if(setTimeout === undefined && /\$DONE()/.test(code)){
-         idoc.writeln("<script type='text/javascript'>");
+        if(setTimeout === undefined && isAsyncTest(code)) {
+        idoc.writeln("<script type='text/javascript'>");
          idoc.writeln(timerContents);
          idoc.writeln("</script>");
         }
@@ -225,15 +228,15 @@ function BrowserRunner() {
 		
         idoc.writeln("<script type='text/javascript'>");
 		
-        if(!/\$DONE()/.test(code))
-        //if the test is synchronous - call $DONE immediately
+        if (!isAsyncTest(code)) {
+            //if the test is synchronous - call $DONE immediately
             idoc.writeln("if(typeof $DONE === 'function') $DONE()");
-        else{
-        //in case the test does not call $DONE asynchronously then
-        //bailout after 1 min or given bailout time by calling $DONE
+        } else {
+            //in case the test does not call $DONE asynchronously then
+            //bailout after 1 min or given bailout time by calling $DONE
             var asyncval = parseInt(test.timeout);
             var testTimeout = asyncval !== asyncval ? 2000 : asyncval;
-			idoc.writeln("setTimeout(function() {$ERROR(\" Test Timed Out at " + testTimeout +"\" )} ," + testTimeout + ")");
+	    idoc.writeln("setTimeout(function() {$ERROR(\" Test Timed Out at " + testTimeout +"\" )} ," + testTimeout + ")");
         }
         idoc.writeln("</script>");
         idoc.close();

--- a/test/harness/timer.js
+++ b/test/harness/timer.js
@@ -12,7 +12,7 @@ if(Promise !== undefined && this.setTimeout === undefined)
             var end = start + delay;
             function check(){
                 var timeLeft = end - Date.now();        
-                if(timeLeft)
+                if(timeLeft > 0)
                     p.then(check);
                 else
                     callback();

--- a/tools/packaging/test262.py
+++ b/tools/packaging/test262.py
@@ -260,11 +260,14 @@ class TestCase(object):
     # "var testDescrip = " + str(self.testRecord) + ';\n\n' + \
     source = self.suite.GetInclude("cth.js") + \
         self.suite.GetInclude("sta.js") + \
-        self.suite.GetInclude("ed.js") + \
-        self.suite.GetInclude("testBuiltInObject.js") + \
-        self.suite.GetInclude("testIntl.js") + \
-	self.suite.GetInclude("timer.js") + \
-	self.suite.GetInclude("doneprintHandle.js").replace('print', self.suite.print_handle) + \
+        self.suite.GetInclude("ed.js")
+
+    if self.IsAsyncTest():
+      source = source + \
+               self.suite.GetInclude("timer.js") + \
+               self.suite.GetInclude("doneprintHandle.js").replace('print', self.suite.print_handle)
+
+    source = source + \
         self.GetAdditionalIncludes() + \
         self.test + '\n'
 


### PR DESCRIPTION
test262.py: only supply async helper scripts when test is async
sth.js: factor out function isAsyncTest()
timer.js: improve workaround for async tests when Promise is defined but setTimeout is noot

timer.js emulates setTimeout using Promise by doing a busy loop that checks
if `timeout` milliseconds have elapsed.  Modified check to (timeLeft > 0) instead
of (!timeLeft) to prevent infinite loop when check does not happen to run
at precise millisecond timeout expires.

Because test262.py did not support the $INCLUDE directive, some helper
scripts were added to every test -- notably testIntl, timer, and donePrintHandle
Now that $INCLUDE is supported, these can be dropped, speeding overall test run time

Additional bonus: unconditionally including `timer.js` in all console tests caused every test to fail when running with node 0.10, due to a `ReferenceError` on the undefined var `Promise`.  Now node 0.10 will only fail async tests -- which is still a problem, but a much more manageable one, since the only tests that currently are async are tests of Promises, which are not implemented in node 0.10.
