### PR TITLE
sth: correct syntax error in new fn isAsyncTest

### DIFF
--- a/test/harness/sth.js
+++ b/test/harness/sth.js
@@ -92,7 +92,7 @@ function BrowserRunner() {
     }
 
     function isAsyncTest(code) {
-        return /\$DONE()/.test(code));
+        return /\$DONE()/.test(code);
     }
 
     /* Run the test. */


### PR DESCRIPTION
Committed a syntax error in an earlier pull request. (#49)
