### PR TITLE
harness: remove unused code

### DIFF
--- a/test/harness/cth.js
+++ b/test/harness/cth.js
@@ -10,6 +10,30 @@ function testRun(id, path, description, codeString, result, error) {
   }
 }
 
-function testFinished() {
-    //no-op
+// define a default `print` function for async tests where there is no 
+// global `print`
+var print;
+
+// in node use console.log
+if (typeof console === "object") {
+    print = function () {
+        var args = Array.prototype.slice.call(arguments);
+        console.log(args.join(" "));
+    };
+}
+
+// in WScript, use WScript.Echo
+if (typeof WScript === "object") {
+    print = function () {
+        var args = Array.prototype.slice.call(arguments);
+        WScript.Echo(args.join(" "));
+    };
+
+    // also override $ERROR to force a nonzero exit code exit 
+    // TODO? report syntax errors
+    var oldError = $ERROR;
+    $ERROR = function (message) {
+        print("Test262 Error: " + message);
+        WScript.Quit(1);
+    };
 }

--- a/test/harness/ed.js
+++ b/test/harness/ed.js
@@ -12,20 +12,3 @@ if (this.window!==undefined) {  //for console support
     };
 }
 
-//This doesn't work with early errors in current versions of Opera
-/*
-if (/opera/i.test(navigator.userAgent)) {
-    (function() {
-        var origError = window.Error;
-        window.Error = function() {
-            if (arguments.length>0) {
-                try {
-                    window.onerror(arguments[0]);
-                } catch(e) {
-                    alert("Failed to invoke window.onerror (from ed.js)");
-                }
-            }
-            return origError.apply(this, arguments);
-        }
-    })();
-}*/

--- a/test/harness/sta.js
+++ b/test/harness/sta.js
@@ -4,31 +4,23 @@
 /// "Use Terms").   Any redistribution of this code must retain the above 
 /// copyright and this notice and otherwise comply with the Use Terms.
 
-
-
-//-----------------------------------------------------------------------------
 var NotEarlyErrorString = "NotEarlyError";
 var EarlyErrorRePat = "^((?!" + NotEarlyErrorString + ").)*$";
 var NotEarlyError = new Error(NotEarlyErrorString);
 
-//-----------------------------------------------------------------------------
-// Copyright 2009 the Sputnik authors.  All rights reserved.
-// This code is governed by the BSD license found in the LICENSE file.
-
 function Test262Error(message) {
-    if (message) this.message = message;
+    this.message = message || "";
 }
 
 Test262Error.prototype.toString = function () {
     return "Test262 Error: " + this.message;
 };
 
-function testFailed(message) {
+var $ERROR;
+$ERROR = function $ERROR(message) {
     throw new Test262Error(message);
-}
+};
 
-function $INCLUDE(message) { }
-function $ERROR(message) {
-    testFailed(message);
+function testFailed(message) {
+    $ERROR(message);
 }
-


### PR DESCRIPTION
Remove some functions that are no longer used. 
Stop `test262.py` including files that provide never-used functions

sta.js:
slight change to Test262Error() semantics; message property now always set
(default "")
remove 2009 copyright in favor of 2012 copyright
remove never-used fn testFailed
remove obsolete fn $INCLUDE

ed.js: remove commented-out obsolete code

cth.js: file is never used

test262.py: don't include ed, cth in console tests
remove two always-included harness files that provide no functions used by any extant test
