### PR TITLE
ES5.S15: new tests to clarify Array.prototype.concat

### DIFF
--- a/test/suite/ch15/15.4/15.4.4/15.4.4.4/S15.4.4.4_A3_T2.js
+++ b/test/suite/ch15/15.4/15.4.4/15.4.4.4/S15.4.4.4_A3_T2.js
@@ -1,0 +1,64 @@
+// Copyright 2014 Ecma International.  All rights reserved.
+// See LICENSE or https://github.com/tc39/test262/blob/master/LICENSE
+
+/*---
+info: Array.prototype.concat uses [[Get]] on 'length' to determine array length
+es5id: 15.4.4.4_A3_T2
+description: >
+  checking whether non-ownProperties are seen, copied by Array.prototype.concat: Array.prototype[1]
+---*/
+
+var a = [0];
+
+if (a.length !== 1) {
+  $ERROR("expected a.length === 1, actually " + a.length);
+}
+
+a.length = 3;
+
+if (a[1] !== undefined) {
+  $ERROR("expected a[1] === undefined, actually " + a[1]);
+}
+if (a[2] !== undefined) {
+  $ERROR("expected a[2] === undefined, actually " + a[2]);
+}
+
+Array.prototype[2] = 2;
+
+if (a[1] !== undefined) {
+  $ERROR("expected a[1] === undefined, actually " + a[1]);
+}
+if (a[2] !== 2) {
+  $ERROR("expected a[2] === 2, actually " + a[2]);
+}
+
+if (a.hasOwnProperty('1') !== false) {
+  $ERROR("a.hasOwnProperty('1') === false, actually " + a.hasOwnProperty('1'));
+}
+if (a.hasOwnProperty('2') !== false) {
+  $ERROR("a.hasOwnProperty('2') === false, actually " + a.hasOwnProperty('2'));
+}
+
+var b = a.concat();
+
+if (b.length !== 3) {
+  $ERROR("expected b.length === 3, actually " + b.length);
+}
+
+if (b[0] !== 0) {
+  $ERROR("expected b[0] === 0, actually " + b[0]);
+}
+if (b[1] !== undefined) {
+  $ERROR("expected b[1] === undefined, actually " + b[1]);
+}
+if (b[2] !== 2) {
+  $ERROR("expected b[2] === 2, actually " + b[2]);
+}
+
+if (b.hasOwnProperty('1') !== false) {
+  $ERROR("expected b.hasOwnProperty('1') === false, actually " + b.hasOwnProperty('1'));
+}
+if (b.hasOwnProperty('2') !== true) {
+  $ERROR("expected b.hasOwnProperty('2') === true, actually " + b.hasOwnProperty('2'));
+}
+

--- a/test/suite/ch15/15.4/15.4.4/15.4.4.4/S15.4.4.4_A3_T3.js
+++ b/test/suite/ch15/15.4/15.4.4/15.4.4.4/S15.4.4.4_A3_T3.js
@@ -1,0 +1,64 @@
+// Copyright 2014 Ecma International.  All rights reserved.
+// See LICENSE or https://github.com/tc39/test262/blob/master/LICENSE
+
+/*---
+info: Array.prototype.concat uses [[Get]] on 'length' to determine array length
+es5id: 15.4.4.4_A3_T3
+description: >
+  checking whether non-ownProperties are seen, copied by Array.prototype.concat: Object.prototype[1]
+---*/
+
+var a = [0];
+
+if (a.length !== 1) {
+  $ERROR("expected a.length === 1, actually " + a.length);
+}
+
+a.length = 3;
+
+if (a[1] !== undefined) {
+  $ERROR("expected a[1] === undefined, actually " + a[1]);
+}
+if (a[2] !== undefined) {
+  $ERROR("expected a[2] === undefined, actually " + a[2]);
+}
+
+Object.prototype[2] = 2;
+
+if (a[1] !== undefined) {
+  $ERROR("expected a[1] === undefined, actually " + a[1]);
+}
+if (a[2] !== 2) {
+  $ERROR("expected a[2] === 2, actually " + a[2]);
+}
+
+if (a.hasOwnProperty('1') !== false) {
+  $ERROR("a.hasOwnProperty('1') === false, actually " + a.hasOwnProperty('1'));
+}
+if (a.hasOwnProperty('2') !== false) {
+  $ERROR("a.hasOwnProperty('2') === false, actually " + a.hasOwnProperty('2'));
+}
+
+var b = a.concat();
+
+if (b.length !== 3) {
+  $ERROR("expected b.length === 3, actually " + b.length);
+}
+
+if (b[0] !== 0) {
+  $ERROR("expected b[0] === 0, actually " + b[0]);
+}
+if (b[1] !== undefined) {
+  $ERROR("expected b[1] === undefined, actually " + b[1]);
+}
+if (b[2] !== 2) {
+  $ERROR("expected b[2] === 2, actually " + b[2]);
+}
+
+if (b.hasOwnProperty('1') !== false) {
+  $ERROR("expected b.hasOwnProperty('1') === false, actually " + b.hasOwnProperty('1'));
+}
+if (b.hasOwnProperty('2') !== true) {
+  $ERROR("expected b.hasOwnProperty('2') === true, actually " + b.hasOwnProperty('2'));
+}
+


### PR DESCRIPTION
[ES5.1 Spec 15.4.4.4](http://www.ecma-international.org/ecma-262/5.1/#sec-15.4.4.4) defines the algorithm for `Array.prototype.concat`.

When `concat` operates on an Array (on an object whose [[Class]] internal property is "Array"), it iterates over that object's indexed properties from `0` to `length-1`.

When extending an array `a` by setting `length`, there will be indices where `a.getOwnProperty()` returns `false`.

When copying elements to the target array, however, `concat`  5.b.iii.2 says to use "the [[HasProperty]] internal method" which will search up the prototype chain.  ([[HasProperty]] is implemented in terms of ([[GetProperty]])[http://www.ecma-international.org/ecma-262/5.1/#sec-8.12.2]).

Then if a property with that index is found, either on the object or in its prototype chain, 5.b.iii.3.b states 'Call the [[DefineOwnProperty]] internal method of A'

This means that the result of Array.prototype.concat should return `true` from `hasOwnProperty` for every property
created by `concat`, up to `length`, as long as that property was defined on either the source object or some object in its prototype chain.

These tests check with Array.prototype and Object.prototype, separately.
