### PR TITLE
Move tests to Math.clz32 (Fixes #41)

### DIFF
--- a/test/suite/es6/Math.clz32/Math.clz32.js
+++ b/test/suite/es6/Math.clz32/Math.clz32.js
@@ -7,13 +7,12 @@
 /*---
 author: Ryan Lewis
 email: ryanhlewis@hotmail.com
-spec: "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.prototype.clz"
-description: Number.prototype.clz should return 31 if passed 1.
+description: Math.clz32 should return 32 if passed 0.
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  if(Number.prototype.clz(1) === 31) {
+  if(Math.clz32(0) === 32) {
   	return true;
   }
  }

--- a/test/suite/es6/Math.clz32/Math.clz32_1.js
+++ b/test/suite/es6/Math.clz32/Math.clz32_1.js
@@ -7,13 +7,12 @@
 /*---
 author: Ryan Lewis
 email: ryanhlewis@hotmail.com
-spec: "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.prototype.clz"
-description: Number.prototype.clz should return 32 if passed 0.
+description: Math.clz32 should return 31 if passed 1.
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  if(Number.prototype.clz(0) === 32) {
+  if(Math.clz32(1) === 31) {
   	return true;
   }
  }

--- a/test/suite/es6/Math.clz32/Math.clz32_2.js
+++ b/test/suite/es6/Math.clz32/Math.clz32_2.js
@@ -7,13 +7,12 @@
 /*---
 author: Ryan Lewis
 email: ryanhlewis@hotmail.com
-spec: "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.prototype.clz"
-description: Number.prototype.clz should return 0 if passed 2147483648
+description: Math.clz32 should return 0 if passed 2147483648
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  if(Number.prototype.clz(2147483648) === 0) {
+  if(Math.clz32(2147483648) === 0) {
   	return true;
   }
  }


### PR DESCRIPTION
Number.prototype.clz() was renamed to Math.clz32(). Also removed superfluous 'spec' entry in test descriptor. (Fixes #41)
