### PR TITLE
Add test coverage for identifier resolution in dynamic scopes

### DIFF
--- a/test/suite/ch11/11.13/11.13.1/S11.13.1_A5_T1.js
+++ b/test/suite/ch11/11.13/11.13.1/S11.13.1_A5_T1.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Assignment Operator calls PutValue(lref, rval)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, rval) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {x: 1};
+
+  with (scope) {
+    x = (delete scope.x, 2);
+  }
+
+  if (scope.x !== 2) {
+    $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.13/11.13.1/S11.13.1_A5_T2.js
+++ b/test/suite/ch11/11.13/11.13.1/S11.13.1_A5_T2.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Assignment Operator calls PutValue(lref, rval)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, rval) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {x: 1};
+
+with (scope) {
+  x = (delete scope.x, 2);
+}
+
+if (scope.x !== 2) {
+  $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.13/11.13.1/S11.13.1_A5_T3.js
+++ b/test/suite/ch11/11.13/11.13.1/S11.13.1_A5_T3.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Assignment Operator calls PutValue(lref, rval)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, rval) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+flags: [noStrict]
+---*/
+
+var outerScope = {x: 0};
+var innerScope = {x: 1};
+
+with (outerScope) {
+  with (innerScope) {
+    x = (delete innerScope.x, 2);
+  }
+}
+
+if (innerScope.x !== 2) {
+  $ERROR('#1: innerScope.x === 2. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.13/11.13.1/S11.13.1_A5_T4.js
+++ b/test/suite/ch11/11.13/11.13.1/S11.13.1_A5_T4.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Assignment Operator calls PutValue(lref, rval)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, rval) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when assignment is in strict-mode code and the
+    original binding is no longer present.
+flags: [noStrict]
+---*/
+
+var scope = {x: 1};
+
+with (scope) {
+  (function() {
+    "use strict";
+    x = (delete scope.x, 2);
+  })();
+}
+
+if (scope.x !== 2) {
+  $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.13/11.13.1/S11.13.1_A5_T5.js
+++ b/test/suite/ch11/11.13/11.13.1/S11.13.1_A5_T5.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Assignment Operator calls PutValue(lref, rval)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, rval) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when assignment is in strict-mode code and the
+    original binding is no longer present.
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  value: 1
+});
+
+(function() {
+  "use strict";
+  x = (delete fnGlobalObject().x, 2);
+})();
+
+if (fnGlobalObject().x !== 2) {
+  $ERROR('#1: fnGlobalObject().x === 2. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.13/11.13.1/S11.13.1_A6_T1.js
+++ b/test/suite/ch11/11.13/11.13.1/S11.13.1_A6_T1.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Assignment Operator calls PutValue(lref, rval)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    declarative environment record. PutValue(lref, rval) uses the initially
+    created Reference even if a more local binding is available.
+flags: [noStrict]
+---*/
+
+function testAssignment() {
+  var x = 0;
+  var innerX = (function() {
+    x = (eval("var x;"), 1);
+    return x;
+  })();
+
+  if (innerX !== undefined) {
+    $ERROR('#1: innerX === undefined. Actual: ' + (innerX));
+  }
+  if (x !== 1) {
+    $ERROR('#2: x === 1. Actual: ' + (x));
+  }
+}
+testAssignment();

--- a/test/suite/ch11/11.13/11.13.1/S11.13.1_A6_T2.js
+++ b/test/suite/ch11/11.13/11.13.1/S11.13.1_A6_T2.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Assignment Operator calls PutValue(lref, rval)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    declarative environment record. PutValue(lref, rval) uses the initially
+    created Reference even if a more local binding is available.
+flags: [noStrict]
+---*/
+
+function testAssignment() {
+  var x = 0;
+  var innerX = (function() {
+    x = (eval("var x = 2;"), 1);
+    return x;
+  })();
+
+  if (innerX !== 2) {
+    $ERROR('#1: innerX === 2. Actual: ' + (innerX));
+  }
+  if (x !== 1) {
+    $ERROR('#2: x === 1. Actual: ' + (x));
+  }
+}
+testAssignment();

--- a/test/suite/ch11/11.13/11.13.1/S11.13.1_A6_T3.js
+++ b/test/suite/ch11/11.13/11.13.1/S11.13.1_A6_T3.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Assignment Operator calls PutValue(lref, rval)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    declarative environment record. PutValue(lref, rval) uses the initially
+    created Reference even if a more local binding is available.
+flags: [noStrict]
+---*/
+
+function testAssignment() {
+  var x = 0;
+  var scope = {};
+
+  with (scope) {
+    x = (scope.x = 2, 1);
+  }
+
+  if (scope.x !== 2) {
+    $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+  }
+  if (x !== 1) {
+    $ERROR('#2: x === 1. Actual: ' + (x));
+  }
+}
+testAssignment();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.10_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.10_T1.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+    Check operator is "x ^= y".
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 2;
+    }
+  };
+
+  with (scope) {
+    x ^= 3;
+  }
+
+  if (scope.x !== 1) {
+    $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.10_T2.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.10_T2.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+    Check operator is "x ^= y".
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  x ^= 3;
+}
+
+if (scope.x !== 1) {
+  $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.10_T3.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.10_T3.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+    Check operator is "x ^= y".
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    x ^= 3;
+  }
+}
+
+if (innerScope.x !== 1) {
+  $ERROR('#1: innerScope.x === 1. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.10_T4.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.10_T4.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x ^= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x ^= y".
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    x ^= 3;
+  })();
+}
+
+if (scope.x !== 1) {
+  $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.10_T5.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.10_T5.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x ^= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x ^= y".
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 2;
+  }
+});
+
+(function() {
+  "use strict";
+  x ^= 3;
+})();
+
+if (fnGlobalObject().x !== 1) {
+  $ERROR('#1: fnGlobalObject().x === 1. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.11_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.11_T1.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+    Check operator is "x |= y".
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 2;
+    }
+  };
+
+  with (scope) {
+    x |= 4;
+  }
+
+  if (scope.x !== 6) {
+    $ERROR('#1: scope.x === 6. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.11_T2.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.11_T2.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+    Check operator is "x |= y".
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  x |= 4;
+}
+
+if (scope.x !== 6) {
+  $ERROR('#1: scope.x === 6. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.11_T3.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.11_T3.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+    Check operator is "x |= y".
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    x |= 4;
+  }
+}
+
+if (innerScope.x !== 6) {
+  $ERROR('#1: innerScope.x === 6. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.11_T4.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.11_T4.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x |= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x |= y".
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    x |= 4;
+  })();
+}
+
+if (scope.x !== 6) {
+  $ERROR('#1: scope.x === 6. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.11_T5.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.11_T5.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x |= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x |= y".
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 2;
+  }
+});
+
+(function() {
+  "use strict";
+  x |= 4;
+})();
+
+if (fnGlobalObject().x !== 6) {
+  $ERROR('#1: fnGlobalObject().x === 6. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.1_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.1_T1.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+    Check operator is "x *= y".
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 2;
+    }
+  };
+
+  with (scope) {
+    x *= 3;
+  }
+
+  if (scope.x !== 6) {
+    $ERROR('#1: scope.x === 6. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.1_T2.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.1_T2.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+    Check operator is "x *= y".
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  x *= 3;
+}
+
+if (scope.x !== 6) {
+  $ERROR('#1: scope.x === 6. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.1_T3.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.1_T3.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+    Check operator is "x *= y".
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    x *= 3;
+  }
+}
+
+if (innerScope.x !== 6) {
+  $ERROR('#1: innerScope.x === 6. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.1_T4.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.1_T4.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x *= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x *= y".
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    x *= 3;
+  })();
+}
+
+if (scope.x !== 6) {
+  $ERROR('#1: scope.x === 6. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.1_T5.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.1_T5.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x *= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x *= y".
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 2;
+  }
+});
+
+(function() {
+  "use strict";
+  x *= 3;
+})();
+
+if (fnGlobalObject().x !== 6) {
+  $ERROR('#1: fnGlobalObject().x === 6. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.2_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.2_T1.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+    Check operator is "x /= y".
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 6;
+    }
+  };
+
+  with (scope) {
+    x /= 3;
+  }
+
+  if (scope.x !== 2) {
+    $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.2_T2.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.2_T2.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+    Check operator is "x /= y".
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 6;
+  }
+};
+
+with (scope) {
+  x /= 3;
+}
+
+if (scope.x !== 2) {
+  $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.2_T3.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.2_T3.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+    Check operator is "x /= y".
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 6;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    x /= 3;
+  }
+}
+
+if (innerScope.x !== 2) {
+  $ERROR('#1: innerScope.x === 2. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.2_T4.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.2_T4.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x /= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x /= y".
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 6;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    x /= 3;
+  })();
+}
+
+if (scope.x !== 2) {
+  $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.2_T5.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.2_T5.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x /= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x /= y".
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 6;
+  }
+});
+
+(function() {
+  "use strict";
+  x /= 3;
+})();
+
+if (fnGlobalObject().x !== 2) {
+  $ERROR('#1: fnGlobalObject().x === 2. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.3_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.3_T1.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+    Check operator is "x %= y".
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 5;
+    }
+  };
+
+  with (scope) {
+    x %= 3;
+  }
+
+  if (scope.x !== 2) {
+    $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.3_T2.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.3_T2.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+    Check operator is "x %= y".
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 5;
+  }
+};
+
+with (scope) {
+  x %= 3;
+}
+
+if (scope.x !== 2) {
+  $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.3_T3.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.3_T3.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+    Check operator is "x %= y".
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 5;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    x %= 3;
+  }
+}
+
+if (innerScope.x !== 2) {
+  $ERROR('#1: innerScope.x === 2. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.3_T4.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.3_T4.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x %= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x %= y".
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 5;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    x %= 3;
+  })();
+}
+
+if (scope.x !== 2) {
+  $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.3_T5.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.3_T5.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x %= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x %= y".
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 5;
+  }
+});
+
+(function() {
+  "use strict";
+  x %= 3;
+})();
+
+if (fnGlobalObject().x !== 2) {
+  $ERROR('#1: fnGlobalObject().x === 2. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.4_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.4_T1.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+    Check operator is "x += y".
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 2;
+    }
+  };
+
+  with (scope) {
+    x += 1;
+  }
+
+  if (scope.x !== 3) {
+    $ERROR('#1: scope.x === 3. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.4_T2.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.4_T2.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+    Check operator is "x += y".
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  x += 1;
+}
+
+if (scope.x !== 3) {
+  $ERROR('#1: scope.x === 3. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.4_T3.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.4_T3.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+    Check operator is "x += y".
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    x += 1;
+  }
+}
+
+if (innerScope.x !== 3) {
+  $ERROR('#1: innerScope.x === 3. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.4_T4.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.4_T4.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x += y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x += y".
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    x += 1;
+  })();
+}
+
+if (scope.x !== 3) {
+  $ERROR('#1: scope.x === 3. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.4_T5.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.4_T5.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x += y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x += y".
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 2;
+  }
+});
+
+(function() {
+  "use strict";
+  x += 1;
+})();
+
+if (fnGlobalObject().x !== 3) {
+  $ERROR('#1: fnGlobalObject().x === 3. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.5_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.5_T1.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+    Check operator is "x -= y".
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 2;
+    }
+  };
+
+  with (scope) {
+    x -= 1;
+  }
+
+  if (scope.x !== 1) {
+    $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.5_T2.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.5_T2.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+    Check operator is "x -= y".
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  x -= 1;
+}
+
+if (scope.x !== 1) {
+  $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.5_T3.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.5_T3.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+    Check operator is "x -= y".
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    x -= 1;
+  }
+}
+
+if (innerScope.x !== 1) {
+  $ERROR('#1: innerScope.x === 1. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.5_T4.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.5_T4.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x -= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x -= y".
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    x -= 1;
+  })();
+}
+
+if (scope.x !== 1) {
+  $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.5_T5.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.5_T5.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x -= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x -= y".
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 2;
+  }
+});
+
+(function() {
+  "use strict";
+  x -= 1;
+})();
+
+if (fnGlobalObject().x !== 1) {
+  $ERROR('#1: fnGlobalObject().x === 1. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.6_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.6_T1.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+    Check operator is "x <<= y".
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 2;
+    }
+  };
+
+  with (scope) {
+    x <<= 3;
+  }
+
+  if (scope.x !== 16) {
+    $ERROR('#1: scope.x === 16. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.6_T2.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.6_T2.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+    Check operator is "x <<= y".
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  x <<= 3;
+}
+
+if (scope.x !== 16) {
+  $ERROR('#1: scope.x === 16. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.6_T3.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.6_T3.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+    Check operator is "x <<= y".
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    x <<= 3;
+  }
+}
+
+if (innerScope.x !== 16) {
+  $ERROR('#1: innerScope.x === 16. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.6_T4.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.6_T4.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x <<= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x <<= y".
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    x <<= 3;
+  })();
+}
+
+if (scope.x !== 16) {
+  $ERROR('#1: scope.x === 16. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.6_T5.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.6_T5.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x <<= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x <<= y".
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 2;
+  }
+});
+
+(function() {
+  "use strict";
+  x <<= 3;
+})();
+
+if (fnGlobalObject().x !== 16) {
+  $ERROR('#1: fnGlobalObject().x === 16. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.7_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.7_T1.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+    Check operator is "x >>= y".
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 16;
+    }
+  };
+
+  with (scope) {
+    x >>= 3;
+  }
+
+  if (scope.x !== 2) {
+    $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.7_T2.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.7_T2.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+    Check operator is "x >>= y".
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 16;
+  }
+};
+
+with (scope) {
+  x >>= 3;
+}
+
+if (scope.x !== 2) {
+  $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.7_T3.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.7_T3.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+    Check operator is "x >>= y".
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 16;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    x >>= 3;
+  }
+}
+
+if (innerScope.x !== 2) {
+  $ERROR('#1: innerScope.x === 2. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.7_T4.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.7_T4.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x >>= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x >>= y".
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 16;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    x >>= 3;
+  })();
+}
+
+if (scope.x !== 2) {
+  $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.7_T5.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.7_T5.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x >>= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x >>= y".
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 16;
+  }
+});
+
+(function() {
+  "use strict";
+  x >>= 3;
+})();
+
+if (fnGlobalObject().x !== 2) {
+  $ERROR('#1: fnGlobalObject().x === 2. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.8_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.8_T1.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+    Check operator is "x >>>= y".
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 16;
+    }
+  };
+
+  with (scope) {
+    x >>>= 3;
+  }
+
+  if (scope.x !== 2) {
+    $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.8_T2.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.8_T2.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+    Check operator is "x >>>= y".
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 16;
+  }
+};
+
+with (scope) {
+  x >>>= 3;
+}
+
+if (scope.x !== 2) {
+  $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.8_T3.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.8_T3.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+    Check operator is "x >>>= y".
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 16;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    x >>>= 3;
+  }
+}
+
+if (innerScope.x !== 2) {
+  $ERROR('#1: innerScope.x === 2. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.8_T4.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.8_T4.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x >>>= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x >>>= y".
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 16;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    x >>>= 3;
+  })();
+}
+
+if (scope.x !== 2) {
+  $ERROR('#1: scope.x === 2. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.8_T5.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.8_T5.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x >>>= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x >>>= y".
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 16;
+  }
+});
+
+(function() {
+  "use strict";
+  x >>>= 3;
+})();
+
+if (fnGlobalObject().x !== 2) {
+  $ERROR('#1: fnGlobalObject().x === 2. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.9_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.9_T1.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+    Check operator is "x &= y".
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 5;
+    }
+  };
+
+  with (scope) {
+    x &= 3;
+  }
+
+  if (scope.x !== 1) {
+    $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.9_T2.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.9_T2.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+    Check operator is "x &= y".
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 5;
+  }
+};
+
+with (scope) {
+  x &= 3;
+}
+
+if (scope.x !== 1) {
+  $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.9_T3.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.9_T3.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+    Check operator is "x &= y".
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 5;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    x &= 3;
+  }
+}
+
+if (innerScope.x !== 1) {
+  $ERROR('#1: innerScope.x === 1. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.9_T4.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.9_T4.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x &= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x &= y".
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 5;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    x &= 3;
+  })();
+}
+
+if (scope.x !== 1) {
+  $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.9_T5.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A5.9_T5.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lref, v) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x &= y' is in strict-mode code and the
+    original binding is no longer present.
+    Check operator is "x &= y".
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 5;
+  }
+});
+
+(function() {
+  "use strict";
+  x &= 3;
+})();
+
+if (fnGlobalObject().x !== 1) {
+  $ERROR('#1: fnGlobalObject().x === 1. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.10_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.10_T1.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    declarative environment record. PutValue(lref, v) uses the initially
+    created Reference even if a more local binding is available.
+    Check operator is "x ^= y".
+flags: [noStrict]
+---*/
+
+function testCompoundAssignment() {
+  var x = 1;
+  var innerX = (function() {
+    x ^= (eval("var x = 2;"), 4);
+    return x;
+  })();
+
+  if (innerX !== 2) {
+    $ERROR('#1: innerX === 2. Actual: ' + (innerX));
+  }
+  if (x !== 5) {
+    $ERROR('#2: x === 5. Actual: ' + (x));
+  }
+}
+testCompoundAssignment();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.11_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.11_T1.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    declarative environment record. PutValue(lref, v) uses the initially
+    created Reference even if a more local binding is available.
+    Check operator is "x |= y".
+flags: [noStrict]
+---*/
+
+function testCompoundAssignment() {
+  var x = 1;
+  var innerX = (function() {
+    x |= (eval("var x = 2;"), 4);
+    return x;
+  })();
+
+  if (innerX !== 2) {
+    $ERROR('#1: innerX === 2. Actual: ' + (innerX));
+  }
+  if (x !== 5) {
+    $ERROR('#2: x === 5. Actual: ' + (x));
+  }
+}
+testCompoundAssignment();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.1_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.1_T1.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    declarative environment record. PutValue(lref, v) uses the initially
+    created Reference even if a more local binding is available.
+    Check operator is "x *= y".
+flags: [noStrict]
+---*/
+
+function testCompoundAssignment() {
+  var x = 3;
+  var innerX = (function() {
+    x *= (eval("var x = 2;"), 4);
+    return x;
+  })();
+
+  if (innerX !== 2) {
+    $ERROR('#1: innerX === 2. Actual: ' + (innerX));
+  }
+  if (x !== 12) {
+    $ERROR('#2: x === 12. Actual: ' + (x));
+  }
+}
+testCompoundAssignment();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.2_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.2_T1.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    declarative environment record. PutValue(lref, v) uses the initially
+    created Reference even if a more local binding is available.
+    Check operator is "x /= y".
+flags: [noStrict]
+---*/
+
+function testCompoundAssignment() {
+  var x = 15;
+  var innerX = (function() {
+    x /= (eval("var x = 2;"), 3);
+    return x;
+  })();
+
+  if (innerX !== 2) {
+    $ERROR('#1: innerX === 2. Actual: ' + (innerX));
+  }
+  if (x !== 5) {
+    $ERROR('#2: x === 5. Actual: ' + (x));
+  }
+}
+testCompoundAssignment();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.3_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.3_T1.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    declarative environment record. PutValue(lref, v) uses the initially
+    created Reference even if a more local binding is available.
+    Check operator is "x %= y".
+flags: [noStrict]
+---*/
+
+function testCompoundAssignment() {
+  var x = 7;
+  var innerX = (function() {
+    x %= (eval("var x = 2;"), 4);
+    return x;
+  })();
+
+  if (innerX !== 2) {
+    $ERROR('#1: innerX === 2. Actual: ' + (innerX));
+  }
+  if (x !== 3) {
+    $ERROR('#2: x === 3. Actual: ' + (x));
+  }
+}
+testCompoundAssignment();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.4_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.4_T1.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    declarative environment record. PutValue(lref, v) uses the initially
+    created Reference even if a more local binding is available.
+    Check operator is "x += y".
+flags: [noStrict]
+---*/
+
+function testCompoundAssignment() {
+  var x = 3;
+  var innerX = (function() {
+    x += (eval("var x = 2;"), 1);
+    return x;
+  })();
+
+  if (innerX !== 2) {
+    $ERROR('#1: innerX === 2. Actual: ' + (innerX));
+  }
+  if (x !== 4) {
+    $ERROR('#2: x === 4. Actual: ' + (x));
+  }
+}
+testCompoundAssignment();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.5_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.5_T1.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    declarative environment record. PutValue(lref, v) uses the initially
+    created Reference even if a more local binding is available.
+    Check operator is "x -= y".
+flags: [noStrict]
+---*/
+
+function testCompoundAssignment() {
+  var x = 5;
+  var innerX = (function() {
+    x -= (eval("var x = 2;"), 1);
+    return x;
+  })();
+
+  if (innerX !== 2) {
+    $ERROR('#1: innerX === 2. Actual: ' + (innerX));
+  }
+  if (x !== 4) {
+    $ERROR('#2: x === 4. Actual: ' + (x));
+  }
+}
+testCompoundAssignment();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.6_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.6_T1.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    declarative environment record. PutValue(lref, v) uses the initially
+    created Reference even if a more local binding is available.
+    Check operator is "x <<= y".
+flags: [noStrict]
+---*/
+
+function testCompoundAssignment() {
+  var x = 1;
+  var innerX = (function() {
+    x <<= (eval("var x = 2;"), 3);
+    return x;
+  })();
+
+  if (innerX !== 2) {
+    $ERROR('#1: innerX === 2. Actual: ' + (innerX));
+  }
+  if (x !== 8) {
+    $ERROR('#2: x === 8. Actual: ' + (x));
+  }
+}
+testCompoundAssignment();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.7_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.7_T1.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    declarative environment record. PutValue(lref, v) uses the initially
+    created Reference even if a more local binding is available.
+    Check operator is "x >>= y".
+flags: [noStrict]
+---*/
+
+function testCompoundAssignment() {
+  var x = 8;
+  var innerX = (function() {
+    x >>= (eval("var x = 2;"), 1);
+    return x;
+  })();
+
+  if (innerX !== 2) {
+    $ERROR('#1: innerX === 2. Actual: ' + (innerX));
+  }
+  if (x !== 4) {
+    $ERROR('#2: x === 4. Actual: ' + (x));
+  }
+}
+testCompoundAssignment();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.8_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.8_T1.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    declarative environment record. PutValue(lref, v) uses the initially
+    created Reference even if a more local binding is available.
+    Check operator is "x >>>= y".
+flags: [noStrict]
+---*/
+
+function testCompoundAssignment() {
+  var x = 8;
+  var innerX = (function() {
+    x >>>= (eval("var x = 2;"), 1);
+    return x;
+  })();
+
+  if (innerX !== 2) {
+    $ERROR('#1: innerX === 2. Actual: ' + (innerX));
+  }
+  if (x !== 4) {
+    $ERROR('#2: x === 4. Actual: ' + (x));
+  }
+}
+testCompoundAssignment();

--- a/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.9_T1.js
+++ b/test/suite/ch11/11.13/11.13.2/S11.13.2_A6.9_T1.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator calls PutValue(lref, v)
+description: >
+    Evaluating LeftHandSideExpression lref returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    declarative environment record. PutValue(lref, v) uses the initially
+    created Reference even if a more local binding is available.
+    Check operator is "x &= y".
+flags: [noStrict]
+---*/
+
+function testCompoundAssignment() {
+  var x = 5;
+  var innerX = (function() {
+    x &= (eval("var x = 2;"), 3);
+    return x;
+  })();
+
+  if (innerX !== 2) {
+    $ERROR('#1: innerX === 2. Actual: ' + (innerX));
+  }
+  if (x !== 1) {
+    $ERROR('#2: x === 1. Actual: ' + (x));
+  }
+}
+testCompoundAssignment();

--- a/test/suite/ch11/11.3/11.3.1/S11.3.1_A5_T1.js
+++ b/test/suite/ch11/11.3/11.3.1/S11.3.1_A5_T1.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x++ calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 2;
+    }
+  };
+
+  with (scope) {
+    x++;
+  }
+
+  if (scope.x !== 3) {
+    $ERROR('#1: scope.x === 3. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.3/11.3.1/S11.3.1_A5_T2.js
+++ b/test/suite/ch11/11.3/11.3.1/S11.3.1_A5_T2.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x++ calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  x++;
+}
+
+if (scope.x !== 3) {
+  $ERROR('#1: scope.x === 3. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.3/11.3.1/S11.3.1_A5_T3.js
+++ b/test/suite/ch11/11.3/11.3.1/S11.3.1_A5_T3.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x++ calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    x++;
+  }
+}
+
+if (innerScope.x !== 3) {
+  $ERROR('#1: innerScope.x === 3. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.3/11.3.1/S11.3.1_A5_T4.js
+++ b/test/suite/ch11/11.3/11.3.1/S11.3.1_A5_T4.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x++ calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x++' is in strict-mode code and the
+    original binding is no longer present.
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    x++;
+  })();
+}
+
+if (scope.x !== 3) {
+  $ERROR('#1: scope.x === 3. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.3/11.3.1/S11.3.1_A5_T5.js
+++ b/test/suite/ch11/11.3/11.3.1/S11.3.1_A5_T5.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x++ calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x++' is in strict-mode code and the
+    original binding is no longer present.
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 2;
+  }
+});
+
+(function() {
+  "use strict";
+  x++;
+})();
+
+if (fnGlobalObject().x !== 3) {
+  $ERROR('#1: fnGlobalObject().x === 3. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.3/11.3.2/S11.3.2_A5_T1.js
+++ b/test/suite/ch11/11.3/11.3.2/S11.3.2_A5_T1.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x-- calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 2;
+    }
+  };
+
+  with (scope) {
+    x--;
+  }
+
+  if (scope.x !== 1) {
+    $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.3/11.3.2/S11.3.2_A5_T2.js
+++ b/test/suite/ch11/11.3/11.3.2/S11.3.2_A5_T2.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x-- calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  x--;
+}
+
+if (scope.x !== 1) {
+  $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.3/11.3.2/S11.3.2_A5_T3.js
+++ b/test/suite/ch11/11.3/11.3.2/S11.3.2_A5_T3.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x-- calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    x--;
+  }
+}
+
+if (innerScope.x !== 1) {
+  $ERROR('#1: innerScope.x === 1. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.3/11.3.2/S11.3.2_A5_T4.js
+++ b/test/suite/ch11/11.3/11.3.2/S11.3.2_A5_T4.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x-- calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x--' is in strict-mode code and the
+    original binding is no longer present.
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    x--;
+  })();
+}
+
+if (scope.x !== 1) {
+  $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.3/11.3.2/S11.3.2_A5_T5.js
+++ b/test/suite/ch11/11.3/11.3.2/S11.3.2_A5_T5.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x-- calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when 'x--' is in strict-mode code and the
+    original binding is no longer present.
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 2;
+  }
+});
+
+(function() {
+  "use strict";
+  x--;
+})();
+
+if (fnGlobalObject().x !== 1) {
+  $ERROR('#1: fnGlobalObject().x === 1. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.4/11.4.4/S11.4.4_A5_T1.js
+++ b/test/suite/ch11/11.4/11.4.4/S11.4.4_A5_T1.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator ++x calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 2;
+    }
+  };
+
+  with (scope) {
+    ++x;
+  }
+
+  if (scope.x !== 3) {
+    $ERROR('#1: scope.x === 3. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.4/11.4.4/S11.4.4_A5_T2.js
+++ b/test/suite/ch11/11.4/11.4.4/S11.4.4_A5_T2.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator ++x calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  ++x;
+}
+
+if (scope.x !== 3) {
+  $ERROR('#1: scope.x === 3. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.4/11.4.4/S11.4.4_A5_T3.js
+++ b/test/suite/ch11/11.4/11.4.4/S11.4.4_A5_T3.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator ++x calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    ++x;
+  }
+}
+
+if (innerScope.x !== 3) {
+  $ERROR('#1: innerScope.x === 3. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.4/11.4.4/S11.4.4_A5_T4.js
+++ b/test/suite/ch11/11.4/11.4.4/S11.4.4_A5_T4.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator ++x calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when '++x' is in strict-mode code and the
+    original binding is no longer present.
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    ++x;
+  })();
+}
+
+if (scope.x !== 3) {
+  $ERROR('#1: scope.x === 3. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.4/11.4.4/S11.4.4_A5_T5.js
+++ b/test/suite/ch11/11.4/11.4.4/S11.4.4_A5_T5.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator ++x calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when '++x' is in strict-mode code and the
+    original binding is no longer present.
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 2;
+  }
+});
+
+(function() {
+  "use strict";
+  ++x;
+})();
+
+if (fnGlobalObject().x !== 3) {
+  $ERROR('#1: fnGlobalObject().x === 3. Actual: ' + (fnGlobalObject().x));
+}

--- a/test/suite/ch11/11.4/11.4.5/S11.4.5_A5_T1.js
+++ b/test/suite/ch11/11.4/11.4.5/S11.4.5_A5_T1.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator --x calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding function environment record is not changed.
+flags: [noStrict]
+---*/
+
+function testFunction() {
+  var x = 0;
+  var scope = {
+    get x() {
+      delete this.x;
+      return 2;
+    }
+  };
+
+  with (scope) {
+    --x;
+  }
+
+  if (scope.x !== 1) {
+    $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+  }
+  if (x !== 0) {
+    $ERROR('#2: x === 0. Actual: ' + (x));
+  }
+}
+testFunction();

--- a/test/suite/ch11/11.4/11.4.5/S11.4.5_A5_T2.js
+++ b/test/suite/ch11/11.4/11.4.5/S11.4.5_A5_T2.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator --x calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding global environment record is not changed.
+flags: [noStrict]
+---*/
+
+var x = 0;
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  --x;
+}
+
+if (scope.x !== 1) {
+  $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+}
+if (x !== 0) {
+  $ERROR('#2: x === 0. Actual: ' + (x));
+}

--- a/test/suite/ch11/11.4/11.4.5/S11.4.5_A5_T3.js
+++ b/test/suite/ch11/11.4/11.4.5/S11.4.5_A5_T3.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator --x calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    Binding in surrounding object environment record is not changed.
+flags: [noStrict]
+---*/
+
+var outerScope = {
+  x: 0
+};
+var innerScope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (outerScope) {
+  with (innerScope) {
+    --x;
+  }
+}
+
+if (innerScope.x !== 1) {
+  $ERROR('#1: innerScope.x === 1. Actual: ' + (innerScope.x));
+}
+if (outerScope.x !== 0) {
+  $ERROR('#2: outerScope.x === 0. Actual: ' + (outerScope.x));
+}

--- a/test/suite/ch11/11.4/11.4.5/S11.4.5_A5_T4.js
+++ b/test/suite/ch11/11.4/11.4.5/S11.4.5_A5_T4.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator --x calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when '--x' is in strict-mode code and the
+    original binding is no longer present.
+flags: [noStrict]
+---*/
+
+var scope = {
+  get x() {
+    delete this.x;
+    return 2;
+  }
+};
+
+with (scope) {
+  (function() {
+    "use strict";
+    --x;
+  })();
+}
+
+if (scope.x !== 1) {
+  $ERROR('#1: scope.x === 1. Actual: ' + (scope.x));
+}

--- a/test/suite/ch11/11.4/11.4.5/S11.4.5_A5_T5.js
+++ b/test/suite/ch11/11.4/11.4.5/S11.4.5_A5_T5.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2014 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator --x calls PutValue(lhs, newValue)
+description: >
+    Evaluating LeftHandSideExpression lhs returns Reference type; Reference
+    base value is an environment record and environment record kind is
+    object environment record. PutValue(lhs, newValue) uses the initially
+    created Reference even if the environment binding is no longer present.
+    No ReferenceError is thrown when '--x' is in strict-mode code and the
+    original binding is no longer present.
+includes:
+    - fnGlobalObject.js
+---*/
+
+Object.defineProperty(fnGlobalObject(), "x", {
+  configurable: true,
+  get: function() {
+    delete this.x;
+    return 2;
+  }
+});
+
+(function() {
+  "use strict";
+  --x;
+})();
+
+if (fnGlobalObject().x !== 1) {
+  $ERROR('#1: fnGlobalObject().x === 1. Actual: ' + (fnGlobalObject().x));
+}


### PR DESCRIPTION
Identifier resolution in dynamic scope context is missing test coverage, resolves https://bugs.ecmascript.org/show_bug.cgi?id=1751 .
