### PR TITLE
load monkeyYaml without assuming it is on path

### DIFF
--- a/tools/packaging/parseTestRecord.py
+++ b/tools/packaging/parseTestRecord.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import imp
 
 # from TestCasePackagerConfig import *
 
@@ -115,6 +116,19 @@ def importYamlLoad():
     try:
         import yaml
         yamlLoad = yaml.load
-    except ImportError:
-        import monkeyYaml
+    except:
+        monkeyYaml = loadMonkeyYaml()
         yamlLoad = monkeyYaml.load
+
+def loadMonkeyYaml():
+    f = None
+    try:
+        p = os.path.dirname(os.path.realpath(__file__))
+        (f, pathname, description) = imp.find_module("monkeyYaml", [p])
+        module = imp.load_module("monkeyYaml", f, pathname, description)
+        return module
+    except:
+        raise ImportError("Cannot load monkeyYaml")
+    finally:
+        if f:
+            f.close()

--- a/tools/packaging/test/test_monkeyYaml.py
+++ b/tools/packaging/test/test_monkeyYaml.py
@@ -7,12 +7,24 @@ import unittest
 
 import os
 import yaml
+import imp
 
 # add parent dir to search path
 import sys
-sys.path.insert(0, "..")
+#sys.path.insert(0, "..")
 
-import monkeyYaml
+f = None
+try:
+  (f, pathname, description) = imp.find_module("monkeyYaml", [os.path.join(os.getcwd(), "../")])
+  module = imp.load_module("monkeyYaml", f, pathname, description)
+  monkeyYaml = module
+except:
+  raise ImportError("Cannot load monkeyYaml")
+finally:
+  if f:
+    f.close()
+
+#import monkeyYaml
 
 class TestMonkeyYAMLParsing(unittest.TestCase):
 


### PR DESCRIPTION
use imp to import monkeyYaml even if not on path

This fixes a problem with the fallback YAML parser, in the test suite for the Chromium project.

The test262 runner is able to load monkeyYaml because monkeyYaml.py is in the same directory as test262.py, which is in python's load path.

The Chromium python runner does not add the path to parseTestRecord.py to its load path, making `import monkeyYaml` not work.
