### PR TITLE
initial tests of Array.prototype.splice requiring settable "length"

### DIFF
--- a/test/suite/ch15/15.4/15.4.4/15.4.4.12/S15.4.4.12_A6.1_T1.js
+++ b/test/suite/ch15/15.4/15.4.4/15.4.4.12/S15.4.4.12_A6.1_T1.js
@@ -1,0 +1,24 @@
+// Copyright 2014 Ecma International.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Array.prototype.splice sets `length` on `this`
+es5id: 15.4.4.12_A6.1_T1
+description: Array.prototype.splice sets `length` on Array
+---*/
+
+var a = [0, 1, 2];
+
+a.splice(1, 2, 4);
+
+if (a.length !== 2) {
+    $ERROR("Expected a.length === 2, actually " + a.length);
+}
+
+if (a[0] !== 0) {
+    $ERROR("Expected a[0] === 0, actually " + a[0]);
+}
+
+if (a[1] !== 4) {
+    $ERROR("Expected a[1] === 4, actually " + a[1]);
+}

--- a/test/suite/ch15/15.4/15.4.4/15.4.4.12/S15.4.4.12_A6.1_T2.js
+++ b/test/suite/ch15/15.4/15.4.4/15.4.4.12/S15.4.4.12_A6.1_T2.js
@@ -1,0 +1,17 @@
+// Copyright 2014 Ecma International.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Array.prototype.splice sets `length` on `this`
+es5id: 15.4.4.12_A6.1_T2
+description: Array.prototype.splice throws if `length` is read-only
+negative: TypeError
+---*/
+
+var a = [0, 1, 2];
+
+Object.defineProperty(a, 'length', {
+    writable: false
+});
+
+a.splice(1, 2, 4);

--- a/test/suite/ch15/15.4/15.4.4/15.4.4.12/S15.4.4.12_A6.1_T3.js
+++ b/test/suite/ch15/15.4/15.4.4/15.4.4.12/S15.4.4.12_A6.1_T3.js
@@ -1,0 +1,22 @@
+// Copyright 2014 Ecma International.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Array.prototype.splice sets `length` on `this`
+es5id: 15.4.4.12_A6.1_T3
+description: Array.prototype.splice throws if `length` is read-only
+---*/
+
+var a = { 
+    get length() { return 0; },
+    splice: Array.prototype.splice 
+};
+
+try {
+    a.splice(1, 2, 4);
+    $ERROR("Expected a TypeError");
+} catch (e) {
+    if (!(e instanceof TypeError)) {
+        throw e;
+    }
+}


### PR DESCRIPTION
add test of object with only "length" getter

This is a start on the questions raised in #84.  Contrary to my claim there, I am currently seeing a fail in node / v8 on 
S15.4.4.12_A6.1_T2.js
