### PR TITLE
add "assert.js" to python, website runners too

### DIFF
--- a/tools/packaging/templates/runner.bestPractice.html
+++ b/tools/packaging/templates/runner.bestPractice.html
@@ -11,6 +11,7 @@
 </script>
 <script type="text/javascript" src="harness/sth.js"></script>
 <script type="text/javascript" src="harness/sta.js"></script>
+<script type="text/javascript" src="harness/assert.js"></script>
 <script type="text/javascript" src="harness/jqueryprogressbar.js"></script>
 <script type="text/javascript" src="harness/helper.js"></script>
 <script type="text/javascript" src="harness/jquery.base64.js"></script>

--- a/tools/packaging/templates/runner.intl402.html
+++ b/tools/packaging/templates/runner.intl402.html
@@ -11,6 +11,7 @@
 </script>
 <script type="text/javascript" src="harness/sth.js"></script>
 <script type="text/javascript" src="harness/sta.js"></script>
+<script type="text/javascript" src="harness/assert.js"></script>
 <script type="text/javascript" src="harness/jqueryprogressbar.js"></script>
 <script type="text/javascript" src="harness/helper.js"></script>
 <script type="text/javascript" src="harness/jquery.base64.js"></script>

--- a/tools/packaging/templates/runner.test262.html
+++ b/tools/packaging/templates/runner.test262.html
@@ -11,6 +11,7 @@
 </script>
 <script type="text/javascript" src="harness/sth.js"></script>
 <script type="text/javascript" src="harness/sta.js"></script>
+<script type="text/javascript" src="harness/assert.js"></script>
 <script type="text/javascript" src="harness/jqueryprogressbar.js"></script>
 <script type="text/javascript" src="harness/helper.js"></script>
 <script type="text/javascript" src="harness/jquery.base64.js"></script>

--- a/tools/packaging/test262.py
+++ b/tools/packaging/test262.py
@@ -290,7 +290,8 @@ try {
   def GetSource(self, command_template):
     # "var testDescrip = " + str(self.testRecord) + ';\n\n' + \
     source = self.suite.GetInclude("sta.js") + \
-        self.suite.GetInclude("cth.js")
+        self.suite.GetInclude("cth.js") + \
+        self.suite.GetInclude("assert.js")
 
     if self.IsAsyncTest():
       source = source + \


### PR DESCRIPTION
Validated fix for python runner ---

```
$ ./tools/packaging/test262.py --command='node --harmony' prototype.find_this-defined
es6/Array.prototype.find/Array.prototype.find_this-defined passed in non-strict mode
```

Theoretical (unvalidated) fix for website runner.

We need some sort of test framework for this stuff -- and I know it sounds nuts to have a test framework for a test framework, but there it is.
