### PR TITLE
Array.prototype.find no longer skips holes

### DIFF
--- a/test/built-ins/Array/prototype/find/Array.prototype.find_skip-empty.js
+++ b/test/built-ins/Array/prototype/find/Array.prototype.find_skip-empty.js
@@ -16,6 +16,6 @@ var b = a.find(function (v) {
 	return v !== 1;
 });
 
-if (b !== 2) {
-	$ERROR('#1: b !== 2. Actual: ' + b);
+if (b !== undefined) {
+	$ERROR('#1: b !== undefined. Actual: ' + b);
 }


### PR DESCRIPTION
In the August meeting it was decided that `[].find` and `[].findIndex` no longer skip holes (no idea why).
