### PR TITLE
Update comments in Object.defineProperties tests (Fixes #138)

### DIFF
--- a/test/built-ins/Object/defineProperties/15.2.3.7-6-a-93-3.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-6-a-93-3.js
@@ -7,7 +7,7 @@
 /*---
 es5id: 15.2.3.7-6-a-93-3
 description: >
-    Object.defineProperties will not fail to update [[Value]] attribute of
+    Object.defineProperties will fail to update [[Value]] attribute of
     named data property 'P' when [[Configurable]] attribute of first
     updating property is false (8.12.9 - step Note & 10.a.ii.1)
 includes: [propertyHelper.js]

--- a/test/built-ins/Object/defineProperties/15.2.3.7-6-a-93-4.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-6-a-93-4.js
@@ -7,7 +7,7 @@
 /*---
 es5id: 15.2.3.7-6-a-93-4
 description: >
-    Object.defineProperties will not fail to update [[Value]] attribute of
+    Object.defineProperties will fail to update [[Value]] attribute of
     indexed data property 'P' when [[Configurable]] attribute of first
     updating property are false  (8.12.9 - step Note & 10.a.ii.1)
 includes: [propertyHelper.js]


### PR DESCRIPTION
The expected values were already changed in a previous commit (@49abae4f5e6b38931d86dc9b9d34ae30d9ced2ca),
only the test descriptions still needed to be updated. (Fixes #138)
