### PR TITLE
First v8 tests

### DIFF
--- a/test/annexB/B.2.3.10.js
+++ b/test/annexB/B.2.3.10.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Tests taken from:
+// http://mathias.html5.org/tests/javascript/string/
+
+/*---
+ description: >
+     String.prototype.link returns a string of HTML describing a single HTML
+     anchor element. The element's content is the `this` value of the function
+     invocation, coerced to a string. If specified, the first argument will be
+     coerced to a string, escaped, and set as the element's `href` attribute.
+ es6id: B.2.3.10
+ ---*/
+
+assert.sameValue('_'.link('b'), '<a href="b">_</a>');
+assert.sameValue('<'.link('<'), '<a href="<"><</a>');
+assert.sameValue('_'.link(0x2A), '<a href="42">_</a>');
+assert.sameValue('_'.link('\x22'), '<a href="&quot;">_</a>');
+assert.sameValue(String.prototype.link.call(0x2A, 0x2A), '<a href="42">42</a>');
+assert.throws(TypeError, function() {
+  String.prototype.link.call(undefined);
+});
+assert.throws(TypeError, function() {
+  String.prototype.link.call(null);
+});
+assert.sameValue(String.prototype.link.length, 1);

--- a/test/annexB/B.2.3.11.js
+++ b/test/annexB/B.2.3.11.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Tests taken from:
+// http://mathias.html5.org/tests/javascript/string/
+
+/*---
+ description: >
+     String.prototype.small returns a string of HTML describing a single HTML
+     small print element. The element's content is the `this` value of the
+     function invocation, coerced to a string.
+ es6id: B.2.3.11
+ ---*/
+
+assert.sameValue('_'.small(), '<small>_</small>');
+assert.sameValue('<'.small(), '<small><</small>');
+assert.sameValue(String.prototype.small.call(0x2A), '<small>42</small>');
+assert.throws(TypeError, function() {
+  String.prototype.small.call(undefined);
+});
+assert.throws(TypeError, function() {
+  String.prototype.small.call(null);
+});
+assert.sameValue(String.prototype.small.length, 0);

--- a/test/annexB/B.2.3.12.js
+++ b/test/annexB/B.2.3.12.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Tests taken from:
+// http://mathias.html5.org/tests/javascript/string/
+
+/*---
+ description: >
+     String.prototype.strike returns a string of HTML describing a single HTML
+     strikethrough element. The element's content is the `this` value of the
+     function invocation, coerced to a string.
+ es6id: B.2.3.12
+ ---*/
+
+assert.sameValue('_'.strike(), '<strike>_</strike>');
+assert.sameValue('<'.strike(), '<strike><</strike>');
+assert.sameValue(String.prototype.strike.call(0x2A), '<strike>42</strike>');
+assert.throws(TypeError, function() {
+  String.prototype.strike.call(undefined);
+});
+assert.throws(TypeError, function() {
+  String.prototype.strike.call(null);
+});
+assert.sameValue(String.prototype.strike.length, 0);

--- a/test/annexB/B.2.3.13.js
+++ b/test/annexB/B.2.3.13.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Tests taken from:
+// http://mathias.html5.org/tests/javascript/string/
+
+/*---
+ description: >
+     String.prototype.sub returns a string of HTML describing a single HTML
+     subscript element. The element's content is the `this` value of the
+     function invocation, coerced to a string.
+ es6id: B.2.3.13
+ ---*/
+
+assert.sameValue('_'.sub(), '<sub>_</sub>');
+assert.sameValue('<'.sub(), '<sub><</sub>');
+assert.sameValue(String.prototype.sub.call(0x2A), '<sub>42</sub>');
+assert.throws(TypeError, function() {
+  String.prototype.sub.call(undefined);
+});
+assert.throws(TypeError, function() {
+  String.prototype.sub.call(null);
+});
+assert.sameValue(String.prototype.sub.length, 0);

--- a/test/annexB/B.2.3.14.js
+++ b/test/annexB/B.2.3.14.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Tests taken from:
+// http://mathias.html5.org/tests/javascript/string/
+
+/*---
+ description: >
+     String.prototype.sup returns a string of HTML describing a single HTML
+     superscript element. The element's content is the `this` value of the
+     function invocation, coerced to a string.
+ es6id: B.2.3.14
+ ---*/
+
+assert.sameValue('_'.sup(), '<sup>_</sup>');
+assert.sameValue('<'.sup(), '<sup><</sup>');
+assert.sameValue(String.prototype.sup.call(0x2A), '<sup>42</sup>');
+assert.throws(TypeError, function() {
+  String.prototype.sup.call(undefined);
+});
+assert.throws(TypeError, function() {
+  String.prototype.sup.call(null);
+});
+assert.sameValue(String.prototype.sup.length, 0);

--- a/test/annexB/B.2.3.2.js
+++ b/test/annexB/B.2.3.2.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Tests taken from:
+// http://mathias.html5.org/tests/javascript/string/
+
+/*---
+ description: >
+     String.prototype.anchor returns a string of HTML describing a single HTML
+     anchor element. The element's content is the `this` value of the function
+     invocation, coerced to a string. If specified, the first argument will be
+     coerced to a string, escaped, and set as the element's `name` attribute.
+ es6id: B.2.3.2
+ ---*/
+
+assert.sameValue('_'.anchor('b'), '<a name="b">_</a>');
+assert.sameValue('<'.anchor('<'), '<a name="<"><</a>');
+assert.sameValue('_'.anchor(0x2A), '<a name="42">_</a>');
+assert.sameValue('_'.anchor('\x22'), '<a name="&quot;">_</a>');
+assert.sameValue(String.prototype.anchor.call(0x2A, 0x2A), '<a name="42">42</a>');
+assert.throws(TypeError, function() {
+  String.prototype.anchor.call(undefined);
+});
+assert.throws(TypeError, function() {
+  String.prototype.anchor.call(null);
+});
+assert.sameValue(String.prototype.anchor.length, 1);

--- a/test/annexB/B.2.3.3.js
+++ b/test/annexB/B.2.3.3.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Tests taken from:
+// http://mathias.html5.org/tests/javascript/string/
+
+/*---
+ description: >
+     String.prototype.big returns a string of HTML describing a single HTML
+     big element. The element's content is the `this` value of the function
+     invocation, coerced to a string.
+ es6id: B.2.3.3
+ ---*/
+
+assert.sameValue('_'.big(), '<big>_</big>');
+assert.sameValue('<'.big(), '<big><</big>');
+assert.sameValue(String.prototype.big.call(0x2A), '<big>42</big>');
+assert.throws(TypeError, function() {
+  String.prototype.big.call(undefined);
+});
+assert.throws(TypeError, function() {
+  String.prototype.big.call(null);
+});
+assert.sameValue(String.prototype.big.length, 0);

--- a/test/annexB/B.2.3.4.js
+++ b/test/annexB/B.2.3.4.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Tests taken from:
+// http://mathias.html5.org/tests/javascript/string/
+
+/*---
+ description: >
+     String.prototype.blink returns a string of HTML describing a single HTML
+     blink element. The element's content is the `this` value of the function
+     invocation, coerced to a string.
+ es6id: B.2.3.4
+ ---*/
+
+assert.sameValue('_'.blink(), '<blink>_</blink>');
+assert.sameValue('<'.blink(), '<blink><</blink>');
+assert.sameValue(String.prototype.blink.call(0x2A), '<blink>42</blink>');
+assert.throws(TypeError, function() {
+  String.prototype.blink.call(undefined);
+});
+assert.throws(TypeError, function() {
+  String.prototype.blink.call(null);
+});
+assert.sameValue(String.prototype.blink.length, 0);

--- a/test/annexB/B.2.3.5.js
+++ b/test/annexB/B.2.3.5.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Tests taken from:
+// http://mathias.html5.org/tests/javascript/string/
+
+/*---
+ description: >
+     String.prototype.bold returns a string of HTML describing a single HTML
+     bold element. The element's content is the `this` value of the function
+     invocation, coerced to a string.
+ es6id: B.2.3.5
+ ---*/
+
+assert.sameValue('_'.bold(), '<b>_</b>');
+assert.sameValue('<'.bold(), '<b><</b>');
+assert.sameValue(String.prototype.bold.call(0x2A), '<b>42</b>');
+assert.throws(TypeError, function() {
+  String.prototype.bold.call(undefined);
+});
+assert.throws(TypeError, function() {
+  String.prototype.bold.call(null);
+});
+assert.sameValue(String.prototype.bold.length, 0);

--- a/test/annexB/B.2.3.6.js
+++ b/test/annexB/B.2.3.6.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Tests taken from:
+// http://mathias.html5.org/tests/javascript/string/
+
+/*---
+ description: >
+     String.prototype.fixed returns a string of HTML describing a single HTML
+     teletype text element. The element's content is the `this` value of the
+     function invocation, coerced to a string.
+ es6id: B.2.3.6
+ ---*/
+
+assert.sameValue('_'.fixed(), '<tt>_</tt>');
+assert.sameValue('<'.fixed(), '<tt><</tt>');
+assert.sameValue(String.prototype.fixed.call(0x2A), '<tt>42</tt>');
+assert.throws(TypeError, function() {
+  String.prototype.fixed.call(undefined);
+});
+assert.throws(TypeError, function() {
+  String.prototype.fixed.call(null);
+});
+assert.sameValue(String.prototype.fixed.length, 0);

--- a/test/annexB/B.2.3.7.js
+++ b/test/annexB/B.2.3.7.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Tests taken from:
+// http://mathias.html5.org/tests/javascript/string/
+
+/*---
+ description: >
+     String.prototype.fontcolor returns a string of HTML describing a single
+     HTML font element. The element's content is the `this` value of the
+     function invocation, coerced to a string. If specified, the first argument
+     will be coerced to a string, escaped, and set as the element's `color`
+     attribute.
+ es6id: B.2.3.7
+ ---*/
+
+assert.sameValue('_'.fontcolor('b'), '<font color="b">_</font>');
+assert.sameValue('<'.fontcolor('<'), '<font color="<"><</font>');
+assert.sameValue('_'.fontcolor(0x2A), '<font color="42">_</font>');
+assert.sameValue('_'.fontcolor('\x22'), '<font color="&quot;">_</font>');
+assert.sameValue(String.prototype.fontcolor.call(0x2A, 0x2A),
+  '<font color="42">42</font>');
+assert.throws(TypeError, function() {
+  String.prototype.fontcolor.call(undefined);
+});
+assert.throws(TypeError, function() {
+  String.prototype.fontcolor.call(null);
+});
+assert.sameValue(String.prototype.fontcolor.length, 1);

--- a/test/annexB/B.2.3.8.js
+++ b/test/annexB/B.2.3.8.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Tests taken from:
+// http://mathias.html5.org/tests/javascript/string/
+
+/*---
+ description: >
+     String.prototype.fontsize returns a string of HTML describing a single
+     HTML font element. The element's content is the `this` value of the
+     function invocation, coerced to a string. If specified, the first argument
+     will be coerced to a string, escaped, and set as the element's `size`
+     attribute.
+ es6id: B.2.3.8
+ ---*/
+
+assert.sameValue('_'.fontsize('b'), '<font size="b">_</font>');
+assert.sameValue('<'.fontsize('<'), '<font size="<"><</font>');
+assert.sameValue('_'.fontsize(0x2A), '<font size="42">_</font>');
+assert.sameValue('_'.fontsize('\x22'), '<font size="&quot;">_</font>');
+assert.sameValue(String.prototype.fontsize.call(0x2A, 0x2A),
+  '<font size="42">42</font>');
+assert.throws(TypeError, function() {
+  String.prototype.fontsize.call(undefined);
+});
+assert.throws(TypeError, function() {
+  String.prototype.fontsize.call(null);
+});
+assert.sameValue(String.prototype.fontsize.length, 1);

--- a/test/annexB/B.2.3.9.js
+++ b/test/annexB/B.2.3.9.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Tests taken from:
+// http://mathias.html5.org/tests/javascript/string/
+
+/*---
+ description: >
+     String.prototype.italics returns a string of HTML describing a single HTML
+     italic element. The element's content is the `this` value of the function
+     invocation, coerced to a string.
+ es6id: B.2.3.9
+ ---*/
+
+assert.sameValue('_'.italics(), '<i>_</i>');
+assert.sameValue('<'.italics(), '<i><</i>');
+assert.sameValue(String.prototype.italics.call(0x2A), '<i>42</i>');
+assert.throws(TypeError, function() {
+  String.prototype.italics.call(undefined);
+});
+assert.throws(TypeError, function() {
+  String.prototype.italics.call(null);
+});
+assert.sameValue(String.prototype.italics.length, 0);


### PR DESCRIPTION
This is the first of a series of test imports from the Google V8 project. The commit message body for this patch contains information relating to the provenance of the tests.

Some modifications were made to retrofit those tests to the Test262 harness. Since each change has the potential to introduce a new bug, I have opted to include the V8 "MJSUnit" assertion suite as a helper utility in Test262. It may seem like overkill for the small set of tests here, but it may be re-used by future contributions from V8.