### PR TITLE
fix undefined var

### DIFF
--- a/harness/assert.js
+++ b/harness/assert.js
@@ -4,7 +4,7 @@ function assert(mustBeTrue, message) {
     }
 
     if (message === undefined) {
-        message = 'Expected true but got ' + String(truthy);
+        message = 'Expected true but got ' + String(mustBeTrue);
     }
     $ERROR(message);
 }


### PR DESCRIPTION
Ran into this today, probably just an omission when the assert function's variable was renamed.