### PR TITLE
2 new tests re: foreign thenables

### DIFF
--- a/test/built-ins/Promise/resolve/S25.Promise_resolve_foreign_thenable_1.js
+++ b/test/built-ins/Promise/resolve/S25.Promise_resolve_foreign_thenable_1.js
@@ -1,0 +1,25 @@
+// Copyright 2014 Cubane Canada, Inc.  All rights reserved.
+// See LICENSE for details.
+
+/*---
+info: >
+   Promise.resolve
+es6id: S25.4.4.5
+author: Sam Mikes
+description: Promise.resolve delegates to foreign thenable
+includes: [PromiseHelper.js]
+---*/
+
+var sequence = [];
+
+var thenable = {
+    then: function(onResolve, onReject) {
+        return onResolve('resolved');
+    }
+};
+
+var p = Promise.resolve(thenable);
+
+p.then(function (r) {
+    assert.sameValue(r, 'resolved');
+}).then($DONE, $DONE);

--- a/test/built-ins/Promise/resolve/S25.Promise_resolve_foreign_thenable_2.js
+++ b/test/built-ins/Promise/resolve/S25.Promise_resolve_foreign_thenable_2.js
@@ -4,7 +4,7 @@
 /*---
 info: >
    Promise.resolve
-es6id: S25.4.4.5_A3.1_T1
+es6id: S25.4.4.5
 author: Sam Mikes
 description: Promise.resolve delegates to foreign thenable
 includes: [PromiseHelper.js]
@@ -14,35 +14,27 @@ var sequence = [];
 
 var thenable = {
     then: function(onResolve, onReject) {
+
         sequence.push(3);
         checkSequence(sequence, "thenable.then called");
 
-        assert.sameValue(this, thenable);
+        assert.sameValue(this, thenable, "thenable.then called with `thenable` as `this`");
 
-        onResolve('resolved');
-
-        sequence.push(4);
-        checkSequence(sequence, "after resolved");
-
-        throw new Error('interrupt flow');
-
-        sequence.push(4);
-        checkSequence(sequence, "duplicate sequence point not pushed");
+        return onResolve('resolved');
     }
 };
 
 sequence.push(1);
 checkSequence(sequence, "no async calls yet");
 
-var p1 = Promise.resolve(thenable);
+var p = Promise.resolve(thenable);
 
 sequence.push(2);
 checkSequence(sequence, "thenable.then queued but not yet called");
 
-p1.then(function (q) {
-    sequence.push(5);
+p.then(function (r) {
+    sequence.push(4);
     checkSequence(sequence, "all done");
 
-    assert.sameValue(q, 'resolved');
-
+    assert.sameValue(r, 'resolved');
 }).then($DONE, $DONE);


### PR DESCRIPTION
This includes two new 'foreign thenables' tests, plus a fix to the previous 'foreign thenables' test, which never called the `onResolve` or `onReject` functions, thus making it an unintentional test of Promise timeouts.  (oops!)
