### PR TITLE
harness: add checks of descriptor attributes

### DIFF
--- a/harness/propertyHelper.js
+++ b/harness/propertyHelper.js
@@ -54,36 +54,52 @@ function verifyEqualTo(obj, name, value) {
 }
 
 function verifyWritable(obj, name, verifyProp, value) {
+    if (!verifyProp) {
+        assert(Object.getOwnPropertyDescriptor(obj, name).writable,
+               "Expected obj[" + String(name) + "] to have writable:true.");
+    }
     if (!isWritable(obj, name, verifyProp, value)) {
         $ERROR("Expected obj[" + String(name) + "] to be writable, but was not.");
     }
 }
 
 function verifyNotWritable(obj, name, verifyProp, value) {
+    if (!verifyProp) {
+        assert(!Object.getOwnPropertyDescriptor(obj, name).writable,
+               "Expected obj[" + String(name) + "] to have writable:false.");
+    }
     if (isWritable(obj, name, verifyProp)) {
         $ERROR("Expected obj[" + String(name) + "] NOT to be writable, but was.");
     }
 }
 
 function verifyEnumerable(obj, name) {
+    assert(Object.getOwnPropertyDescriptor(obj, name).enumerable,
+           "Expected obj[" + String(name) + "] to have enumerable:true.");
     if (!isEnumerable(obj, name)) {
         $ERROR("Expected obj[" + String(name) + "] to be enumerable, but was not.");
     }
 }
 
 function verifyNotEnumerable(obj, name) {
+    assert(!Object.getOwnPropertyDescriptor(obj, name).enumerable,
+           "Expected obj[" + String(name) + "] to have enumerable:false.");
     if (isEnumerable(obj, name)) {
         $ERROR("Expected obj[" + String(name) + "] NOT to be enumerable, but was.");
     }
 }
 
 function verifyConfigurable(obj, name) {
+    assert(Object.getOwnPropertyDescriptor(obj, name).configurable,
+           "Expected obj[" + String(name) + "] to have configurable:true.");
     if (!isConfigurable(obj, name)) {
         $ERROR("Expected obj[" + String(name) + "] to be configurable, but was not.");
     }
 }
 
 function verifyNotConfigurable(obj, name) {
+    assert(!Object.getOwnPropertyDescriptor(obj, name).configurable,
+           "Expected obj[" + String(name) + "] to have configurable:false.");
     if (isConfigurable(obj, name)) {
         $ERROR("Expected obj[" + String(name) + "] NOT to be configurable, but was.");
     }


### PR DESCRIPTION
First check if descriptor is set up correctly, then actually
verify that the attribute (writability, enumerability,
configurability) is as expected.