### PR TITLE
Import tests from Google V8 (Class syntax & semantics)

### DIFF
--- a/test/language/class/arguments/access.js
+++ b/test/language/class/arguments/access.js
@@ -1,0 +1,54 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class arguments access
+---*/
+var constructCounts = {
+  base: 0,
+  subclass: 0,
+  subclass2: 0
+};
+
+class Base {
+  constructor() {
+    constructCounts.base++;
+    assert.sameValue(arguments.length, 2, "The value of `arguments.length` is `2`");
+    assert.sameValue(arguments[0], 1, "The value of `arguments[0]` is `1`");
+    assert.sameValue(arguments[1], 2, "The value of `arguments[1]` is `2`");
+  }
+}
+
+var b = new Base(1, 2);
+
+class Subclass extends Base {
+  constructor() {
+    constructCounts.subclass++;
+    assert.sameValue(arguments.length, 2, "The value of `arguments.length` is `2`");
+    assert.sameValue(arguments[0], 3, "The value of `arguments[0]` is `3`");
+    assert.sameValue(arguments[1], 4, "The value of `arguments[1]` is `4`");
+    super(1, 2);
+  }
+}
+
+var s = new Subclass(3, 4);
+assert.sameValue(Subclass.length, 0, "The value of `Subclass.length` is `0`, because there are 0 formal parameters");
+
+class Subclass2 extends Base {
+  constructor(x, y) {
+    constructCounts.subclass2++;
+    assert.sameValue(arguments.length, 2, "The value of `arguments.length` is `2`");
+    assert.sameValue(arguments[0], 3, "The value of `arguments[0]` is `3`");
+    assert.sameValue(arguments[1], 4, "The value of `arguments[1]` is `4`");
+    super(1, 2);
+  }
+}
+
+var s2 = new Subclass2(3, 4);
+assert.sameValue(Subclass2.length, 2, "The value of `Subclass2.length` is `2`, because there are 2 formal parameters");
+
+
+assert.sameValue(constructCounts.base, 3, "The value of `constructCounts.base` is `3`");
+assert.sameValue(constructCounts.subclass, 1, "The value of `constructCounts.subclass` is `1`");
+assert.sameValue(constructCounts.subclass2, 1, "The value of `constructCounts.subclass2` is `1`");

--- a/test/language/class/arguments/default-constructor.js
+++ b/test/language/class/arguments/default-constructor.js
@@ -1,0 +1,30 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class default constructor arguments
+---*/
+var args, that;
+class Base {
+  constructor() {
+    that = this;
+    args = arguments;
+  }
+}
+class Derived extends Base {}
+
+new Derived;
+assert.sameValue(args.length, 0, "The value of `args.length` is `0`");
+
+new Derived(0, 1, 2);
+assert.sameValue(args.length, 3, "The value of `args.length` is `3`");
+assert.sameValue(
+  that instanceof Derived,
+  true,
+  "The result of `that instanceof Derived` is `true`"
+);
+
+var arr = new Array(100);
+var obj = {};
+assert.throws(TypeError, function() {Derived.apply(obj, arr);});

--- a/test/language/class/definition/accessors.js
+++ b/test/language/class/definition/accessors.js
@@ -1,0 +1,52 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class accessors
+---*/
+
+function assertAccessorDescriptor(object, name) {
+  var desc = Object.getOwnPropertyDescriptor(object, name);
+  assert.sameValue(desc.configurable, true, "The value of `desc.configurable` is `true`");
+  assert.sameValue(desc.enumerable, false, "The value of `desc.enumerable` is `false`");
+  assert.sameValue(typeof desc.get, 'function', "`typeof desc.get` is `'function'`");
+  assert.sameValue(typeof desc.set, 'function', "`typeof desc.set` is `'function'`");
+  assert.sameValue(
+    'prototype' in desc.get,
+    false,
+    "The result of `'prototype' in desc.get` is `false`"
+  );
+  assert.sameValue(
+    'prototype' in desc.set,
+    false,
+    "The result of `'prototype' in desc.set` is `false`"
+  );
+}
+
+
+class C {
+  constructor(x) {
+    this._x = x;
+  }
+
+  get x() { return this._x; }
+  set x(v) { this._x = v; }
+
+  static get staticX() { return this._x; }
+  static set staticX(v) { this._x = v; }
+}
+
+assertAccessorDescriptor(C.prototype, 'x');
+assertAccessorDescriptor(C, 'staticX');
+
+var c = new C(1);
+c._x = 1;
+assert.sameValue(c.x, 1, "The value of `c.x` is `1`, after executing `c._x = 1;`");
+c.x = 2;
+assert.sameValue(c._x, 2, "The value of `c._x` is `2`, after executing `c.x = 2;`");
+
+C._x = 3;
+assert.sameValue(C.staticX, 3, "The value of `C.staticX` is `3`, after executing `C._x = 3;`");
+C._x = 4;
+assert.sameValue(C.staticX, 4, "The value of `C.staticX` is `4`, after executing `C._x = 4;`");

--- a/test/language/class/definition/basics.js
+++ b/test/language/class/definition/basics.js
@@ -1,0 +1,43 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class basics
+---*/
+var C = class C {}
+assert.sameValue(typeof C, 'function', "`typeof C` is `'function'`");
+assert.sameValue(
+    Object.getPrototypeOf(C.prototype),
+    Object.prototype,
+    "`Object.getPrototypeOf(C.prototype)` returns `Object.prototype`"
+);
+assert.sameValue(
+    Object.getPrototypeOf(C),
+    Function.prototype,
+    "`Object.getPrototypeOf(C)` returns `Function.prototype`"
+);
+assert.sameValue(C.name, 'C', "The value of `C.name` is `'C'`");
+
+class D {}
+assert.sameValue(typeof D, 'function', "`typeof D` is `'function'`");
+assert.sameValue(
+    Object.getPrototypeOf(D.prototype),
+    Object.prototype,
+    "`Object.getPrototypeOf(D.prototype)` returns `Object.prototype`"
+);
+assert.sameValue(
+    Object.getPrototypeOf(D),
+    Function.prototype,
+    "`Object.getPrototypeOf(D)` returns `Function.prototype`"
+);
+assert.sameValue(D.name, 'D', "The value of `D.name` is `'D'`");
+
+class D2 { constructor() {} }
+assert.sameValue(D2.name, 'D2', "The value of `D2.name` is `'D2'`");
+
+var E = class {}
+assert.sameValue(E.name, 'E', "The value of `E.name` is `'E'`");
+
+var F = class { constructor() {} };
+assert.sameValue(F.name, 'F', "The value of `F.name` is `'F'`");

--- a/test/language/class/definition/constructable-but-no-prototype.js
+++ b/test/language/class/definition/constructable-but-no-prototype.js
@@ -1,0 +1,11 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class constructable but no prototype
+---*/
+var Base = function() {}.bind();
+assert.throws(TypeError, function() {
+  class C extends Base {}
+});

--- a/test/language/class/definition/constructor-property.js
+++ b/test/language/class/definition/constructor-property.js
@@ -1,0 +1,17 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class constructor property
+---*/
+class C {}
+assert.sameValue(
+    C,
+    C.prototype.constructor,
+    "The value of `C` is `C.prototype.constructor`"
+);
+var desc = Object.getOwnPropertyDescriptor(C.prototype, 'constructor');
+assert.sameValue(desc.configurable, true, "The value of `desc.configurable` is `true`, after executing `var desc = Object.getOwnPropertyDescriptor(C.prototype, 'constructor');`");
+assert.sameValue(desc.enumerable, false, "The value of `desc.enumerable` is `false`, after executing `var desc = Object.getOwnPropertyDescriptor(C.prototype, 'constructor');`");
+assert.sameValue(desc.writable, true, "The value of `desc.writable` is `true`, after executing `var desc = Object.getOwnPropertyDescriptor(C.prototype, 'constructor');`");

--- a/test/language/class/definition/constructor-strict-by-default.js
+++ b/test/language/class/definition/constructor-strict-by-default.js
@@ -1,0 +1,15 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class constructor strict
+---*/
+class C {
+  constructor() {
+    assert.throws(ReferenceError, function() {
+      nonExistingBinding = 42;
+    });
+  }
+}
+new C();

--- a/test/language/class/definition/constructor.js
+++ b/test/language/class/definition/constructor.js
@@ -1,0 +1,35 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class constructor
+---*/
+var count = 0;
+class C {
+  constructor() {
+    assert.sameValue(
+      Object.getPrototypeOf(this),
+      C.prototype,
+      "`Object.getPrototypeOf(this)` returns `C.prototype`"
+    );
+    count++;
+  }
+}
+assert.sameValue(
+  C,
+  C.prototype.constructor,
+  "The value of `C` is `C.prototype.constructor`"
+);
+var desc = Object.getOwnPropertyDescriptor(C.prototype, 'constructor');
+assert.sameValue(desc.configurable, true, "The value of `desc.configurable` is `true`, after executing `var desc = Object.getOwnPropertyDescriptor(C.prototype, 'constructor');`");
+assert.sameValue(desc.enumerable, false, "The value of `desc.enumerable` is `false`, after executing `var desc = Object.getOwnPropertyDescriptor(C.prototype, 'constructor');`");
+assert.sameValue(desc.writable, true, "The value of `descr.writable` is `true`, after executing `var desc = Object.getOwnPropertyDescriptor(C.prototype, 'constructor');`");
+
+var c = new C();
+assert.sameValue(count, 1, "The value of `count` is `1`");
+assert.sameValue(
+  Object.getPrototypeOf(c),
+  C.prototype,
+  "`Object.getPrototypeOf(c)` returns `C.prototype`"
+);

--- a/test/language/class/definition/getters-2.js
+++ b/test/language/class/definition/getters-2.js
@@ -1,0 +1,26 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class getters 2
+---*/
+class C {
+  get eval() {
+    return 1;
+  }
+  get arguments() {
+    return 2;
+  }
+  static get eval() {
+    return 3;
+  }
+  static get arguments() {
+    return 4;
+  }
+};
+
+assert.sameValue(new C().eval, 1, "The value of `new C().eval` is `1`");
+assert.sameValue(new C().arguments, 2, "The value of `new C().arguments` is `2`");
+assert.sameValue(C.eval, 3, "The value of `C.eval` is `3`");
+assert.sameValue(C.arguments, 4, "The value of `C.arguments` is `4`");

--- a/test/language/class/definition/getters.js
+++ b/test/language/class/definition/getters.js
@@ -1,0 +1,33 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class getters
+---*/
+
+function assertGetterDescriptor(object, name) {
+  var desc = Object.getOwnPropertyDescriptor(object, name);
+  assert.sameValue(desc.configurable, true, "The value of `desc.configurable` is `true`");
+  assert.sameValue(desc.enumerable, false, "The value of `desc.enumerable` is `false`");
+  assert.sameValue(typeof desc.get, 'function', "`typeof desc.get` is `'function'`");
+  assert.sameValue('prototype' in desc.get, false, "The result of `'prototype' in desc.get` is `false`");
+  assert.sameValue(desc.set, undefined, "The value of `desc.set` is `undefined`");
+}
+
+class C {
+  get x() { return 1; }
+  static get staticX() { return 2; }
+  get y() { return 3; }
+  static get staticY() { return 4; }
+}
+
+assertGetterDescriptor(C.prototype, 'x');
+assertGetterDescriptor(C.prototype, 'y');
+assertGetterDescriptor(C, 'staticX');
+assertGetterDescriptor(C, 'staticY');
+
+assert.sameValue(new C().x, 1, "The value of `new C().x` is `1`. Defined as `get x() { return 1; }`");
+assert.sameValue(C.staticX, 2, "The value of `C.staticX` is `2`. Defined as `static get staticX() { return 2; }`");
+assert.sameValue(new C().y, 3, "The value of `new C().y` is `3`. Defined as `get y() { return 3; }`");
+assert.sameValue(C.staticY, 4, "The value of `C.staticY` is `4`. Defined as `static get staticY() { return 4; }`");

--- a/test/language/class/definition/implicit-constructor.js
+++ b/test/language/class/definition/implicit-constructor.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class implicit constructor
+---*/
+class C {}
+var c = new C();
+assert.sameValue(
+    Object.getPrototypeOf(c),
+    C.prototype,
+    "`Object.getPrototypeOf(c)` returns `C.prototype`"
+);

--- a/test/language/class/definition/invalid-extends.js
+++ b/test/language/class/definition/invalid-extends.js
@@ -1,0 +1,21 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class invalid extends
+---*/
+assert.throws(TypeError, function() {
+  class C extends 42 {}
+});
+
+assert.throws(TypeError, function() {
+  // Function but its .prototype is not null or a function.
+  class C extends Math.abs {}
+});
+
+assert.throws(TypeError, function() {
+  Math.abs.prototype = 42;
+  class C extends Math.abs {}
+});
+delete Math.abs.prototype;

--- a/test/language/class/definition/methods-named-eval-arguments.js
+++ b/test/language/class/definition/methods-named-eval-arguments.js
@@ -1,0 +1,26 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class methods 2
+---*/
+class C {
+  eval() {
+    return 1;
+  }
+  arguments() {
+    return 2;
+  }
+  static eval() {
+    return 3;
+  }
+  static arguments() {
+    return 4;
+  }
+};
+
+assert.sameValue(new C().eval(), 1, "`new C().eval()` returns `1`");
+assert.sameValue(new C().arguments(), 2, "`new C().arguments()` returns `2`");
+assert.sameValue(C.eval(), 3, "`C.eval()` returns `3`");
+assert.sameValue(C.arguments(), 4, "`C.arguments()` returns `4`");

--- a/test/language/class/definition/methods.js
+++ b/test/language/class/definition/methods.js
@@ -1,0 +1,32 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class methods
+---*/
+function assertMethodDescriptor(object, name) {
+  var desc = Object.getOwnPropertyDescriptor(object, name);
+  assert.sameValue(desc.configurable, true, "The value of `desc.configurable` is `true`");
+  assert.sameValue(desc.enumerable, false, "The value of `desc.enumerable` is `false`");
+  assert.sameValue(desc.writable, true, "The value of `desc.writable` is `true`");
+  assert.sameValue(typeof desc.value, 'function', "`typeof desc.value` is `'function'`");
+  assert.sameValue('prototype' in desc.value, false, "The result of `'prototype' in desc.value` is `false`");
+}
+
+class C {
+  method() { return 1; }
+  static staticMethod() { return 2; }
+  method2() { return 3; }
+  static staticMethod2() { return 4; }
+}
+
+assertMethodDescriptor(C.prototype, 'method');
+assertMethodDescriptor(C.prototype, 'method2');
+assertMethodDescriptor(C, 'staticMethod');
+assertMethodDescriptor(C, 'staticMethod2');
+
+assert.sameValue(new C().method(), 1, "`new C().method()` returns `1`. Defined as `method() { return 1; }`");
+assert.sameValue(C.staticMethod(), 2, "`C.staticMethod()` returns `2`. Defined as `static staticMethod() { return 2; }`");
+assert.sameValue(new C().method2(), 3, "`new C().method2()` returns `3`. Defined as `method2() { return 3; }`");
+assert.sameValue(C.staticMethod2(), 4, "`C.staticMethod2()` returns `4`. Defined as `static staticMethod2() { return 4; }`");

--- a/test/language/class/definition/numeric-property-names.js
+++ b/test/language/class/definition/numeric-property-names.js
@@ -1,0 +1,63 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class numeric property names
+---*/
+function assertMethodDescriptor(object, name) {
+  var desc = Object.getOwnPropertyDescriptor(object, name);
+  assert.sameValue(desc.configurable, true, "The value of `desc.configurable` is `true`");
+  assert.sameValue(desc.enumerable, false, "The value of `desc.enumerable` is `false`");
+  assert.sameValue(desc.writable, true, "The value of `desc.writable` is `true`");
+  assert.sameValue(typeof desc.value, 'function', "`typeof desc.value` is `'function'`");
+  assert.sameValue('prototype' in desc.value, false, "The result of `'prototype' in desc.value` is `false`");
+}
+
+function assertGetterDescriptor(object, name) {
+  var desc = Object.getOwnPropertyDescriptor(object, name);
+  assert.sameValue(desc.configurable, true, "The value of `desc.configurable` is `true`");
+  assert.sameValue(desc.enumerable, false, "The value of `desc.enumerable` is `false`");
+  assert.sameValue(typeof desc.get, 'function', "`typeof desc.get` is `'function'`");
+  assert.sameValue('prototype' in desc.get, false, "The result of `'prototype' in desc.get` is `false`");
+  assert.sameValue(desc.set, undefined, "The value of `desc.set` is `undefined`");
+}
+
+function assertSetterDescriptor(object, name) {
+  var desc = Object.getOwnPropertyDescriptor(object, name);
+  assert.sameValue(desc.configurable, true, "The value of `desc.configurable` is `true`");
+  assert.sameValue(desc.enumerable, false, "The value of `desc.enumerable` is `false`");
+  assert.sameValue(typeof desc.set, 'function', "`typeof desc.set` is `'function'`");
+  assert.sameValue('prototype' in desc.set, false, "The result of `'prototype' in desc.set` is `false`");
+  assert.sameValue(desc.get, undefined, "The value of `desc.get` is `undefined`");
+}
+
+class B {
+  1() { return 1; }
+  get 2() { return 2; }
+  set 3(_) {}
+
+  static 4() { return 4; }
+  static get 5() { return 5; }
+  static set 6(_) {}
+}
+
+assertMethodDescriptor(B.prototype, '1');
+assertGetterDescriptor(B.prototype, '2');
+assertSetterDescriptor(B.prototype, '3');
+
+assertMethodDescriptor(B, '4');
+assertGetterDescriptor(B, '5');
+assertSetterDescriptor(B, '6');
+
+class C extends B {
+  1() { return super[1](); }
+  get 2() { return super[2]; }
+  static 4() { return super[4](); }
+  static get 5() { return super[5]; }
+}
+
+assert.sameValue(new C()[1](), 1, "`new C()[1]()` returns `1`. Defined as `1() { return super[1](); }`");
+assert.sameValue(new C()[2], 2, "The value of `new C()[2]` is `2`. Defined as `get 2() { return super[2]; }`");
+assert.sameValue(C[4](), 4, "`C[4]()` returns `4`. Defined as `static 4() { return super[4](); }`");
+assert.sameValue(C[5], 5, "The value of `C[5]` is `5`. Defined as `static get 5() { return super[5]; }`");

--- a/test/language/class/definition/prototype-getter.js
+++ b/test/language/class/definition/prototype-getter.js
@@ -1,0 +1,31 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class prototype getter
+---*/
+var calls = 0;
+var Base = function() {}.bind();
+Object.defineProperty(Base, 'prototype', {
+  get: function() {
+    calls++;
+    return null;
+  },
+  configurable: true
+});
+class C extends Base {}
+assert.sameValue(calls, 1, "The value of `calls` is `1`");
+
+calls = 0;
+Object.defineProperty(Base, 'prototype', {
+  get: function() {
+    calls++;
+    return 42;
+  },
+  configurable: true
+});
+assert.throws(TypeError, function() {
+  class C extends Base {}
+});
+assert.sameValue(calls, 1, "The value of `calls` is `1`");

--- a/test/language/class/definition/prototype-property.js
+++ b/test/language/class/definition/prototype-property.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class prototype property
+---*/
+class C {}
+var descr = Object.getOwnPropertyDescriptor(C, 'prototype');
+assert.sameValue(descr.configurable, false, "The value of `descr.configurable` is `false`");
+assert.sameValue(descr.enumerable, false, "The value of `descr.enumerable` is `false`");
+assert.sameValue(descr.writable, false, "The value of `descr.writable` is `false`");

--- a/test/language/class/definition/prototype-setter.js
+++ b/test/language/class/definition/prototype-setter.js
@@ -1,0 +1,16 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class prototype setter
+---*/
+var Base = function() {}.bind();
+Object.defineProperty(Base, 'prototype', {
+  set: function() {
+    $ERROR("Cannot create a setter property named `prototype`");
+  }
+});
+assert.throws(TypeError, function() {
+  class C extends Base {}
+});

--- a/test/language/class/definition/prototype-wiring.js
+++ b/test/language/class/definition/prototype-wiring.js
@@ -1,0 +1,73 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class prototype wiring
+---*/
+
+class Base {
+  constructor(x) {
+    this.foobar = x;
+  }
+}
+
+class Subclass extends Base {
+  constructor(x) {
+    super(x);
+  }
+}
+
+var s = new Subclass(1);
+assert.sameValue(s.foobar, 1, "The value of `s.foobar` is `1`");
+assert.sameValue(
+  Object.getPrototypeOf(s),
+  Subclass.prototype,
+  "`Object.getPrototypeOf(s)` returns `Subclass.prototype`"
+);
+
+var s1 = new Subclass(1, 2);
+assert.sameValue(s1.foobar, 1, "The value of `s1.foobar` is `1`");
+assert.sameValue(
+  Object.getPrototypeOf(s1) === Subclass.prototype,
+  true,
+  "The result of `Object.getPrototypeOf(s1) === Subclass.prototype` is `true`"
+);
+
+var s2 = new Subclass();
+assert.sameValue(s2.foobar, undefined, "The value of `s2.foobar` is `undefined`");
+assert.sameValue(
+  Object.getPrototypeOf(s2),
+  Subclass.prototype,
+  "`Object.getPrototypeOf(s2)` returns `Subclass.prototype`"
+);
+assert.throws(TypeError, function() { Subclass(1); });
+assert.throws(TypeError, function() { Subclass(1,2,3,4); });
+
+class Subclass2 extends Subclass {
+  constructor() {
+    super(5, 6, 7);
+  }
+}
+
+var ss2 = new Subclass2();
+assert.sameValue(ss2.foobar, 5, "The value of `ss2.foobar` is `5`");
+assert.sameValue(
+  Object.getPrototypeOf(ss2),
+  Subclass2.prototype,
+  "`Object.getPrototypeOf(ss2)` returns `Subclass2.prototype`"
+);
+
+class Subclass3 extends Base {
+  constructor(x, y) {
+    super(x + y);
+  }
+}
+
+var ss3 = new Subclass3(27,42-27);
+assert.sameValue(ss3.foobar, 42, "The value of `ss3.foobar` is `42`");
+assert.sameValue(
+  Object.getPrototypeOf(ss3),
+  Subclass3.prototype,
+  "`Object.getPrototypeOf(ss3)` returns `Subclass3.prototype`"
+);

--- a/test/language/class/definition/setters-2.js
+++ b/test/language/class/definition/setters-2.js
@@ -1,0 +1,31 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class setters 2
+---*/
+var x = 0;
+class C {
+  set eval(v) {
+    x = v;
+  }
+  set arguments(v) {
+    x = v;
+  }
+  static set eval(v) {
+    x = v;
+  }
+  static set arguments(v) {
+    x = v;
+  }
+};
+
+new C().eval = 1;
+assert.sameValue(x, 1, "The value of `x` is `1`");
+new C().arguments = 2;
+assert.sameValue(x, 2, "The value of `x` is `2`");
+C.eval = 3;
+assert.sameValue(x, 3, "The value of `x` is `3`");
+C.arguments = 4;
+assert.sameValue(x, 4, "The value of `x` is `4`");

--- a/test/language/class/definition/setters.js
+++ b/test/language/class/definition/setters.js
@@ -1,0 +1,37 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class setters
+---*/
+function assertSetterDescriptor(object, name) {
+  var descr = Object.getOwnPropertyDescriptor(object, name);
+  assert.sameValue(descr.configurable, true, "The value of `descr.configurable` is `true`");
+  assert.sameValue(descr.enumerable, false, "The value of `descr.enumerable` is `false`");
+  assert.sameValue(typeof descr.set, 'function', "`typeof descr.set` is `'function'`");
+  assert.sameValue('prototype' in descr.set, false, "The result of `'prototype' in descr.set` is `false`");
+  assert.sameValue(descr.get, undefined, "The value of `descr.get` is `undefined`");
+}
+
+var x, staticX, y, staticY;
+class C {
+  set x(v) { x = v; }
+  static set staticX(v) { staticX = v; }
+  set y(v) { y = v; }
+  static set staticY(v) { staticY = v; }
+}
+
+assertSetterDescriptor(C.prototype, 'x');
+assertSetterDescriptor(C.prototype, 'y');
+assertSetterDescriptor(C, 'staticX');
+assertSetterDescriptor(C, 'staticY');
+
+assert.sameValue(new C().x = 1, 1, "`new C().x = 1` is `1`");
+assert.sameValue(x, 1, "The value of `x` is `1`");
+assert.sameValue(C.staticX = 2, 2, "`C.staticX = 2` is `2`");
+assert.sameValue(staticX, 2, "The value of `staticX` is `2`");
+assert.sameValue(new C().y = 3, 3, "`new C().y = 3` is `3`");
+assert.sameValue(y, 3, "The value of `y` is `3`");
+assert.sameValue(C.staticY = 4, 4, "`C.staticY = 4` is `4`");
+assert.sameValue(staticY, 4, "The value of `staticY` is `4`");

--- a/test/language/class/definition/side-effects-in-extends.js
+++ b/test/language/class/definition/side-effects-in-extends.js
@@ -1,0 +1,18 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class side effect in extends
+---*/
+var calls = 0;
+class C {}
+class D extends (calls++, C) {}
+assert.sameValue(calls, 1, "The value of `calls` is `1`");
+assert.sameValue(typeof D, 'function', "`typeof D` is `'function'`");
+assert.sameValue(Object.getPrototypeOf(D), C, "`Object.getPrototypeOf(D)` returns `C`");
+assert.sameValue(
+    C.prototype,
+    Object.getPrototypeOf(D.prototype),
+    "The value of `C.prototype` is `Object.getPrototypeOf(D.prototype)`"
+);

--- a/test/language/class/definition/side-effects-in-property-define.js
+++ b/test/language/class/definition/side-effects-in-property-define.js
@@ -1,0 +1,20 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class side effects in property define
+---*/
+function B() {}
+B.prototype = {
+  constructor: B,
+  set m(v) {
+    throw Error();
+  }
+};
+
+class C extends B {
+  m() { return 1; }
+}
+
+assert.sameValue(new C().m(), 1, "`new C().m()` returns `1`");

--- a/test/language/class/definition/this-access-restriction-2.js
+++ b/test/language/class/definition/this-access-restriction-2.js
@@ -1,0 +1,88 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class this access restriction 2
+---*/
+class Base {
+  constructor(a, b) {
+    var o = new Object();
+    o.prp = a + b;
+    return o;
+  }
+}
+
+class Subclass extends Base {
+  constructor(a, b) {
+    var exn;
+    try {
+      this.prp1 = 3;
+    } catch (e) {
+      exn = e;
+    }
+    assert.sameValue(
+      exn instanceof ReferenceError,
+      true,
+      "The result of `exn instanceof ReferenceError` is `true`"
+    );
+    super(a, b);
+    assert.sameValue(this.prp, a + b, "The value of `this.prp` is `a + b`");
+    assert.sameValue(this.prp1, undefined, "The value of `this.prp1` is `undefined`");
+    assert.sameValue(
+      this.hasOwnProperty("prp1"),
+      false,
+      "`this.hasOwnProperty(\"prp1\")` returns `false`"
+    );
+    return this;
+  }
+}
+
+var b = new Base(1, 2);
+assert.sameValue(b.prp, 3, "The value of `b.prp` is `3`");
+
+
+var s = new Subclass(2, -1);
+assert.sameValue(s.prp, 1, "The value of `s.prp` is `1`");
+assert.sameValue(s.prp1, undefined, "The value of `s.prp1` is `undefined`");
+assert.sameValue(
+  s.hasOwnProperty("prp1"),
+  false,
+  "`s.hasOwnProperty(\"prp1\")` returns `false`"
+);
+
+class Subclass2 extends Base {
+  constructor(x) {
+    super(1,2);
+
+    if (x < 0) return;
+
+    var called = false;
+    function tmp() { called = true; return 3; }
+    var exn = null;
+    try {
+      super(tmp(),4);
+    } catch (e) { exn = e; }
+    assert.sameValue(
+      exn instanceof ReferenceError,
+      true,
+      "The result of `exn instanceof ReferenceError` is `true`"
+    );
+    assert.sameValue(called, true, "The value of `called` is `true`");
+  }
+}
+
+var s2 = new Subclass2(1);
+assert.sameValue(s2.prp, 3, "The value of `s2.prp` is `3`");
+
+var s3 = new Subclass2(-1);
+assert.sameValue(s3.prp, 3, "The value of `s3.prp` is `3`");
+
+assert.throws(TypeError, function() { Subclass.call(new Object(), 1, 2); });
+assert.throws(TypeError, function() { Base.call(new Object(), 1, 2); });
+
+class BadSubclass extends Base {
+  constructor() {}
+}
+
+assert.throws(ReferenceError, function() { new BadSubclass(); });

--- a/test/language/class/definition/this-access-restriction.js
+++ b/test/language/class/definition/this-access-restriction.js
@@ -1,0 +1,98 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class this access restriction
+---*/
+class Base {}
+(function() {
+  class C extends Base {
+    constructor() {
+      var y;
+      super();
+    }
+  }; new C();
+}());
+assert.throws(ReferenceError, function() {
+  class C extends Base {
+    constructor() {
+      super(this.x);
+    }
+  }; new C();
+});
+assert.throws(ReferenceError, function() {
+  class C extends Base {
+    constructor() {
+      super(this);
+    }
+  }; new C();
+});
+assert.throws(ReferenceError, function() {
+  class C extends Base {
+    constructor() {
+      super.method();
+      super(this);
+    }
+  }; new C();
+});
+assert.throws(ReferenceError, function() {
+  class C extends Base {
+    constructor() {
+      super(super.method());
+    }
+  }; new C();
+});
+assert.throws(ReferenceError, function() {
+  class C extends Base {
+    constructor() {
+      super(super());
+    }
+  }; new C();
+});
+assert.throws(ReferenceError, function() {
+  class C extends Base {
+    constructor() {
+      super(1, 2, Object.getPrototypeOf(this));
+    }
+  }; new C();
+});
+(function() {
+  class C extends Base {
+    constructor() {
+      { super(1, 2); }
+    }
+  }; new C();
+}());
+(function() {
+  class C extends Base {
+    constructor() {
+      if (1) super();
+    }
+  }; new C();
+}());
+
+class C1 extends Object {
+  constructor() {
+    'use strict';
+    super();
+  }
+};
+new C1();
+
+class C2 extends Object {
+  constructor() {
+    ; 'use strict';;;;;
+    super();
+  }
+};
+new C2();
+
+class C3 extends Object {
+  constructor() {
+    ; 'use strict';;;;;
+    // This is a comment.
+    super();
+  }
+};
+new C3();

--- a/test/language/class/definition/this-check-ordering.js
+++ b/test/language/class/definition/this-check-ordering.js
@@ -1,0 +1,70 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class this check ordering
+---*/
+var baseCalled = 0;
+class Base {
+  constructor() { baseCalled++ }
+}
+
+var fCalled = 0;
+function f() { fCalled++; return 3; }
+
+class Subclass1 extends Base {
+  constructor() {
+    baseCalled = 0;
+    super();
+    assert.sameValue(baseCalled, 1, "The value of `baseCalled` is `1`");
+    var obj = this;
+
+    var exn = null;
+    baseCalled = 0;
+    fCalled = 0;
+    try {
+      super(f());
+    } catch (e) { exn = e; }
+    assert.sameValue(
+      exn instanceof ReferenceError,
+      true,
+      "The result of `exn instanceof ReferenceError` is `true`"
+    );
+    assert.sameValue(fCalled, 1, "The value of `fCalled` is `1`");
+    assert.sameValue(baseCalled, 1, "The value of `baseCalled` is `1`");
+    assert.sameValue(this, obj, "`this` is `obj`");
+
+    exn = null;
+    baseCalled = 0;
+    fCalled = 0;
+    try {
+      super(super(), f());
+    } catch (e) { exn = e; }
+    assert.sameValue(
+      exn instanceof ReferenceError,
+      true,
+      "The result of `exn instanceof ReferenceError` is `true`"
+    );
+    assert.sameValue(fCalled, 0, "The value of `fCalled` is `0`");
+    assert.sameValue(baseCalled, 1, "The value of `baseCalled` is `1`");
+    assert.sameValue(this, obj, "`this` is `obj`");
+
+    exn = null;
+    baseCalled = 0;
+    fCalled = 0;
+    try {
+      super(f(), super());
+    } catch (e) { exn = e; }
+    assert.sameValue(
+      exn instanceof ReferenceError,
+      true,
+      "The result of `exn instanceof ReferenceError` is `true`"
+    );
+    assert.sameValue(fCalled, 1, "The value of `fCalled` is `1`");
+    assert.sameValue(baseCalled, 1, "The value of `baseCalled` is `1`");
+    assert.sameValue(this, obj, "`this` is `obj`");
+  }
+}
+
+new Subclass1();

--- a/test/language/class/name-binding/basic.js
+++ b/test/language/class/name-binding/basic.js
@@ -1,0 +1,36 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class name binding
+---*/
+var C2;
+class C {
+  constructor() {
+    C2 = C;
+  }
+  m() {
+    C2 = C;
+  }
+  get x() {
+    C2 = C;
+  }
+  set x(_) {
+    C2 = C;
+  }
+}
+new C();
+assert.sameValue(C, C2, "The value of `C` is `C2`");
+
+C2 = undefined;
+new C().m();
+assert.sameValue(C, C2, "The value of `C` is `C2`");
+
+C2 = undefined;
+new C().x;
+assert.sameValue(C, C2, "The value of `C` is `C2`");
+
+C2 = undefined;
+new C().x = 1;
+assert.sameValue(C, C2, "The value of `C` is `C2`");

--- a/test/language/class/name-binding/const.js
+++ b/test/language/class/name-binding/const.js
@@ -1,0 +1,31 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class name binding const
+---*/
+assert.throws(TypeError, function() {
+  class C { constructor() { C = 42; } }; new C();
+});
+assert.throws(TypeError, function() {
+  new (class C { constructor() { C = 42; } })
+});
+assert.throws(TypeError, function() {
+  class C { m() { C = 42; } }; new C().m()
+});
+assert.throws(TypeError, function() {
+  new (class C { m() { C = 42; } }).m()
+});
+assert.throws(TypeError, function() {
+  class C { get x() { C = 42; } }; new C().x
+});
+assert.throws(TypeError, function() {
+  (new (class C { get x() { C = 42; } })).x
+});
+assert.throws(TypeError, function() {
+  class C { set x(_) { C = 42; } }; new C().x = 15;
+});
+assert.throws(TypeError, function() {
+  (new (class C { set x(_) { C = 42; } })).x = 15;
+});

--- a/test/language/class/name-binding/expression.js
+++ b/test/language/class/name-binding/expression.js
@@ -1,0 +1,41 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class name binding expression
+---*/
+var Cc;
+var Cm;
+var Cgx;
+var Csx;
+var Cv = class C {
+  constructor() {
+    assert.sameValue(C, Cv, "The value of `C` is `Cv`, inside `constructor()`");
+    Cc = C;
+  }
+  m() {
+    assert.sameValue(C, Cv, "The value of `C` is `Cv`, inside `m()`");
+    Cm = C;
+  }
+  get x() {
+    assert.sameValue(C, Cv, "The value of `C` is `Cv`, inside `get x()`");
+    Cgx = C;
+  }
+  set x(_) {
+    assert.sameValue(C, Cv, "The value of `C` is `Cv`, inside `set x()`");
+    Csx = C;
+  }
+};
+
+new Cv();
+assert.sameValue(Cc, Cv, "The value of `Cc` is `Cv`, after executing `new Cv();`");
+
+new Cv().m();
+assert.sameValue(Cm, Cv, "The value of `Cm` is `Cv`, after executing `new Cv().m();`");
+
+new Cv().x;
+assert.sameValue(Cgx, Cv, "The value of `Cgx` is `Cv`, after executing `new Cv().x;`");
+
+new Cv().x = 1;
+assert.sameValue(Csx, Cv, "The value of `Csx` is `Cv`, after executing `new Cv().x = 1;`");

--- a/test/language/class/name-binding/in-extends-expression-assigned.js
+++ b/test/language/class/name-binding/in-extends-expression-assigned.js
@@ -1,0 +1,9 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class name binding in extends expression, assigned
+negative: ReferenceError
+---*/
+var x = (class x extends x {});

--- a/test/language/class/name-binding/in-extends-expression-grouped.js
+++ b/test/language/class/name-binding/in-extends-expression-grouped.js
@@ -1,0 +1,9 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class name binding in extends expression, grouped
+negative: ReferenceError
+---*/
+(class x extends x {});

--- a/test/language/class/name-binding/in-extends-expression.js
+++ b/test/language/class/name-binding/in-extends-expression.js
@@ -1,0 +1,9 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class name binding in extends expression
+negative: ReferenceError
+---*/
+class x extends x {}

--- a/test/language/class/strict-mode/arguments-caller.js
+++ b/test/language/class/strict-mode/arguments-caller.js
@@ -1,0 +1,16 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class strict mode
+---*/
+var D = class extends function() {
+  arguments.caller;
+} {};
+assert.throws(TypeError, function() {
+  Object.getPrototypeOf(D).arguments;
+});
+assert.throws(TypeError, function() {
+  new D;
+});

--- a/test/language/class/strict-mode/with.js
+++ b/test/language/class/strict-mode/with.js
@@ -1,0 +1,11 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class strict mode: `with` disallowed
+negative: SyntaxError
+---*/
+
+class C extends (function B() { with ({}); return B; }()) {}
+

--- a/test/language/class/subclass/binding.js
+++ b/test/language/class/subclass/binding.js
@@ -1,0 +1,52 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class subclass binding
+---*/
+class Base {
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+}
+
+var obj = {};
+class Subclass extends Base {
+  constructor(x, y) {
+    super(x,y);
+    assert.sameValue(this !== obj, true, "The result of `this !== obj` is `true`");
+  }
+}
+
+var f = Subclass.bind(obj);
+assert.throws(TypeError, function () { f(1, 2); });
+var s = new f(1, 2);
+assert.sameValue(s.x, 1, "The value of `s.x` is `1`");
+assert.sameValue(s.y, 2, "The value of `s.y` is `2`");
+assert.sameValue(
+  Object.getPrototypeOf(s),
+  Subclass.prototype,
+  "`Object.getPrototypeOf(s)` returns `Subclass.prototype`"
+);
+
+var s1 = new f(1);
+assert.sameValue(s1.x, 1, "The value of `s1.x` is `1`");
+assert.sameValue(s1.y, undefined, "The value of `s1.y` is `undefined`");
+assert.sameValue(
+  Object.getPrototypeOf(s1),
+  Subclass.prototype,
+  "`Object.getPrototypeOf(s1)` returns `Subclass.prototype`"
+);
+
+var g = Subclass.bind(obj, 1);
+assert.throws(TypeError, function () { g(8); });
+var s2 = new g(8);
+assert.sameValue(s2.x, 1, "The value of `s2.x` is `1`");
+assert.sameValue(s2.y, 8, "The value of `s2.y` is `8`");
+assert.sameValue(
+  Object.getPrototypeOf(s),
+  Subclass.prototype,
+  "`Object.getPrototypeOf(s)` returns `Subclass.prototype`"
+);

--- a/test/language/class/subclass/builtins.js
+++ b/test/language/class/subclass/builtins.js
@@ -1,0 +1,30 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class sublclassing builtins
+---*/
+class ExtendedUint8Array extends Uint8Array {
+  constructor() {
+    super(10);
+    this[0] = 255;
+    this[1] = 0xFFA;
+  }
+}
+
+var eua = new ExtendedUint8Array();
+assert.sameValue(eua.length, 10, "The value of `eua.length` is `10`");
+assert.sameValue(eua.byteLength, 10, "The value of `eua.byteLength` is `10`");
+assert.sameValue(eua[0], 0xFF, "The value of `eua[0]` is `0xFF`");
+assert.sameValue(eua[1], 0xFA, "The value of `eua[1]` is `0xFA`");
+assert.sameValue(
+  Object.getPrototypeOf(eua),
+  ExtendedUint8Array.prototype,
+  "`Object.getPrototypeOf(eua)` returns `ExtendedUint8Array.prototype`"
+);
+assert.sameValue(
+  Object.prototype.toString.call(eua),
+  "[object Uint8Array]",
+  "`Object.prototype.toString.call(eua)` returns `\"[object Uint8Array]\"`"
+);

--- a/test/language/class/subclass/default-constructor-2.js
+++ b/test/language/class/subclass/default-constructor-2.js
@@ -1,0 +1,63 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class default constructor 2
+---*/
+class Base1 { }
+assert.throws(TypeError, function() { Base1(); });
+
+class Subclass1 extends Base1 { }
+
+assert.throws(TypeError, function() { Subclass1(); });
+
+var s1 = new Subclass1();
+assert.sameValue(
+  Subclass1.prototype,
+  Object.getPrototypeOf(s1),
+  "The value of `Subclass1.prototype` is `Object.getPrototypeOf(s1)`, after executing `var s1 = new Subclass1();`"
+);
+
+class Base2 {
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+}
+
+class Subclass2 extends Base2 {};
+
+var s2 = new Subclass2(1, 2);
+
+assert.sameValue(
+  Subclass2.prototype,
+  Object.getPrototypeOf(s2),
+  "The value of `Subclass2.prototype` is `Object.getPrototypeOf(s2)`, after executing `var s2 = new Subclass2(1, 2);`"
+);
+assert.sameValue(s2.x, 1, "The value of `s2.x` is `1`");
+assert.sameValue(s2.y, 2, "The value of `s2.y` is `2`");
+
+var f = Subclass2.bind({}, 3, 4);
+var s2prime = new f();
+assert.sameValue(
+  Subclass2.prototype,
+  Object.getPrototypeOf(s2prime),
+  "The value of `Subclass2.prototype` is `Object.getPrototypeOf(s2prime)`"
+);
+assert.sameValue(s2prime.x, 3, "The value of `s2prime.x` is `3`");
+assert.sameValue(s2prime.y, 4, "The value of `s2prime.y` is `4`");
+
+
+var obj = {};
+class Base3 {
+  constructor() {
+    return obj;
+  }
+}
+
+class Subclass3 extends Base3 {};
+
+var s3 = new Subclass3();
+assert.sameValue(s3, obj, "The value of `s3` is `obj`");
+

--- a/test/language/class/subclass/default-constructor.js
+++ b/test/language/class/subclass/default-constructor.js
@@ -1,0 +1,20 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class default constructor
+---*/
+var calls = 0;
+class Base {
+  constructor() {
+    calls++;
+  }
+}
+class Derived extends Base {}
+var object = new Derived;
+assert.sameValue(calls, 1, "The value of `calls` is `1`");
+
+calls = 0;
+assert.throws(TypeError, function() { Derived(); });
+assert.sameValue(calls, 0, "The value of `calls` is `0`");

--- a/test/language/class/subclass/null.js
+++ b/test/language/class/subclass/null.js
@@ -1,0 +1,18 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class subclassing null
+---*/
+var N = null;
+
+class Foo extends N {
+  constructor(x, y) {
+    assert.sameValue(x, 1, "The value of `x` is `1`");
+    assert.sameValue(y, 2, "The value of `y` is `2`");
+    return {};
+  }
+}
+
+new Foo(1,2);

--- a/test/language/class/subclass/superclass-prototype-setter-constructor.js
+++ b/test/language/class/subclass/superclass-prototype-setter-constructor.js
@@ -1,0 +1,18 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    superclass setter "constructor" override
+---*/
+function Base() {}
+
+Base.prototype = {
+  set constructor(_) {
+    $ERROR("`Base.prototype.constructor` is unreachable.");
+  }
+};
+
+class C extends Base {}
+
+new C();

--- a/test/language/class/subclass/superclass-prototype-setter-method-override.js
+++ b/test/language/class/subclass/superclass-prototype-setter-method-override.js
@@ -1,0 +1,22 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    superclass prototype override
+---*/
+function Base() {}
+
+Base.prototype = {
+  set m(_) {
+    $ERROR("`Base.prototype.m` is unreachable.");
+  }
+};
+
+class C extends Base {
+  m() {
+    return 1;
+  }
+}
+
+assert.sameValue(new C().m(), 1, "`new C().m()` returns `1`");

--- a/test/language/class/subclass/superclass-static-method-override.js
+++ b/test/language/class/subclass/superclass-static-method-override.js
@@ -1,0 +1,21 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    Static method override
+---*/
+function Base() {}
+Object.defineProperty(Base, 'staticM', {
+  set: function() {
+    $ERROR("`Base.staticM` is unreachable.");
+  }
+});
+
+class C extends Base {
+  static staticM() {
+    return 1;
+  }
+}
+
+assert.sameValue(C.staticM(), 1, "`C.staticM()` returns `1`");

--- a/test/language/class/super/in-constructor.js
+++ b/test/language/class/super/in-constructor.js
@@ -1,0 +1,21 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class super in constructor
+---*/
+var calls = 0;
+class B {}
+B.prototype.x = 42;
+
+class C extends B {
+  constructor() {
+    super();
+    calls++;
+    assert.sameValue(super.x, 42, "The value of `super.x` is `42`");
+  }
+}
+
+new C;
+assert.sameValue(calls, 1, "The value of `calls` is `1`");

--- a/test/language/class/super/in-getter.js
+++ b/test/language/class/super/in-getter.js
@@ -1,0 +1,22 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class super in getter
+---*/
+class B {
+  method() {
+    return 1;
+  }
+  get x() {
+    return 2;
+  }
+}
+class C extends B {
+  get y() {
+    assert.sameValue(super.x, 2, "The value of `super.x` is `2`");
+    return super.method();
+  }
+}
+assert.sameValue(new C().y, 1, "The value of `new C().y` is `1`");

--- a/test/language/class/super/in-methods.js
+++ b/test/language/class/super/in-methods.js
@@ -1,0 +1,22 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class super in methods
+---*/
+class B {
+  method() {
+    return 1;
+  }
+  get x() {
+    return 2;
+  }
+}
+class C extends B {
+  method() {
+    assert.sameValue(super.x, 2, "The value of `super.x` is `2`");
+    return super.method();
+  }
+}
+assert.sameValue(new C().method(), 1, "`new C().method()` returns `1`");

--- a/test/language/class/super/in-setter.js
+++ b/test/language/class/super/in-setter.js
@@ -1,0 +1,23 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class super in setter
+---*/
+class B {
+  method() {
+    return 1;
+  }
+  get x() {
+    return 2;
+  }
+}
+class C extends B {
+  set y(v) {
+    assert.sameValue(v, 3, "The value of `v` is `3`");
+    assert.sameValue(super.x, 2, "The value of `super.x` is `2`");
+    assert.sameValue(super.method(), 1, "`super.method()` returns `1`");
+  }
+}
+assert.sameValue(new C().y = 3, 3, "`new C().y = 3` is `3`");

--- a/test/language/class/super/in-static-getter.js
+++ b/test/language/class/super/in-static-getter.js
@@ -1,0 +1,22 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class super in static getter
+---*/
+class B {
+  static method() {
+    return 1;
+  }
+  static get x() {
+    return 2;
+  }
+}
+class C extends B {
+  static get x() {
+    assert.sameValue(super.x, 2, "The value of `super.x` is `2`");
+    return super.method();
+  }
+}
+assert.sameValue(C.x, 1, "The value of `C.x` is `1`");

--- a/test/language/class/super/in-static-methods.js
+++ b/test/language/class/super/in-static-methods.js
@@ -1,0 +1,22 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class super in static methods
+---*/
+class B {
+  static method() {
+    return 1;
+  }
+  static get x() {
+    return 2;
+  }
+}
+class C extends B {
+  static method() {
+    assert.sameValue(super.x, 2, "The value of `super.x` is `2`");
+    return super.method();
+  }
+}
+assert.sameValue(C.method(), 1, "`C.method()` returns `1`");

--- a/test/language/class/super/in-static-setter.js
+++ b/test/language/class/super/in-static-setter.js
@@ -1,0 +1,23 @@
+// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 14.5
+description: >
+    class super in static setter
+---*/
+class B {
+  static method() {
+    return 1;
+  }
+  static get x() {
+    return 2;
+  }
+}
+class C extends B {
+  static set x(v) {
+    assert.sameValue(v, 3, "The value of `v` is `3`");
+    assert.sameValue(super.x, 2, "The value of `super.x` is `2`");
+    assert.sameValue(super.method(), 1, "`super.method()` returns `1`");
+  }
+}
+assert.sameValue(C.x = 3, 3, "`C.x = 3` is `3`");


### PR DESCRIPTION
These tests are derived from the following files within the Google V8
project:

- test/mjsunit/harmony/class-computed-property-names-super.js
- test/mjsunit/harmony/class-property-name-eval-arguments.js
- test/mjsunit/harmony/classes-experimental.js
- test/mjsunit/harmony/classes-lazy-parsing.js
- test/mjsunit/harmony/classes.js



I'd like to recommend adding the following to the harness: 

```js
assert.methodDescriptor = function(object, name) {
  var descr = Object.getOwnPropertyDescriptor(object, name);
  assert.sameValue(descr.configurable, true);
  assert.sameValue(descr.enumerable, false);
  assert.sameValue(descr.writable, true);
  assert.sameValue(typeof descr.value, 'function');
  assert.sameValue('prototype' in descr.value, false);
};

assert.getterDescriptor = function(object, name) {
  var descr = Object.getOwnPropertyDescriptor(object, name);
  assert.sameValue(descr.configurable, true);
  assert.sameValue(descr.enumerable, false);
  assert.sameValue(typeof descr.get, 'function');
  assert.sameValue('prototype' in descr.get, false);
  assert.sameValue(descr.set, undefined);
};

assert.accessorDescriptor = function(object, name) {
  var descr = Object.getOwnPropertyDescriptor(object, name);
  assert.sameValue(descr.configurable, true);
  assert.sameValue(descr.enumerable, false);
  assert.sameValue(typeof descr.get, 'function');
  assert.sameValue(typeof descr.set, 'function');
  assert.sameValue('prototype' in descr.get, false);
  assert.sameValue('prototype' in descr.set, false);
};

assert.setterDescriptor = function(object, name) {
  var descr = Object.getOwnPropertyDescriptor(object, name);
  assert.sameValue(descr.configurable, true);
  assert.sameValue(descr.enumerable, false);
  assert.sameValue(descr.get, undefined);
  assert.sameValue(typeof descr.set, 'function');
  assert.sameValue('prototype' in descr.set, false);
};

```

I'm confident that there are plenty of places these could be used in the existing tests, as well as future tests. There is already some duplication among the tests here, but that could be eliminated by porting the V8 versions to test262 (as shown above)



# Notes: 

The frontmatter description field values are just the name of the file, which came from the IIFE they were originally wrapped in. I sincerely hope that I don't have to write 51 specific descriptions. The frontmatter es6id field values all point to the class section of the spec and no deeper. Locating the specific deep sections and writing descriptions should be written up as a new issue and offered as a "good first bug" to a community contributor. 