### PR TITLE
Import tests from Google V8 (Block Scoping)

### DIFF
--- a/test/language/block-scope/leave/finally-block-let-declaration-only-shadows-outer-parameter-value-1.js
+++ b/test/language/block-scope/leave/finally-block-let-declaration-only-shadows-outer-parameter-value-1.js
@@ -1,0 +1,18 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    finally block let declaration only shadows outer parameter value 1
+---*/
+try {
+  (function(x) {
+    try {
+      let x = 'inner';
+      throw 0;
+    } finally {
+      assert.sameValue(x, 'outer');
+    }
+  })('outer');
+} catch (e) {}
+

--- a/test/language/block-scope/leave/finally-block-let-declaration-only-shadows-outer-parameter-value-2.js
+++ b/test/language/block-scope/leave/finally-block-let-declaration-only-shadows-outer-parameter-value-2.js
@@ -1,0 +1,21 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    finally block let declaration only shadows outer parameter value 2
+---*/
+(function(x) {
+  try {
+    let x = 'middle';
+    {
+      let x = 'inner';
+      throw 0;
+    }
+  } catch(e) {
+
+  } finally {
+    assert.sameValue(x, 'outer');
+  }
+})('outer');
+

--- a/test/language/block-scope/leave/for-loop-block-let-declaration-only-shadows-outer-parameter-value-1.js
+++ b/test/language/block-scope/leave/for-loop-block-let-declaration-only-shadows-outer-parameter-value-1.js
@@ -1,0 +1,15 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    for loop block let declaration only shadows outer parameter value 1
+---*/
+(function(x) {
+  for (var i = 0; i < 10; ++i) {
+    let x = 'inner' + i;
+    continue;
+  }
+  assert.sameValue(x, 'outer');
+})('outer');
+

--- a/test/language/block-scope/leave/for-loop-block-let-declaration-only-shadows-outer-parameter-value-2.js
+++ b/test/language/block-scope/leave/for-loop-block-let-declaration-only-shadows-outer-parameter-value-2.js
@@ -1,0 +1,18 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    for loop block let declaration only shadows outer parameter value 2
+---*/
+(function(x) {
+  label: for (var i = 0; i < 10; ++i) {
+    let x = 'middle' + i;
+    for (var j = 0; j < 10; ++j) {
+      let x = 'inner' + j;
+      continue label;
+    }
+  }
+  assert.sameValue(x, 'outer');
+})('outer');
+

--- a/test/language/block-scope/leave/nested-block-let-declaration-only-shadows-outer-parameter-value-1.js
+++ b/test/language/block-scope/leave/nested-block-let-declaration-only-shadows-outer-parameter-value-1.js
@@ -1,0 +1,15 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    nested block let declaration only shadows outer parameter value 1
+---*/
+(function(x) {
+  label: {
+    let x = 'inner';
+    break label;
+  }
+  assert.sameValue(x, 'outer');
+})('outer');
+

--- a/test/language/block-scope/leave/nested-block-let-declaration-only-shadows-outer-parameter-value-2.js
+++ b/test/language/block-scope/leave/nested-block-let-declaration-only-shadows-outer-parameter-value-2.js
@@ -1,0 +1,18 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    nested block let declaration only shadows outer parameter value 2
+---*/
+(function(x) {
+  label: {
+    let x = 'middle';
+    {
+      let x = 'inner';
+      break label;
+    }
+  }
+  assert.sameValue(x, 'outer');
+})('outer');
+

--- a/test/language/block-scope/leave/outermost-binding-updated-in-catch-block-nested-block-let-declaration-unseen-outside-of-block.js
+++ b/test/language/block-scope/leave/outermost-binding-updated-in-catch-block-nested-block-let-declaration-unseen-outside-of-block.js
@@ -1,0 +1,30 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    outermost binding updated in catch block; nested block let declaration unseen outside of block
+---*/
+var caught = false;
+try {
+  {
+    let xx = 18;
+    throw 25;
+  }
+} catch (e) {
+  caught = true;
+  assert.sameValue(e, 25);
+  (function () {
+    try {
+      // NOTE: This checks that the block scope containing xx has been
+      // removed from the context chain.
+      assert.sameValue(xx, undefined);
+      eval('xx');
+      assert(false);  // should not reach here
+    } catch (e2) {
+      assert(e2 instanceof ReferenceError);
+    }
+  })();
+}
+assert(caught);
+

--- a/test/language/block-scope/leave/try-block-let-declaration-only-shadows-outer-parameter-value-1.js
+++ b/test/language/block-scope/leave/try-block-let-declaration-only-shadows-outer-parameter-value-1.js
@@ -1,0 +1,16 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    try block let declaration only shadows outer parameter value 1
+---*/
+(function(x) {
+  try {
+    let x = 'inner';
+    throw 0;
+  } catch (e) {
+    assert.sameValue(x, 'outer');
+  }
+})('outer');
+

--- a/test/language/block-scope/leave/try-block-let-declaration-only-shadows-outer-parameter-value-2.js
+++ b/test/language/block-scope/leave/try-block-let-declaration-only-shadows-outer-parameter-value-2.js
@@ -1,0 +1,19 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    try block let declaration only shadows outer parameter value 2
+---*/
+(function(x) {
+  try {
+    let x = 'middle';
+    {
+      let x = 'inner';
+      throw 0;
+    }
+  } catch (e) {
+    assert.sameValue(x, 'outer');
+  }
+})('outer');
+

--- a/test/language/block-scope/leave/verify-context-in-finally-block.js
+++ b/test/language/block-scope/leave/verify-context-in-finally-block.js
@@ -1,0 +1,20 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    verify context in finally block 1
+---*/
+function f() {}
+
+(function(x) {
+  try {
+    let x = 'inner';
+    throw 0;
+  } catch(e) {
+
+  } finally {
+    f();
+    assert.sameValue(x, 'outer');
+  }
+})('outer');

--- a/test/language/block-scope/leave/verify-context-in-for-loop-block.js
+++ b/test/language/block-scope/leave/verify-context-in-for-loop-block.js
@@ -1,0 +1,18 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    verify context in for loop block 2
+---*/
+function f() {}
+
+(function(x) {
+  for (var i = 0; i < 10; ++i) {
+    let x = 'inner';
+    continue;
+  }
+  f();
+  assert.sameValue(x, 'outer');
+})('outer');
+

--- a/test/language/block-scope/leave/verify-context-in-labelled-block.js
+++ b/test/language/block-scope/leave/verify-context-in-labelled-block.js
@@ -1,0 +1,18 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    verify context in labelled block 1
+---*/
+function f() {}
+
+(function(x) {
+  label: {
+    let x = 'inner';
+    break label;
+  }
+  f();  // The context could be restored from the stack after the call.
+  assert.sameValue(x, 'outer');
+})('outer');
+

--- a/test/language/block-scope/leave/verify-context-in-try-block.js
+++ b/test/language/block-scope/leave/verify-context-in-try-block.js
@@ -1,0 +1,19 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    verify context in try block 1
+---*/
+function f() {}
+
+(function(x) {
+  try {
+    let x = 'inner';
+    throw 0;
+  } catch (e) {
+    f();
+    assert.sameValue(x, 'outer');
+  }
+})('outer');
+

--- a/test/language/block-scope/leave/x-after-break-to-label.js
+++ b/test/language/block-scope/leave/x-after-break-to-label.js
@@ -1,0 +1,17 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    x after break to label
+---*/
+{
+  let x = 2;
+  L: {
+    let x = 3;
+    assert.sameValue(x, 3);
+    break L;
+    assert(false);
+  }
+  assert.sameValue(x, 2);
+}

--- a/test/language/block-scope/leave/x-before-continue.js
+++ b/test/language/block-scope/leave/x-before-continue.js
@@ -1,0 +1,18 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    x before continue
+---*/
+do {
+  let x = 4;
+  assert.sameValue(x, 4);
+  {
+    let x = 5;
+    assert.sameValue(x, 5);
+    continue;
+    assert(false);
+  }
+} while (false);
+

--- a/test/language/block-scope/return-from/block-const.js
+++ b/test/language/block-scope/return-from/block-const.js
@@ -1,0 +1,16 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    return from block
+---*/
+function fn() {
+  const u = 3;
+  {
+    const v = 6;
+    return u + v;
+  }
+}
+assert.sameValue(fn(), 9);
+

--- a/test/language/block-scope/return-from/block-let.js
+++ b/test/language/block-scope/return-from/block-let.js
@@ -1,0 +1,16 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    return from block
+---*/
+function fn() {
+  let x = 3;
+  {
+    let y = 6;
+    return x + y;
+  }
+}
+assert.sameValue(fn(), 9);
+

--- a/test/language/block-scope/semantics/const/block-local-closure-get-before-initialization.js
+++ b/test/language/block-scope/semantics/const/block-local-closure-get-before-initialization.js
@@ -1,0 +1,15 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const: block local closure [[Get]] before initialization.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+{
+  function f() { return x + 1; }
+  f();
+  const x = 1;
+}
+

--- a/test/language/block-scope/semantics/const/block-local-use-before-initialization-in-declaration-statement.js
+++ b/test/language/block-scope/semantics/const/block-local-use-before-initialization-in-declaration-statement.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const: block local use before initialization in declaration statement.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+{
+  const x = x + 1;
+}

--- a/test/language/block-scope/semantics/const/block-local-use-before-initialization-in-prior-statement.js
+++ b/test/language/block-scope/semantics/const/block-local-use-before-initialization-in-prior-statement.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const: block local use before initialization in prior statement.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+{
+  x; const x = 1;
+}

--- a/test/language/block-scope/semantics/const/function-local-closure-get-before-initialization.js
+++ b/test/language/block-scope/semantics/const/function-local-closure-get-before-initialization.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const: function local closure [[Get]] before initialization.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+(function() {
+  function f() { return x + 1; }
+  f();
+  const x = 1;
+}());

--- a/test/language/block-scope/semantics/const/function-local-use-before-initialization-in-declaration-statement.js
+++ b/test/language/block-scope/semantics/const/function-local-use-before-initialization-in-declaration-statement.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const: function local use before initialization in declaration statement.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+(function() {
+  const x = x + 1;
+}());

--- a/test/language/block-scope/semantics/const/function-local-use-before-initialization-in-prior-statement.js
+++ b/test/language/block-scope/semantics/const/function-local-use-before-initialization-in-prior-statement.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const: function local use before initialization in prior statement.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+(function() {
+  x; const x = 1;
+}());

--- a/test/language/block-scope/semantics/const/global-closure-get-before-initialization.js
+++ b/test/language/block-scope/semantics/const/global-closure-get-before-initialization.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const: global closure [[Get]] before initialization.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+function f() { return x + 1; }
+f();
+const x = 1;

--- a/test/language/block-scope/semantics/const/global-use-before-initialization-in-declaration-statement.js
+++ b/test/language/block-scope/semantics/const/global-use-before-initialization-in-declaration-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const: global use before initialization in declaration statement.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+const x = x + 1;

--- a/test/language/block-scope/semantics/const/global-use-before-initialization-in-prior-statement.js
+++ b/test/language/block-scope/semantics/const/global-use-before-initialization-in-prior-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const: global use before initialization in prior statement.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+x; const x = 1;

--- a/test/language/block-scope/semantics/let/block-local-closure-get-before-initialization.js
+++ b/test/language/block-scope/semantics/let/block-local-closure-get-before-initialization.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: block local closure [[Get]] before initialization.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+{
+  function f() { return x + 1; }
+  f();
+  let x;
+}

--- a/test/language/block-scope/semantics/let/block-local-closure-set-before-initialization.js
+++ b/test/language/block-scope/semantics/let/block-local-closure-set-before-initialization.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: block local closure [[Set]] before initialization.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+{
+  function f() { x = 1; }
+  f();
+  let x;
+}

--- a/test/language/block-scope/semantics/let/block-local-use-before-initialization-in-declaration-statement.js
+++ b/test/language/block-scope/semantics/let/block-local-use-before-initialization-in-declaration-statement.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: block local use before initialization in declaration statement.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+{
+  let x = x + 1;
+}

--- a/test/language/block-scope/semantics/let/block-local-use-before-initialization-in-prior-statement.js
+++ b/test/language/block-scope/semantics/let/block-local-use-before-initialization-in-prior-statement.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: block local use before initialization in prior statement.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+{
+  x; let x;
+}

--- a/test/language/block-scope/semantics/let/function-local-closure-get-before-initialization.js
+++ b/test/language/block-scope/semantics/let/function-local-closure-get-before-initialization.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: function local closure [[Get]] before initialization.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+(function() {
+  function f() { return x + 1; }
+  f();
+  let x;
+}());

--- a/test/language/block-scope/semantics/let/function-local-closure-set-before-initialization.js
+++ b/test/language/block-scope/semantics/let/function-local-closure-set-before-initialization.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: function local closure [[Set]] before initialization.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+(function() {
+  function f() { x = 1; }
+  f();
+  let x;
+}());

--- a/test/language/block-scope/semantics/let/function-local-use-before-initialization-in-declaration-statement.js
+++ b/test/language/block-scope/semantics/let/function-local-use-before-initialization-in-declaration-statement.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: function local use before initialization in declaration statement.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+(function() {
+  let x = x + 1;
+}());

--- a/test/language/block-scope/semantics/let/function-local-use-before-initialization-in-prior-statement.js
+++ b/test/language/block-scope/semantics/let/function-local-use-before-initialization-in-prior-statement.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: function local use before initialization in prior statement.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+(function() {
+  x; let x;
+}());

--- a/test/language/block-scope/semantics/let/global-closure-get-before-initialization.js
+++ b/test/language/block-scope/semantics/let/global-closure-get-before-initialization.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: global closure [[Get]] before initialization.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+function f() { return x + 1; }
+f();
+let x;

--- a/test/language/block-scope/semantics/let/global-closure-set-before-initialization.js
+++ b/test/language/block-scope/semantics/let/global-closure-set-before-initialization.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: global closure [[Set]] before initialization.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+function f() { x = 1; }
+f();
+let x;

--- a/test/language/block-scope/semantics/let/global-use-before-initialization-in-declaration-statement.js
+++ b/test/language/block-scope/semantics/let/global-use-before-initialization-in-declaration-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: global use before initialization in declaration statement.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+let x = x + 1;

--- a/test/language/block-scope/semantics/let/global-use-before-initialization-in-prior-statement.js
+++ b/test/language/block-scope/semantics/let/global-use-before-initialization-in-prior-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: global use before initialization in prior statement.
+    (TDZ, Temporal Dead Zone)
+negative: ReferenceError
+---*/
+x; let x;

--- a/test/language/block-scope/shadowing/catch-parameter-shadowing-catch-parameter.js
+++ b/test/language/block-scope/shadowing/catch-parameter-shadowing-catch-parameter.js
@@ -1,0 +1,26 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    catch parameter shadowing catch parameter
+---*/
+function fn() {
+  var c = 1;
+  try {
+    throw 'stuff3';
+  } catch (c) {
+    try {
+      throw 'stuff4';
+    } catch(c) {
+      assert.sameValue(c,'stuff4');
+      // catch parameter shadowing catch parameter
+      c = 3;
+      assert.sameValue(c, 3);
+    }
+    assert.sameValue(c, 'stuff3');
+  }
+  assert.sameValue(c, 1);
+}
+fn(1);
+

--- a/test/language/block-scope/shadowing/catch-parameter-shadowing-function-parameter-name.js
+++ b/test/language/block-scope/shadowing/catch-parameter-shadowing-function-parameter-name.js
@@ -1,0 +1,19 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    catch parameter shadowing function parameter name
+---*/
+function fn(a) {
+  try {
+    throw 'stuff1';
+  } catch (a) {
+    assert.sameValue(a, 'stuff1');
+    // catch parameter shadowing function parameter name
+    a = 2;
+    assert.sameValue(a, 2);
+  }
+}
+fn(1);
+

--- a/test/language/block-scope/shadowing/catch-parameter-shadowing-let-declaration.js
+++ b/test/language/block-scope/shadowing/catch-parameter-shadowing-let-declaration.js
@@ -1,0 +1,20 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    catch parameter shadowing let declaration
+---*/
+{
+  let a = 3;
+  try {
+    throw 'stuff2';
+  } catch (a) {
+    assert.sameValue(a, 'stuff2');
+    // catch parameter shadowing let declaration
+    a = 4;
+    assert.sameValue(a, 4);
+  }
+  assert.sameValue(a, 3);
+}
+

--- a/test/language/block-scope/shadowing/catch-parameter-shadowing-var-variable.js
+++ b/test/language/block-scope/shadowing/catch-parameter-shadowing-var-variable.js
@@ -1,0 +1,19 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    catch parameter shadowing var variable
+---*/
+function fn() {
+  var a = 1;
+  try {
+    throw 'stuff3';
+  } catch (a) {
+    // catch parameter shadowing var variable
+    assert.sameValue(a, 'stuff3');
+  }
+  assert.sameValue(a, 1);
+}
+fn();
+

--- a/test/language/block-scope/shadowing/const-declaration-shadowing-catch-parameter.js
+++ b/test/language/block-scope/shadowing/const-declaration-shadowing-catch-parameter.js
@@ -1,0 +1,23 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declaration shadowing catch parameter
+---*/
+function fn() {
+  var a = 1;
+  try {
+    throw 'stuff3';
+  } catch (a) {
+    {
+      // const declaration shadowing catch parameter
+      const a = 3;
+      assert.sameValue(a, 3);
+    }
+    assert.sameValue(a, 'stuff3');
+  }
+  assert.sameValue(a, 1);
+}
+fn();
+

--- a/test/language/block-scope/shadowing/const-declarations-shadowing-parameter-name-let-const-and-var-variables.js
+++ b/test/language/block-scope/shadowing/const-declarations-shadowing-parameter-name-let-const-and-var-variables.js
@@ -1,0 +1,29 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations shadowing parameter name, let, const and var variables
+---*/
+function fn(a) {
+  let b = 1;
+  var c = 1;
+  const d = 1;
+  {
+    const a = 2;
+    const b = 2;
+    const c = 2;
+    const d = 2;
+    assert.sameValue(a, 2);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 2);
+    assert.sameValue(d, 2);
+  }
+
+  assert.sameValue(a, 1);
+  assert.sameValue(b, 1);
+  assert.sameValue(c, 1);
+  assert.sameValue(d, 1);
+}
+fn(1);
+

--- a/test/language/block-scope/shadowing/dynamic-lookup-from-closure.js
+++ b/test/language/block-scope/shadowing/dynamic-lookup-from-closure.js
@@ -1,0 +1,28 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    dynamic lookup from closure
+---*/
+function fn(one) {
+  var x = one + 1;
+  let y = one + 2;
+  const u = one + 4;
+  {
+    let z = one + 3;
+    const v = one + 5;
+    function f() {
+      assert.sameValue(one, 1);
+      assert.sameValue(x, 2);
+      assert.sameValue(y, 3);
+      assert.sameValue(z, 4);
+      assert.sameValue(u, 5);
+      assert.sameValue(v, 6);
+    }
+
+    f();
+  }
+}
+fn(1);
+

--- a/test/language/block-scope/shadowing/dynamic-lookup-in-and-through-block-contexts.js
+++ b/test/language/block-scope/shadowing/dynamic-lookup-in-and-through-block-contexts.js
@@ -1,0 +1,25 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    dynamic lookup in and through block contexts
+---*/
+function fn(one) {
+  var x = one + 1;
+  let y = one + 2;
+  const u = one + 4;
+  {
+    let z = one + 3;
+    const v = one + 5;
+    assert.sameValue(one, 1);
+    assert.sameValue(x, 2);
+    assert.sameValue(y, 3);
+    assert.sameValue(z, 4);
+    assert.sameValue(u, 5);
+    assert.sameValue(v, 6);
+  }
+}
+
+fn(1);
+

--- a/test/language/block-scope/shadowing/hoisting-var-declarations-out-of-blocks.js
+++ b/test/language/block-scope/shadowing/hoisting-var-declarations-out-of-blocks.js
@@ -1,0 +1,17 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    hoisting var declarations out of blocks
+---*/
+function fn() {
+  {
+    var x = 1;
+    var y;
+  }
+  assert.sameValue(x, 1);
+  assert.sameValue(y, undefined);
+}
+fn();
+

--- a/test/language/block-scope/shadowing/let-declaration-shadowing-catch-parameter.js
+++ b/test/language/block-scope/shadowing/let-declaration-shadowing-catch-parameter.js
@@ -1,0 +1,18 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declaration shadowing catch parameter
+---*/
+try {
+  throw 'stuff1';
+} catch (a) {
+  {
+    // let declaration shadowing catch parameter
+    let a = 3;
+    assert.sameValue(a, 3);
+  }
+  assert.sameValue(a, 'stuff1');
+}
+

--- a/test/language/block-scope/shadowing/let-declarations-shadowing-parameter-name-let-const-and-var.js
+++ b/test/language/block-scope/shadowing/let-declarations-shadowing-parameter-name-let-const-and-var.js
@@ -1,0 +1,24 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations shadowing parameter name, let, const and var
+---*/
+function fn(a) {
+  let b = 1;
+  var c = 1;
+  const d = 1;
+  {
+    let a = 2;
+    let b = 2;
+    let c = 2;
+    let d = 2;
+    assert.sameValue(a, 2);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 2);
+    assert.sameValue(d, 2);
+  }
+}
+fn(1);
+

--- a/test/language/block-scope/shadowing/lookup-from-closure.js
+++ b/test/language/block-scope/shadowing/lookup-from-closure.js
@@ -1,0 +1,28 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    lookup from closure
+---*/
+function f5(one) {
+  var x = one + 1;
+  let y = one + 2;
+  const u = one + 4;
+  {
+    let z = one + 3;
+    const v = one + 5;
+    function f() {
+      assert.sameValue(one, 1);
+      assert.sameValue(x, 2);
+      assert.sameValue(y, 3);
+      assert.sameValue(z, 4);
+      assert.sameValue(u, 5);
+      assert.sameValue(v, 6);
+    }
+
+    f();
+  }
+}
+f5(1);
+

--- a/test/language/block-scope/shadowing/lookup-in-and-through-block-contexts.js
+++ b/test/language/block-scope/shadowing/lookup-in-and-through-block-contexts.js
@@ -1,0 +1,25 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    lookup in and through block contexts
+---*/
+function fn(one) {
+  var x = one + 1;
+  let y = one + 2;
+  const u = one + 4;
+  {
+    let z = one + 3;
+    const v = one + 5;
+    assert.sameValue(one, 1);
+    assert.sameValue(x, 2);
+    assert.sameValue(y, 3);
+    assert.sameValue(z, 4);
+    assert.sameValue(u, 5);
+    assert.sameValue(v, 6);
+  }
+}
+
+fn(1);
+

--- a/test/language/block-scope/shadowing/parameter-name-shadowing-catch-parameter.js
+++ b/test/language/block-scope/shadowing/parameter-name-shadowing-catch-parameter.js
@@ -1,0 +1,23 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    parameter name shadowing catch parameter
+---*/
+function fn() {
+  var c = 1;
+  try {
+    throw 'stuff3';
+  } catch (c) {
+    (function(c) {
+      // parameter name shadowing catch parameter
+      c = 3;
+      assert.sameValue(c, 3);
+    })();
+    assert.sameValue(c, 'stuff3');
+  }
+  assert.sameValue(c, 1);
+}
+fn();
+

--- a/test/language/block-scope/shadowing/parameter-name-shadowing-parameter-name-let-const-and-var.js
+++ b/test/language/block-scope/shadowing/parameter-name-shadowing-parameter-name-let-const-and-var.js
@@ -1,0 +1,32 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    parameter name shadowing parameter name, let, const and var
+---*/
+function fn(a) {
+  let b = 1;
+  var c = 1;
+  const d = 1;
+
+  (function(a, b, c, d) {
+    a = 2;
+    b = 2;
+    c = 2;
+    d = 2;
+
+    assert.sameValue(a, 2);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 2);
+    assert.sameValue(d, 2);
+  })(1, 1);
+
+  assert.sameValue(a, 1);
+  assert.sameValue(b, 1);
+  assert.sameValue(c, 1);
+  assert.sameValue(d, 1);
+}
+
+fn(1);
+

--- a/test/language/block-scope/syntax/const-declaration/block-scope-syntax-const-declarations-mixed-with-without-initialiser.js
+++ b/test/language/block-scope/syntax/const-declaration/block-scope-syntax-const-declarations-mixed-with-without-initialiser.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations mixed: with, without initialiser
+negative: SyntaxError
+---*/
+const x = 1, y;
+

--- a/test/language/block-scope/syntax/const-declaration/block-scope-syntax-const-declarations-mixed-without-with-initialiser.js
+++ b/test/language/block-scope/syntax/const-declaration/block-scope-syntax-const-declarations-mixed-without-with-initialiser.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations mixed: without, with initialiser
+negative: SyntaxError
+---*/
+const x, y = 1;
+

--- a/test/language/block-scope/syntax/const-declaration/block-scope-syntax-const-declarations-without-initialiser.js
+++ b/test/language/block-scope/syntax/const-declaration/block-scope-syntax-const-declarations-without-initialiser.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations without initialiser
+negative: SyntaxError
+---*/
+const x;
+

--- a/test/language/block-scope/syntax/const-declaration/with-initializer-case-expression-statement-list.js
+++ b/test/language/block-scope/syntax/const-declaration/with-initializer-case-expression-statement-list.js
@@ -1,0 +1,9 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations with initialisers in statement positions:
+    case Expression : StatementList
+---*/
+switch (true) { case true: const x = 1; }

--- a/test/language/block-scope/syntax/const-declaration/with-initializer-default-statement-list.js
+++ b/test/language/block-scope/syntax/const-declaration/with-initializer-default-statement-list.js
@@ -1,0 +1,9 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations with initialisers in statement positions:
+    default : StatementList
+---*/
+switch (true) { default: const x = 1; }

--- a/test/language/block-scope/syntax/const-declaration/with-initializer-do-statement-while-expression.js
+++ b/test/language/block-scope/syntax/const-declaration/with-initializer-do-statement-while-expression.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations with initialisers in statement positions: 
+    do Statement while ( Expression )
+negative: SyntaxError
+---*/
+do const x = 1; while (false)

--- a/test/language/block-scope/syntax/const-declaration/with-initializer-for-statement.js
+++ b/test/language/block-scope/syntax/const-declaration/with-initializer-for-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations with initialisers in statement positions: 
+    for ( ;;) Statement
+negative: SyntaxError
+---*/
+for (;false;) const x = 1;

--- a/test/language/block-scope/syntax/const-declaration/with-initializer-if-expression-statement-else-statement.js
+++ b/test/language/block-scope/syntax/const-declaration/with-initializer-if-expression-statement-else-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations with initialisers in statement positions: 
+    if ( Expression ) Statement else Statement
+negative: SyntaxError
+---*/
+if (true) {} else const x = 1;

--- a/test/language/block-scope/syntax/const-declaration/with-initializer-if-expression-statement.js
+++ b/test/language/block-scope/syntax/const-declaration/with-initializer-if-expression-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations with initialisers in statement positions: 
+    if ( Expression ) Statement
+negative: SyntaxError
+---*/
+if (true) const x = 1;

--- a/test/language/block-scope/syntax/const-declaration/with-initializer-label-statement.js
+++ b/test/language/block-scope/syntax/const-declaration/with-initializer-label-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations with initialisers in statement positions: 
+    label: Statement
+negative: SyntaxError
+---*/
+label: const x = 1;

--- a/test/language/block-scope/syntax/const-declaration/with-initializer-while-expression-statement.js
+++ b/test/language/block-scope/syntax/const-declaration/with-initializer-while-expression-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations with initialisers in statement positions: 
+    while ( Expression ) Statement
+negative: SyntaxError
+---*/
+while (false) const x = 1;

--- a/test/language/block-scope/syntax/const-declaration/without-initializer-case-expression-statement-list.js
+++ b/test/language/block-scope/syntax/const-declaration/without-initializer-case-expression-statement-list.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations without initialisers in statement positions: 
+    case Expression : StatementList
+negative: SyntaxError
+---*/
+switch (true) { case true: const x; }

--- a/test/language/block-scope/syntax/const-declaration/without-initializer-default-statement-list.js
+++ b/test/language/block-scope/syntax/const-declaration/without-initializer-default-statement-list.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations without initialisers in statement positions: 
+    default : StatementList
+negative: SyntaxError
+---*/
+switch (true) { default: const x; }

--- a/test/language/block-scope/syntax/const-declaration/without-initializer-do-statement-while-expression.js
+++ b/test/language/block-scope/syntax/const-declaration/without-initializer-do-statement-while-expression.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations without initialisers in statement positions: 
+    do Statement while ( Expression )
+negative: SyntaxError
+---*/
+do const x; while (false)

--- a/test/language/block-scope/syntax/const-declaration/without-initializer-for-statement.js
+++ b/test/language/block-scope/syntax/const-declaration/without-initializer-for-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations without initialisers in statement positions: 
+    for ( ;;) Statement
+negative: SyntaxError
+---*/
+for (;false;) const x;

--- a/test/language/block-scope/syntax/const-declaration/without-initializer-if-expression-statement-else-statement.js
+++ b/test/language/block-scope/syntax/const-declaration/without-initializer-if-expression-statement-else-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations without initialisers in statement positions: 
+    if ( Expression ) Statement else Statement
+negative: SyntaxError
+---*/
+if (true) {} else const x;

--- a/test/language/block-scope/syntax/const-declaration/without-initializer-if-expression-statement.js
+++ b/test/language/block-scope/syntax/const-declaration/without-initializer-if-expression-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations without initialisers in statement positions: 
+    if ( Expression ) Statement
+negative: SyntaxError
+---*/
+if (true) const x;

--- a/test/language/block-scope/syntax/const-declaration/without-initializer-label-statement.js
+++ b/test/language/block-scope/syntax/const-declaration/without-initializer-label-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations without initialisers in statement positions: 
+    label: Statement
+negative: SyntaxError
+---*/
+label: const x;

--- a/test/language/block-scope/syntax/const-declaration/without-initializer-while-expression-statement.js
+++ b/test/language/block-scope/syntax/const-declaration/without-initializer-while-expression-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const declarations without initialisers in statement positions: 
+    while ( Expression ) Statement
+negative: SyntaxError
+---*/
+while (false) const x;

--- a/test/language/block-scope/syntax/for-in/acquire-properties-from-array.js
+++ b/test/language/block-scope/syntax/for-in/acquire-properties-from-array.js
@@ -1,0 +1,21 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    for-in to acquire properties from array
+includes: [compareArray.js]
+---*/
+function props(x) {
+  var array = [];
+  for (let p in x) array.push(p);
+  return array.sort();
+}
+
+assert.sameValue(props([]).length, 0);
+assert.sameValue(props([1]).length, 1);
+assert.sameValue(props([1,2]).length, 2);
+
+assert(compareArray(props([1]), ["0"]));
+assert(compareArray(props([1,2]), ["0", "1"]));
+assert(compareArray(props([1,2,3]), ["0", "1", "2"]));

--- a/test/language/block-scope/syntax/for-in/acquire-properties-from-object.js
+++ b/test/language/block-scope/syntax/for-in/acquire-properties-from-object.js
@@ -1,0 +1,21 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    for-in to acquire properties from object
+includes: [compareArray.js]
+---*/
+function props(x) {
+  var array = [];
+  for (let p in x) array.push(p);
+  return array.sort();
+}
+
+assert.sameValue(props({}).length, 0);
+assert.sameValue(props({x:1}).length, 1);
+assert.sameValue(props({x:1, y:2}).length, 2);
+
+assert(compareArray(props({x:1}), ["x"]));
+assert(compareArray(props({x:1, y:2}), ["x", "y"]));
+assert(compareArray(props({x:1, y:2, zoom:3}), ["x", "y", "zoom"]));

--- a/test/language/block-scope/syntax/for-in/disallow-initialization-assignment.js
+++ b/test/language/block-scope/syntax/for-in/disallow-initialization-assignment.js
@@ -1,0 +1,11 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    for declaration:
+    disallow initialization assignment
+negative: SyntaxError
+---*/
+for (let x = 3 in {}) { }
+

--- a/test/language/block-scope/syntax/for-in/disallow-multiple-lexical-bindings-with-and-without-initializer.js
+++ b/test/language/block-scope/syntax/for-in/disallow-multiple-lexical-bindings-with-and-without-initializer.js
@@ -1,0 +1,11 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    for declaration:
+    disallow multiple lexical bindings, with and without initializer
+negative: SyntaxError
+---*/
+for (let x = 3, y in {}) { }
+

--- a/test/language/block-scope/syntax/for-in/disallow-multiple-lexical-bindings-with-initializer.js
+++ b/test/language/block-scope/syntax/for-in/disallow-multiple-lexical-bindings-with-initializer.js
@@ -1,0 +1,11 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    for declaration:
+    disallow multiple lexical bindings, with initializer
+negative: SyntaxError
+---*/
+for (let x = 3, y = 4 in {}) { }
+

--- a/test/language/block-scope/syntax/for-in/disallow-multiple-lexical-bindings-without-and-with-initializer.js
+++ b/test/language/block-scope/syntax/for-in/disallow-multiple-lexical-bindings-without-and-with-initializer.js
@@ -1,0 +1,11 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    for declaration:
+    disallow multiple lexical bindings, without and with initializer
+negative: SyntaxError
+---*/
+for (let x, y = 4 in {}) { }
+

--- a/test/language/block-scope/syntax/for-in/disallow-multiple-lexical-bindings.js
+++ b/test/language/block-scope/syntax/for-in/disallow-multiple-lexical-bindings.js
@@ -1,0 +1,11 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    for declaration:
+    disallow multiple lexical bindings
+negative: SyntaxError
+---*/
+for (let x, y in {}) { }
+

--- a/test/language/block-scope/syntax/for-in/missing-identifier-let-disallowed-as-bound-name.js
+++ b/test/language/block-scope/syntax/for-in/missing-identifier-let-disallowed-as-bound-name.js
@@ -1,0 +1,11 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    for declaration:
+    missing identifier, "let" disallowed as bound name
+negative: SyntaxError
+---*/
+for (let in {}) { }
+

--- a/test/language/block-scope/syntax/for-in/mixed-values-in-iteration.js
+++ b/test/language/block-scope/syntax/for-in/mixed-values-in-iteration.js
@@ -1,0 +1,21 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    Mixed values in iteration
+---*/
+"use strict";
+function fn(x) {
+  let a = [];
+  for (let p in x) {
+    a.push(function () { return p; });
+  }
+  let k = 0;
+  for (let q in x) {
+    assert.sameValue(q, a[k]());
+    ++k;
+  }
+}
+fn({a : [0], b : 1, c : {v : 1}, get d() {}, set e(x) {}});
+

--- a/test/language/block-scope/syntax/for-loop/const-invalid-assignment-next-expression.js
+++ b/test/language/block-scope/syntax/for-loop/const-invalid-assignment-next-expression.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2015 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    const: invalid assignment in next expression
+negative: TypeError
+---*/
+
+for (const i = 0; i < 1; i++) { }

--- a/test/language/block-scope/syntax/for-loop/const-outer-inner-let-bindings.js
+++ b/test/language/block-scope/syntax/for-loop/const-outer-inner-let-bindings.js
@@ -1,0 +1,22 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    outer const binding unchanged by for-loop const binding
+---*/
+//
+
+const x = "outer_x";
+const y = "outer_y";
+var i = 0;
+
+for (const x = "inner_x"; i < 1; i++) {
+  const y = "inner_y";
+
+  assert.sameValue(x, "inner_x");
+  assert.sameValue(y, "inner_y");
+}
+assert.sameValue(x, "outer_x");
+assert.sameValue(y, "outer_y");
+

--- a/test/language/block-scope/syntax/for-loop/let-closure-inside-condition.js
+++ b/test/language/block-scope/syntax/for-loop/let-closure-inside-condition.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: closure inside for loop condition
+---*/
+let a = [];
+for (let i = 0; a.push(function () { return i; }), i < 5; ++i) { }
+for (let k = 0; k < 5; ++k) {
+  assert.sameValue(k, a[k]());
+}

--- a/test/language/block-scope/syntax/for-loop/let-closure-inside-initialization.js
+++ b/test/language/block-scope/syntax/for-loop/let-closure-inside-initialization.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: closure inside for loop initialization
+---*/
+let a = [];
+for (let i = 0, f = function() { return i }; i < 5; ++i) {
+  a.push(f);
+}
+for (let k = 0; k < 5; ++k) {
+  assert.sameValue(0, a[k]());
+}

--- a/test/language/block-scope/syntax/for-loop/let-closure-inside-next-expression.js
+++ b/test/language/block-scope/syntax/for-loop/let-closure-inside-next-expression.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let: closure inside for loop next-expression
+---*/
+let a = [];
+for (let i = 0; i < 5; a.push(function () { return i; }), ++i) { }
+for (let k = 0; k < 5; ++k) {
+  assert.sameValue(k + 1, a[k]());
+}

--- a/test/language/block-scope/syntax/for-loop/let-iteration-variable-is-freshly-allocated-for-each-iteration-multi-let-binding.js
+++ b/test/language/block-scope/syntax/for-loop/let-iteration-variable-is-freshly-allocated-for-each-iteration-multi-let-binding.js
@@ -1,0 +1,16 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    In a normal for statement the iteration variable is freshly allocated for each iteration. Multi let binding
+---*/
+let a = [], b = [];
+for (let i = 0, j = 10; i < 5; ++i, ++j) {
+  a.push(function () { return i; });
+  b.push(function () { return j; });
+}
+for (let k = 0; k < 5; ++k) {
+  assert.sameValue(k, a[k]());
+  assert.sameValue(k + 10, b[k]());
+}

--- a/test/language/block-scope/syntax/for-loop/let-iteration-variable-is-freshly-allocated-for-each-iteration-single-let-binding.js
+++ b/test/language/block-scope/syntax/for-loop/let-iteration-variable-is-freshly-allocated-for-each-iteration-single-let-binding.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    In a normal for statement the iteration variable is freshly allocated for each iteration. Single let binding
+---*/
+let a = [];
+for (let i = 0; i < 5; ++i) {
+  a.push(function () { return i; });
+}
+for (let j = 0; j < 5; ++j) {
+  assert.sameValue(j, a[j]());
+}

--- a/test/language/block-scope/syntax/for-loop/let-outer-inner-let-bindings.js
+++ b/test/language/block-scope/syntax/for-loop/let-outer-inner-let-bindings.js
@@ -1,0 +1,21 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    outer let binding unchanged by for-loop let binding
+---*/
+//
+
+let x = "outer_x";
+let y = "outer_y";
+
+for (let x = "inner_x", i = 0; i < 1; i++) {
+  let y = "inner_y";
+
+  assert.sameValue(x, "inner_x");
+  assert.sameValue(y, "inner_y");
+}
+assert.sameValue(x, "outer_x");
+assert.sameValue(y, "outer_y");
+

--- a/test/language/block-scope/syntax/function-declarations/in-statement-position-case-expression-statement-list.js
+++ b/test/language/block-scope/syntax/function-declarations/in-statement-position-case-expression-statement-list.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    function declarations in statement position in strict mode:
+    case Expression : StatementList
+---*/
+switch (true) { case true: function g() {} }
+

--- a/test/language/block-scope/syntax/function-declarations/in-statement-position-default-statement-list.js
+++ b/test/language/block-scope/syntax/function-declarations/in-statement-position-default-statement-list.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    function declarations in statement position in strict mode:
+    default : StatementList
+---*/
+switch (true) { default: function g() {} }
+

--- a/test/language/block-scope/syntax/function-declarations/in-statement-position-do-statement-while-expression.js
+++ b/test/language/block-scope/syntax/function-declarations/in-statement-position-do-statement-while-expression.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    function declarations in statement position in strict mode:
+    do Statement while ( Expression )
+negative: SyntaxError
+flags: [onlyStrict]
+---*/
+do function g() {} while (false)
+

--- a/test/language/block-scope/syntax/function-declarations/in-statement-position-for-statement.js
+++ b/test/language/block-scope/syntax/function-declarations/in-statement-position-for-statement.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    function declarations in statement position in strict mode:
+    for ( ;;) Statement
+negative: SyntaxError
+flags: [onlyStrict]
+---*/
+for (;false;) function g() {}
+

--- a/test/language/block-scope/syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js
+++ b/test/language/block-scope/syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    function declarations in statement position in strict mode:
+    if ( Expression ) Statement else Statement
+negative: SyntaxError
+flags: [onlyStrict]
+---*/
+if (true) {} else function g() {}
+

--- a/test/language/block-scope/syntax/function-declarations/in-statement-position-if-expression-statement.js
+++ b/test/language/block-scope/syntax/function-declarations/in-statement-position-if-expression-statement.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    function declarations in statement position in strict mode:
+    if ( Expression ) Statement
+negative: SyntaxError
+flags: [onlyStrict]
+---*/
+if (true) function g() {}
+

--- a/test/language/block-scope/syntax/function-declarations/in-statement-position-label-statement.js
+++ b/test/language/block-scope/syntax/function-declarations/in-statement-position-label-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    function declarations in statement position in strict mode:
+    label: Statement
+---*/
+label: function g() {}
+

--- a/test/language/block-scope/syntax/function-declarations/in-statement-position-while-expression-statement.js
+++ b/test/language/block-scope/syntax/function-declarations/in-statement-position-while-expression-statement.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    function declarations in statement position in strict mode:
+    while ( Expression ) Statement
+negative: SyntaxError
+flags: [onlyStrict]
+---*/
+while (false) function g() {}
+

--- a/test/language/block-scope/syntax/global-and-block/const.js
+++ b/test/language/block-scope/syntax/global-and-block/const.js
@@ -1,0 +1,21 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    global and block scope const
+---*/
+const z = 4;
+
+// Block local
+{
+  const z = 5;
+}
+
+assert.sameValue(z, 4);
+
+if (true) {
+  const z = 1;
+  assert.sameValue(z, 1);
+}
+

--- a/test/language/block-scope/syntax/global-and-block/let.js
+++ b/test/language/block-scope/syntax/global-and-block/let.js
@@ -1,0 +1,24 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    global and block scope let
+---*/
+let x;
+let y = 2;
+
+// Block local
+{
+  let y;
+  let x = 3;
+}
+
+assert.sameValue(x, undefined);
+assert.sameValue(y, 2);
+
+if (true) {
+  let y;
+  assert.sameValue(y, undefined);
+}
+

--- a/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-case-expression-statement-list.js
+++ b/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-case-expression-statement-list.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations with initialisers in statement positions:
+    case Expression : StatementList
+---*/
+switch (true) { case true: let x = 1; }
+

--- a/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-default-statement-list.js
+++ b/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-default-statement-list.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations with initialisers in statement positions:
+    default : StatementList
+---*/
+switch (true) { default: let x = 1; }
+

--- a/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-do-statement-while-expression.js
+++ b/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-do-statement-while-expression.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations with initialisers in statement positions: 
+    do Statement while ( Expression )
+negative: SyntaxError
+---*/
+do let x = 1; while (false)

--- a/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-for-statement.js
+++ b/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-for-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations with initialisers in statement positions: 
+    for ( ;;) Statement
+negative: SyntaxError
+---*/
+for (;false;) let x = 1;

--- a/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-if-expression-statement-else-statement.js
+++ b/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-if-expression-statement-else-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations with initialisers in statement positions: 
+    if ( Expression ) Statement else Statement
+negative: SyntaxError
+---*/
+if (true) {} else let x = 1;

--- a/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-if-expression-statement.js
+++ b/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-if-expression-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations with initialisers in statement positions: 
+    if ( Expression ) Statement
+negative: SyntaxError
+---*/
+if (true) let x = 1;

--- a/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-label-statement.js
+++ b/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-label-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations with initialisers in statement positions: 
+    label: Statement
+negative: SyntaxError
+---*/
+label: let x = 1;

--- a/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-while-expression-statement.js
+++ b/test/language/block-scope/syntax/let-declarations/with-initialisers-in-statement-positions-while-expression-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations with initialisers in statement positions: 
+    while ( Expression ) Statement
+negative: SyntaxError
+---*/
+while (false) let x = 1;

--- a/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-case-expression-statement-list.js
+++ b/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-case-expression-statement-list.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations without initialisers in statement positions: 
+    case Expression : StatementList
+negative: SyntaxError
+---*/
+switch (true) { case true: let x; }

--- a/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-default-statement-list.js
+++ b/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-default-statement-list.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations without initialisers in statement positions: 
+    default : StatementList
+negative: SyntaxError
+---*/
+switch (true) { default: let x; }

--- a/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-do-statement-while-expression.js
+++ b/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-do-statement-while-expression.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations without initialisers in statement positions: 
+    do Statement while ( Expression )
+negative: SyntaxError
+---*/
+do let x; while (false)

--- a/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-for-statement.js
+++ b/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-for-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations without initialisers in statement positions: 
+    for ( ;;) Statement
+negative: SyntaxError
+---*/
+for (;false;) let x;

--- a/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-if-expression-statement-else-statement.js
+++ b/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-if-expression-statement-else-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations without initialisers in statement positions: 
+    if ( Expression ) Statement else Statement
+negative: SyntaxError
+---*/
+if (true) {} else let x;

--- a/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-if-expression-statement.js
+++ b/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-if-expression-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations without initialisers in statement positions: 
+    if ( Expression ) Statement
+negative: SyntaxError
+---*/
+if (true) let x;

--- a/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-label-statement.js
+++ b/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-label-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations without initialisers in statement positions: 
+    label: Statement
+negative: SyntaxError
+---*/
+label: let x;

--- a/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-while-expression-statement.js
+++ b/test/language/block-scope/syntax/let-declarations/without-initialisers-in-statement-positions-while-expression-statement.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    let declarations without initialisers in statement positions: 
+    while ( Expression ) Statement
+negative: SyntaxError
+---*/
+while (false) let x;

--- a/test/language/block-scope/syntax/redeclaration-global/allowed-to-declare-function-with-function-declaration.js
+++ b/test/language/block-scope/syntax/redeclaration-global/allowed-to-declare-function-with-function-declaration.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    redeclaration outermost:
+    allowed to declare function with function declaration
+---*/
+function f() {}
+

--- a/test/language/block-scope/syntax/redeclaration-global/allowed-to-redeclare-function-declaration-with-function-declaration.js
+++ b/test/language/block-scope/syntax/redeclaration-global/allowed-to-redeclare-function-declaration-with-function-declaration.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    redeclaration outermost:
+    allowed to redeclare function declaration with function declaration
+---*/
+function f() {} function f() {}
+

--- a/test/language/block-scope/syntax/redeclaration-global/allowed-to-redeclare-function-declaration-with-var.js
+++ b/test/language/block-scope/syntax/redeclaration-global/allowed-to-redeclare-function-declaration-with-var.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    redeclaration outermost:
+    allowed to redeclare function declaration with var
+---*/
+function f() {} var f;
+

--- a/test/language/block-scope/syntax/redeclaration-global/allowed-to-redeclare-var-with-function-declaration.js
+++ b/test/language/block-scope/syntax/redeclaration-global/allowed-to-redeclare-var-with-function-declaration.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    redeclaration outermost:
+    allowed to redeclare var with function declaration
+---*/
+var f; function f() {}
+

--- a/test/language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-function-declaration-with-function-declaration.js
+++ b/test/language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-function-declaration-with-function-declaration.js
@@ -1,0 +1,11 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: B.3.3
+description: >
+    redeclaration within block:
+    attempt to redeclare function declaration with function declaration
+negative: SyntaxError
+---*/
+{ function f() {} function f() {} }
+

--- a/test/language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-function-declaration-with-let.js
+++ b/test/language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-function-declaration-with-let.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: B.3.3
+description: >
+    redeclaration within block:
+    attempt to redeclare function declaration with let
+negative: SyntaxError
+---*/
+{ function f() {} let f; }

--- a/test/language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-function-declaration-with-var.js
+++ b/test/language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-function-declaration-with-var.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: B.3.3
+description: >
+    redeclaration within block:
+    attempt to redeclare function declaration with var
+negative: SyntaxError
+---*/
+{ function f() {} var f; }

--- a/test/language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-let-binding-with-function-declaration.js
+++ b/test/language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-let-binding-with-function-declaration.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: B.3.3
+description: >
+    redeclaration within block:
+    attempt to redeclare let binding with function declaration
+negative: SyntaxError
+---*/
+{ let f; function f() {} }

--- a/test/language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-let-binding-with-var.js
+++ b/test/language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-let-binding-with-var.js
@@ -1,0 +1,11 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: B.3.3
+description: >
+    redeclaration within block:
+    attempt to redeclare let binding with var
+negative: SyntaxError
+---*/
+{ let f; var f; }
+

--- a/test/language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-var-binding-with-let.js
+++ b/test/language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-var-binding-with-let.js
@@ -1,0 +1,11 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: B.3.3
+description: >
+    redeclaration within block:
+    attempt to redeclare var binding with let
+negative: SyntaxError
+---*/
+{ var f; let f; }
+

--- a/test/language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-var-with-function-declaration.js
+++ b/test/language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-var-with-function-declaration.js
@@ -1,0 +1,11 @@
+// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: B.3.3
+description: >
+    redeclaration within block:
+    attempt to redeclare var with function declaration
+negative: SyntaxError
+---*/
+{ var f; function f() {} }
+


### PR DESCRIPTION
These tests are derived from the following files within the Google V8
project:

	test/mjsunit/harmony/block-conflicts.js
	test/mjsunit/harmony/block-for.js
	test/mjsunit/harmony/block-leave.js
	test/mjsunit/harmony/block-let-declaration.js
	test/mjsunit/harmony/block-let-semantics.js
	test/mjsunit/harmony/block-scoping.js