### PR TITLE
Symbol.species tests

### DIFF
--- a/test/built-ins/Symbol/species/Symbol.species.builtin-getter-name.js
+++ b/test/built-ins/Symbol/species/Symbol.species.builtin-getter-name.js
@@ -1,0 +1,24 @@
+// Copyright 2015 Cubane Canada, Inc.  All rights reserved.
+// See LICENSE for details.
+
+/*---
+info: >
+ ES6 spec 'get [Symbol.species]'
+es6id: 21.2.4.2, 22.1.2.5, 22.2.2.4, 23.1.2.2, 23.2.2.2
+author: Sam Mikes
+description: Symbol.species getters have defined names
+includes: 
+  - propertyHelper.js
+---*/
+
+function getGetterName(obj, name) {
+    var getter = Object.getOwnPropertyDescriptor(obj, Symbol.species).get;
+    return getter && getter.name;
+}
+
+assert.sameValue(getGetterName(Array, Symbol.species), "get [Symbol.species]");
+assert.sameValue(getGetterName(Map, Symbol.species), "get [Symbol.species]");
+assert.sameValue(getGetterName(Promise, Symbol.species), "get [Symbol.species]");
+assert.sameValue(getGetterName(RegExp, Symbol.species), "get [Symbol.species]");
+assert.sameValue(getGetterName(Set, Symbol.species), "get [Symbol.species]");
+

--- a/test/built-ins/Symbol/species/Symbol.species.exists.js
+++ b/test/built-ins/Symbol/species/Symbol.species.exists.js
@@ -1,0 +1,19 @@
+// Copyright 2015 Cubane Canada, Inc.  All rights reserved.
+// See LICENSE for details.
+
+/*---
+info: >
+ Symbol.species is a well-known symbol
+es6id: 19.4.2.10
+author: Sam Mikes
+description: Symbol.species exists
+includes: 
+  - propertyHelper.js
+---*/
+
+assert(Symbol !== undefined, "Symbol exists");
+assert(Symbol.species !== undefined, "Symbol.species exists");
+
+verifyNotWritable(Symbol, "species");
+verifyNotEnumerable(Symbol, "species");
+verifyNotConfigurable(Symbol, "species");

--- a/test/built-ins/Symbol/species/Symbol.species.in_Array.js
+++ b/test/built-ins/Symbol/species/Symbol.species.in_Array.js
@@ -1,0 +1,18 @@
+// Copyright 2015 Cubane Canada, Inc.  All rights reserved.
+// See LICENSE for details.
+
+/*---
+info: >
+ Array has a property at `Symbol.species`
+es6id: 22.1.2.5
+author: Sam Mikes
+description: Array[Symbol.species] exists per spec
+includes: 
+  - propertyHelper.js
+---*/
+
+assert.sameValue(Array[Symbol.species], Array, "Array[Symbol.species] is Array");
+
+verifyNotWritable(Array, Symbol.species, Symbol.species);
+verifyNotEnumerable(Array, Symbol.species);
+verifyConfigurable(Array, Symbol.species);

--- a/test/built-ins/Symbol/species/Symbol.species.in_ArrayBuffer.js
+++ b/test/built-ins/Symbol/species/Symbol.species.in_ArrayBuffer.js
@@ -1,0 +1,22 @@
+// Copyright 2015 Cubane Canada, Inc.  All rights reserved.
+// See LICENSE for details.
+
+/*---
+info: >
+ ArrayBuffer has a property at `Symbol.species`
+es6id: 24.1.3.3
+author: Sam Mikes
+description: ArrayBuffer[Symbol.species] exists per spec
+features: [ ArrayBuffer, Symbol.species ]
+includes: 
+  - propertyHelper.js
+---*/
+
+assert.sameValue(ArrayBuffer[Symbol.species], ArrayBuffer, "ArrayBuffer[Symbol.species] is ArrayBuffer");
+
+assert.sameValue(Object.getOwnPropertyDescriptor(ArrayBuffer, Symbol.species).get.name,
+                 "get [Symbol.species]");
+
+verifyNotWritable(ArrayBuffer, Symbol.species, Symbol.species);
+verifyNotEnumerable(ArrayBuffer, Symbol.species);
+verifyConfigurable(ArrayBuffer, Symbol.species);

--- a/test/built-ins/Symbol/species/Symbol.species.in_Map.js
+++ b/test/built-ins/Symbol/species/Symbol.species.in_Map.js
@@ -1,0 +1,18 @@
+// Copyright 2015 Cubane Canada, Inc.  All rights reserved.
+// See LICENSE for details.
+
+/*---
+info: >
+ Map has a property at `Symbol.species`
+es6id: 23.1.2.2
+author: Sam Mikes
+description: Map[Symbol.species] exists per spec
+includes: 
+  - propertyHelper.js
+---*/
+
+assert.sameValue(Map[Symbol.species], Map, "Map[Symbol.species] is Map");
+
+verifyNotWritable(Map, Symbol.species, Symbol.species);
+verifyNotEnumerable(Map, Symbol.species);
+verifyConfigurable(Map, Symbol.species);

--- a/test/built-ins/Symbol/species/Symbol.species.in_Promise.js
+++ b/test/built-ins/Symbol/species/Symbol.species.in_Promise.js
@@ -1,0 +1,18 @@
+// Copyright 2015 Cubane Canada, Inc.  All rights reserved.
+// See LICENSE for details.
+
+/*---
+info: >
+ Promise has a property at `Symbol.species`
+es6id: 6.1.5.1
+author: Sam Mikes
+description: Promise[Symbol.species] exists per spec
+includes: 
+  - propertyHelper.js
+---*/
+
+assert.sameValue(Promise[Symbol.species], Promise, "Promise[Symbol.species] is Promise");
+
+verifyNotWritable(Promise, Symbol.species, Symbol.species);
+verifyNotEnumerable(Promise, Symbol.species);
+verifyConfigurable(Promise, Symbol.species);

--- a/test/built-ins/Symbol/species/Symbol.species.in_RegExp.js
+++ b/test/built-ins/Symbol/species/Symbol.species.in_RegExp.js
@@ -1,0 +1,18 @@
+// Copyright 2015 Cubane Canada, Inc.  All rights reserved.
+// See LICENSE for details.
+
+/*---
+info: >
+ RegExp has a property at `Symbol.species`
+es6id: 21.2.4.2
+author: Sam Mikes
+description: RegExp[Symbol.species] exists per spec
+includes: 
+  - propertyHelper.js
+---*/
+
+assert.sameValue(RegExp[Symbol.species], RegExp, "RegExp[Symbol.species] is RegExp");
+
+verifyNotWritable(RegExp, Symbol.species, Symbol.species);
+verifyNotEnumerable(RegExp, Symbol.species);
+verifyConfigurable(RegExp, Symbol.species);

--- a/test/built-ins/Symbol/species/Symbol.species.in_Set.js
+++ b/test/built-ins/Symbol/species/Symbol.species.in_Set.js
@@ -1,0 +1,18 @@
+// Copyright 2015 Cubane Canada, Inc.  All rights reserved.
+// See LICENSE for details.
+
+/*---
+info: >
+ Set has a property at `Symbol.species`
+es6id: 23.2.2.2
+author: Sam Mikes
+description: Set[Symbol.species] exists per spec
+includes: 
+  - propertyHelper.js
+---*/
+
+assert.sameValue(Set[Symbol.species], Set, "Set[Symbol.species] is Set");
+
+verifyNotWritable(Set, Symbol.species, Symbol.species);
+verifyNotEnumerable(Set, Symbol.species);
+verifyConfigurable(Set, Symbol.species);

--- a/test/built-ins/Symbol/species/Symbol.species.notChangedByExtends.js
+++ b/test/built-ins/Symbol/species/Symbol.species.notChangedByExtends.js
@@ -1,0 +1,18 @@
+// Copyright 2015 Cubane Canada, Inc.  All rights reserved.
+// See LICENSE for details.
+
+/*---
+info: >
+ Symbol.species is retained on subclassing
+es6id: 
+author: Sam Mikes
+description: Symbol.species is retained on subclassing
+includes: 
+  - propertyHelper.js
+---*/
+
+class MyRegExp extends RegExp {
+};
+
+assert.sameValue(MyRegExp[Symbol.species], MyRegExp);
+


### PR DESCRIPTION
Initial tests for property existence
move getter name test to builtin-getter-name
initial cut at extends test