### PR TITLE
Import tests from Google V8 (Object Literal Concise Method and Property Initialization)

### DIFF
--- a/test/language/object-literal/concise-generator.js
+++ b/test/language/object-literal/concise-generator.js
@@ -1,0 +1,26 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5
+description: >
+    super method calls in object literal concise generator
+---*/
+var proto = {
+  method() {
+    return 42;
+  }
+};
+
+var object = {
+  *g() {
+    yield super.method();
+  }
+};
+
+Object.setPrototypeOf(object, proto);
+
+assert.sameValue(
+  object.g().next().value,
+  42,
+  "The value of `object.g().next().value` is `42`, after executing `Object.setPrototypeOf(object, proto);`, where `object " + String(object) + "`"
+);

--- a/test/language/object-literal/descriptor.js
+++ b/test/language/object-literal/descriptor.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5
+desciption: >
+    object literal property shorthand desciptor defaults
+---*/
+var x = 1;
+var object = {x};
+var desc = Object.getOwnPropertyDescriptor(object, 'x');
+assert.sameValue(desc.value, 1, "The value of `desc.value` is `1`, where `var desc = Object.getOwnPropertyDescriptor(object, 'x');`");
+assert.sameValue(desc.enumerable, true, "The value of `desc.enumerable` is `true`, where `var desc = Object.getOwnPropertyDescriptor(object, 'x');`");
+assert.sameValue(desc.writable, true, "The value of `desc.writable` is `true`, where `var desc = Object.getOwnPropertyDescriptor(object, 'x');`");
+assert.sameValue(desc.configurable, true, "The value of `desc.configurable` is `true`, where `var desc = Object.getOwnPropertyDescriptor(object, 'x');`");

--- a/test/language/object-literal/getter.js
+++ b/test/language/object-literal/getter.js
@@ -1,0 +1,29 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5
+description: >
+    super method calls in object literal getter
+---*/
+var proto = {
+  _x: 42,
+  get x() {
+    return 'proto' + this._x;
+  }
+};
+
+var object = {
+  get x() {
+    return super.x;
+  }
+};
+
+Object.setPrototypeOf(object, proto);
+
+assert.sameValue(object.x, 'proto42', "The value of `object.x` is `'proto42'`, after executing `Object.setPrototypeOf(object, proto);`");
+assert.sameValue(object._x, 42, "The value of `object._x` is `42`, after executing `Object.setPrototypeOf(object, proto);`");
+assert.sameValue(
+  Object.getPrototypeOf(object)._x,
+  42,
+  "The value of `Object.getPrototypeOf(object)._x` is `42`"
+);

--- a/test/language/object-literal/identifier-reference-property-get-access.js
+++ b/test/language/object-literal/identifier-reference-property-get-access.js
@@ -1,0 +1,9 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5
+description: >
+    Basic identifier reference property initialization
+---*/
+var p = "1";
+var o = {p};

--- a/test/language/object-literal/let-non-strict-access.js
+++ b/test/language/object-literal/let-non-strict-access.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5
+description: >
+    In non-strict mode, let is a valid Identifier.
+flags: [noStrict]
+---*/
+var let = 1;
+var object = {let};
+
+assert.sameValue(object.let, 1, "The value of `object.let` is `1`");

--- a/test/language/object-literal/let-non-strict-syntax.js
+++ b/test/language/object-literal/let-non-strict-syntax.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5
+description: >
+    In non-strict mode, let is a valid Identifier.
+flags: [noStrict]
+---*/
+var let = 1;
+var object = {let};

--- a/test/language/object-literal/method.js
+++ b/test/language/object-literal/method.js
@@ -1,0 +1,28 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5
+description: >
+    super method calls in object literal method
+---*/
+var proto = {
+  method(x) {
+    return 'proto' + x;
+  }
+};
+
+var object = {
+  method(x) {
+    return super.method(x);
+  }
+};
+
+Object.setPrototypeOf(object, proto);
+
+assert.sameValue(object.method(42), 'proto42', "`object.method(42)` returns `'proto42'`, after executing `Object.setPrototypeOf(object, proto);`");
+assert.sameValue(proto.method(42), 'proto42', "`proto.method(42)` returns `'proto42'`, after executing `Object.setPrototypeOf(object, proto);`");
+assert.sameValue(
+  Object.getPrototypeOf(object).method(42),
+  'proto42',
+  "`Object.getPrototypeOf(object).method(42)` returns `'proto42'`"
+);

--- a/test/language/object-literal/not-defined.js
+++ b/test/language/object-literal/not-defined.js
@@ -1,0 +1,9 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5
+description: >
+    Throws when IdentifierReference is undefined
+negative: ReferenceError
+---*/
+var o = {notDefined};

--- a/test/language/object-literal/properties-names-eval-arguments.js
+++ b/test/language/object-literal/properties-names-eval-arguments.js
@@ -1,0 +1,18 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5
+description: >
+    property names `eval` and `arguments`
+---*/
+var o = {
+  eval() {
+    return 1;
+  },
+  arguments() {
+    return 2;
+  },
+};
+
+assert.sameValue(o.eval(), 1, "`o.eval()` returns `1`");
+assert.sameValue(o.arguments(), 2, "`o.arguments()` returns `2`");

--- a/test/language/object-literal/setter.js
+++ b/test/language/object-literal/setter.js
@@ -1,0 +1,29 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5
+description: >
+    super method calls in object literal setters
+---*/
+var proto = {
+  _x: 0,
+  set x(v) {
+    return this._x = v;
+  }
+};
+
+var object = {
+  set x(v) {
+    super.x = v;
+  }
+};
+
+Object.setPrototypeOf(object, proto);
+
+assert.sameValue(object.x = 1, 1, "`object.x = 1` is `1`, after executing `Object.setPrototypeOf(object, proto);`");
+assert.sameValue(object._x, 1, "The value of `object._x` is `1`, after executing `Object.setPrototypeOf(object, proto);`");
+assert.sameValue(
+  Object.getPrototypeOf(object)._x,
+  0,
+  "The value of `Object.getPrototypeOf(object)._x` is `0`"
+);

--- a/test/language/object-literal/yield-non-strict-access.js
+++ b/test/language/object-literal/yield-non-strict-access.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5
+description: >
+    In non-strict mode, yield is a valid Identifier.
+flags: [noStrict]
+---*/
+var yield = 1;
+var object = {yield};
+
+assert.sameValue(object.yield, 1, "The value of `object.yield` is `1`");

--- a/test/language/object-literal/yield-non-strict-syntax.js
+++ b/test/language/object-literal/yield-non-strict-syntax.js
@@ -1,0 +1,10 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5
+description: >
+    In non-strict mode, yield is a valid Identifier.
+flags: [noStrict]
+---*/
+var yield = 1;
+var object = {yield};


### PR DESCRIPTION
These tests are derived from the following files within the Google V8 project:

        test/mjsunit/harmony/method-name-eval-arguments.js
        test/mjsunit/harmony/object-literals-method.js
        test/mjsunit/harmony/object-literals-property-shorthand.js
        test/mjsunit/harmony/object-literals-super.js