### PR TITLE
Import tests from Google V8 (generator syntax)

### DIFF
--- a/test/language/class/method-definition/generator-no-yield.js
+++ b/test/language/class/method-definition/generator-no-yield.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      Generators declared with GeneratorMethod syntax do not require a
+      `yield` expression.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var result;
+class A {
+  *foo(a) {}
+}
+
+result = A.prototype.foo(3).next();
+
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/class/method-definition/generator-return.js
+++ b/test/language/class/method-definition/generator-return.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `return` is a valid statement within generator function bodies.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var result;
+class A {
+  *g1() { return; }
+  *g2() { return 1; }
+}
+
+result = A.prototype.g1().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+result = A.prototype.g2().next();
+assert.sameValue(result.value, 1);
+assert.sameValue(result.done, true);

--- a/test/language/class/method-definition/yield-as-binding-identifier.js
+++ b/test/language/class/method-definition/yield-as-binding-identifier.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a reserved keyword within generator function bodies and may
+      not be used as a binding identifier.
+  features: [generators]
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+class A {
+  *g() {
+    yield = 1;
+  }
+}

--- a/test/language/class/method-definition/yield-as-expression-with-rhs.js
+++ b/test/language/class/method-definition/yield-as-expression-with-rhs.js
@@ -1,0 +1,118 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid expression within generator function bodies.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var iter, result;
+class A {
+  *g1() { (yield 1) }
+  *g2() { [yield 1] }
+  *g3() { {yield 1} }
+  *g4() { yield 1, yield 2; }
+  *g5() { (yield 1) ? yield 2 : yield 3; }
+}
+
+iter = A.prototype.g1();
+result = iter.next();
+assert.sameValue(result.value, 1, 'Within grouping operator: result `value`');
+assert.sameValue(
+  result.done, false, 'Within grouping operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following grouping operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following grouping operator: result `done` flag'
+);
+
+iter = A.prototype.g2();
+result = iter.next();
+assert.sameValue(result.value, 1, 'Within array literal: result `value`');
+assert.sameValue(
+  result.done, false, 'Within array literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following array literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following array literal: result `done` flag'
+);
+
+iter = A.prototype.g3();
+result = iter.next();
+assert.sameValue(result.value, 1, 'Within object literal: result `value`');
+assert.sameValue(
+  result.done, false, 'Within object literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following object literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following object literal: result `done` flag'
+);
+
+iter = A.prototype.g4();
+result = iter.next();
+assert.sameValue(
+  result.value, 1, 'First expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'First expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, 2, 'Second expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Second expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following comma expression: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following comma expression: result `done` flag'
+);
+
+iter = A.prototype.g5();
+result = iter.next();
+assert.sameValue(
+  result.value,
+  1,
+  'Conditional expression in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Conditional expression in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value,
+  3,
+  'Branch in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Branch in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following conditional operator: result `done` flag'
+);

--- a/test/language/class/method-definition/yield-as-expression-without-rhs.js
+++ b/test/language/class/method-definition/yield-as-expression-without-rhs.js
@@ -1,0 +1,128 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid expression within generator function bodies.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var iter, result;
+class A {
+  *g1() { (yield) }
+  *g2() { [yield] }
+  *g3() { {yield} }
+  *g4() { yield, yield; }
+  *g5() { (yield) ? yield : yield; }
+}
+
+iter = A.prototype.g1();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Within grouping operator: result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Within grouping operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following grouping operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following grouping operator: result `done` flag'
+);
+
+iter = A.prototype.g2();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Within array literal: result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Within array literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following array literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following array literal: result `done` flag'
+);
+
+iter = A.prototype.g3();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Within object literal: result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Within object literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following object literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following object literal: result `done` flag'
+);
+
+iter = A.prototype.g4();
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'First expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'First expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'Second expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Second expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following comma expression: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following comma expression: result `done` flag'
+);
+
+iter = A.prototype.g5();
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'Conditional expression in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Conditional expression in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'Branch in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Branch in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following conditional operator: result `done` flag'
+);

--- a/test/language/class/method-definition/yield-as-function-expression-binding-identifier.js
+++ b/test/language/class/method-definition/yield-as-function-expression-binding-identifier.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` may be used as the binding identifier of a function expression
+      within generator bodies.
+  features: [generators]
+  es6id: 14.1
+  flags: [noStrict]
+ ---*/
+
+var result;
+class A {
+  *g() {
+    (function yield() {});
+  }
+}
+
+result = A.prototype.g().next();
+
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/class/method-definition/yield-as-generator-method-binding-identifier.js
+++ b/test/language/class/method-definition/yield-as-generator-method-binding-identifier.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid BindingIdentifier for GeneratorMethods outside of
+      strict mode.
+  features: [generators]
+  es6id: 12.1.1
+  flags: [noStrict]
+ ---*/
+
+var iter, result;
+class A {
+  *yield() { (yield 3) + (yield 4); }
+}
+
+iter = A.prototype.yield();
+
+result = iter.next();
+assert.sameValue(result.value, 3, 'First result `value`');
+assert.sameValue(result.done, false, 'First result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, 4, 'Second result `value`');
+assert.sameValue(result.done, false, 'Second result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Third result `value`');
+assert.sameValue(result.done, true, 'Third result `done` flag');

--- a/test/language/class/method-definition/yield-as-identifier-in-nested-function.js
+++ b/test/language/class/method-definition/yield-as-identifier-in-nested-function.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is not a reserved keyword within normal function bodies declared
+      within generator function bodies.
+  features: [generators]
+  es6id: 12.1.1
+  flags: [noStrict]
+ ---*/
+
+var result;
+class A {
+  *g() {
+    function h() {
+      yield = 1;
+    }
+  }
+}
+
+result = A.prototype.g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/class/method-definition/yield-as-label.js
+++ b/test/language/class/method-definition/yield-as-label.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a reserved keyword within generator function bodies and may
+      not be used as a label.
+  features: [generators]
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+class A {
+  *g() {
+    yield: 1;
+  }
+}

--- a/test/language/class/method-definition/yield-as-literal-property-name.js
+++ b/test/language/class/method-definition/yield-as-literal-property-name.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` may be used as a literal property name in an object literal
+      within generator function bodies.
+  features: [generators]
+  es6id: 12.1.1
+ ---*/
+
+var result;
+class A {
+  *g() {
+    ({ get yield() { return 1 } });
+  }
+}
+
+result = A.prototype.g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/class/method-definition/yield-as-logical-or-expression.js
+++ b/test/language/class/method-definition/yield-as-logical-or-expression.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` expressions are not LogicalOrExpressions.
+  features: [generators]
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+class A {
+  *g() {
+    yield ? yield : yield;
+  }
+}

--- a/test/language/class/method-definition/yield-as-parameter.js
+++ b/test/language/class/method-definition/yield-as-parameter.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a reserved keyword within generator function bodies and may
+      not be used as the binding identifier of a parameter.
+  features: [generators]
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+class A {
+  *g(yield) {}
+}

--- a/test/language/class/method-definition/yield-as-property-name.js
+++ b/test/language/class/method-definition/yield-as-property-name.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` may be used as a literal property name in an object literal
+      within generator function bodies.
+  features: [generators]
+  es6id: 12.1.1
+ ---*/
+
+var result;
+class A {
+  *g() {
+    ({  yield: 1 });
+  }
+}
+
+result = A.prototype.g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/class/method-definition/yield-as-statement.js
+++ b/test/language/class/method-definition/yield-as-statement.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid statement within generator function bodies.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var iter, result;
+class A {
+  *g1() { yield; }
+  *g2() { yield 1; }
+}
+
+iter = A.prototype.g1();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Without right-hand-side: first result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Without right-hand-side: first result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Without right-hand-side: second result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Without right-hand-eside: second result `done` flag'
+);
+
+iter = A.prototype.g2();
+result = iter.next();
+assert.sameValue(
+  result.value, 1, 'With right-hand-side: first result `value`'
+);
+assert.sameValue(
+  result.done, false, 'With right-hand-side: first result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'With right-hand-side: second result `value`'
+);
+assert.sameValue(
+  result.done, true, 'With right-hand-eside: second result `done` flag'
+);

--- a/test/language/class/method-definition/yield-as-yield-operand.js
+++ b/test/language/class/method-definition/yield-as-yield-operand.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` expressions may be used as the right-hand-side of other `yield`
+      expressions.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var iter, result;
+class A {
+  *g() {
+    yield yield 1;
+  }
+}
+
+iter = A.prototype.g();
+
+result = iter.next();
+assert.sameValue(result.value, 1, 'First result `value`');
+assert.sameValue(result.done, false, 'First result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Second result `value`');
+assert.sameValue(result.done, false, 'Second result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Third result `value`');
+assert.sameValue(result.done, true, 'Thid result `done` flag');

--- a/test/language/class/method-definition/yield-newline.js
+++ b/test/language/class/method-definition/yield-newline.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      Newlines terminate `yield` expressions.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var iter, result;
+class A {
+  *g() {
+    yield
+    1
+  }
+}
+
+iter = A.prototype.g();
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'First result `value`');
+assert.sameValue(result.done, false, 'First result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Second result `value`');
+assert.sameValue(result.done, true, 'Second result `done` flag');

--- a/test/language/class/method-definition/yield-star-after-newline.js
+++ b/test/language/class/method-definition/yield-star-after-newline.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      A newline may not precede the `*` token in a `yield` expression.
+  features: [generators]
+  es6id: 14.4
+  negative: SyntaxError
+ ---*/
+
+class A {
+  *g() {
+    yield
+    * 1
+  }
+}

--- a/test/language/class/method-definition/yield-star-before-newline.js
+++ b/test/language/class/method-definition/yield-star-before-newline.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      The right-hand side of a `yield *` expression may appear on a new line.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var result;
+class A {
+  *g() {
+    yield *
+    g2()
+  }
+}
+var g2 = function*() {};
+
+result = A.prototype.g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/class/method-definition/yield-weak-binding.js
+++ b/test/language/class/method-definition/yield-weak-binding.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` expressions bind weakly
+  features: [generators]
+  es6id: 14.4
+  negative: SyntaxError
+ ---*/
+
+class A {
+  *g() { yield 3 + yield 4; }
+}

--- a/test/language/expressions/generators/no-yield.js
+++ b/test/language/expressions/generators/no-yield.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      Generators declared with GeneratorExpression syntax do not require a
+      `yield` expression.
+  es6id: 14.4
+ ---*/
+
+var result;
+var foo = function*(a) {};
+
+result = foo(3).next();
+
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/expressions/generators/return.js
+++ b/test/language/expressions/generators/return.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `return` is a valid statement within generator function bodies.
+  es6id: 14.4
+ ---*/
+
+var result;
+var g1 = function*() { return; };
+var g2 = function*() { return 1; };
+
+result = g1().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+result = g2().next();
+assert.sameValue(result.value, 1);
+assert.sameValue(result.done, true);

--- a/test/language/expressions/generators/yield-as-binding-identifier.js
+++ b/test/language/expressions/generators/yield-as-binding-identifier.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a reserved keyword within generator function bodies and may
+      not be used as a binding identifier.
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+var g = function*() {
+  yield = 1;
+};

--- a/test/language/expressions/generators/yield-as-expression-with-rhs.js
+++ b/test/language/expressions/generators/yield-as-expression-with-rhs.js
@@ -1,0 +1,115 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid expression within generator function bodies.
+  es6id: 14.4
+ ---*/
+
+var result, iter;
+var g1 = function*() { (yield 1) };
+var g2 = function*() { [yield 1] };
+var g3 = function*() { {yield 1} };
+var g4 = function*() { yield 1, yield 2; };
+var g5 = function*() { (yield 1) ? yield 2 : yield 3; };
+
+iter = g1();
+result = iter.next();
+assert.sameValue(result.value, 1, 'Within grouping operator: result `value`');
+assert.sameValue(
+  result.done, false, 'Within grouping operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following grouping operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following grouping operator: result `done` flag'
+);
+
+iter = g2();
+result = iter.next();
+assert.sameValue(result.value, 1, 'Within array literal: result `value`');
+assert.sameValue(
+  result.done, false, 'Within array literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following array literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following array literal: result `done` flag'
+);
+
+iter = g3();
+result = iter.next();
+assert.sameValue(result.value, 1, 'Within object literal: result `value`');
+assert.sameValue(
+  result.done, false, 'Within object literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following object literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following object literal: result `done` flag'
+);
+
+iter = g4();
+result = iter.next();
+assert.sameValue(
+  result.value, 1, 'First expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'First expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, 2, 'Second expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Second expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following comma expression: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following comma expression: result `done` flag'
+);
+
+iter = g5();
+result = iter.next();
+assert.sameValue(
+  result.value,
+  1,
+  'Conditional expression in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Conditional expression in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value,
+  3,
+  'Branch in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Branch in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following conditional operator: result `done` flag'
+);

--- a/test/language/expressions/generators/yield-as-expression-without-rhs.js
+++ b/test/language/expressions/generators/yield-as-expression-without-rhs.js
@@ -1,0 +1,125 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid expression within generator function bodies.
+  es6id: 14.4
+ ---*/
+
+var iter, result;
+var g1 = function*() { (yield) };
+var g2 = function*() { [yield] };
+var g3 = function*() { {yield} };
+var g4 = function*() { yield, yield; };
+var g5 = function*() { (yield) ? yield : yield; };
+
+iter = g1();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Within grouping operator: result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Within grouping operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following grouping operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following grouping operator: result `done` flag'
+);
+
+iter = g2();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Within array literal: result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Within array literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following array literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following array literal: result `done` flag'
+);
+
+iter = g3();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Within object literal: result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Within object literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following object literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following object literal: result `done` flag'
+);
+
+iter = g4();
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'First expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'First expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'Second expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Second expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following comma expression: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following comma expression: result `done` flag'
+);
+
+iter = g5();
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'Conditional expression in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Conditional expression in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'Branch in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Branch in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following conditional operator: result `done` flag'
+);

--- a/test/language/expressions/generators/yield-as-function-expression-binding-identifier.js
+++ b/test/language/expressions/generators/yield-as-function-expression-binding-identifier.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` may be used as the binding identifier of a function expression
+      within generator bodies.
+  es6id: 14.1
+  flags: [noStrict]
+ ---*/
+
+var result;
+var g = function*() {
+  (function yield() {});
+};
+
+result = g().next();
+
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/expressions/generators/yield-as-generator-expression-binding-identifier.js
+++ b/test/language/expressions/generators/yield-as-generator-expression-binding-identifier.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is not a valid BindingIdentifier for GeneratorExpressions.
+  es6id: 12.1.1
+  flags: [noStrict]
+  negative: SyntaxError
+ ---*/
+
+var g = function* yield() {};

--- a/test/language/expressions/generators/yield-as-identifier-in-nested-function.js
+++ b/test/language/expressions/generators/yield-as-identifier-in-nested-function.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is not a reserved keyword within normal function bodies declared
+      within generator function bodies.
+  es6id: 12.1.1
+  flags: [noStrict]
+ ---*/
+
+var result;
+var g = function*() {
+  function h() {
+    yield = 1;
+  }
+};
+
+result = g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/expressions/generators/yield-as-label.js
+++ b/test/language/expressions/generators/yield-as-label.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a reserved keyword within generator function bodies and may
+      not be used as a label.
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+var g = function*() {
+  yield: 1;
+};

--- a/test/language/expressions/generators/yield-as-literal-property-name.js
+++ b/test/language/expressions/generators/yield-as-literal-property-name.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` may be used as a literal property name in an object literal
+      within generator function bodies.
+  es6id: 12.1.1
+ ---*/
+
+var result;
+var g = function*() {
+  ({ get yield() { return 1 } });
+};
+
+result = g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/expressions/generators/yield-as-logical-or-expression.js
+++ b/test/language/expressions/generators/yield-as-logical-or-expression.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` expressions are not LogicalOrExpressions.
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+
+var g = function*() {
+  yield ? yield : yield;
+};

--- a/test/language/expressions/generators/yield-as-parameter.js
+++ b/test/language/expressions/generators/yield-as-parameter.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a reserved keyword within generator function bodies and may
+      not be used as the binding identifier of a parameter.
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+var g = function*(yield) {};

--- a/test/language/expressions/generators/yield-as-property-name.js
+++ b/test/language/expressions/generators/yield-as-property-name.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` may be used as a literal property name in an object literal
+      within generator function bodies.
+  es6id: 12.1.1
+ ---*/
+
+var result;
+var g = function*() {
+  ({  yield: 1 });
+};
+
+result = g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/expressions/generators/yield-as-statement.js
+++ b/test/language/expressions/generators/yield-as-statement.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid statement within generator function bodies.
+  es6id: 14.4
+ ---*/
+
+var iter, result;
+var g1 = function*() { yield; };
+var g2 = function*() { yield 1; };
+
+iter = g1();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Without right-hand-side: first result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Without right-hand-side: first result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Without right-hand-side: second result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Without right-hand-eside: second result `done` flag'
+);
+
+iter = g2();
+result = iter.next();
+assert.sameValue(
+  result.value, 1, 'With right-hand-side: first result `value`'
+);
+assert.sameValue(
+  result.done, false, 'With right-hand-side: first result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'With right-hand-side: second result `value`'
+);
+assert.sameValue(
+  result.done, true, 'With right-hand-eside: second result `done` flag'
+);

--- a/test/language/expressions/generators/yield-as-yield-operand.js
+++ b/test/language/expressions/generators/yield-as-yield-operand.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` expressions may be used as the right-hand-side of other `yield`
+      expressions.
+  es6id: 14.4
+ ---*/
+
+var iter, result;
+var g = function*() {
+  yield yield 1;
+};
+
+iter = g();
+
+result = iter.next();
+assert.sameValue(result.value, 1, 'First result `value`');
+assert.sameValue(result.done, false, 'First result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Second result `value`');
+assert.sameValue(result.done, false, 'Second result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Third result `value`');
+assert.sameValue(result.done, true, 'Thid result `done` flag');

--- a/test/language/expressions/generators/yield-newline.js
+++ b/test/language/expressions/generators/yield-newline.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      Newlines terminate `yield` expressions.
+  es6id: 14.4
+ ---*/
+
+var iter, result;
+var g = function*() {
+  yield
+  1
+};
+
+iter = g();
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'First result `value`');
+assert.sameValue(result.done, false, 'First result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Second result `value`');
+assert.sameValue(result.done, true, 'Second result `done` flag');

--- a/test/language/expressions/generators/yield-star-after-newline.js
+++ b/test/language/expressions/generators/yield-star-after-newline.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      A newline may not precede the `*` token in a `yield` expression.
+  es6id: 14.4
+  negative: SyntaxError
+ ---*/
+
+var g = function*() {
+  yield
+  * 1
+};

--- a/test/language/expressions/generators/yield-star-before-newline.js
+++ b/test/language/expressions/generators/yield-star-before-newline.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      The right-hand side of a `yield *` expression may appear on a new line.
+  es6id: 14.4
+ ---*/
+
+var result;
+var g = function*() {
+  yield *
+  g2();
+};
+var g2 = function*() {};
+
+result = g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/expressions/generators/yield-weak-binding.js
+++ b/test/language/expressions/generators/yield-weak-binding.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` expressions bind weakly
+  es6id: 14.4
+  negative: SyntaxError
+ ---*/
+
+var g = function*() { yield 3 + yield 4; };

--- a/test/language/expressions/object/method-definition/generator-no-yield.js
+++ b/test/language/expressions/object/method-definition/generator-no-yield.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      Generators declared with GeneratorMethod syntax do not require a
+      `yield` expression.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var result;
+var obj = {
+  *foo(a) {}
+};
+
+result = obj.foo(3).next();
+
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/expressions/object/method-definition/generator-return.js
+++ b/test/language/expressions/object/method-definition/generator-return.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `return` is a valid statement within generator function bodies.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var result;
+var obj = {
+  *g1() { return; },
+  *g2() { return 1; }
+};
+
+result = obj.g1().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+result = obj.g2().next();
+assert.sameValue(result.value, 1);
+assert.sameValue(result.done, true);

--- a/test/language/expressions/object/method-definition/yield-as-binding-identifier.js
+++ b/test/language/expressions/object/method-definition/yield-as-binding-identifier.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a reserved keyword within generator function bodies and may
+      not be used as a binding identifier.
+  features: [generators]
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+var obj = {
+  *g() {
+    yield = 1;
+  }
+};

--- a/test/language/expressions/object/method-definition/yield-as-expression-with-rhs.js
+++ b/test/language/expressions/object/method-definition/yield-as-expression-with-rhs.js
@@ -1,0 +1,118 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid expression within generator function bodies.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var iter, result;
+var obj = {
+  *g1() { (yield 1) },
+  *g2() { [yield 1] },
+  *g3() { {yield 1} },
+  *g4() { yield 1, yield 2; },
+  *g5() { (yield 1) ? yield 2 : yield 3; }
+};
+
+iter = obj.g1();
+result = iter.next();
+assert.sameValue(result.value, 1, 'Within grouping operator: result `value`');
+assert.sameValue(
+  result.done, false, 'Within grouping operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following grouping operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following grouping operator: result `done` flag'
+);
+
+iter = obj.g2();
+result = iter.next();
+assert.sameValue(result.value, 1, 'Within array literal: result `value`');
+assert.sameValue(
+  result.done, false, 'Within array literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following array literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following array literal: result `done` flag'
+);
+
+iter = obj.g3();
+result = iter.next();
+assert.sameValue(result.value, 1, 'Within object literal: result `value`');
+assert.sameValue(
+  result.done, false, 'Within object literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following object literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following object literal: result `done` flag'
+);
+
+iter = obj.g4();
+result = iter.next();
+assert.sameValue(
+  result.value, 1, 'First expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'First expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, 2, 'Second expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Second expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following comma expression: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following comma expression: result `done` flag'
+);
+
+iter = obj.g5();
+result = iter.next();
+assert.sameValue(
+  result.value,
+  1,
+  'Conditional expression in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Conditional expression in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value,
+  3,
+  'Branch in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Branch in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following conditional operator: result `done` flag'
+);

--- a/test/language/expressions/object/method-definition/yield-as-expression-without-rhs.js
+++ b/test/language/expressions/object/method-definition/yield-as-expression-without-rhs.js
@@ -1,0 +1,128 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid expression within generator function bodies.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var iter, result;
+var obj = {
+  *g1() { (yield) },
+  *g2() { [yield] },
+  *g3() { {yield} },
+  *g4() { yield, yield; },
+  *g5() { (yield) ? yield : yield; }
+};
+
+iter = obj.g1();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Within grouping operator: result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Within grouping operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following grouping operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following grouping operator: result `done` flag'
+);
+
+iter = obj.g2();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Within array literal: result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Within array literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following array literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following array literal: result `done` flag'
+);
+
+iter = obj.g3();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Within object literal: result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Within object literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following object literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following object literal: result `done` flag'
+);
+
+iter = obj.g4();
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'First expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'First expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'Second expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Second expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following comma expression: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following comma expression: result `done` flag'
+);
+
+iter = obj.g5();
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'Conditional expression in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Conditional expression in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'Branch in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Branch in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following conditional operator: result `done` flag'
+);

--- a/test/language/expressions/object/method-definition/yield-as-function-expression-binding-identifier.js
+++ b/test/language/expressions/object/method-definition/yield-as-function-expression-binding-identifier.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` may be used as the binding identifier of a function expression
+      within generator bodies.
+  features: [generators]
+  es6id: 14.1
+  flags: [noStrict]
+ ---*/
+
+var result;
+var obj = {
+  *g() {
+    (function yield() {});
+  }
+};
+
+result = A.prototype.g().next();
+
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/expressions/object/method-definition/yield-as-generator-method-binding-identifier.js
+++ b/test/language/expressions/object/method-definition/yield-as-generator-method-binding-identifier.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid BindingIdentifier for GeneratorMethods outside of
+      strict mode.
+  features: [generators]
+  es6id: 12.1.1
+  flags: [noStrict]
+ ---*/
+
+var iter, result;
+var obj = {
+  *yield() { (yield 3) + (yield 4); }
+}
+
+iter = obj.yield();
+
+result = iter.next();
+assert.sameValue(result.value, 3, 'First result `value`');
+assert.sameValue(result.done, false, 'First result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, 4, 'Second result `value`');
+assert.sameValue(result.done, false, 'Second result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Third result `value`');
+assert.sameValue(result.done, true, 'Third result `done` flag');;

--- a/test/language/expressions/object/method-definition/yield-as-identifier-in-nested-function.js
+++ b/test/language/expressions/object/method-definition/yield-as-identifier-in-nested-function.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is not a reserved keyword within normal function bodies declared
+      within generator function bodies.
+  features: [generators]
+  es6id: 12.1.1
+  flags: [noStrict]
+ ---*/
+
+var result;
+var obj = {
+  *g() {
+    function h() {
+      yield = 1;
+    }
+  }
+};
+
+result = obj.g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/expressions/object/method-definition/yield-as-label.js
+++ b/test/language/expressions/object/method-definition/yield-as-label.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a reserved keyword within generator function bodies and may
+      not be used as a label.
+  features: [generators]
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+var obj = {
+  *g() {
+    yield: 1;
+  }
+};

--- a/test/language/expressions/object/method-definition/yield-as-literal-property-name.js
+++ b/test/language/expressions/object/method-definition/yield-as-literal-property-name.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` may be used as a literal property name in an object literal
+      within generator function bodies.
+  features: [generators]
+  es6id: 12.1.1
+ ---*/
+
+var result;
+var obj = {
+  *g() {
+    ({ get yield() { return 1 } });
+  }
+};
+
+result = obj.g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/expressions/object/method-definition/yield-as-logical-or-expression.js
+++ b/test/language/expressions/object/method-definition/yield-as-logical-or-expression.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` expressions are not LogicalOrExpressions.
+  features: [generators]
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+var obj = {
+  *g() {
+    yield ? yield : yield;
+  }
+};

--- a/test/language/expressions/object/method-definition/yield-as-parameter.js
+++ b/test/language/expressions/object/method-definition/yield-as-parameter.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a reserved keyword within generator function bodies and may
+      not be used as the binding identifier of a parameter.
+  features: [generators]
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+var obj = {
+  *g(yield) {}
+};

--- a/test/language/expressions/object/method-definition/yield-as-property-name.js
+++ b/test/language/expressions/object/method-definition/yield-as-property-name.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` may be used as a literal property name in an object literal
+      within generator function bodies.
+  features: [generators]
+  es6id: 12.1.1
+ ---*/
+
+var result;
+var obj = {
+  *g() {
+    ({  yield: 1 });
+  }
+};
+
+result = obj.g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/expressions/object/method-definition/yield-as-statement.js
+++ b/test/language/expressions/object/method-definition/yield-as-statement.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid statement within generator function bodies.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var iter, result;
+var obj = {
+  *g1() { yield; },
+  *g2() { yield 1; }
+};
+
+iter = obj.g1();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Without right-hand-side: first result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Without right-hand-side: first result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Without right-hand-side: second result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Without right-hand-eside: second result `done` flag'
+);
+
+iter = obj.g2();
+result = iter.next();
+assert.sameValue(
+  result.value, 1, 'With right-hand-side: first result `value`'
+);
+assert.sameValue(
+  result.done, false, 'With right-hand-side: first result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'With right-hand-side: second result `value`'
+);
+assert.sameValue(
+  result.done, true, 'With right-hand-eside: second result `done` flag'
+);

--- a/test/language/expressions/object/method-definition/yield-as-yield-operand.js
+++ b/test/language/expressions/object/method-definition/yield-as-yield-operand.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` expressions may be used as the right-hand-side of other `yield`
+      expressions.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var iter, result;
+var obj = {
+  *g() {
+    yield yield 1;
+  }
+};
+
+iter = obj.g();
+
+result = iter.next();
+assert.sameValue(result.value, 1, 'First result `value`');
+assert.sameValue(result.done, false, 'First result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Second result `value`');
+assert.sameValue(result.done, false, 'Second result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Third result `value`');
+assert.sameValue(result.done, true, 'Thid result `done` flag');

--- a/test/language/expressions/object/method-definition/yield-newline.js
+++ b/test/language/expressions/object/method-definition/yield-newline.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      Newlines terminate `yield` expressions.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var iter, result;
+var obj = {
+  *g() {
+    yield
+    1
+  }
+};
+
+iter = obj.g();
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'First result `value`');
+assert.sameValue(result.done, false, 'First result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Second result `value`');
+assert.sameValue(result.done, true, 'Second result `done` flag');

--- a/test/language/expressions/object/method-definition/yield-star-after-newline.js
+++ b/test/language/expressions/object/method-definition/yield-star-after-newline.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      A newline may not precede the `*` token in a `yield` expression.
+  features: [generators]
+  es6id: 14.4
+  negative: SyntaxError
+ ---*/
+
+var obj = {
+  *g() {
+    yield
+    * 1
+  }
+};

--- a/test/language/expressions/object/method-definition/yield-star-before-newline.js
+++ b/test/language/expressions/object/method-definition/yield-star-before-newline.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      The right-hand side of a `yield *` expression may appear on a new line.
+  features: [generators]
+  es6id: 14.4
+ ---*/
+
+var result;
+var obj = {
+  *g() {
+    yield *
+    g2()
+  }
+};
+var g2 = function*() {};
+
+result = obj.g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/expressions/object/method-definition/yield-weak-binding.js
+++ b/test/language/expressions/object/method-definition/yield-weak-binding.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` expressions bind weakly
+  features: [generators]
+  es6id: 14.4
+  negative: SyntaxError
+ ---*/
+
+var obj = {
+  *g() { yield 3 + yield 4; }
+};

--- a/test/language/identifiers/yield-as-binding-identifier-in-strict.js
+++ b/test/language/identifiers/yield-as-binding-identifier-in-strict.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a reserved identifier in strict mode code and may not be used
+      as an identifier.
+  es6id: 12.1.1
+  negative: SyntaxError
+  flags: [onlyStrict]
+ ---*/
+
+var yield = 13;

--- a/test/language/identifiers/yield-as-key.js
+++ b/test/language/identifiers/yield-as-key.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` may be used as a literal property name in an object literal.
+  es6id: 12.1.1
+ ---*/
+
+({ yield: 1 });

--- a/test/language/identifiers/yield-as-label-in-sloppy.js
+++ b/test/language/identifiers/yield-as-label-in-sloppy.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is not a reserved identifier in non-strict mode code and may be
+      used as a label.
+  es6id: 12.1.1
+  flags: [noStrict]
+ ---*/
+
+yield: 1;

--- a/test/language/identifiers/yield-as-label-in-strict.js
+++ b/test/language/identifiers/yield-as-label-in-strict.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a reserved identifier in strict mode code and may not be used
+      as a label.
+  es6id: 12.1.1
+  negative: SyntaxError
+  flags: [onlyStrict]
+ ---*/
+
+yield: 1;

--- a/test/language/statements/generators/no-yield.js
+++ b/test/language/statements/generators/no-yield.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      Generators declared with GeneratorDeclaration syntax do not require a
+      `yield` expression.
+  es6id: 14.4
+ ---*/
+
+function *foo(a) {}
+
+var g = foo(3);
+
+assert.sameValue(g.next().value, undefined);
+assert.sameValue(g.next().done, true);

--- a/test/language/statements/generators/return.js
+++ b/test/language/statements/generators/return.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `return` is a valid statement within generator function bodies.
+  es6id: 14.4
+ ---*/
+
+function* g() { return; }
+function* g() { return 1; }

--- a/test/language/statements/generators/return.js
+++ b/test/language/statements/generators/return.js
@@ -7,5 +7,13 @@
   es6id: 14.4
  ---*/
 
-function* g() { return; }
-function* g() { return 1; }
+function* g1() { return; }
+function* g2() { return 1; }
+
+var result = g1().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);
+
+result = g2().next();
+assert.sameValue(result.value, 1);
+assert.sameValue(result.done, true);

--- a/test/language/statements/generators/yield-as-binding-identifier.js
+++ b/test/language/statements/generators/yield-as-binding-identifier.js
@@ -9,6 +9,11 @@
   negative: SyntaxError
  ---*/
 
+var result;
 function* g() {
   yield = 1;
 }
+
+result = g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/statements/generators/yield-as-binding-identifier.js
+++ b/test/language/statements/generators/yield-as-binding-identifier.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a reserved keyword within generator function bodies and may
+      not be used as a binding identifier.
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+function* g() {
+  yield = 1;
+}

--- a/test/language/statements/generators/yield-as-expression-with-rhs.js
+++ b/test/language/statements/generators/yield-as-expression-with-rhs.js
@@ -7,8 +7,109 @@
   es6id: 14.4
  ---*/
 
-function* g() { (yield 1) }
-function* g() { [yield 1] }
-function* g() { {yield 1} }
-function* g() { yield 1, yield 1; }
-function* g() { (yield 1) ? yield 1 : yield 1 }
+var result, iter;
+function* g1() { (yield 1) }
+function* g2() { [yield 1] }
+function* g3() { {yield 1} }
+function* g4() { yield 1, yield 2; }
+function* g5() { (yield 1) ? yield 2 : yield 3; }
+
+iter = g1();
+result = iter.next();
+assert.sameValue(result.value, 1, 'Within grouping operator: result `value`');
+assert.sameValue(
+  result.done, false, 'Within grouping operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following grouping operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following grouping operator: result `done` flag'
+);
+
+iter = g2();
+result = iter.next();
+assert.sameValue(result.value, 1, 'Within array literal: result `value`');
+assert.sameValue(
+  result.done, false, 'Within array literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following array literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following array literal: result `done` flag'
+);
+
+iter = g3();
+result = iter.next();
+assert.sameValue(result.value, 1, 'Within object literal: result `value`');
+assert.sameValue(
+  result.done, false, 'Within object literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following object literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following object literal: result `done` flag'
+);
+
+iter = g4();
+result = iter.next();
+assert.sameValue(
+  result.value, 1, 'First expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'First expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, 2, 'Second expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Second expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following comma expression: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following comma expression: result `done` flag'
+);
+
+iter = g5();
+result = iter.next();
+assert.sameValue(
+  result.value,
+  1,
+  'Conditional expression in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Conditional expression in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value,
+  3,
+  'Branch in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Branch in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following conditional operator: result `done` flag'
+);

--- a/test/language/statements/generators/yield-as-expression-with-rhs.js
+++ b/test/language/statements/generators/yield-as-expression-with-rhs.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid expression within generator function bodies.
+  es6id: 14.4
+ ---*/
+
+function* g() { (yield 1) }
+function* g() { [yield 1] }
+function* g() { {yield 1} }
+function* g() { yield 1, yield 1; }
+function* g() { (yield 1) ? yield 1 : yield 1 }

--- a/test/language/statements/generators/yield-as-expression-without-rhs.js
+++ b/test/language/statements/generators/yield-as-expression-without-rhs.js
@@ -7,8 +7,119 @@
   es6id: 14.4
  ---*/
 
-function* g() { (yield) }
-function* g() { [yield] }
-function* g() { {yield} }
-function* g() { yield, yield; }
-function* g() { (yield) ? yield : yield }
+var iter, result;
+function* g1() { (yield) }
+function* g2() { [yield] }
+function* g3() { {yield} }
+function* g4() { yield, yield; }
+function* g5() { (yield) ? yield : yield; }
+
+iter = g1();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Within grouping operator: result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Within grouping operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following grouping operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following grouping operator: result `done` flag'
+);
+
+iter = g2();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Within array literal: result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Within array literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following array literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following array literal: result `done` flag'
+);
+
+iter = g3();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Within object literal: result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Within object literal: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following object literal: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following object literal: result `done` flag'
+);
+
+iter = g4();
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'First expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'First expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'Second expression in comma expression: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Second expression in comma expression: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following comma expression: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following comma expression: result `done` flag'
+);
+
+iter = g5();
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'Conditional expression in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Conditional expression in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value,
+  undefined,
+  'Branch in conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done,
+  false,
+  'Branch in conditional operator: result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Following conditional operator: result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Following conditional operator: result `done` flag'
+);

--- a/test/language/statements/generators/yield-as-expression-without-rhs.js
+++ b/test/language/statements/generators/yield-as-expression-without-rhs.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid expression within generator function bodies.
+  es6id: 14.4
+ ---*/
+
+function* g() { (yield) }
+function* g() { [yield] }
+function* g() { {yield} }
+function* g() { yield, yield; }
+function* g() { (yield) ? yield : yield }

--- a/test/language/statements/generators/yield-as-function-expression-binding-identifier.js
+++ b/test/language/statements/generators/yield-as-function-expression-binding-identifier.js
@@ -9,6 +9,12 @@
   flags: [noStrict]
  ---*/
 
+var result;
 function* g() {
   (function yield() {})
 }
+
+result = g().next();
+
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/statements/generators/yield-as-function-expression-binding-identifier.js
+++ b/test/language/statements/generators/yield-as-function-expression-binding-identifier.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` may be used as the binding identifier of a function expression
+      within generator bodies.
+  es6id: 14.1
+  flags: [noStrict]
+ ---*/
+
+function* g() {
+  (function yield() {})
+}

--- a/test/language/statements/generators/yield-as-generator-declaration-binding-identifier.js
+++ b/test/language/statements/generators/yield-as-generator-declaration-binding-identifier.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid BindingIdentifier for GeneratorDeclarations outside of
+      strict mode.
+  es6id: 12.1.1
+  flags: [noStrict]
+ ---*/
+
+function* yield() { (yield 3) + (yield 4); }

--- a/test/language/statements/generators/yield-as-generator-declaration-binding-identifier.js
+++ b/test/language/statements/generators/yield-as-generator-declaration-binding-identifier.js
@@ -9,4 +9,19 @@
   flags: [noStrict]
  ---*/
 
+var iter, result;
 function* yield() { (yield 3) + (yield 4); }
+
+iter = yield();
+
+result = iter.next();
+assert.sameValue(result.value, 3, 'First result `value`');
+assert.sameValue(result.done, false, 'First result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, 4, 'Second result `value`');
+assert.sameValue(result.done, false, 'Second result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Third result `value`');
+assert.sameValue(result.done, true, 'Third result `done` flag');

--- a/test/language/statements/generators/yield-as-identifier-in-nested-function.js
+++ b/test/language/statements/generators/yield-as-identifier-in-nested-function.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is not a reserved keyword within normal function bodies declared
+      within generator function bodies.
+  es6id: 12.1.1
+  flags: [noStrict]
+ ---*/
+
+function* g() {
+  function h() {
+    yield = 1;
+  }
+}

--- a/test/language/statements/generators/yield-as-identifier-in-nested-function.js
+++ b/test/language/statements/generators/yield-as-identifier-in-nested-function.js
@@ -9,8 +9,13 @@
   flags: [noStrict]
  ---*/
 
+var result;
 function* g() {
   function h() {
     yield = 1;
   }
 }
+
+result = g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/statements/generators/yield-as-label.js
+++ b/test/language/statements/generators/yield-as-label.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a reserved keyword within generator function bodies and may
+      not be used as a label.
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+function* g() {
+  yield: 1;
+}

--- a/test/language/statements/generators/yield-as-literal-property-name.js
+++ b/test/language/statements/generators/yield-as-literal-property-name.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` may be used as a literal property name in an object literal
+      within generator function bodies.
+  es6id: 12.1.1
+ ---*/
+
+function* g() {
+  ({ get yield() { return 1 } });
+}

--- a/test/language/statements/generators/yield-as-literal-property-name.js
+++ b/test/language/statements/generators/yield-as-literal-property-name.js
@@ -8,6 +8,11 @@
   es6id: 12.1.1
  ---*/
 
+var result;
 function* g() {
   ({ get yield() { return 1 } });
 }
+
+result = g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/statements/generators/yield-as-logical-or-expression.js
+++ b/test/language/statements/generators/yield-as-logical-or-expression.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` expressions are not LogicalOrExpressions.
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+
+function* g() {
+  yield ? yield : yield
+}

--- a/test/language/statements/generators/yield-as-parameter.js
+++ b/test/language/statements/generators/yield-as-parameter.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a reserved keyword within generator function bodies and may
+      not be used as the binding identifier of a parameter.
+  es6id: 12.1.1
+  negative: SyntaxError
+ ---*/
+
+function* g(yield) {}

--- a/test/language/statements/generators/yield-as-property-name.js
+++ b/test/language/statements/generators/yield-as-property-name.js
@@ -8,6 +8,11 @@
   es6id: 12.1.1
  ---*/
 
+var result;
 function* g() {
   ({  yield: 1 });
 }
+
+result = g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/statements/generators/yield-as-property-name.js
+++ b/test/language/statements/generators/yield-as-property-name.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` may be used as a literal property name in an object literal
+      within generator function bodies.
+  es6id: 12.1.1
+ ---*/
+
+function* g() {
+  ({  yield: 1 });
+}

--- a/test/language/statements/generators/yield-as-statement.js
+++ b/test/language/statements/generators/yield-as-statement.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` is a valid statement within generator function bodies.
+  es6id: 14.4
+ ---*/
+
+function* g() { yield; }
+function* g() { yield 1; }

--- a/test/language/statements/generators/yield-as-statement.js
+++ b/test/language/statements/generators/yield-as-statement.js
@@ -7,5 +7,38 @@
   es6id: 14.4
  ---*/
 
-function* g() { yield; }
-function* g() { yield 1; }
+var iter, result;
+function* g1() { yield; }
+function* g2() { yield 1; }
+
+iter = g1();
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Without right-hand-side: first result `value`'
+);
+assert.sameValue(
+  result.done, false, 'Without right-hand-side: first result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'Without right-hand-side: second result `value`'
+);
+assert.sameValue(
+  result.done, true, 'Without right-hand-eside: second result `done` flag'
+);
+
+iter = g2();
+result = iter.next();
+assert.sameValue(
+  result.value, 1, 'With right-hand-side: first result `value`'
+);
+assert.sameValue(
+  result.done, false, 'With right-hand-side: first result `done` flag'
+);
+result = iter.next();
+assert.sameValue(
+  result.value, undefined, 'With right-hand-side: second result `value`'
+);
+assert.sameValue(
+  result.done, true, 'With right-hand-eside: second result `done` flag'
+);

--- a/test/language/statements/generators/yield-as-yield-operand.js
+++ b/test/language/statements/generators/yield-as-yield-operand.js
@@ -8,6 +8,21 @@
   es6id: 14.4
  ---*/
 
+var iter, result;
 function* g() {
   yield yield 1;
 }
+
+iter = g();
+
+result = iter.next();
+assert.sameValue(result.value, 1, 'First result `value`');
+assert.sameValue(result.done, false, 'First result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Second result `value`');
+assert.sameValue(result.done, false, 'Second result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Third result `value`');
+assert.sameValue(result.done, true, 'Thid result `done` flag');

--- a/test/language/statements/generators/yield-as-yield-operand.js
+++ b/test/language/statements/generators/yield-as-yield-operand.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` expressions may be used as the right-hand-side of other `yield`
+      expressions.
+  es6id: 14.4
+ ---*/
+
+function* g() {
+  yield yield 1;
+}

--- a/test/language/statements/generators/yield-newline.js
+++ b/test/language/statements/generators/yield-newline.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      Newlines terminate `yield` expressions.
+  es6id: 14.4
+ ---*/
+
+function* g() {
+  yield
+  1
+}
+
+assert.sameValue(g().next().value, undefined);

--- a/test/language/statements/generators/yield-newline.js
+++ b/test/language/statements/generators/yield-newline.js
@@ -7,9 +7,18 @@
   es6id: 14.4
  ---*/
 
+var iter, result;
 function* g() {
   yield
   1
 }
 
-assert.sameValue(g().next().value, undefined);
+iter = g();
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'First result `value`');
+assert.sameValue(result.done, false, 'First result `done` flag');
+
+result = iter.next();
+assert.sameValue(result.value, undefined, 'Second result `value`');
+assert.sameValue(result.done, true, 'Second result `done` flag');

--- a/test/language/statements/generators/yield-star-after-newline.js
+++ b/test/language/statements/generators/yield-star-after-newline.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      A newline may not precede the `*` token in a `yield` expression.
+  es6id: 14.4
+  negative: SyntaxError
+ ---*/
+
+function* g() {
+  yield
+  * 1
+}

--- a/test/language/statements/generators/yield-star-before-newline.js
+++ b/test/language/statements/generators/yield-star-before-newline.js
@@ -7,7 +7,13 @@
   es6id: 14.4
  ---*/
 
+var result;
 function* g() {
   yield *
-  1
+  g2();
 }
+function* g2() {}
+
+result = g().next();
+assert.sameValue(result.value, undefined);
+assert.sameValue(result.done, true);

--- a/test/language/statements/generators/yield-star-before-newline.js
+++ b/test/language/statements/generators/yield-star-before-newline.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      The right-hand side of a `yield *` expression may appear on a new line.
+  es6id: 14.4
+ ---*/
+
+function* g() {
+  yield *
+  1
+}

--- a/test/language/statements/generators/yield-weak-binding.js
+++ b/test/language/statements/generators/yield-weak-binding.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      `yield` expressions bind weakly
+  es6id: 14.4
+  negative: SyntaxError
+ ---*/
+
+function* g() { yield 3 + yield 4; }


### PR DESCRIPTION
These tests are derived from the following files within the Google V8
project:

    test/mjsunit/es6/generators-parsing.js

I have deliberately omitted one assertion from the original test file because I believe it to be invalid:

```js
assertThrows("function* yield() { \"use strict\"; (yield 3) + (yield 4); }",
             SyntaxError);
```

(source: https://github.com/v8/v8-git-mirror/blob/3a79259c0d4ae2d314bb57ad2d8dcde8f2478974/test/mjsunit/es6/generators-parsing.js#L96-L97)

[I've reported this to the V8 team by filing a bug against that project](https://code.google.com/p/v8/issues/detail?id=3975)