### PR TITLE
Invalid language tests

### DIFF
--- a/test/annexB/labelled-function-declaration.js
+++ b/test/annexB/labelled-function-declaration.js
@@ -3,8 +3,9 @@
 /*---
 es6id: 13.1
 description: >
-    function declarations in statement position in strict mode:
+    function declarations in statement position in non-strict mode:
     label: Statement
+flags: [noStrict]
 ---*/
 label: function g() {}
 

--- a/test/built-ins/Object/getOwnPropertyNames/15.2.3.4-4-2.js
+++ b/test/built-ins/Object/getOwnPropertyNames/15.2.3.4-4-2.js
@@ -15,7 +15,6 @@ includes:
 function testcase() {
   var result = Object.getOwnPropertyNames(Object);
   var expResult = ["getPrototypeOf", "getOwnPropertyDescriptor", "getOwnPropertyNames", "create", "defineProperty", "defineProperties", "seal", "freeze", "preventExtensions", "isSealed", "isFrozen", "isExtensible", "keys", "prototype", "length"];
-  var found;
 
   return arrayContains(result, expResult);
  }

--- a/test/built-ins/Object/getOwnPropertyNames/15.2.3.4-4-44.js
+++ b/test/built-ins/Object/getOwnPropertyNames/15.2.3.4-4-44.js
@@ -19,9 +19,9 @@ function testcase() {
   var str = new String("abc");
   str[5] = "de";
 
-  var expected = ["0", "1", "2", "length", "5"];
+  var expected = ["0", "1", "2", "5", "length"];
   var actual = Object.getOwnPropertyNames(str);
 
-  return compareArray(actual.sort(), expected.sort());
+  return compareArray(actual, expected);
 }
 runTestCase(testcase);

--- a/test/built-ins/Object/getOwnPropertyNames/15.2.3.4-4-49.js
+++ b/test/built-ins/Object/getOwnPropertyNames/15.2.3.4-4-49.js
@@ -19,6 +19,6 @@ function testcase() {
   var expected = ["0", "1", "2", "length"];
   var actual = Object.getOwnPropertyNames(arr);
 
-  return compareArray(actual.sort(), expected.sort());
+  return compareArray(actual, expected);
 }
 runTestCase(testcase);

--- a/test/built-ins/Object/getOwnPropertyNames/15.2.3.4-4-b-2.js
+++ b/test/built-ins/Object/getOwnPropertyNames/15.2.3.4-4-b-2.js
@@ -42,6 +42,6 @@ function testcase() {
   var actual = Object.getOwnPropertyNames(obj);
   var expected = ["a", "b", "c", "d"];
 
-  return compareArray(actual.sort(), expected.sort());
+  return compareArray(actual, expected);
 }
 runTestCase(testcase);

--- a/test/built-ins/Object/is/length.js
+++ b/test/built-ins/Object/is/length.js
@@ -13,6 +13,5 @@ includes: [propertyHelper.js]
 assert.sameValue(Object.is.length, 2, "The value of `Object.is.length` is `2`");
 
 verifyNotEnumerable(Object.is, "length");
-verifyConfigurable(Object.is, "length");
 verifyNotWritable(Object.is, "length");
-
+verifyConfigurable(Object.is, "length");

--- a/test/language/block-scope/syntax/for-in/acquire-properties-from-array.js
+++ b/test/language/block-scope/syntax/for-in/acquire-properties-from-array.js
@@ -4,18 +4,19 @@
 es6id: 13.1
 description: >
     for-in to acquire properties from array
-includes: [compareArray.js]
+includes: [arrayContains.js]
 ---*/
 function props(x) {
   var array = [];
   for (let p in x) array.push(p);
-  return array.sort();
+  return array;
 }
 
 assert.sameValue(props([]).length, 0);
 assert.sameValue(props([1]).length, 1);
 assert.sameValue(props([1,2]).length, 2);
+assert.sameValue(props([1,2,3]).length, 3);
 
-assert(compareArray(props([1]), ["0"]));
-assert(compareArray(props([1,2]), ["0", "1"]));
-assert(compareArray(props([1,2,3]), ["0", "1", "2"]));
+assert(arrayContains(props([1]), ["0"]));
+assert(arrayContains(props([1,2]), ["0", "1"]));
+assert(arrayContains(props([1,2,3]), ["0", "1", "2"]));

--- a/test/language/block-scope/syntax/for-in/acquire-properties-from-object.js
+++ b/test/language/block-scope/syntax/for-in/acquire-properties-from-object.js
@@ -4,18 +4,19 @@
 es6id: 13.1
 description: >
     for-in to acquire properties from object
-includes: [compareArray.js]
+includes: [arrayContains.js]
 ---*/
 function props(x) {
   var array = [];
   for (let p in x) array.push(p);
-  return array.sort();
+  return array;
 }
 
 assert.sameValue(props({}).length, 0);
 assert.sameValue(props({x:1}).length, 1);
 assert.sameValue(props({x:1, y:2}).length, 2);
+assert.sameValue(props({x:1, y:2, zoom:3}).length, 3);
 
-assert(compareArray(props({x:1}), ["x"]));
-assert(compareArray(props({x:1, y:2}), ["x", "y"]));
-assert(compareArray(props({x:1, y:2, zoom:3}), ["x", "y", "zoom"]));
+assert(arrayContains(props({x:1}), ["x"]));
+assert(arrayContains(props({x:1, y:2}), ["x", "y"]));
+assert(arrayContains(props({x:1, y:2, zoom:3}), ["x", "y", "zoom"]));

--- a/test/language/class/method-definition/yield-as-function-expression-binding-identifier.js
+++ b/test/language/class/method-definition/yield-as-function-expression-binding-identifier.js
@@ -3,21 +3,15 @@
 
 /*---
   description: >
-      `yield` may be used as the binding identifier of a function expression
-      within generator bodies.
+      `yield` may not be used as the binding identifier of a function
+      expression within classes.
   features: [generators]
   es6id: 14.1
-  flags: [noStrict]
+  negative: SyntaxError
  ---*/
 
-var result;
 class A {
   *g() {
     (function yield() {});
   }
 }
-
-result = A.prototype.g().next();
-
-assert.sameValue(result.value, undefined);
-assert.sameValue(result.done, true);

--- a/test/language/class/method-definition/yield-as-generator-method-binding-identifier.js
+++ b/test/language/class/method-definition/yield-as-generator-method-binding-identifier.js
@@ -7,7 +7,6 @@
       strict mode.
   features: [generators]
   es6id: 12.1.1
-  flags: [noStrict]
  ---*/
 
 var iter, result;

--- a/test/language/class/method-definition/yield-as-identifier-in-nested-function.js
+++ b/test/language/class/method-definition/yield-as-identifier-in-nested-function.js
@@ -3,14 +3,13 @@
 
 /*---
   description: >
-      `yield` is not a reserved keyword within normal function bodies declared
-      within generator function bodies.
+      `yield` is a reserved keyword within normal function bodies declared
+      within classes.
   features: [generators]
   es6id: 12.1.1
-  flags: [noStrict]
+  negative: SyntaxError
  ---*/
 
-var result;
 class A {
   *g() {
     function h() {
@@ -18,7 +17,3 @@ class A {
     }
   }
 }
-
-result = A.prototype.g().next();
-assert.sameValue(result.value, undefined);
-assert.sameValue(result.done, true);

--- a/test/language/computed-property-names/basics/symbol.js
+++ b/test/language/computed-property-names/basics/symbol.js
@@ -27,24 +27,7 @@ assert(
   compareArray(Object.keys(object), ['a', 'c']),
   "`compareArray(Object.keys(object), ['a', 'c'])` returns `true`"
 );
-
-// compareArray expects arguments to be sorted,
-// which will cause an array containing symbols to
-// throw an exception when toString() is called.
-//
-// Since there is no guarantee of order:
-//
-//    - Assert only that the symbol is present
-//    - Assert that the length is correct
-//
-var symbols = Object.getOwnPropertySymbols(object);
-
 assert(
-  symbols.indexOf(sym1) !== -1,
-  "The result of `symbols.indexOf(sym1) !== -1` is `true`, after executing `var symbols = Object.getOwnPropertySymbols(object);`"
+  compareArray(Object.getOwnPropertySymbols(object), [sym1, sym2]),
+  "`compareArray(Object.getOwnPropertySymbols(object), [sym1, sym2])` returns `true`"
 );
-assert(
-  symbols.indexOf(sym2) !== -1,
-  "The result of `symbols.indexOf(sym2) !== -1` is `true`, after executing `var symbols = Object.getOwnPropertySymbols(object);`"
-);
-assert.sameValue(symbols.length, 2, "The value of `symbols.length` is `2`, after executing `var symbols = Object.getOwnPropertySymbols(object);`");

--- a/test/language/computed-property-names/class/method/symbol.js
+++ b/test/language/computed-property-names/class/method/symbol.js
@@ -31,24 +31,7 @@ assert(
   compareArray(Object.getOwnPropertyNames(C.prototype), ['constructor', 'a', 'c']),
   "`compareArray(Object.getOwnPropertyNames(C.prototype), ['constructor', 'a', 'c'])` returns `true`"
 );
-
-// compareArray expects arguments to be sorted,
-// which will cause an array containing symbols to
-// throw an exception when toString() is called.
-//
-// Since there is no guarantee of order:
-//
-//    - Assert only that the symbol is present
-//    - Assert that the length is correct
-//
-var symbols = Object.getOwnPropertySymbols(C.prototype);
-
 assert(
-  symbols.indexOf(sym1) !== -1,
-  "The result of `symbols.indexOf(sym1) !== -1` is `true`, after executing `var symbols = Object.getOwnPropertySymbols(C.prototype);`"
+  compareArray(Object.getOwnPropertySymbols(C.prototype), [sym1, sym2]),
+  "`compareArray(Object.getOwnPropertySymbols(C.prototype), [sym1, sym2])` returns `true`"
 );
-assert(
-  symbols.indexOf(sym2) !== -1,
-  "The result of `symbols.indexOf(sym2) !== -1` is `true`, after executing `var symbols = Object.getOwnPropertySymbols(C.prototype);`"
-);
-assert.sameValue(symbols.length, 2, "The value of `symbols.length` is `2`, after executing `var symbols = Object.getOwnPropertySymbols(C.prototype);`");

--- a/test/language/computed-property-names/class/static/method-number.js
+++ b/test/language/computed-property-names/class/static/method-number.js
@@ -21,6 +21,6 @@ assert(
   "`compareArray(Object.keys(C), [])` returns `true`"
 );
 assert(
-  compareArray(Object.getOwnPropertyNames(C), ['1', '2', 'length', 'name', 'prototype', 'a', 'c']),
-  "`compareArray(Object.getOwnPropertyNames(C), ['1', '2', 'length', 'name', 'prototype', 'a', 'c'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(C), ['1', '2', 'length', 'prototype', 'a', 'c', 'name']),
+  "`compareArray(Object.getOwnPropertyNames(C), ['1', '2', 'length', 'prototype', 'a', 'c', 'name'])` returns `true`"
 );

--- a/test/language/computed-property-names/class/static/method-string.js
+++ b/test/language/computed-property-names/class/static/method-string.js
@@ -21,6 +21,6 @@ assert(
   "`compareArray(Object.keys(C), [])` returns `true`"
 );
 assert(
-  compareArray(Object.getOwnPropertyNames(C), ['length', 'name', 'prototype', 'a', 'b', 'c', 'd']),
-  "`compareArray(Object.getOwnPropertyNames(C), ['length', 'name', 'prototype', 'a', 'b', 'c', 'd'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'a', 'b', 'c', 'd', 'name']),
+  "`compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'a', 'b', 'c', 'd', 'name'])` returns `true`"
 );

--- a/test/language/computed-property-names/class/static/method-symbol.js
+++ b/test/language/computed-property-names/class/static/method-symbol.js
@@ -23,32 +23,10 @@ assert(
   "`compareArray(Object.keys(C), [])` returns `true`"
 );
 assert(
-  compareArray(Object.getOwnPropertyNames(C), ['length', 'name', 'prototype', 'a', 'c']),
-  "`compareArray(Object.getOwnPropertyNames(C), ['length', 'name', 'prototype', 'a', 'c'])` returns `true`"
-);
-
-
-// compareArray expects arguments to be sorted,
-// which will cause an array containing symbols to
-// throw an exception when toString() is called.
-//
-// Since there is no guarantee of order:
-//
-//    - Assert only that the symbol is present
-//    - Assert that the length is correct
-//
-var symbols = Object.getOwnPropertySymbols(C);
-
-assert(
-  symbols.indexOf(sym1) !== -1,
-  "The result of `symbols.indexOf(sym1) !== -1` is `true`, after executing `var symbols = Object.getOwnPropertySymbols(C);`"
+  compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'a', 'c', 'name']),
+  "`compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'a', 'c', 'name'])` returns `true`"
 );
 assert(
-  symbols.indexOf(sym2) !== -1,
-  "The result of `symbols.indexOf(sym2) !== -1` is `true`, after executing `var symbols = Object.getOwnPropertySymbols(C);`"
-);
-assert.sameValue(
-  symbols.length,
-  2,
-  "The value of `symbols.length` is `2`, after executing `var symbols = Object.getOwnPropertySymbols(C);`"
+  compareArray(Object.getOwnPropertySymbols(C), [sym1, sym2]),
+  "`compareArray(Object.getOwnPropertySymbols(C), [sym1, sym2])` returns `true`"
 );

--- a/test/language/computed-property-names/object/method/symbol.js
+++ b/test/language/computed-property-names/object/method/symbol.js
@@ -27,24 +27,7 @@ assert(
   compareArray(Object.keys(object), ['a', 'c']),
   "`compareArray(Object.keys(object), ['a', 'c'])` returns `true`"
 );
-
-// compareArray expects arguments to be sorted,
-// which will cause an array containing symbols to
-// throw an exception when toString() is called.
-//
-// Since there is no guarantee of order:
-//
-//    - Assert only that the symbol is present
-//    - Assert that the length is correct
-//
-var symbols = Object.getOwnPropertySymbols(object);
-
 assert(
-  symbols.indexOf(sym1) !== -1,
-  "The result of `symbols.indexOf(sym1) !== -1` is `true`, after executing `var symbols = Object.getOwnPropertySymbols(object);`"
+  compareArray(Object.getOwnPropertySymbols(object), [sym1, sym2]),
+  "`compareArray(Object.getOwnPropertySymbols(object), [sym1, sym2])` returns `true`"
 );
-assert(
-  symbols.indexOf(sym2) !== -1,
-  "The result of `symbols.indexOf(sym2) !== -1` is `true`, after executing `var symbols = Object.getOwnPropertySymbols(object);`"
-);
-assert.sameValue(symbols.length, 2, "The value of `symbols.length` is `2`, after executing `var symbols = Object.getOwnPropertySymbols(object);`");

--- a/test/language/expressions/object/method-definition/yield-as-function-expression-binding-identifier.js
+++ b/test/language/expressions/object/method-definition/yield-as-function-expression-binding-identifier.js
@@ -17,7 +17,7 @@ var obj = {
   }
 };
 
-result = A.prototype.g().next();
+result = obj.g().next();
 
 assert.sameValue(result.value, undefined);
 assert.sameValue(result.done, true);

--- a/test/language/statements/labeled/labelled-function-declaration-strict.js
+++ b/test/language/statements/labeled/labelled-function-declaration-strict.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.1
+description: >
+    function declarations in statement position in strict mode:
+    label: Statement
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+label: function g() {}
+

--- a/test/language/statements/let/syntax/identifier-let-allowed-as-lefthandside-expression-strict.js
+++ b/test/language/statements/let/syntax/identifier-let-allowed-as-lefthandside-expression-strict.js
@@ -6,7 +6,7 @@ description: >
     for declaration:
     identifier "let" disallowed as lefthandside expression in strict mode
 flags: [onlyStrict]
-negative: ReferrenceError
+negative: SyntaxError
 ---*/
 var o = { a: 1 };
 for (let in o) { }


### PR DESCRIPTION
- in-statement-position-label-statement.js is an Annex-B test (B.3.2 Labelled Function Declarations), moved to annexB directory
- identifier-let-allowed-as-lefthandside-expression-strict.js needs to check for a SyntaxError (ES6, 12.1.1)
- method-*.js: compareArray() no longer sorts its input, added Array.prototype.sort() calls