### PR TITLE
Correct error messages

### DIFF
--- a/harness/testBuiltInObject.js
+++ b/harness/testBuiltInObject.js
@@ -81,13 +81,13 @@ function testBuiltInObject(obj, isFunction, isConstructor, properties, length) {
         }
         // accessor properties don't have writable attribute
         if (desc.hasOwnProperty("writable") && !desc.writable) {
-            $ERROR("The " + prop + " property of this built-in function must be writable.");
+            $ERROR("The " + prop + " property of this built-in object must be writable.");
         }
         if (desc.enumerable) {
-            $ERROR("The " + prop + " property of this built-in function must not be enumerable.");
+            $ERROR("The " + prop + " property of this built-in object must not be enumerable.");
         }
         if (!desc.configurable) {
-            $ERROR("The " + prop + " property of this built-in function must be configurable.");
+            $ERROR("The " + prop + " property of this built-in object must be configurable.");
         }
     });
 


### PR DESCRIPTION
The `testBuiltInObject` function verifies the presence of the specified
properties for *all* object types (not just function objects). Update
the error messages to reflect this.