### PR TITLE
Add Tests for Harness Helper Functions

### DIFF
--- a/test/harness/assert-false.js
+++ b/test/harness/assert-false.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    `false` does not satisfy the assertion.
+---*/
+
+var threw = false;
+
+try {
+  assert(false);
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/assert-notsamevalue-nan.js
+++ b/test/harness/assert-notsamevalue-nan.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Two references to NaN do not satisfy the assertion.
+---*/
+
+var threw = false;
+
+try {
+  assert.notSameValue(NaN, NaN);
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/assert-notsamevalue-notsame.js
+++ b/test/harness/assert-notsamevalue-notsame.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Values that are not strictly equal satisfy the assertion.
+---*/
+
+assert.notSameValue(undefined, null);
+assert.notSameValue(null, undefined);
+assert.notSameValue(0, 1);
+assert.notSameValue(1, 0);
+assert.notSameValue('', 's');
+assert.notSameValue('s', '');

--- a/test/harness/assert-notsamevalue-objects.js
+++ b/test/harness/assert-notsamevalue-objects.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Distinct objects satisfy the assertion.
+---*/
+
+assert.notSameValue({}, {});

--- a/test/harness/assert-notsamevalue-zeros.js
+++ b/test/harness/assert-notsamevalue-zeros.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Positive and negative zero satisfy the assertion.
+---*/
+
+assert.notSameValue(0, -0);

--- a/test/harness/assert-obj.js
+++ b/test/harness/assert-obj.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    An object literal does not satisfy the assertion.
+---*/
+
+var threw = false;
+
+try {
+  assert({});
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/assert-samevalue-nan.js
+++ b/test/harness/assert-samevalue-nan.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Two references to NaN satisfy the assertion.
+---*/
+
+assert.sameValue(NaN, NaN);

--- a/test/harness/assert-samevalue-objects.js
+++ b/test/harness/assert-samevalue-objects.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Distinct objects do not satisfy the assertion.
+---*/
+
+var threw = false;
+
+try {
+  assert.sameValue({}, {});
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/assert-samevalue-same.js
+++ b/test/harness/assert-samevalue-same.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Values that are strictly equal satisfy the assertion.
+---*/
+var obj;
+
+assert.sameValue(undefined, undefined);
+assert.sameValue(null, null);
+assert.sameValue(0, 0);
+assert.sameValue(1, 1);
+assert.sameValue('', '');
+assert.sameValue('s', 's');
+
+obj = {};
+assert.sameValue(obj, obj);

--- a/test/harness/assert-samevalue-zeros.js
+++ b/test/harness/assert-samevalue-zeros.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Positive and negative zero do not satisfy the assertion.
+---*/
+
+var threw = false;
+
+try {
+  assert.sameValue(0, -0);
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/assert-throws-custom.js
+++ b/test/harness/assert-throws-custom.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Functions that throw instances of the specified constructor function
+    satisfy the assertion.
+---*/
+
+function MyError() {}
+
+assert.throws(MyError, function() {
+  throw new MyError();
+});

--- a/test/harness/assert-throws-incorrect-ctor.js
+++ b/test/harness/assert-throws-incorrect-ctor.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Functions that throw values whose constructor does not match the specified
+    constructor do not satisfy the assertion.
+---*/
+
+var threw = false;
+
+try {
+  assert.throws(Error, function() {
+    throw new TypeError();
+  });
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/assert-throws-native.js
+++ b/test/harness/assert-throws-native.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Functions that throw instances of the specified native Error constructor
+    satisfy the assertion.
+---*/
+
+assert.throws(Error, function() {
+  throw new Error();
+});
+
+assert.throws(EvalError, function() {
+  throw new EvalError();
+});
+
+assert.throws(RangeError, function() {
+  throw new RangeError();
+});
+
+assert.throws(ReferenceError, function() {
+  throw new ReferenceError();
+});
+
+assert.throws(SyntaxError, function() {
+  throw new SyntaxError();
+});
+
+assert.throws(TypeError, function() {
+  throw new TypeError();
+});
+
+assert.throws(URIError, function() {
+  throw new URIError();
+});

--- a/test/harness/assert-throws-no-arg.js
+++ b/test/harness/assert-throws-no-arg.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The assertion fails when invoked without arguments.
+---*/
+
+var threw = false;
+
+try {
+  assert.throws();
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/assert-throws-no-error.js
+++ b/test/harness/assert-throws-no-error.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Functions that do not throw errors do not satisfy the assertion.
+---*/
+
+var threw = false;
+
+try {
+  assert.throws(Error, function() {});
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/assert-throws-null.js
+++ b/test/harness/assert-throws-null.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Functions that throw the `null` value do not satisfy the assertion.
+---*/
+
+var threw = false;
+
+try {
+  assert.throws(Error, function() {
+    throw null;
+  });
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/assert-throws-primitive.js
+++ b/test/harness/assert-throws-primitive.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Functions that throw primitive values do not satisfy the assertion.
+---*/
+
+var threw = false;
+
+try {
+  assert.throws(Error, function() {
+    throw 3;
+  });
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/assert-throws-single-arg.js
+++ b/test/harness/assert-throws-single-arg.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The assertion fails when invoked with a single argument.
+---*/
+
+var threw = false;
+
+try {
+  assert.throws(function() {});
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/assert-true.js
+++ b/test/harness/assert-true.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    `true` satisfies the assertion.
+---*/
+
+assert(true);

--- a/test/harness/compare-array-different-elements.js
+++ b/test/harness/compare-array-different-elements.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Arrays containing different elements are not equivalent.
+includes: [compareArray.js]
+---*/
+
+var first = [0, 'a', undefined];
+var second = [0, 'b', undefined];
+
+if (compareArray(first, second) !== false) {
+  $ERROR('Arrays containing different elements are not equivalent.');
+}

--- a/test/harness/compare-array-different-length.js
+++ b/test/harness/compare-array-different-length.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Arrays of differing lengths are not equivalent.
+includes: [compareArray.js]
+---*/
+
+if (compareArray([], [undefined]) !== false) {
+  $ERROR('Arrays of differing lengths are not equivalent.');
+}
+
+if (compareArray([undefined], []) !== false) {
+  $ERROR('Arrays of differing lengths are not equivalent.');
+}

--- a/test/harness/compare-array-empty.js
+++ b/test/harness/compare-array-empty.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Empty arrays of are equivalent.
+includes: [compareArray.js]
+---*/
+
+if (compareArray([], []) !== true) {
+  $ERROR('Empty arrays are equivalent.');
+}

--- a/test/harness/compare-array-same-elements-different-order.js
+++ b/test/harness/compare-array-same-elements-different-order.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Arrays containg the same elements in different order are not equivalent.
+includes: [compareArray.js]
+---*/
+
+var obj = {};
+var first = [0, 1, '', 's', null, undefined, obj];
+var second = [0, 1, '', 's', undefined, null, obj];
+
+if (compareArray(first, second) !== false) {
+  $ERROR('Arrays containing the same elements in different order are not equivalent.');
+}

--- a/test/harness/compare-array-same-elements-same-order.js
+++ b/test/harness/compare-array-same-elements-same-order.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Arrays containg the same elements in the same order are equivalent.
+includes: [compareArray.js]
+---*/
+
+var obj = {};
+var first = [0, 1, '', 's', undefined, null, obj];
+var second = [0, 1, '', 's', undefined, null, obj];
+
+if (compareArray(first, second) !== true) {
+  $ERROR('Arrays containing the same elements in the same order are equivalent.');
+}

--- a/test/harness/compare-array-sparse.js
+++ b/test/harness/compare-array-sparse.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Spares arrays are only equivalent if they have the same length.
+includes: [compareArray.js]
+---*/
+
+if (compareArray([,], [,]) !== true) {
+  $ERROR('Sparse arrays of the same length are equivalent.');
+}
+
+if (compareArray([,], [,,]) !== false) {
+  $ERROR('Sparse arrays of differing lengths are not equivalent.');
+}
+
+if (compareArray([,,], [,]) !== false) {
+  $ERROR('Sparse arrays of differing lengths are not equivalent.');
+}
+
+if (compareArray([,], []) !== false) {
+  $ERROR('Sparse arrays are not equivalent to empty arrays.');
+}
+
+if (compareArray([], [,]) !== false) {
+  $ERROR('Sparse arrays are not equivalent to empty arrays.');
+}

--- a/test/harness/error.js
+++ b/test/harness/error.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The global `$ERROR` function throws an instance of the global `Test262`
+    function with the specified message.
+---*/
+
+var threw = false;
+
+try {
+  $ERROR('This is a test message');
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    throw new Error(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+  if (err.message !== 'This is a test message') {
+    throw new Error('The error thrown did not define the specified message.');
+  }
+}
+
+if (threw === false) {
+  throw new Error('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/propertyhelper-verifyconfigurable-configurable.js
+++ b/test/harness/propertyhelper-verifyconfigurable-configurable.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is configurable satisfy the assertion.
+includes: [propertyHelper.js]
+---*/
+
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  configurable: true
+});
+
+verifyConfigurable(obj, 'a');

--- a/test/harness/propertyhelper-verifyconfigurable-not-configurable-not-strict.js
+++ b/test/harness/propertyhelper-verifyconfigurable-not-configurable-not-strict.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is not configurable do not satisfy the
+    assertion outside of strict mode.
+includes: [propertyHelper.js]
+flags: [noStrict]
+---*/
+
+var threw = false;
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  configurable: false
+});
+
+try {
+  verifyConfigurable(obj, 'a');
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/propertyhelper-verifyconfigurable-not-configurable-strict.js
+++ b/test/harness/propertyhelper-verifyconfigurable-not-configurable-strict.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is not configurable do not satisfy the
+    assertion in strict mode.
+includes: [propertyHelper.js]
+flags: [onlyStrict]
+---*/
+
+var threw = false;
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  configurable: false
+});
+
+try {
+  verifyConfigurable(obj, 'a');
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/propertyhelper-verifyenumerable-enumerable.js
+++ b/test/harness/propertyhelper-verifyenumerable-enumerable.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is enumerable satisfy the assertion.
+includes: [propertyHelper.js]
+---*/
+
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  enumerable: true
+});
+
+verifyEnumerable(obj, 'a');

--- a/test/harness/propertyhelper-verifyenumerable-not-enumerable.js
+++ b/test/harness/propertyhelper-verifyenumerable-not-enumerable.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is not enumerable do not satisfy the
+    assertion.
+includes: [propertyHelper.js]
+---*/
+
+var threw = false;
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  enumerable: false
+});
+
+try {
+  verifyEnumerable(obj, 'a');
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/propertyhelper-verifynotconfigurable-configurable.js
+++ b/test/harness/propertyhelper-verifynotconfigurable-configurable.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is configurable do not satisfy the
+    assertion.
+includes: [propertyHelper.js]
+---*/
+
+var threw = false;
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  configurable: true
+});
+
+try {
+  verifyNotConfigurable(obj, 'a');
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/propertyhelper-verifynotconfigurable-not-configurable-not-strict.js
+++ b/test/harness/propertyhelper-verifynotconfigurable-not-configurable-not-strict.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is not configurable satisfy the assertion
+    outside of strict mode.
+includes: [propertyHelper.js]
+flags: [noStrict]
+---*/
+
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  configurable: false
+});
+
+verifyNotConfigurable(obj, 'a');

--- a/test/harness/propertyhelper-verifynotconfigurable-not-configurable-strict.js
+++ b/test/harness/propertyhelper-verifynotconfigurable-not-configurable-strict.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is not configurable satisfy the assertion
+    in strict mode.
+includes: [propertyHelper.js]
+flags: [onlyStrict]
+---*/
+
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  configurable: false
+});
+
+verifyNotConfigurable(obj, 'a');

--- a/test/harness/propertyhelper-verifynotenumerable-enumerable.js
+++ b/test/harness/propertyhelper-verifynotenumerable-enumerable.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is enumerable do not satisfy the
+    assertion.
+includes: [propertyHelper.js]
+---*/
+
+var threw = false;
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  enumerable: true
+});
+
+try {
+  verifyNotEnumerable(obj, 'a');
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/propertyhelper-verifynotenumerable-not-enumerable.js
+++ b/test/harness/propertyhelper-verifynotenumerable-not-enumerable.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is not enumerable satisfy the assertion.
+includes: [propertyHelper.js]
+---*/
+
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  enumerable: false
+});
+
+verifyNotEnumerable(obj, 'a');

--- a/test/harness/propertyhelper-verifynotwritable-not-writable-not-strict.js
+++ b/test/harness/propertyhelper-verifynotwritable-not-writable-not-strict.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is not writable satisfy the assertion
+    outside of strict mode.
+includes: [propertyHelper.js]
+flags: [noStrict]
+---*/
+
+var obj = {};
+
+Object.defineProperty(obj, 'a', {
+  writable: false,
+  value: 123
+});
+
+verifyNotWritable(obj, 'a');
+
+if (obj.a !== 123) {
+  $ERROR('`verifyNotWritable` should be non-destructive.');
+}

--- a/test/harness/propertyhelper-verifynotwritable-not-writable-strict.js
+++ b/test/harness/propertyhelper-verifynotwritable-not-writable-strict.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is not writable satisfy the assertion in
+    strict mode.
+includes: [propertyHelper.js]
+flags: [onlyStrict]
+---*/
+
+var obj = {};
+
+Object.defineProperty(obj, 'a', {
+  writable: false,
+  value: 123
+});
+
+verifyNotWritable(obj, 'a');
+
+if (obj.a !== 123) {
+  $ERROR('`verifyNotWritable` should be non-destructive.');
+}

--- a/test/harness/propertyhelper-verifynotwritable-writable.js
+++ b/test/harness/propertyhelper-verifynotwritable-writable.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is writable do not satisfy the assertion.
+includes: [propertyHelper.js]
+---*/
+
+var threw = false;
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  writable: true,
+  value: 1
+});
+
+try {
+  verifyNotWritable(obj, 'a');
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/propertyhelper-verifywritable-not-writable-not-strict.js
+++ b/test/harness/propertyhelper-verifywritable-not-writable-not-strict.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is not writable do not satisfy the
+    assertion outside of strict mode.
+includes: [propertyHelper.js]
+flags: [noStrict]
+---*/
+
+var threw = false;
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  writable: false
+});
+
+try {
+  verifyWritable(obj, 'a');
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/propertyhelper-verifywritable-not-writable-strict.js
+++ b/test/harness/propertyhelper-verifywritable-not-writable-strict.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is not writable do not satisfy the
+    assertion in strict mode.
+includes: [propertyHelper.js]
+flags: [onlyStrict]
+---*/
+
+var threw = false;
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  writable: false
+});
+
+try {
+  verifyWritable(obj, 'a');
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/propertyhelper-verifywritable-writable.js
+++ b/test/harness/propertyhelper-verifywritable-writable.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is writable satisfy the assertion.
+includes: [propertyHelper.js]
+---*/
+
+var obj = {};
+
+Object.defineProperty(obj, 'a', {
+  writable: true,
+  value: 123
+});
+
+verifyWritable(obj, 'a');
+
+if (obj.a !== 123) {
+  $ERROR('`verifyWritable` should be non-destructive.');
+}

--- a/test/harness/testbuiltinobject-function-badstring.js
+++ b/test/harness/testbuiltinobject-function-badstring.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects that are expected to be functions but do not define the correct
+    [[Class]] internal property do not satisfy the assertion.
+includes: [testBuiltInObject.js]
+---*/
+
+var threw = false;
+
+try {
+  testBuiltInObject(null, true);
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/testbuiltinobject-function-expected-length.js
+++ b/test/harness/testbuiltinobject-function-expected-length.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Functions whose `length` property does not match the expected value do not
+    satisfy the assertion.
+includes: [testBuiltInObject.js]
+---*/
+
+var threw = false;
+
+try {
+  testBuiltInObject(function(a, b) {}, true, false, [], 3);
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/testbuiltinobject-function-not-constructor-no-error.js
+++ b/test/harness/testbuiltinobject-function-not-constructor-no-error.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Non-constructor functions that do not throw an when invoked via `new` do
+    not satisfy the assertion.
+includes: [testBuiltInObject.js]
+---*/
+
+var threw = false;
+
+try {
+  testBuiltInObject(function() {}, true, false, [], 0);
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/testbuiltinobject-function-not-constructor-no-typeerror.js
+++ b/test/harness/testbuiltinobject-function-not-constructor-no-typeerror.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Non-constructor functions that do not throw a TypeError when invoked via
+    `new` do not satisfy the assertion.
+includes: [testBuiltInObject.js]
+---*/
+
+var threw = false;
+var fn = function() {
+  throw new Error();
+};
+
+try {
+  testBuiltInObject(fn, true, false, [], 0);
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/testbuiltinobject-non-extensible.js
+++ b/test/harness/testbuiltinobject-non-extensible.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects that are not extensible  do not satisfy the assertion.
+includes: [testBuiltInObject.js]
+---*/
+
+var threw = false;
+var obj = {};
+Object.preventExtensions(obj);
+
+try {
+  testBuiltInObject(obj);
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/testbuiltinobject-not-function-badstring.js
+++ b/test/harness/testbuiltinobject-not-function-badstring.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects that are not expected to be functions but do not define the correct
+    [[Class]] internal property do not satisfy the assertion.
+includes: [testBuiltInObject.js]
+---*/
+
+var threw = false;
+
+try {
+  testBuiltInObject(function() {}, false);
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/testbuiltinobject-prop-enumerable.js
+++ b/test/harness/testbuiltinobject-prop-enumerable.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects that do not define all of the specified "own" properties as
+    non-enumerable do not satisfy the assertion.
+includes: [testBuiltInObject.js]
+---*/
+
+var threw = false;
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  writable: true, enumerable: false, configurable: true
+});
+Object.defineProperty(obj, 'b', {
+  writable: true, enumerable: true, configurable: true
+});
+Object.defineProperty(obj, 'c', {
+  writable: true, enumerable: false, configurable: true
+});
+
+try {
+  testBuiltInObject(obj, false, false, ['a', 'b', 'c']);
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/testbuiltinobject-prop-missing.js
+++ b/test/harness/testbuiltinobject-prop-missing.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects that do not define all of the specified "own" properties do not
+    satisfy the assertion.
+includes: [testBuiltInObject.js]
+---*/
+
+var threw = false;
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  writable: true, enumerable: false, configurable: true
+});
+Object.defineProperty(obj, 'c', {
+  writable: true, enumerable: false, configurable: true
+});
+
+try {
+  testBuiltInObject(obj, false, false, ['a', 'b', 'c']);
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/testbuiltinobject-prop-not-configurable.js
+++ b/test/harness/testbuiltinobject-prop-not-configurable.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects that do not define all of the specified "own" properties as
+    configurable do not satisfy the assertion.
+includes: [testBuiltInObject.js]
+---*/
+
+var threw = false;
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  writable: true, enumerable: false, configurable: true
+});
+Object.defineProperty(obj, 'b', {
+  writable: true, enumerable: false, configurable: false
+});
+Object.defineProperty(obj, 'c', {
+  writable: true, enumerable: false, configurable: true
+});
+
+try {
+  testBuiltInObject(obj, false, false, ['a', 'b', 'c']);
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/testbuiltinobject-prop-not-writable.js
+++ b/test/harness/testbuiltinobject-prop-not-writable.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects that do not define all of the specified "own" properties as
+    writable do not satisfy the assertion.
+includes: [testBuiltInObject.js]
+---*/
+
+var threw = false;
+var obj = {};
+Object.defineProperty(obj, 'a', {
+  writable: true, enumerable: false, configurable: true
+});
+Object.defineProperty(obj, 'b', {
+  writable: false, enumerable: false, configurable: true
+});
+Object.defineProperty(obj, 'c', {
+  writable: true, enumerable: false, configurable: true
+});
+
+try {
+  testBuiltInObject(obj, false, false, ['a', 'b', 'c']);
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/testbuiltinobject-undefined.js
+++ b/test/harness/testbuiltinobject-undefined.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    `undefined` does not satisfy the assertion.
+includes: [testBuiltInObject.js]
+---*/
+
+var threw = false;
+
+try {
+  testBuiltInObject(undefined);
+} catch(err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR(
+      'Expected a Test262Error, but a "' + err.constructor.name +
+      '" was thrown.'
+    );
+  }
+}
+
+if (threw === false) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}


### PR DESCRIPTION
Introduce tests for code in the `harness/` directory. This is limited to what I thought were the most critical files in that directory (`assert.js`, `compareArray.js`, `testBuiltInObject.js`, and `propertyHelper.js`), but I'd be happy to add tests for any others.

For the `verifyEnumerable` and `verifyConfigurable` assertions, I've created distinct files for strict mode and non-strict mode (because that distinction matters for the internal execution). It might be better to combine these and just use a more robust test runner (i.e. one that can run tests whose mode is unspecified in *both* strict and non-strict mode).

There are a few specific details that I couldn't find a way to validate. If anyone has any suggestions about these, I'm all ears!

- [testBuiltInObject.js](https://github.com/tc39/test262/blob/6d945e2a1e83c716cf86ab200b51958c197f5ff3/harness/testBuiltInObject.js)
  - function objects' prototypes (as in `(function() {}).__proto__`, not `(function() {}).prototype`) ([untested code](https://github.com/tc39/test262/blob/6d945e2a1e83c716cf86ab200b51958c197f5ff3/harness/testBuiltInObject.js#L40-L42))
  - plain objects' prototypes (again, `({}).__proto__`) ([untested code](https://github.com/tc39/test262/blob/6d945e2a1e83c716cf86ab200b51958c197f5ff3/harness/testBuiltInObject.js#L44-L46))
  - function lengths--incorrect property descriptors ([untested code](https://github.com/tc39/test262/blob/6d945e2a1e83c716cf86ab200b51958c197f5ff3/harness/testBuiltInObject.js#L65-L74))
  - function lengths--non-integer values ([untested code](https://github.com/tc39/test262/blob/6d945e2a1e83c716cf86ab200b51958c197f5ff3/harness/testBuiltInObject.js#L56-L58))
  - function objects without `prototype` properties ([untested code](https://github.com/tc39/test262/blob/6d945e2a1e83c716cf86ab200b51958c197f5ff3/harness/testBuiltInObject.js#L117-L119))
- [propertyHelper.js](https://github.com/tc39/test262/blob/6d945e2a1e83c716cf86ab200b51958c197f5ff3/harness/propertyHelper.js)
  - non-`TypeError` thrown in response to deleting a configurable property ([untested code](https://github.com/tc39/test262/blob/6d945e2a1e83c716cf86ab200b51958c197f5ff3/harness/propertyHelper.js#L6-L8))
  - non-`TypeError` thrown in response to setting a writable property ([untested code](https://github.com/tc39/test262/blob/6d945e2a1e83c716cf86ab200b51958c197f5ff3/harness/propertyHelper.js#L39-L41))