### PR TITLE
negative tests always fail when ran by test262.py

### DIFF
--- a/tools/packaging/test262.py
+++ b/tools/packaging/test262.py
@@ -218,7 +218,7 @@ class TestResult(object):
     if self.case.IsAsyncTest():
        return self.AsyncHasFailed() or self.HasFailed()
     elif self.case.IsNegative():
-       return not (self.HasFailed() and self.case.NegativeMatch(self.GetErrorOutput()))
+       return not (not self.HasFailed() and self.case.NegativeMatch(self.GetErrorOutput()))
     else:
        return self.HasFailed()
 


### PR DESCRIPTION
Don't fail when a negative test finishes with a pass state since gs.js returns a pass state.