### PR TITLE
Update remaining tests for ES2015 compatibility (rev38)

### DIFF
--- a/test/built-ins/Array/isArray/15.4.3.2-0-5.js
+++ b/test/built-ins/Array/isArray/15.4.3.2-0-5.js
@@ -14,7 +14,7 @@ includes: [runTestCase.js]
 
 function testcase() {
   var b = Array.isArray(Array.prototype);
-  if (b === false) {
+  if (b === true) {
     return true;
   }
  }

--- a/test/built-ins/Array/prototype/S15.4.3.1_A5.js
+++ b/test/built-ins/Array/prototype/S15.4.3.1_A5.js
@@ -2,12 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-info: The length property of Array.prototype is undefined
+info: The length property of Array.prototype is 0
 es5id: 15.4.3.1_A5
-description: Array.prototype.length === undefined
+description: Array.prototype.length === 0
 ---*/
 
 //CHECK#1
-if (Array.prototype.length !== undefined) {
-  $ERROR('#1.1: Array.prototype.length === undefined. Actual: ' + (Array.prototype.length));
+if (Array.prototype.length !== 0) {
+  $ERROR('#1.1: Array.prototype.length === 0. Actual: ' + (Array.prototype.length));
 }

--- a/test/built-ins/Array/prototype/S15.4.4_A1.1_T2.js
+++ b/test/built-ins/Array/prototype/S15.4.4_A1.1_T2.js
@@ -4,12 +4,12 @@
 /*---
 es5id: 15.4.4_A1.1_T2
 description: >
-    The Array prototype object is itself not an array; its [[Class]]
-    is "Object",
+    The Array prototype object is itself an array; its [[Class]]
+    is "Array",
 ---*/
 
 //CHECK#1
-if (Object.prototype.toString.call(Array.prototype) !== "[object Object]") {
-  $ERROR('The Array prototype object is itself not an array; its' +
-         '[[Class]] is "Object".');
+if (Object.prototype.toString.call(Array.prototype) !== "[object Array]") {
+  $ERROR('The Array prototype object is itself an array; its' +
+         '[[Class]] is "Array".');
 }

--- a/test/built-ins/Array/prototype/S15.4.4_A1.2_T1.js
+++ b/test/built-ins/Array/prototype/S15.4.4_A1.2_T1.js
@@ -2,13 +2,13 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-info: The [[Class]] property of the Array prototype object is set to "Object"
+info: The [[Class]] property of the Array prototype object is set to "Array"
 es5id: 15.4.4_A1.2_T1
 description: Checking use Object.prototype.toString
 ---*/
 
 //CHECK#1
 Array.prototype.getClass = Object.prototype.toString;
-if (Array.prototype.getClass() !== "[object " + "Object" + "]") {
-  $ERROR('#1: Array.prototype.getClass = Object.prototype.toString; Array.prototype is Object object. Actual: ' + (Array.prototype.getClass()));
+if (Array.prototype.getClass() !== "[object " + "Array" + "]") {
+  $ERROR('#1: Array.prototype.getClass = Object.prototype.toString; Array.prototype is Array object. Actual: ' + (Array.prototype.getClass()));
 }

--- a/test/built-ins/Array/prototype/S15.4.4_A1.3_T1.js
+++ b/test/built-ins/Array/prototype/S15.4.4_A1.3_T1.js
@@ -2,12 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-info: Array prototype object does not have a length property
+info: Array prototype object has a length property
 es5id: 15.4.4_A1.3_T1
-description: Array.prototype.length === undefined
+description: Array.prototype.length === 0
 ---*/
 
 //CHECK#1
-if (Array.prototype.length !== undefined) {
-  $ERROR('#1.1: Array.prototype.length === undefined. Actual: ' + (Array.prototype.length));
+if (Array.prototype.length !== 0) {
+  $ERROR('#1.1: Array.prototype.length === 0. Actual: ' + (Array.prototype.length));
 }

--- a/test/built-ins/Array/prototype/push/S15.4.4.7_A2_T2.js
+++ b/test/built-ins/Array/prototype/push/S15.4.4.7_A2_T2.js
@@ -34,19 +34,16 @@ if (obj["0"] !== -1) {
 
 //CHECK#4
 obj.length = Number.POSITIVE_INFINITY;
-var push = obj.push(-4);
-if (push !== 9007199254740992) {
-  $ERROR('#4: var obj = {}; obj.length = Number.POSITIVE_INFINITY; obj.push = Array.prototype.push; obj.push(-4) === 9007199254740992. Actual: ' + (push));
-}
+assert.throws(TypeError, function() { obj.push(-4); });
 
 //CHECK#5
-if (obj.length !== 9007199254740992) {
-  $ERROR('#6: var obj = {}; obj.length = Number.POSITIVE_INFINITY; obj.push = Array.prototype.push; obj.push(-4); obj.length === 9007199254740992. Actual: ' + (obj.length));
+if (obj.length !== Number.POSITIVE_INFINITY) {
+  $ERROR('#6: var obj = {}; obj.length = Number.POSITIVE_INFINITY; obj.push = Array.prototype.push; obj.push(-4); obj.length === Number.POSITIVE_INFINITY. Actual: ' + (obj.length));
 }
 
 //CHECK#6
-if (obj[9007199254740991] !== -4) {
-  $ERROR('#6: var obj = {}; obj.length = Number.POSITIVE_INFINITY; obj.push = Array.prototype.push; obj.push(-4); obj[9007199254740991] === -4. Actual: ' + (obj["0"]));
+if (obj[9007199254740991] !== undefined) {
+  $ERROR('#6: var obj = {}; obj.length = Number.POSITIVE_INFINITY; obj.push = Array.prototype.push; obj.push(-4); obj[9007199254740991] === undefined. Actual: ' + (obj["9007199254740991"]));
 }
 
 //CHECK#7

--- a/test/built-ins/Function/prototype/bind/15.3.4.5-15-2.js
+++ b/test/built-ins/Function/prototype/bind/15.3.4.5-15-2.js
@@ -8,7 +8,6 @@
 es5id: 15.3.4.5-15-2
 description: >
     Function.prototype.bind, 'length' is a data valued own property
-    with default attributes (false)
 includes: [runTestCase.js]
 ---*/
 
@@ -21,7 +20,7 @@ function testcase() {
   if (desc.value === 0 &&
       desc.enumerable === false &&
       desc.writable === false &&
-      desc.configurable == false) {
+      desc.configurable == true) {
     return true;
   }
  }

--- a/test/built-ins/RegExp/15.10.4.1-1.js
+++ b/test/built-ins/RegExp/15.10.4.1-1.js
@@ -7,20 +7,14 @@
 /*---
 es5id: 15.10.4.1-1
 description: >
-    RegExp - the thrown error is TypeError instead of RegExpError when
-    pattern is an object whose [[Class]] property is 'RegExp' and
-    flags is not undefined
+    RegExp - no TypeError is thrown when pattern is an object whose
+    [[Class]] property is 'RegExp' and flags is not undefined
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-        var regObj = new RegExp();
-        try {
-            var regExpObj = new RegExp(regObj, true);
-
-            return false;
-        } catch (e) {
-            return e instanceof TypeError;
-        }
-    }
+    var regObj = new RegExp();
+    var regExpObj = new RegExp(regObj, "g");
+    return regExpObj.global;
+}
 runTestCase(testcase);

--- a/test/built-ins/RegExp/S15.10.3.1_A2_T1.js
+++ b/test/built-ins/RegExp/S15.10.3.1_A2_T1.js
@@ -13,9 +13,9 @@ description: >
 
 //CHECK#1
 try {
-	$ERROR('#1.1: RegExp(new RegExp("\\d"), "1")) throw TypeError. Actual: ' + (RegExp(new RegExp("\d"), "1")));
+	$ERROR('#1.1: RegExp(new RegExp("\\d"), "1")) throw SyntaxError. Actual: ' + (RegExp(new RegExp("\d"), "1")));
 } catch (e) {
-	if ((e instanceof TypeError) !== true) {
-		$ERROR('#1.2: RegExp(new RegExp("\\d"), "1")) throw TypeError. Actual: ' + (e));
+	if ((e instanceof SyntaxError) !== true) {
+		$ERROR('#1.2: RegExp(new RegExp("\\d"), "1")) throw SyntaxError. Actual: ' + (e));
 	}
 }

--- a/test/built-ins/RegExp/S15.10.3.1_A2_T2.js
+++ b/test/built-ins/RegExp/S15.10.3.1_A2_T2.js
@@ -15,9 +15,9 @@ var x = 1;
 
 //CHECK#1
 try {
-	$ERROR('#1.1: var x = 1; RegExp(/[a-b]?/, x) throw TypeError. Actual: ' + (RegExp(/[a-b]?/, x)));
+	$ERROR('#1.1: var x = 1; RegExp(/[a-b]?/, x) throw SyntaxError. Actual: ' + (RegExp(/[a-b]?/, x)));
 } catch (e) {
-	if ((e instanceof TypeError) !== true) {
-		$ERROR('#1.2: var x = 1; RegExp(/[a-b]?/, x) throw TypeError. Actual: ' + (e));
+	if ((e instanceof SyntaxError) !== true) {
+		$ERROR('#1.2: var x = 1; RegExp(/[a-b]?/, x) throw SyntaxError. Actual: ' + (e));
 	} 
 }

--- a/test/built-ins/RegExp/S15.10.4.1_A2_T1.js
+++ b/test/built-ins/RegExp/S15.10.4.1_A2_T1.js
@@ -3,19 +3,14 @@
 
 /*---
 info: >
-    If pattern is an object R whose [[Class]] property is "RegExp" and flags
-    is not undefined, then throw a TypeError exception
+    pattern is an object R whose [[Class]] property is "RegExp" and flags
+    is not undefined
 es5id: 15.10.4.1_A2_T1
 description: >
     Checking if execution of "new RegExp(pattern, "i")", where the
-    pattern is "/\u0042/i", fails
+    pattern is "/\u0042/i", does not fail
 ---*/
 
 //CHECK#1
-try {
-	$ERROR('#1.1: new RegExp(/\\u0042/i, "i") throw TypeError. Actual: ' + (new RegExp(/\u0042/i, "i"))); 
-} catch (e) {
-	if ((e instanceof TypeError) !== true) {
-		$ERROR('#1.2: new RegExp(/\\u0042/i, "i") throw TypeError. Actual: ' + (e));
-	}
-}
+var regExpObj = new RegExp(/\u0042/i, "i");
+assert(regExpObj.ignoreCase);

--- a/test/built-ins/RegExp/S15.10.4.1_A2_T2.js
+++ b/test/built-ins/RegExp/S15.10.4.1_A2_T2.js
@@ -3,8 +3,9 @@
 
 /*---
 info: >
-    If pattern is an object R whose [[Class]] property is "RegExp" and flags
-    is not undefined, then throw a TypeError exception
+    pattern is an object R whose [[Class]] property is "RegExp" and flags
+    is not undefined. If ToString(pattern) is not a valid flags arguments,
+    then throw a SyntaxError exception
 es5id: 15.10.4.1_A2_T2
 description: >
     Checking if execution of "new RegExp(pattern, {})", where the
@@ -13,9 +14,9 @@ description: >
 
 //CHECK#1
 try {
-  $ERROR('#1.1: new RegExp(/1?1/mig, {}) throw TypeError. Actual: ' + (new RegExp(/1?1/mig, {}))); 
+  $ERROR('#1.1: new RegExp(/1?1/mig, {}) throw SyntaxError. Actual: ' + (new RegExp(/1?1/mig, {})));
 } catch (e) {
-  if ((e instanceof TypeError) !== true) {
-    $ERROR('#1.2: new RegExp(/1?1/mig, {}) throw TypeError. Actual: ' + (e));
+  if ((e instanceof SyntaxError) !== true) {
+    $ERROR('#1.2: new RegExp(/1?1/mig, {}) throw SyntaxError. Actual: ' + (e));
   }
 }

--- a/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A5_T3.js
+++ b/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A5_T3.js
@@ -4,8 +4,8 @@
 /*---
 info: >
     RegExp.prototype.exec behavior depends on global property.
-    Let global is true and let I = If ToInteger(lastIndex).
-    Then if I<0 orI>length then set lastIndex to 0 and return null
+    Let global is true and let I = If ToLength(lastIndex).
+    Then if I>length then set lastIndex to 0 and return null
 es5id: 15.10.6.2_A5_T3
 description: "Set lastIndex to -1 and call /(?:ab|cd)\\d?/g.exec(\"aacd22 \")"
 ---*/
@@ -15,24 +15,24 @@ __re.lastIndex=-1;
 __executed = __re.test("aacd22 ");
 
 //CHECK#1
-if (__executed) {
+if (!__executed) {
 	$ERROR('#1: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.test("aacd22 "); __executed === true');
 }
 
 //CHECK#2
-if (__re.lastIndex !== 0) {
-	$ERROR('#2: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.test("aacd22 "); __re.lastIndex === 0. Actual: ' + (__re.lastIndex));
+if (__re.lastIndex !== 5) {
+	$ERROR('#2: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.test("aacd22 "); __re.lastIndex === 5. Actual: ' + (__re.lastIndex));
 }
 
 __re.lastIndex=-100;
 __executed = __re.test("aacd22 ");
 
 //CHECK#3
-if (__executed) {
+if (!__executed) {
 	$ERROR('#3: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.test("aacd22 "); __re.lastIndex=-100; __executed = __re.test("aacd22 "); __executed === true');
 }
 
 //CHECK#4
-if (__re.lastIndex !== 0) {
-	$ERROR('#4: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.test("aacd22 "); __re.lastIndex=-100; __executed = __re.test("aacd22 "); __re.lastIndex === 0. Actual: ' + (__re.lastIndex));
+if (__re.lastIndex !== 5) {
+	$ERROR('#4: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.test("aacd22 "); __re.lastIndex=-100; __executed = __re.test("aacd22 "); __re.lastIndex === 5. Actual: ' + (__re.lastIndex));
 }

--- a/test/language/expressions/object/11.1.5-2gs.js
+++ b/test/language/expressions/object/11.1.5-2gs.js
@@ -7,12 +7,8 @@
 /*---
 es5id: 11.1.5-2gs
 description: >
-    Strict Mode - SyntaxError is thrown when eval code contains an
-    ObjectLiteral with more than one definition of any data property
-negative: SyntaxError
-flags: [onlyStrict]
+    Duplicate definitions of data properties are allowed in ObjectLiterals.
 ---*/
 
-"use strict";
-throw NotEarlyError;
-var obj = { _11_1_5_2_gs: 10, _11_1_5_2_gs: 10 };
+var obj = { _11_1_5_2_gs: 10, _11_1_5_2_gs: 20 };
+assert.sameValue(obj._11_1_5_2_gs, 20);

--- a/test/language/expressions/object/11.1.5-4-4-a-1-s.js
+++ b/test/language/expressions/object/11.1.5-4-4-a-1-s.js
@@ -5,30 +5,14 @@
 // copyright and this notice and otherwise comply with the Use Terms.
 
 /*---
-info: >
-    Refer 11.1.5; 
-    The production
-    PropertyNameAndValueList :  PropertyNameAndValueList , PropertyAssignment
-    4. If previous is not undefined then throw a SyntaxError exception if any of the following conditions are true
-    a. This production is contained in strict code and IsDataDescriptor(previous) is true and IsDataDescriptor(propId.descriptor) is true
 es5id: 11.1.5-4-4-a-1-s
 description: >
-    Object literal - SyntaxError for duplicate date property name in
-    strict mode
-flags: [onlyStrict]
+    Object literal - No SyntaxError for duplicate data property names
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  
-  try
-  {
-    eval("'use strict'; ({foo:0,foo:1});");
-    return false;
-  }
-  catch(e)
-  {
-    return (e instanceof SyntaxError);
-  }
- }
+  eval("({foo:0,foo:1});");
+  return true;
+}
 runTestCase(testcase);

--- a/test/language/expressions/object/11.1.5_4-4-b-1.js
+++ b/test/language/expressions/object/11.1.5_4-4-b-1.js
@@ -5,28 +5,15 @@
 // copyright and this notice and otherwise comply with the Use Terms.
 
 /*---
-info: >
-    Refer 11.1.5; 
-    The production
-    PropertyNameAndValueList :  PropertyNameAndValueList , PropertyAssignment
-    4. If previous is not undefined then throw a SyntaxError exception if any of the following conditions are true
-    b.IsDataDescriptor(previous) is true and IsAccessorDescriptor(propId.descriptor) is true.
 es5id: 11.1.5_4-4-b-1
 description: >
-    Object literal - SyntaxError if a data property definition is
+    Object literal - No SyntaxError if a data property definition is
     followed by get accessor definition with the same name
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  try
-  {
-    eval("({foo : 1, get foo(){}});");
-    return false;
-  }
-  catch(e)
-  {
-    return e instanceof SyntaxError;
-  }
- }
+  eval("({foo : 1, get foo(){}});");
+  return true;
+}
 runTestCase(testcase);

--- a/test/language/expressions/object/11.1.5_4-4-b-2.js
+++ b/test/language/expressions/object/11.1.5_4-4-b-2.js
@@ -5,28 +5,15 @@
 // copyright and this notice and otherwise comply with the Use Terms.
 
 /*---
-info: >
-    Refer 11.1.5; 
-    The production
-    PropertyNameAndValueList :  PropertyNameAndValueList , PropertyAssignment
-    4. If previous is not undefined then throw a SyntaxError exception if any of the following conditions are true
-    b.IsDataDescriptor(previous) is true and IsAccessorDescriptor(propId.descriptor) is true.
 es5id: 11.1.5_4-4-b-2
 description: >
-    Object literal - SyntaxError if a data property definition is
+    Object literal - No SyntaxError if a data property definition is
     followed by set accessor definition with the same name
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  try
-  {
-    eval("({foo : 1, set foo(x){}});");
-    return false;
-  }
-  catch(e)
-  {
-    return e instanceof SyntaxError;
-  }
- }
+  eval("({foo : 1, set foo(x){}});");
+  return true;
+}
 runTestCase(testcase);

--- a/test/language/expressions/object/11.1.5_4-4-c-1.js
+++ b/test/language/expressions/object/11.1.5_4-4-c-1.js
@@ -5,28 +5,15 @@
 // copyright and this notice and otherwise comply with the Use Terms.
 
 /*---
-info: >
-    Refer 11.1.5; 
-    The production
-    PropertyNameAndValueList :  PropertyNameAndValueList , PropertyAssignment
-    4. If previous is not undefined then throw a SyntaxError exception if any of the following conditions are true
-    c.IsAccessorDescriptor(previous) is true and IsDataDescriptor(propId.descriptor) is true.
 es5id: 11.1.5_4-4-c-1
 description: >
-    Object literal - SyntaxError if a get accessor property definition
+    Object literal - No SyntaxError if a get accessor property definition
     is followed by a data property definition with the same name
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  try
-  {
-    eval("({get foo(){}, foo : 1});");
-    return false;
-  }
-  catch(e)
-  {
-    return e instanceof SyntaxError;
-  }
- }
+  eval("({get foo(){}, foo : 1});");
+  return true;
+}
 runTestCase(testcase);

--- a/test/language/expressions/object/11.1.5_4-4-c-2.js
+++ b/test/language/expressions/object/11.1.5_4-4-c-2.js
@@ -5,28 +5,15 @@
 // copyright and this notice and otherwise comply with the Use Terms.
 
 /*---
-info: >
-    Refer 11.1.5; 
-    The production
-    PropertyNameAndValueList :  PropertyNameAndValueList , PropertyAssignment
-    4. If previous is not undefined then throw a SyntaxError exception if any of the following conditions are true
-    c.IsAccessorDescriptor(previous) is true and IsDataDescriptor(propId.descriptor) is true.
 es5id: 11.1.5_4-4-c-2
 description: >
-    Object literal - SyntaxError if a set accessor property definition
+    Object literal - No SyntaxError if a set accessor property definition
     is followed by a data property definition with the same name
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  try
-  {
-    eval("({set foo(x){}, foo : 1});");
-    return false;
-  }
-  catch(e)
-  {
-    return e instanceof SyntaxError;
-  }
- }
+  eval("({set foo(x){}, foo : 1});");
+  return true;
+}
 runTestCase(testcase);

--- a/test/language/expressions/object/11.1.5_4-4-d-1.js
+++ b/test/language/expressions/object/11.1.5_4-4-d-1.js
@@ -5,26 +5,13 @@
 // copyright and this notice and otherwise comply with the Use Terms.
 
 /*---
-info: >
-    Refer 11.1.5; 
-    The production
-    PropertyNameAndValueList :  PropertyNameAndValueList , PropertyAssignment
-    4. If previous is not undefined then throw a SyntaxError exception if any of the following conditions are true
-    d.	IsAccessorDescriptor(previous) is true and IsAccessorDescriptor(propId.descriptor) is true and either both previous and propId.descriptor have [[Get]] fields or both previous and propId.descriptor have [[Set]] fields
 es5id: 11.1.5_4-4-d-1
-description: Object literal - SyntaxError for duplicate property name (get,get)
+description: Object literal - No SyntaxError for duplicate property name (get,get)
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  try
-  {
-    eval("({get foo(){}, get foo(){}});");
-    return false;
-  }
-  catch(e)
-  {
-    return e instanceof SyntaxError;
-  }
- }
+  eval("({get foo(){}, get foo(){}});");
+  return true;
+}
 runTestCase(testcase);

--- a/test/language/expressions/object/11.1.5_4-4-d-2.js
+++ b/test/language/expressions/object/11.1.5_4-4-d-2.js
@@ -5,26 +5,13 @@
 // copyright and this notice and otherwise comply with the Use Terms.
 
 /*---
-info: >
-    Refer 11.1.5; 
-    The production
-    PropertyNameAndValueList :  PropertyNameAndValueList , PropertyAssignment
-    4. If previous is not undefined then throw a SyntaxError exception if any of the following conditions are true
-    d.	IsAccessorDescriptor(previous) is true and IsAccessorDescriptor(propId.descriptor) is true and either both previous and propId.descriptor have [[Get]] fields or both previous and propId.descriptor have [[Set]] fields
 es5id: 11.1.5_4-4-d-2
-description: Object literal - SyntaxError for duplicate property name (set,set)
+description: Object literal - No SyntaxError for duplicate property name (set,set)
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  try
-  {
-    eval("({set foo(arg){}, set foo(arg1){}});");
-    return false;
-  }
-  catch(e)
-  {
-    return e instanceof SyntaxError;
-  }
- }
+  eval("({set foo(arg){}, set foo(arg1){}});");
+  return true;
+}
 runTestCase(testcase);

--- a/test/language/expressions/object/11.1.5_4-4-d-3.js
+++ b/test/language/expressions/object/11.1.5_4-4-d-3.js
@@ -5,28 +5,15 @@
 // copyright and this notice and otherwise comply with the Use Terms.
 
 /*---
-info: >
-    Refer 11.1.5; 
-    The production
-    PropertyNameAndValueList :  PropertyNameAndValueList , PropertyAssignment
-    4. If previous is not undefined then throw a SyntaxError exception if any of the following conditions are true
-    d.	IsAccessorDescriptor(previous) is true and IsAccessorDescriptor(propId.descriptor) is true and either both previous and propId.descriptor have [[Get]] fields or both previous and propId.descriptor have [[Set]] fields
 es5id: 11.1.5_4-4-d-3
 description: >
-    Object literal - SyntaxError for duplicate property name
+    Object literal - No SyntaxError for duplicate property name
     (get,set,get)
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  try
-  {
-    eval("({get foo(){}, set foo(arg){}, get foo(){}});");
-    return false;
-  }
-  catch(e)
-  {
-    return e instanceof SyntaxError;
-  }
- }
+  eval("({get foo(){}, set foo(arg){}, get foo(){}});");
+  return true;
+}
 runTestCase(testcase);

--- a/test/language/expressions/object/11.1.5_4-4-d-4.js
+++ b/test/language/expressions/object/11.1.5_4-4-d-4.js
@@ -5,28 +5,15 @@
 // copyright and this notice and otherwise comply with the Use Terms.
 
 /*---
-info: >
-    Refer 11.1.5; 
-    The production
-    PropertyNameAndValueList :  PropertyNameAndValueList , PropertyAssignment
-    4. If previous is not undefined then throw a SyntaxError exception if any of the following conditions are true
-    d.	IsAccessorDescriptor(previous) is true and IsAccessorDescriptor(propId.descriptor) is true and either both previous and propId.descriptor have [[Get]] fields or both previous and propId.descriptor have [[Set]] fields
 es5id: 11.1.5_4-4-d-4
 description: >
-    Object literal - SyntaxError for duplicate property name
+    Object literal - No SyntaxError for duplicate property name
     (set,get,set)
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  try
-  {
-    eval("({set foo(arg){}, get foo(){}, set foo(arg1){}});");
-    return false;
-  }
-  catch(e)
-  {
-    return e instanceof SyntaxError;
-  }
- }
+  eval("({set foo(arg){}, get foo(){}, set foo(arg1){}});");
+  return true;
+}
 runTestCase(testcase);


### PR DESCRIPTION
- Duplicate properties are allowed in object literals: test/language/expressions/object/*.js
- RegExpBuiltinExec was changed to use ToLength(lastIndex): test/built-ins/RegExp/prototype/exec/S15.10.6.2_A5_T3.js
- Non-undefined flags arguments allowed in RegExp constructor call: test/built-ins/RegExp/*.js
- Array.prototype.push throws TypeError if new length exceeds Number.MAX_SAFE_INTEGER: test/built-ins/Array/prototype/push/S15.4.4.7_A2_T2.js
- .length property of bound functions is configurable: test/built-ins/Function/prototype/bind/15.3.4.5-15-2.js
- Array.prototype changed back to exotic Array object: test/built-ins/Array/prototype/*.js, test/built-ins/Array/isArray/15.4.3.2-0-5.js