### PR TITLE
Fix strict mode errors in built-ins/Array

### DIFF
--- a/test/built-ins/Array/S15.4.3_A2.1.js
+++ b/test/built-ins/Array/S15.4.3_A2.1.js
@@ -13,8 +13,8 @@ if (Array.propertyIsEnumerable('length') !== false) {
 }
 
 //CHECK#2
-result = true;
-for (p in Array){
+var result = true;
+for (var p in Array){
   if (p === "length") {
     result = false;
   }  

--- a/test/built-ins/Array/S15.4.3_A2.3.js
+++ b/test/built-ins/Array/S15.4.3_A2.3.js
@@ -8,7 +8,7 @@ description: Checking if varying the length property fails
 ---*/
 
 //CHECK#1
-x = Array.length;
+var x = Array.length;
 Array.length = Infinity;
 if (Array.length !== x) {
   $ERROR('#1: x = Array.length; Array.length = Infinity; Array.length === x. Actual: ' + (Array.length));

--- a/test/built-ins/Array/S15.4_A1.1_T1.js
+++ b/test/built-ins/Array/S15.4_A1.1_T1.js
@@ -10,7 +10,7 @@ description: Checking for boolean primitive
 ---*/
 
 //CHECK#1
-x = [];
+var x = [];
 x[true] = 1;
 if (x[1] !== undefined) {
   $ERROR('#1: x = []; x[true] = 1; x[1] === undefined. Actual: ' + (x[1]));  

--- a/test/built-ins/Array/S15.4_A1.1_T10.js
+++ b/test/built-ins/Array/S15.4_A1.1_T10.js
@@ -10,9 +10,9 @@ description: Array index is power of two
 ---*/
 
 //CHECK#
-x = [];
-k = 1;
-for (i = 0; i < 32; i++) {
+var x = [];
+var k = 1;
+for (var i = 0; i < 32; i++) {
   k = k * 2;
   x[k - 2] = k;  
 }

--- a/test/built-ins/Array/S15.4_A1.1_T2.js
+++ b/test/built-ins/Array/S15.4_A1.1_T2.js
@@ -10,7 +10,7 @@ description: Checking for number primitive
 ---*/
 
 //CHECK#1
-x = [];
+var x = [];
 x[NaN] = 1;
 if (x[0] !== undefined) {
   $ERROR('#1: x = []; x[NaN] = 1; x[0] === undefined. Actual: ' + (x[0]));  
@@ -22,7 +22,7 @@ if (x["NaN"] !== 1) {
 } 
 
 //CHECK#3
-y = [];
+var y = [];
 y[Number.POSITIVE_INFINITY] = 1;
 if (y[0] !== undefined) {
   $ERROR('#3: y = []; y[Number.POSITIVE_INFINITY] = 1; y[0] === undefined. Actual: ' + (y[0]));  
@@ -34,7 +34,7 @@ if (y["Infinity"] !== 1) {
 } 
 
 //CHECK#5
-z = [];
+var z = [];
 z[Number.NEGATIVE_INFINITY] = 1;
 if (z[0] !== undefined) {
   $ERROR('#5: z = []; z[Number.NEGATIVE_INFINITY] = 1; z[0] === undefined. Actual: ' + (z[0]));  

--- a/test/built-ins/Array/S15.4_A1.1_T3.js
+++ b/test/built-ins/Array/S15.4_A1.1_T3.js
@@ -10,7 +10,7 @@ description: Checking for number primitive
 ---*/
 
 //CHECK#1
-x = [];
+var x = [];
 x[4294967296] = 1;
 if (x[0] !== undefined) {
   $ERROR('#1: x = []; x[4294967296] = 1; x[0] === undefined. Actual: ' + (x[0]));  
@@ -22,7 +22,7 @@ if (x["4294967296"] !== 1) {
 }
 
 //CHECK#3
-y = [];
+var y = [];
 y[4294967297] = 1;
 if (y[1] !== undefined) {
   $ERROR('#3: y = []; y[4294967297] = 1; y[1] === undefined. Actual: ' + (y[1]));  
@@ -34,7 +34,7 @@ if (y["4294967297"] !== 1) {
 }
 
 //CHECK#5
-z = [];
+var z = [];
 z[1.1] = 1;
 if (z[1] !== undefined) {
   $ERROR('#5: z = []; z[1.1] = 1; z[1] === undefined. Actual: ' + (z[1]));  

--- a/test/built-ins/Array/S15.4_A1.1_T4.js
+++ b/test/built-ins/Array/S15.4_A1.1_T4.js
@@ -10,14 +10,14 @@ description: Checking for string primitive
 ---*/
 
 //CHECK#1
-x = [];
+var x = [];
 x["0"] = 0;
 if (x[0] !== 0) {
   $ERROR('#1: x = []; x["0"] = 0; x[0] === 0. Actual: ' + (x[0]));  
 } 
 
 //CHECK#2
-y = [];
+var y = [];
 y["1"] = 1;
 if (y[1] !== 1) {
   $ERROR('#2: y = []; y["1"] = 1; y[1] === 1. Actual: ' + (y[1]));  

--- a/test/built-ins/Array/S15.4_A1.1_T5.js
+++ b/test/built-ins/Array/S15.4_A1.1_T5.js
@@ -10,7 +10,7 @@ description: Checking for null and undefined
 ---*/
 
 //CHECK#1
-x = [];
+var x = [];
 x[null] = 0;
 if (x[0] !== undefined) {
   $ERROR('#1: x = []; x[null] = 1; x[0] === undefined. Actual: ' + (x[0]));  
@@ -22,7 +22,7 @@ if (x["null"] !== 0) {
 }
 
 //CHECK#3
-y = [];
+var y = [];
 y[undefined] = 0;
 if (y[0] !== undefined) {
   $ERROR('#3: y = []; y[undefined] = 0; y[0] === undefined. Actual: ' + (y[0]));  

--- a/test/built-ins/Array/S15.4_A1.1_T6.js
+++ b/test/built-ins/Array/S15.4_A1.1_T6.js
@@ -10,7 +10,7 @@ description: Checking for Boolean object
 ---*/
 
 //CHECK#1
-x = [];
+var x = [];
 x[new Boolean(true)] = 1;
 if (x[1] !== undefined) {
   $ERROR('#1: x = []; x[new Boolean(true)] = 1; x[1] === undefined. Actual: ' + (x[1]));  

--- a/test/built-ins/Array/S15.4_A1.1_T7.js
+++ b/test/built-ins/Array/S15.4_A1.1_T7.js
@@ -10,21 +10,21 @@ description: Checking for Number object
 ---*/
 
 //CHECK#1
-x = [];
+var x = [];
 x[new Number(0)] = 0;
 if (x[0] !== 0) {
   $ERROR('#1: x = []; x[new Number(0)] = 0; x[0] === 0. Actual: ' + (x[0]));  
 } 
 
 //CHECK#2
-y = [];
+var y = [];
 y[new Number(1)] = 1;
 if (y[1] !== 1) {
   $ERROR('#2: y = []; y[new Number(1)] = 1; y[1] === 1. Actual: ' + (y[1]));  
 }
 
 //CHECK#3
-z = [];
+var z = [];
 z[new Number(1.1)] = 1;
 if (z["1.1"] !== 1) {
   $ERROR('#3: z = []; z[new Number(1.1)] = 1; z["1.1"] === 1. Actual: ' + (z["1.1"]));  

--- a/test/built-ins/Array/S15.4_A1.1_T8.js
+++ b/test/built-ins/Array/S15.4_A1.1_T8.js
@@ -10,21 +10,21 @@ description: Checking for Number object
 ---*/
 
 //CHECK#1
-x = [];
+var x = [];
 x[new String("0")] = 0;
 if (x[0] !== 0) {
   $ERROR('#1: x = []; x[new String("0")] = 0; x[0] === 0. Actual: ' + (x[0]));  
 } 
 
 //CHECK#2
-y = [];
+var y = [];
 y[new String("1")] = 1;
 if (y[1] !== 1) {
   $ERROR('#2: y = []; y[new String("1")] = 1; y[1] === 1. Actual: ' + (y[1]));  
 }
 
 //CHECK#3
-z = [];
+var z = [];
 z[new String("1.1")] = 1;
 if (z["1.1"] !== 1) {
   $ERROR('#3: z = []; z[new String("1.1")] = 1; z["1.1"] === 1. Actual: ' + (z["1.1"]));  

--- a/test/built-ins/Array/S15.4_A1.1_T9.js
+++ b/test/built-ins/Array/S15.4_A1.1_T9.js
@@ -10,7 +10,7 @@ description: If Type(value) is Object, evaluate ToPrimitive(value, String)
 ---*/
 
 //CHECK#1
-x = [];
+var x = [];
 var object = {valueOf: function() {return 1}};
 x[object] = 0;
 if (x["[object Object]"] !== 0) {

--- a/test/built-ins/Array/of/Array.of_assignment-to-new-object-length.js
+++ b/test/built-ins/Array/of/Array.of_assignment-to-new-object-length.js
@@ -14,7 +14,4 @@ function Empty() {}
 Empty.of = Array.of;
 Object.defineProperty(Empty.prototype, "length", {get: function() { return 0; }});
 
-var nothing = new Empty;
-nothing.length = 2;  // no exception; this is not a strict mode assignment
-
 assert.throws(TypeError, function() { Empty.of(); });

--- a/test/built-ins/Array/prototype/concat/Array.prototype.concat_sloppy-arguments-with-dupes.js
+++ b/test/built-ins/Array/prototype/concat/Array.prototype.concat_sloppy-arguments-with-dupes.js
@@ -6,6 +6,7 @@
 /*---
 es6id: 22.1.3.1_3
 description: Array.prototype.concat sloppy arguments with dupes
+flags: [noStrict]
 includes: [compareArray.js]
 ---*/
 var args = (function(a, a, a) { return arguments; })(1,2,3);

--- a/test/built-ins/Array/prototype/every/15.4.4.16-5-1.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-5-1.js
@@ -7,6 +7,7 @@
 /*---
 es5id: 15.4.4.16-5-1
 description: Array.prototype.every - thisArg not passed
+flags: [noStrict]
 includes:
     - runTestCase.js
     - fnGlobalObject.js

--- a/test/built-ins/Array/prototype/every/15.4.4.16-7-b-16.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-7-b-16.js
@@ -9,6 +9,7 @@ es5id: 15.4.4.16-7-b-16
 description: >
     Array.prototype.every - decreasing length of array does not delete
     non-configurable properties
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/filter/15.4.4.20-5-1.js
+++ b/test/built-ins/Array/prototype/filter/15.4.4.20-5-1.js
@@ -7,6 +7,7 @@
 /*---
 es5id: 15.4.4.20-5-1
 description: Array.prototype.filter - thisArg is passed
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/filter/15.4.4.20-5-30.js
+++ b/test/built-ins/Array/prototype/filter/15.4.4.20-5-30.js
@@ -7,6 +7,7 @@
 /*---
 es5id: 15.4.4.20-5-30
 description: Array.prototype.filter - thisArg not passed
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/filter/15.4.4.20-9-b-16.js
+++ b/test/built-ins/Array/prototype/filter/15.4.4.20-9-b-16.js
@@ -9,6 +9,7 @@ es5id: 15.4.4.20-9-b-16
 description: >
     Array.prototype.filter - decreasing length of array does not
     delete non-configurable properties
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/find/Array.prototype.find_this-arg-receiver-primitive.js
+++ b/test/built-ins/Array/prototype/find/Array.prototype.find_this-arg-receiver-primitive.js
@@ -2,16 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 /*---
-es6id: 22.1.3.9
+es6id: 22.1.3.8
 description: >
     Create a new object in each function call when receiver is a
     primitive value. See ECMA-262, Annex C.
 flags: [noStrict]
+includes: [compareArray.js]
 ---*/
-var a = [];
-[1, 2].findIndex(function() { a.push(this) }, "");
-assert(a[0] !== a[1]);
 
-var b = [];
-[1, 2].findIndex(function() { b.push(this) }, 1);
-assert(b[0] !== b[1]);
+// Create a new object in each function call when receiver is a
+// primitive value. See ECMA-262, Annex C.
+var a = [];
+[1, 2].find(function() { a.push(this) }, "");
+assert(a[0] !== a[1]);

--- a/test/built-ins/Array/prototype/find/Array.prototype.find_this-arg.js
+++ b/test/built-ins/Array/prototype/find/Array.prototype.find_this-arg.js
@@ -31,14 +31,8 @@ found = ["a", "b", "c"].find(function(val, key) {
 }, thisArg);
 assert.sameValue("b", found);
 
-// Create a new object in each function call when receiver is a
-// primitive value. See ECMA-262, Annex C.
-a = [];
-[1, 2].find(function() { a.push(this) }, "");
-assert(a[0] !== a[1]);
-
-// Do not create a new object otherwise.
-a = [];
+// Check thisArg parameter does not change.
+var a = [];
 [1, 2].find(function() { a.push(this) }, {});
 assert.sameValue(a[0], a[1]);
 

--- a/test/built-ins/Array/prototype/findIndex/Array.prototype.findIndex_this-arg.js
+++ b/test/built-ins/Array/prototype/findIndex/Array.prototype.findIndex_this-arg.js
@@ -30,14 +30,8 @@ index = ["a", "b", "c"].findIndex(function(val, key) {
 }, thisArg);
 assert.sameValue(index, 1);
 
-// Create a new object in each function call when receiver is a
-// primitive value. See ECMA-262, Annex C.
-a = [];
-[1, 2].findIndex(function() { a.push(this) }, "");
-assert(a[0] !== a[1]);
-
-// Do not create a new object otherwise.
-a = [];
+// Check thisArg parameter does not change.
+var a = [];
 [1, 2].findIndex(function() { a.push(this) }, {});
 assert.sameValue(a[1], a[0]);
 

--- a/test/built-ins/Array/prototype/forEach/15.4.4.18-5-1.js
+++ b/test/built-ins/Array/prototype/forEach/15.4.4.18-5-1.js
@@ -7,6 +7,7 @@
 /*---
 es5id: 15.4.4.18-5-1
 description: Array.prototype.forEach - thisArg is passed
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/forEach/15.4.4.18-5-25.js
+++ b/test/built-ins/Array/prototype/forEach/15.4.4.18-5-25.js
@@ -7,6 +7,7 @@
 /*---
 es5id: 15.4.4.18-5-25
 description: Array.prototype.forEach - thisArg not passed
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/forEach/15.4.4.18-7-b-16.js
+++ b/test/built-ins/Array/prototype/forEach/15.4.4.18-7-b-16.js
@@ -9,6 +9,7 @@ es5id: 15.4.4.18-7-b-16
 description: >
     Array.prototype.forEach - decreasing length of array does not
     delete non-configurable properties
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/indexOf/15.4.4.14-9-a-19.js
+++ b/test/built-ins/Array/prototype/indexOf/15.4.4.14-9-a-19.js
@@ -9,6 +9,7 @@ es5id: 15.4.4.14-9-a-19
 description: >
     Array.prototype.indexOf - decreasing length of array does not
     delete non-configurable properties
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-19.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-19.js
@@ -9,6 +9,7 @@ es5id: 15.4.4.15-8-a-19
 description: >
     Array.prototype.lastIndexOf -  decreasing length of array does not
     delete non-configurable properties
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/map/15.4.4.19-2-5.js
+++ b/test/built-ins/Array/prototype/map/15.4.4.19-2-5.js
@@ -30,7 +30,6 @@ function testcase() {
         Con.prototype = proto;
 
         var child = new Con();
-        child.length = 2;
         Object.defineProperty(child, "length", {
             value: 2,
             configurable: true

--- a/test/built-ins/Array/prototype/map/15.4.4.19-5-1.js
+++ b/test/built-ins/Array/prototype/map/15.4.4.19-5-1.js
@@ -7,6 +7,7 @@
 /*---
 es5id: 15.4.4.19-5-1
 description: Array.prototype.map - thisArg not passed
+flags: [noStrict]
 includes:
     - runTestCase.js
     - fnGlobalObject.js

--- a/test/built-ins/Array/prototype/map/15.4.4.19-8-b-16.js
+++ b/test/built-ins/Array/prototype/map/15.4.4.19-8-b-16.js
@@ -9,6 +9,7 @@ es5id: 15.4.4.19-8-b-16
 description: >
     Array.prototype.map - decreasing length of array does not delete
     non-configurable properties
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/map/15.4.4.19-8-c-ii-1.js
+++ b/test/built-ins/Array/prototype/map/15.4.4.19-8-c-ii-1.js
@@ -23,7 +23,7 @@ function testcase() {
 
   var srcArr = [0,1,true,null,new Object(),"five"];
   srcArr[999999] = -6.6;
-  resArr = srcArr.map(callbackfn);
+  var resArr = srcArr.map(callbackfn);
   
   if(bCalled === true && bPar === true)
     return true;

--- a/test/built-ins/Array/prototype/reduce/15.4.4.21-9-b-16.js
+++ b/test/built-ins/Array/prototype/reduce/15.4.4.21-9-b-16.js
@@ -9,6 +9,7 @@ es5id: 15.4.4.21-9-b-16
 description: >
     Array.prototype.reduce - decreasing length of array in step 8 does
     not delete non-configurable properties
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/reduce/15.4.4.21-9-b-29.js
+++ b/test/built-ins/Array/prototype/reduce/15.4.4.21-9-b-29.js
@@ -9,6 +9,7 @@ es5id: 15.4.4.21-9-b-29
 description: >
     Array.prototype.reduce - decreasing length of array does not
     delete non-configurable properties
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-16.js
+++ b/test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-16.js
@@ -9,6 +9,7 @@ es5id: 15.4.4.22-9-b-16
 description: >
     Array.prototype.reduceRight - decreasing length of array in step 8
     does not delete non-configurable properties
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-29.js
+++ b/test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-29.js
@@ -9,6 +9,7 @@ es5id: 15.4.4.22-9-b-29
 description: >
     Array.prototype.reduceRight - decreasing length of array does not
     delete non-configurable properties
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/some/15.4.4.17-5-1.js
+++ b/test/built-ins/Array/prototype/some/15.4.4.17-5-1.js
@@ -7,6 +7,7 @@
 /*---
 es5id: 15.4.4.17-5-1
 description: Array.prototype.some - thisArg is passed
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/some/15.4.4.17-5-25.js
+++ b/test/built-ins/Array/prototype/some/15.4.4.17-5-25.js
@@ -7,6 +7,7 @@
 /*---
 es5id: 15.4.4.17-5-25
 description: Array.prototype.some - thisArg not passed
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/some/15.4.4.17-7-b-16.js
+++ b/test/built-ins/Array/prototype/some/15.4.4.17-7-b-16.js
@@ -9,6 +9,7 @@ es5id: 15.4.4.17-7-b-16
 description: >
     Array.prototype.some - decreasing length of array does not delete
     non-configurable properties
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/unshift/S15.4.4.13_A4_T1.js
+++ b/test/built-ins/Array/prototype/unshift/S15.4.4.13_A4_T1.js
@@ -10,7 +10,7 @@ description: >
 ---*/
 
 Array.prototype[0] = -1;
-x = [1];
+var x = [1];
 x.length = 1;
 
 //CHECK#1


### PR DESCRIPTION
- Add missing "var" declarations and noStrict flags
- Move code which requires non-strict semantics from Array.prototype.find_this-arg.js to Array.prototype.find_this-arg-receiver-primitive.js
- Remove duplicate code from Array.prototype.findIndex_this-arg.js, already present in Array.prototype.findIndex_this-arg-receiver-primitive.js
- Remove test code from Array.of_assignment-to-new-object-length.js, does not work in strict mode

Part of issue #35