### PR TITLE
Fix strict mode errors in built-ins/Boolean

### DIFF
--- a/test/built-ins/Boolean/S15.6.1.1_A1_T5.js
+++ b/test/built-ins/Boolean/S15.6.1.1_A1_T5.js
@@ -9,6 +9,8 @@ es5id: 15.6.1.1_A1_T5
 description: Used various assigning values to any variable as argument
 ---*/
 
+var x;
+
 //CHECK#1
 if( typeof Boolean(x=0) !== "boolean" ) {
   $ERROR('#1.1: typeof Boolean(x=0) should be "boolean", actual is "'+typeof Boolean(x=0)+'"');

--- a/test/built-ins/Boolean/prototype/S15.6.3.1_A2.js
+++ b/test/built-ins/Boolean/prototype/S15.6.3.1_A2.js
@@ -5,6 +5,7 @@
 info: Boolean.prototype has the attribute ReadOnly
 es5id: 15.6.3.1_A2
 description: Checking if varying the Boolean.prototype property fails
+flags: [noStrict]
 ---*/
 
 // CHECK#1

--- a/test/built-ins/Boolean/prototype/S15.6.3.1_A3.js
+++ b/test/built-ins/Boolean/prototype/S15.6.3.1_A3.js
@@ -5,6 +5,7 @@
 info: Boolean.prototype has the attribute DontDelete
 es5id: 15.6.3.1_A3
 description: Checking if deleting the Boolean.prototype property fails
+flags: [noStrict]
 ---*/
 
 // CHECK#1


### PR DESCRIPTION
Add missing "var" declarations and noStrict flags.

Part of issue #35.