### PR TITLE
Fix strict mode errors in built-ins/Number

### DIFF
--- a/test/built-ins/Number/MAX_VALUE/S15.7.3.2_A2.js
+++ b/test/built-ins/Number/MAX_VALUE/S15.7.3.2_A2.js
@@ -5,6 +5,7 @@
 info: Number.MAX_VALUE is ReadOnly
 es5id: 15.7.3.2_A2
 description: Checking if varying Number.MAX_VALUE fails
+flags: [noStrict]
 ---*/
 
 // CHECK#1

--- a/test/built-ins/Number/MIN_VALUE/S15.7.3.3_A2.js
+++ b/test/built-ins/Number/MIN_VALUE/S15.7.3.3_A2.js
@@ -5,6 +5,7 @@
 info: Number.MIN_VALUE is ReadOnly
 es5id: 15.7.3.3_A2
 description: Checking if varying Number.MIN_VALUE fails
+flags: [noStrict]
 ---*/
 
 // CHECK#1

--- a/test/built-ins/Number/NEGATIVE_INFINITY/S15.7.3.5_A2.js
+++ b/test/built-ins/Number/NEGATIVE_INFINITY/S15.7.3.5_A2.js
@@ -5,6 +5,7 @@
 info: Number.NEGATIVE_INFINITY is ReadOnly
 es5id: 15.7.3.5_A2
 description: Checking if varying Number.NEGATIVE_INFINITY fails
+flags: [noStrict]
 ---*/
 
 // CHECK#1

--- a/test/built-ins/Number/NaN/S15.7.3.4_A2.js
+++ b/test/built-ins/Number/NaN/S15.7.3.4_A2.js
@@ -5,6 +5,7 @@
 info: Number.NaN is ReadOnly
 es5id: 15.7.3.4_A2
 description: Checking if varying Number.NaN fails
+flags: [noStrict]
 ---*/
 
 // CHECK#1

--- a/test/built-ins/Number/POSITIVE_INFINITY/S15.7.3.6_A2.js
+++ b/test/built-ins/Number/POSITIVE_INFINITY/S15.7.3.6_A2.js
@@ -5,6 +5,7 @@
 info: Number.POSITIVE_INFINITY is ReadOnly
 es5id: 15.7.3.6_A2
 description: Checking if varying Number.POSITIVE_INFINITY fails
+flags: [noStrict]
 ---*/
 
 // CHECK#1

--- a/test/built-ins/Number/prototype/S15.7.3.1_A1_T1.js
+++ b/test/built-ins/Number/prototype/S15.7.3.1_A1_T1.js
@@ -7,6 +7,7 @@ info: >
     attributes
 es5id: 15.7.3.1_A1_T1
 description: Checking if varying the Number.prototype property fails
+flags: [noStrict]
 ---*/
 
 //CHECK#1

--- a/test/built-ins/Number/prototype/S15.7.3.1_A1_T3.js
+++ b/test/built-ins/Number/prototype/S15.7.3.1_A1_T3.js
@@ -13,7 +13,7 @@ if (Number.propertyIsEnumerable('prototype')) {
   $ERROR('#1: The Number.prototype property has the attribute DontEnum');
 }
 
-for(x in Number) {
+for(var x in Number) {
   if(x === "prototype") {
     $ERROR('#2: The Number.prototype has the attribute DontEnum');
   }


### PR DESCRIPTION
Add missing "var" declarations and noStrict flags.

Part of issue #35.