### PR TITLE
Fix some strict mode errors in built-ins/Object

### DIFF
--- a/test/built-ins/Object/isExtensible/15.2.3.13-2-1.js
+++ b/test/built-ins/Object/isExtensible/15.2.3.13-2-1.js
@@ -10,7 +10,7 @@ description: Object.isExtensible returns true for all built-in objects (Global)
 includes: [runTestCase.js]
 ---*/
 
-global = this;
+var global = this;
 function testcase() {
   // in non-strict mode, 'this' is bound to the global object.
   var e = Object.isExtensible(this);

--- a/test/built-ins/Object/prototype/S15.2.3.1_A1.js
+++ b/test/built-ins/Object/prototype/S15.2.3.1_A1.js
@@ -5,6 +5,7 @@
 info: The Object.prototype property has the attribute ReadOnly
 es5id: 15.2.3.1_A1
 description: Checking if varying "Object.prototype" property fails
+flags: [noStrict]
 ---*/
 
 var obj = Object.prototype;

--- a/test/built-ins/Object/prototype/S15.2.3.1_A2.js
+++ b/test/built-ins/Object/prototype/S15.2.3.1_A2.js
@@ -15,7 +15,7 @@ if (Object.propertyIsEnumerable('prototype')) {
 // CHECK#2
 var cout=0;
 
-for (p in Object){
+for (var p in Object){
   if (p==="prototype") cout++;
 }
 

--- a/test/built-ins/Object/prototype/S15.2.4_A4.js
+++ b/test/built-ins/Object/prototype/S15.2.4_A4.js
@@ -14,7 +14,7 @@ includes:
 
 //CHECK#1
 try {
-  instance = new Object.prototype;
+  var instance = new Object.prototype;
   $FAIL('#1: Since Object prototype object is not function it has not [[create]] method');
 } catch (e) {
   $PRINT(e);

--- a/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A10.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A10.js
@@ -9,6 +9,7 @@ es5id: 15.2.4.5_A10
 description: >
     Checking if varying the Object.prototype.hasOwnProperty.length
     property fails
+flags: [noStrict]
 includes: [$FAIL.js]
 ---*/
 

--- a/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A7.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A7.js
@@ -13,7 +13,7 @@ includes:
 var FACTORY = Object.prototype.hasOwnProperty;
 
 try {
-  instance = new FACTORY;
+  var instance = new FACTORY;
   $FAIL('#1: Object.prototype.hasOwnProperty can\'t be used as a constructor');
 } catch (e) {
   $PRINT(e);

--- a/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A8.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A8.js
@@ -24,7 +24,7 @@ if (Object.prototype.hasOwnProperty.propertyIsEnumerable('length')) {
 }
 
 // CHECK#2
-for (p in Object.prototype.hasOwnProperty){
+for (var p in Object.prototype.hasOwnProperty){
   if (p==="length")
         $ERROR('#2: the Object.prototype.hasOwnProperty.length property has the attributes DontEnum');
 }

--- a/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A7.js
+++ b/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A7.js
@@ -13,7 +13,7 @@ includes:
 var FACTORY = Object.prototype.isPrototypeOf;
 
 try {
-  instance = new FACTORY;
+  var instance = new FACTORY;
   $FAIL('#1: Object.prototype.isPrototypeOf can\'t be used as a constructor');
 } catch (e) {
   $PRINT(e);

--- a/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A8.js
+++ b/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A8.js
@@ -24,7 +24,7 @@ if (Object.prototype.isPrototypeOf.propertyIsEnumerable('length')) {
 }
 
 // CHECK#2
-for (p in Object.prototype.isPrototypeOf){
+for (var p in Object.prototype.isPrototypeOf){
   if (p==="length")
         $ERROR('#2: the Object.prototype.isPrototypeOf.length property has the attributes DontEnum');
 }

--- a/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A7.js
+++ b/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A7.js
@@ -15,7 +15,7 @@ includes:
 var FACTORY = Object.prototype.propertyIsEnumerable;
 
 try {
-  instance = new FACTORY;
+  var instance = new FACTORY;
   $FAIL('#1: Object.prototype.propertyIsEnumerable can\'t be used as a constructor');
 } catch (e) {
   $PRINT(e);

--- a/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A8.js
+++ b/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A8.js
@@ -24,7 +24,7 @@ if (Object.prototype.propertyIsEnumerable.propertyIsEnumerable('length')) {
 }
 
 // CHECK#2
-for (p in Object.prototype.propertyIsEnumerable){
+for (var p in Object.prototype.propertyIsEnumerable){
   if (p==="length")
         $ERROR('#2: the Object.prototype.propertyIsEnumerable.length property has the attributes DontEnum');
 }

--- a/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A10.js
+++ b/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A10.js
@@ -9,6 +9,7 @@ es5id: 15.2.4.3_A10
 description: >
     Checking if varying the Object.prototype.toLocaleString.length
     property fails
+flags: [noStrict]
 includes: [$FAIL.js]
 ---*/
 

--- a/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A7.js
+++ b/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A7.js
@@ -13,7 +13,7 @@ includes:
 var FACTORY = Object.prototype.toLocaleString;
 
 try {
-  instance = new FACTORY;
+  var instance = new FACTORY;
   $FAIL('#1: Object.prototype.toLocaleString can\'t be used as a constructor');
 } catch (e) {
   $PRINT(e);

--- a/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A8.js
+++ b/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A8.js
@@ -24,7 +24,7 @@ if (Object.prototype.toLocaleString.propertyIsEnumerable('length')) {
 }
 
 // CHECK#2
-for (p in Object.prototype.toLocaleString){
+for (var p in Object.prototype.toLocaleString){
   if (p==="length")
         $ERROR('#2: the Object.prototype.toLocaleString.length property has the attributes DontEnum');
 }

--- a/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A9.js
+++ b/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A9.js
@@ -9,7 +9,6 @@ es5id: 15.2.4.3_A9
 description: >
     Checknig if deleting of the Object.prototype.toLocaleString.length
     property fails
-flags: [noStrict]
 includes: [$FAIL.js]
 ---*/
 

--- a/test/built-ins/Object/prototype/toString/S15.2.4.2_A7.js
+++ b/test/built-ins/Object/prototype/toString/S15.2.4.2_A7.js
@@ -13,7 +13,7 @@ includes:
 var FACTORY = Object.prototype.toString;
 
 try {
-  instance = new FACTORY;
+  var instance = new FACTORY;
   $FAIL('#1: Object.prototype.toString can\'t be used as a constructor');
 } catch (e) {
   $PRINT(e);

--- a/test/built-ins/Object/prototype/toString/S15.2.4.2_A9.js
+++ b/test/built-ins/Object/prototype/toString/S15.2.4.2_A9.js
@@ -9,7 +9,6 @@ es5id: 15.2.4.2_A9
 description: >
     Checknig if deleting of the Object.prototype.toString.length
     property fails
-flags: [noStrict]
 includes: [$FAIL.js]
 ---*/
 

--- a/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A10.js
+++ b/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A10.js
@@ -7,6 +7,7 @@ es5id: 15.2.4.4_A10
 description: >
     Checking if varying the Object.prototype.valueOf.length property
     fails
+flags: [noStrict]
 includes: [$FAIL.js]
 ---*/
 

--- a/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A7.js
+++ b/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A7.js
@@ -13,7 +13,7 @@ includes:
 var FACTORY = Object.prototype.valueOf;
 
 try {
-  instance = new FACTORY;
+  var instance = new FACTORY;
   $FAIL('#1: Object.prototype.valueOf can\'t be used as a constructor');
 } catch (e) {
   $PRINT(e);

--- a/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A8.js
+++ b/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A8.js
@@ -22,7 +22,7 @@ if (Object.prototype.valueOf.propertyIsEnumerable('length')) {
 }
 
 // CHECK#2
-for (p in Object.prototype.valueOf){
+for (var p in Object.prototype.valueOf){
   if (p==="length")
         $ERROR('#2: the Object.prototype.valueOf.length property has the attributes DontEnum');
 }

--- a/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A9.js
+++ b/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A9.js
@@ -9,7 +9,6 @@ es5id: 15.2.4.4_A9
 description: >
     Checknig if deleting of the Object.prototype.valueOf.length
     property fails
-flags: [noStrict]
 includes: [$FAIL.js]
 ---*/
 


### PR DESCRIPTION
- Add missing "var" declarations and noStrict flags
- Remove invalid noStrict flags
- ietestcenter tests need fixed, require updates to use propertyHelper.js

Part of issue #35.