### PR TITLE
Fix strict mode errors in built-ins/{isFinite, isNaN, parseFloat, parseI...

### DIFF
--- a/test/built-ins/isFinite/S15.1.2.5_A2.1.js
+++ b/test/built-ins/isFinite/S15.1.2.5_A2.1.js
@@ -14,7 +14,7 @@ if (isFinite.propertyIsEnumerable('length') !== false) {
 
 //CHECK#2
 var result = true;
-for (p in isFinite){
+for (var p in isFinite){
   if (p === "length") {
     result = false;
   }  

--- a/test/built-ins/isFinite/S15.1.2.5_A2.2.js
+++ b/test/built-ins/isFinite/S15.1.2.5_A2.2.js
@@ -5,7 +5,6 @@
 info: The length property of isFinite does not have the attribute DontDelete
 es5id: 15.1.2.5_A2.2
 description: Checking use hasOwnProperty, delete
-flags: [noStrict]
 includes: [$FAIL.js]
 ---*/
 

--- a/test/built-ins/isFinite/S15.1.2.5_A2.5.js
+++ b/test/built-ins/isFinite/S15.1.2.5_A2.5.js
@@ -14,7 +14,7 @@ if (this.propertyIsEnumerable('isFinite') !== false) {
 
 //CHECK#2
 var result = true;
-for (p in this){
+for (var p in this){
   if (p === "isFinite") {
     result = false;
   }  

--- a/test/built-ins/isNaN/S15.1.2.4_A2.1.js
+++ b/test/built-ins/isNaN/S15.1.2.4_A2.1.js
@@ -14,7 +14,7 @@ if (isNaN.propertyIsEnumerable('length') !== false) {
 
 //CHECK#2
 var result = true;
-for (p in isNaN){
+for (var p in isNaN){
   if (p === "length") {
     result = false;
   }  

--- a/test/built-ins/isNaN/S15.1.2.4_A2.2.js
+++ b/test/built-ins/isNaN/S15.1.2.4_A2.2.js
@@ -5,7 +5,6 @@
 info: The length property of isNaN does not have the attribute DontDelete
 es5id: 15.1.2.4_A2.2
 description: Checking use hasOwnProperty, delete
-flags: [noStrict]
 includes: [$FAIL.js]
 ---*/
 

--- a/test/built-ins/isNaN/S15.1.2.4_A2.5.js
+++ b/test/built-ins/isNaN/S15.1.2.4_A2.5.js
@@ -14,7 +14,7 @@ if (this.propertyIsEnumerable('isNaN') !== false) {
 
 //CHECK#2
 var result = true;
-for (p in this){
+for (var p in this){
   if (p === "isNaN") {
     result = false;
   }  

--- a/test/built-ins/parseFloat/S15.1.2.3_A7.2.js
+++ b/test/built-ins/parseFloat/S15.1.2.3_A7.2.js
@@ -5,7 +5,6 @@
 info: The length property of parseFloat does not have the attribute DontDelete
 es5id: 15.1.2.3_A7.2
 description: Checking use hasOwnProperty, delete
-flags: [noStrict]
 includes: [$FAIL.js]
 ---*/
 

--- a/test/built-ins/parseInt/S15.1.2.2_A9.2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A9.2.js
@@ -5,7 +5,6 @@
 info: The length property of parseInt does not have the attribute DontDelete
 es5id: 15.1.2.2_A9.2
 description: Checking use hasOwnProperty, delete
-flags: [noStrict]
 includes: [$FAIL.js]
 ---*/
 

--- a/test/built-ins/undefined/15.1.1.3-3.js
+++ b/test/built-ins/undefined/15.1.1.3-3.js
@@ -9,6 +9,7 @@ es5id: 15.1.1.3-3
 description: >
     undefined is not writable, simple assignment should return the
     rval value (11.13.1-6)
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/built-ins/undefined/S15.1.1.3_A3.2.js
+++ b/test/built-ins/undefined/S15.1.1.3_A3.2.js
@@ -8,7 +8,7 @@ description: Use for-in statement
 ---*/
 
 // CHECK#1
-for (prop in this) {
+for (var prop in this) {
   if (prop === "undefined") {
 	$ERROR('#1: The undefined is DontEnum');
   }	 	


### PR DESCRIPTION
...nt, undefined}

- Add missing "var" declarations and noStrict flags
- Remove invalid noStrict flags

Part of issue #35.