### PR TITLE
Fix strict mode errors in {decode, encode}URI[Component]

### DIFF
--- a/test/built-ins/decodeURI/S15.1.3.1_A2.2_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.2_T1.js
@@ -20,7 +20,7 @@ for (var indexB1 = 0x00; indexB1 <= 0x7F; indexB1++) {
   var index = indexB1;  
   try {
     var hex = String.fromCharCode(index);
-    for (indexC = 0; indexC < uriReserved.length; indexC++) {    
+    for (var indexC = 0; indexC < uriReserved.length; indexC++) {
       if (hex === uriReserved[indexC]) continue l;        
     } 
     if (hex === "#") continue l;

--- a/test/built-ins/decodeURI/S15.1.3.1_A5.1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A5.1.js
@@ -13,8 +13,8 @@ if (decodeURI.propertyIsEnumerable('length') !== false) {
 }
 
 //CHECK#2
-result = true;
-for (p in decodeURI){
+var result = true;
+for (var p in decodeURI){
   if (p === "length") {
     result = false;
   }  

--- a/test/built-ins/decodeURI/S15.1.3.1_A5.2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A5.2.js
@@ -5,7 +5,6 @@
 info: The length property of decodeURI does not have the attribute DontDelete
 es5id: 15.1.3.1_A5.2
 description: Checking use hasOwnProperty, delete
-flags: [noStrict]
 includes: [$FAIL.js]
 ---*/
 

--- a/test/built-ins/decodeURI/S15.1.3.1_A5.5.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A5.5.js
@@ -13,8 +13,8 @@ if (this.propertyIsEnumerable('decodeURI') !== false) {
 }
 
 //CHECK#2
-result = true;
-for (p in this){
+var result = true;
+for (var p in this){
   if (p === "decodeURI") {
     result = false;
   }  

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.10_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.10_T1.js
@@ -10,10 +10,10 @@ description: Complex tests
 ---*/
 
 //CHECK
-result = true;
+var result = true;
 var interval = [[0x00, 0x29], [0x40,0x40], [0x47, 0x60], [0x67, 0xFFFF]];
-for (indexI = 0; indexI < interval.length; indexI++) {
-  for (indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
+for (var indexI = 0; indexI < interval.length; indexI++) {
+  for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
     try {
       decodeURIComponent("%C0%" + String.fromCharCode(indexJ, indexJ));
       result = false;      

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.11_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.11_T1.js
@@ -13,10 +13,10 @@ description: >
 ---*/
 
 //CHECK
-result = true;
+var result = true;
 var interval = [[0x00, 0x29], [0x40,0x40], [0x47, 0x60], [0x67, 0xFFFF]];
-for (indexI = 0; indexI < interval.length; indexI++) {
-  for (indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
+for (var indexI = 0; indexI < interval.length; indexI++) {
+  for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
     try {
       decodeURIComponent("%E0%" + String.fromCharCode(indexJ, indexJ) + "%A0");
       result = false;      

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.11_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.11_T2.js
@@ -13,10 +13,10 @@ description: >
 ---*/
 
 //CHECK
-result = true;
+var result = true;
 var interval = [[0x00, 0x29], [0x40,0x40], [0x47, 0x60], [0x67, 0xFFFF]];
-for (indexI = 0; indexI < interval.length; indexI++) {
-  for (indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
+for (var indexI = 0; indexI < interval.length; indexI++) {
+  for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
     try {
       decodeURIComponent("%E0%" + "%A0" + String.fromCharCode(indexJ, indexJ));
       result = false;      

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.12_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.12_T1.js
@@ -14,10 +14,10 @@ description: >
 ---*/
 
 //CHECK
-result = true;
+var result = true;
 var interval = [[0x00, 0x29], [0x40,0x40], [0x47, 0x60], [0x67, 0xFFFF]];
-for (indexI = 0; indexI < interval.length; indexI++) {
-  for (indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
+for (var indexI = 0; indexI < interval.length; indexI++) {
+  for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
     try {
       decodeURIComponent("%F0%" + String.fromCharCode(indexJ, indexJ) + "%A0%A0");
       result = false;      

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.12_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.12_T2.js
@@ -14,10 +14,10 @@ description: >
 ---*/
 
 //CHECK
-result = true;
+var result = true;
 var interval = [[0x00, 0x29], [0x40,0x40], [0x47, 0x60], [0x67, 0xFFFF]];
-for (indexI = 0; indexI < interval.length; indexI++) {
-  for (indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
+for (var indexI = 0; indexI < interval.length; indexI++) {
+  for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
     try {
       decodeURIComponent("%F0%" + "%A0" + String.fromCharCode(indexJ, indexJ) + "%A0");
       result = false;      

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.12_T3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.12_T3.js
@@ -14,10 +14,10 @@ description: >
 ---*/
 
 //CHECK
-result = true;
+var result = true;
 var interval = [[0x00, 0x29], [0x40,0x40], [0x47, 0x60], [0x67, 0xFFFF]];
-for (indexI = 0; indexI < interval.length; indexI++) {
-  for (indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
+for (var indexI = 0; indexI < interval.length; indexI++) {
+  for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
     try {
       decodeURIComponent("%F0%" + "%A0%A0" + String.fromCharCode(indexJ, indexJ));
       result = false;      

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T1.js
@@ -9,17 +9,17 @@ es5id: 15.1.3.2_A1.13_T1
 description: Complex tests. B = [0xC0 - 0xDF], C = [0x00, 0x7F]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB = 0xC0; indexB <= 0xDF; indexB++) {
+for (var indexB = 0xC0; indexB <= 0xDF; indexB++) {
   count++; 
-  hexB = decimalToHexString(indexB);  
-  result = true;
-  for (indexC = 0x00; indexC <= 0x7F; indexC++) {
-    hexC = decimalToHexString(indexC);  
+  var hexB = decimalToHexString(indexB);
+  var result = true;
+  for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
+    var hexC = decimalToHexString(indexC);
     try {
       decodeURIComponent("%" + hexB.substring(2) + "%" + hexC.substring(2));
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T2.js
@@ -9,17 +9,17 @@ es5id: 15.1.3.2_A1.13_T2
 description: Complex tests. B = [0xC0 - 0xDF], C = [0xC0, 0xFF]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB = 0xC0; indexB <= 0xDF; indexB++) {
+for (var indexB = 0xC0; indexB <= 0xDF; indexB++) {
   count++; 
-  hexB = decimalToHexString(indexB);  
-  result = true;
-  for (indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    hexC = decimalToHexString(indexC);  
+  var hexB = decimalToHexString(indexB);
+  var result = true;
+  for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
+    var hexC = decimalToHexString(indexC);
     try {
       decodeURIComponent("%" + hexB.substring(2) + "%" + hexC.substring(2));
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T1.js
@@ -9,17 +9,17 @@ es5id: 15.1.3.2_A1.14_T1
 description: Complex tests. B = [0xE0 - 0xEF], C = [0x00, 0x7F]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB = 0xE0; indexB <= 0xEF; indexB++) {
+for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  hexB = decimalToHexString(indexB); 
-  result = true;
-  for (indexC = 0x00; indexC <= 0x7F; indexC++) {
-    hexC = decimalToHexString(indexC);  
+  var hexB = decimalToHexString(indexB);
+  var result = true;
+  for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
+    var hexC = decimalToHexString(indexC);
     try {
       decodeURIComponent("%" + hexB.substring(2) + "%" + hexC.substring(2) + "%A0");
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T2.js
@@ -9,17 +9,17 @@ es5id: 15.1.3.2_A1.14_T2
 description: Complex tests. B = [0xE0 - 0xEF], C = [0x00, 0x7F]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB = 0xE0; indexB <= 0xEF; indexB++) {
+for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  hexB = decimalToHexString(indexB);  
-  result = true;
-  for (indexC = 0x00; indexC <= 0x7F; indexC++) {
-    hexC = decimalToHexString(indexC);  
+  var hexB = decimalToHexString(indexB);
+  var result = true;
+  for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
+    var hexC = decimalToHexString(indexC);
     try {
       decodeURIComponent("%" + hexB.substring(2) + "%A0" + "%" + hexC.substring(2));
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T3.js
@@ -9,17 +9,17 @@ es5id: 15.1.3.2_A1.14_T3
 description: Complex tests. B = [0xE0 - 0xEF], C = [0xC0, 0xFF]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB = 0xE0; indexB <= 0xEF; indexB++) {
+for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  hexB = decimalToHexString(indexB); 
-  result = true;
-  for (indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    hexC = decimalToHexString(indexC);  
+  var hexB = decimalToHexString(indexB);
+  var result = true;
+  for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
+    var hexC = decimalToHexString(indexC);
     try {
       decodeURIComponent("%" + hexB.substring(2) + "%" + hexC.substring(2) + "%A0");
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T4.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T4.js
@@ -9,17 +9,17 @@ es5id: 15.1.3.2_A1.14_T4
 description: Complex tests. B = [0xE0 - 0xEF], C = [0xC0, 0xFF]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB = 0xE0; indexB <= 0xEF; indexB++) {
+for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  hexB = decimalToHexString(indexB);  
-  result = true;
-  for (indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    hexC = decimalToHexString(indexC);  
+  var hexB = decimalToHexString(indexB);
+  var result = true;
+  for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
+    var hexC = decimalToHexString(indexC);
     try {
       decodeURIComponent("%" + hexB.substring(2) + "%A0" + "%" + hexC.substring(2));
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T1.js
@@ -9,17 +9,17 @@ es5id: 15.1.3.2_A1.15_T1
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0x00, 0x7F]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB = 0xF0; indexB <= 0xF7; indexB++) {
+for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  hexB = decimalToHexString(indexB); 
-  result = true;
-  for (indexC = 0x00; indexC <= 0x7F; indexC++) {
-    hexC = decimalToHexString(indexC);  
+  var hexB = decimalToHexString(indexB);
+  var result = true;
+  for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
+    var hexC = decimalToHexString(indexC);
     try {
       decodeURIComponent("%" + hexB.substring(2) + "%" + hexC.substring(2) + "%A0%A0");
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T2.js
@@ -9,17 +9,17 @@ es5id: 15.1.3.2_A1.15_T2
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0x00, 0x7F]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB = 0xF0; indexB <= 0xF7; indexB++) {
+for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  hexB = decimalToHexString(indexB); 
-  result = true;
-  for (indexC = 0x00; indexC <= 0x7F; indexC++) {
-    hexC = decimalToHexString(indexC);  
+  var hexB = decimalToHexString(indexB);
+  var result = true;
+  for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
+    var hexC = decimalToHexString(indexC);
     try {
       decodeURIComponent("%" + hexB.substring(2) + "%A0" + "%" + hexC.substring(2) + "%A0");
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T3.js
@@ -9,17 +9,17 @@ es5id: 15.1.3.2_A1.15_T3
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0x00, 0x7F]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB = 0xF0; indexB <= 0xF7; indexB++) {
+for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  hexB = decimalToHexString(indexB); 
-  result = true;
-  for (indexC = 0x00; indexC <= 0x7F; indexC++) {
-    hexC = decimalToHexString(indexC);  
+  var hexB = decimalToHexString(indexB);
+  var result = true;
+  for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
+    var hexC = decimalToHexString(indexC);
     try {
       decodeURIComponent("%" + hexB.substring(2) + "%A0%A0" + "%" + hexC.substring(2));
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T4.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T4.js
@@ -9,17 +9,17 @@ es5id: 15.1.3.2_A1.15_T4
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0xC0, 0xFF]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB = 0xF0; indexB <= 0xF7; indexB++) {
+for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  hexB = decimalToHexString(indexB); 
-  result = true;
-  for (indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    hexC = decimalToHexString(indexC);  
+  var hexB = decimalToHexString(indexB);
+  var result = true;
+  for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
+    var hexC = decimalToHexString(indexC);
     try {
       decodeURIComponent("%" + hexB.substring(2) + "%" + hexC.substring(2) + "%A0%A0");
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T5.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T5.js
@@ -9,17 +9,17 @@ es5id: 15.1.3.2_A1.15_T5
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0xC0, 0xFF]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB = 0xF0; indexB <= 0xF7; indexB++) {
+for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  hexB = decimalToHexString(indexB); 
-  result = true;
-  for (indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    hexC = decimalToHexString(indexC);  
+  var hexB = decimalToHexString(indexB);
+  var result = true;
+  for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
+    var hexC = decimalToHexString(indexC);
     try {
       decodeURIComponent("%" + hexB.substring(2) + "%A0" + "%" + hexC.substring(2) + "%A0");
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T6.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T6.js
@@ -9,17 +9,17 @@ es5id: 15.1.3.2_A1.15_T6
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0xC0, 0xFF]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB = 0xF0; indexB <= 0xF7; indexB++) {
+for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  hexB = decimalToHexString(indexB); 
-  result = true;
-  for (indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    hexC = decimalToHexString(indexC);  
+  var hexB = decimalToHexString(indexB);
+  var result = true;
+  for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
+    var hexC = decimalToHexString(indexC);
     try {
       decodeURIComponent("%" + hexB.substring(2) + "%A0%A0" + "%" + hexC.substring(2));
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.1_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.1_T1.js
@@ -7,7 +7,7 @@ es5id: 15.1.3.2_A1.1_T1
 description: Complex tests
 ---*/
 
-result = true;
+var result = true;
 
 //CHECK#1
 try {

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.2_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.2_T1.js
@@ -10,10 +10,10 @@ description: Complex tests
 ---*/
 
 //CHECK
-result = true;
+var result = true;
 var interval = [[0x00, 0x29], [0x40,0x40], [0x47, 0x60], [0x67, 0xFFFF]];
-for (indexI = 0; indexI < interval.length; indexI++) {
-  for (indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
+for (var indexI = 0; indexI < interval.length; indexI++) {
+  for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
     try {
       decodeURIComponent("%" + String.fromCharCode(indexJ) + "1");
       result = false;

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.2_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.2_T2.js
@@ -10,10 +10,10 @@ description: Complex tests
 ---*/
 
 //CHECK
-result = true;
+var result = true;
 var interval = [[0x00, 0x29], [0x40,0x40], [0x47, 0x60], [0x67, 0xFFFF]];
-for (indexI = 0; indexI < interval.length; indexI++) {
-  for (indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
+for (var indexI = 0; indexI < interval.length; indexI++) {
+  for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
     try {
       decodeURIComponent("%" + "1" + String.fromCharCode(indexJ));
       result = false;

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T1.js
@@ -7,14 +7,14 @@ es5id: 15.1.3.2_A1.3_T1
 description: Complex tests. B = 10xxxxxx -> B in [0x80 - 0xBF]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0x80; index <= 0xBF; index++) {
+for (var index = 0x80; index <= 0xBF; index++) {
   count++; 
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     decodeURIComponent("%" + hex.substring(2));
   } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T2.js
@@ -7,14 +7,14 @@ es5id: 15.1.3.2_A1.3_T2
 description: Complex tests. B = 11111xxx -> B in [0xF8 - 0xFF]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xF8; index <= 0xFF; index++) {
+for (var index = 0xF8; index <= 0xFF; index++) {
   count++; 
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     decodeURIComponent("%" + hex.substring(2));
   } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.4_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.4_T1.js
@@ -7,17 +7,17 @@ es5id: 15.1.3.2_A1.4_T1
 description: Complex tests. B = [0xC0 - 0xDF]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xC0; index <= 0xDF; index++) {
+for (var index = 0xC0; index <= 0xDF; index++) {
   count++; 
-  str = "";
-  result = true;
-  for (len = 0; len < 3; len++) {
-    hex = decimalToHexString(index);
+  var str = "";
+  var result = true;
+  for (var len = 0; len < 3; len++) {
+    var hex = decimalToHexString(index);
     try {
       decodeURIComponent("%" + hex.substring(2) + str);      
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.5_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.5_T1.js
@@ -7,17 +7,17 @@ es5id: 15.1.3.2_A1.5_T1
 description: Complex tests. B = [0xE0 - 0xEF]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xE0; index <= 0xEF; index++) {
+for (var index = 0xE0; index <= 0xEF; index++) {
   count++; 
-  str = "";
-  result = true;
-  for (len = 0; len < 6; len++) {
-    hex = decimalToHexString(index);
+  var str = "";
+  var result = true;
+  for (var len = 0; len < 6; len++) {
+    var hex = decimalToHexString(index);
     try {
       decodeURIComponent("%" + hex.substring(2) + str);      
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.6_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.6_T1.js
@@ -7,17 +7,17 @@ es5id: 15.1.3.2_A1.6_T1
 description: Complex tests. B = [0xF0 - 0xF7]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xF0; index <= 0xF7; index++) {
+for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  str = "";
-  result = true;
-  for (len = 0; len < 9; len++) {
-    hex = decimalToHexString(index);
+  var str = "";
+  var result = true;
+  for (var len = 0; len < 9; len++) {
+    var hex = decimalToHexString(index);
     try {
       decodeURIComponent("%" + hex.substring(2) + str);      
     } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.7_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.7_T1.js
@@ -9,14 +9,14 @@ es5id: 15.1.3.2_A1.7_T1
 description: Complex tests. B = [0xC0 - 0xDF]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xC0; index <= 0xDF; index++) {
+for (var index = 0xC0; index <= 0xDF; index++) {
   count++; 
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     decodeURIComponent("%" + hex.substring(2) + "111");
   } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T1.js
@@ -11,14 +11,14 @@ description: >
     "%"
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xE0; index <= 0xEF; index++) {
+for (var index = 0xE0; index <= 0xEF; index++) {
   count++; 
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     decodeURIComponent("%" + hex.substring(2) + "111%A0");
   } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T2.js
@@ -11,14 +11,14 @@ description: >
     "%"
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xE0; index <= 0xEF; index++) {
+for (var index = 0xE0; index <= 0xEF; index++) {
   count++; 
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     decodeURIComponent("%" + hex.substring(2) + "%A0111");
   } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T1.js
@@ -11,14 +11,14 @@ description: >
     "%"
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xF0; index <= 0xF7; index++) {
+for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     decodeURIComponent("%" + hex.substring(2) + "111%A0%A0");
   } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T2.js
@@ -11,14 +11,14 @@ description: >
     "%"
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xF0; index <= 0xF7; index++) {
+for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     decodeURIComponent("%" + hex.substring(2) + "%A0111%A0");
   } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T3.js
@@ -11,14 +11,14 @@ description: >
     "%"
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xF0; index <= 0xF7; index++) {
+for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     decodeURIComponent("%" + hex.substring(2) + "%A0%A0111");
   } catch (e) { 

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.1_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.1_T1.js
@@ -8,11 +8,11 @@ description: Complex tests
 ---*/
 
 //CHECK
-errorCount = 0;
-count = 0;
-for (indexI = 0; indexI <= 65535; indexI++) {
+var errorCount = 0;
+var count = 0;
+for (var indexI = 0; indexI <= 65535; indexI++) {
   if (indexI !== 0x25) {
-    hex = decimalToHexString(indexI);
+    var hex = decimalToHexString(indexI);
     try {    
       var str = String.fromCharCode(indexI);
       if (decodeURIComponent(str) !== str) {    

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.2_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.2_T1.js
@@ -8,16 +8,16 @@ description: Complex tests, use RFC 3629
 includes: [Test262Error.js]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
-for (indexB1 = 0x00; indexB1 <= 0x7F; indexB1++) {       
+for (var indexB1 = 0x00; indexB1 <= 0x7F; indexB1++) {
   count++;
   var hexB1 = decimalToHexString(indexB1);  
   var index = indexB1;  
   try {
-    hex = String.fromCharCode(index);
+    var hex = String.fromCharCode(index);
     if (decodeURIComponent("%" + hexB1.substring(2)) === hex) continue;
   } catch (e) {
     if (e instanceof Test262Error) throw e;

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
@@ -10,14 +10,14 @@ description: Complex tests, use RFC 3629
 includes: [Test262Error.js]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB1 = 0xC2; indexB1 <= 0xDF; indexB1++) {     
+for (var indexB1 = 0xC2; indexB1 <= 0xDF; indexB1++) {
   var hexB1 = decimalToHexString(indexB1);
-  for (indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
+  for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     count++;
     var hexB2 = decimalToHexString(indexB2);
     var index = (indexB1 & 0x1F) * 0x40 + (indexB2 & 0x3F);  

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
@@ -11,18 +11,18 @@ description: Complex tests, use RFC 3629
 includes: [Test262Error.js]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB1 = 0xE0; indexB1 <= 0xEF; indexB1++) {     
+for (var indexB1 = 0xE0; indexB1 <= 0xEF; indexB1++) {
   var hexB1 = decimalToHexString(indexB1);
-  for (indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
+  for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     if ((indexB1 === 0xE0) && (indexB2 <= 0x9F)) continue;
     if ((indexB1 === 0xED) && (0xA0 <= indexB2)) continue;         
     var hexB2 = decimalToHexString(indexB2);
-    for (indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
+    for (var indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
       count++;
       var hexB3 = decimalToHexString(indexB3);
       var index = (indexB1 & 0x0F) * 0x1000 + (indexB2 & 0x3F) * 0x40 + (indexB3 & 0x3F);  

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
@@ -11,20 +11,20 @@ description: Complex tests, use RFC 3629
 includes: [Test262Error.js]
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {     
+for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
   var hexB1 = decimalToHexString(indexB1);
-  for (indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
+  for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     if ((indexB1 === 0xF0) && (indexB2 <= 0x9F)) continue;            
     if ((indexB1 === 0xF4) && (indexB2 >= 0x90)) continue;
     var hexB2 = decimalToHexString(indexB2);
-    for (indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
+    for (var indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
       var hexB3 = decimalToHexString(indexB3);
-      for (indexB4 = 0x80; indexB4 <= 0xBF; indexB4++) {
+      for (var indexB4 = 0x80; indexB4 <= 0xBF; indexB4++) {
         var hexB4 = decimalToHexString(indexB4);
         count++;
         var index = (indexB1 & 0x07) * 0x40000 + (indexB2 & 0x3F) * 0x1000 + (indexB3 & 0x3F) * 0x40 + (indexB4 & 0x3F);

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A5.1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A5.1.js
@@ -13,8 +13,8 @@ if (decodeURIComponent.propertyIsEnumerable('length') !== false) {
 }
 
 //CHECK#2
-result = true;
-for (p in decodeURIComponent){
+var result = true;
+for (var p in decodeURIComponent){
   if (p === "length") {
     result = false;
   }  

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A5.3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A5.3.js
@@ -5,6 +5,7 @@
 info: The length property of decodeURIComponent has the attribute ReadOnly
 es5id: 15.1.3.2_A5.3
 description: Checking if varying the length property fails
+flags: [noStrict]
 ---*/
 
 //CHECK#1

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A5.5.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A5.5.js
@@ -13,8 +13,8 @@ if (this.propertyIsEnumerable('decodeURIComponent') !== false) {
 }
 
 //CHECK#2
-result = true;
-for (p in this){
+var result = true;
+for (var p in this){
   if (p === "decodeURIComponent") {
     result = false;
   }  

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.1_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.1_T1.js
@@ -7,14 +7,14 @@ es5id: 15.1.3.3_A1.1_T1
 description: Complex tests
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xDC00; index <= 0xDFFF; index++) {
+for (var index = 0xDC00; index <= 0xDFFF; index++) {
   count++; 
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     encodeURI(String.fromCharCode(index));
   } catch (e) { 

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.1_T2.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.1_T2.js
@@ -7,14 +7,14 @@ es5id: 15.1.3.3_A1.1_T2
 description: Complex tests
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xDC00; index <= 0xDFFF; index++) { 
+for (var index = 0xDC00; index <= 0xDFFF; index++) {
   count++; 
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     encodeURI(String.fromCharCode(index, 0x0041));
   } catch (e) { 

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.2_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.2_T1.js
@@ -9,14 +9,14 @@ es5id: 15.1.3.3_A1.2_T1
 description: Complex tests
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xD800; index <= 0xDBFF; index++) {
+for (var index = 0xD800; index <= 0xDBFF; index++) {
   count++;   
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     encodeURI(String.fromCharCode(index));
   } catch (e) { 

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.2_T2.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.2_T2.js
@@ -9,14 +9,14 @@ es5id: 15.1.3.3_A1.2_T2
 description: Complex tests
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xD800; index <= 0xDBFF; index++) { 
+for (var index = 0xD800; index <= 0xDBFF; index++) {
   count++; 
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     encodeURI(String.fromCharCode(0x0041, index));
   } catch (e) { 

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.3_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.3_T1.js
@@ -11,17 +11,17 @@ description: >
     0xDBFE, 0xDBFF, 0xE000, 0xFFFF]
 ---*/
 
-chars = [0x0000, 0xD7FF, 0xD800, 0xDBFE, 0xDBFF, 0xE000, 0xFFFF];
-errorCount = 0;
-count = 0;
+var chars = [0x0000, 0xD7FF, 0xD800, 0xDBFE, 0xDBFF, 0xE000, 0xFFFF];
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xD800; index <= 0xDBFF; index++) {
+for (var index = 0xD800; index <= 0xDBFF; index++) {
   count++; 
-  res = true;
-  for (indexC = 0; indexC < chars.length; indexC++) {  
-    hex = decimalToHexString(index);
+  var res = true;
+  for (var indexC = 0; indexC < chars.length; indexC++) {
+    var hex = decimalToHexString(index);
     try {
       encodeURI(String.fromCharCode(index, chars[indexC]));    
     } catch (e) { 

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.1_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.1_T1.js
@@ -9,18 +9,18 @@ es5id: 15.1.3.3_A2.1_T1
 description: Complex tests, use RFC 3629
 ---*/
 
-uriReserved = [";", "/", "?", ":", "@", "&", "=", "+", "$", ","];
-uriUnescaped = ["-", "_", ".", "!", "~", "*", "'", "(", ")", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]; 
-errorCount = 0;
-count = 0;
+var uriReserved = [";", "/", "?", ":", "@", "&", "=", "+", "$", ","];
+var uriUnescaped = ["-", "_", ".", "!", "~", "*", "'", "(", ")", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
 l : 
-for (index = 0x0000; index <= 0x007F; index++) {
+for (var index = 0x0000; index <= 0x007F; index++) {
   count++;
-  str = String.fromCharCode(index);
-  for (indexC = 0; indexC < uriReserved.length; indexC++) {    
+  var str = String.fromCharCode(index);
+  for (var indexC = 0; indexC < uriReserved.length; indexC++) {
     if (uriReserved[indexC] === str) continue l;
   }
    for (indexC = 0; indexC < uriUnescaped.length; indexC++) {

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.2_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.2_T1.js
@@ -9,16 +9,16 @@ es5id: 15.1.3.3_A2.2_T1
 description: Complex tests, use RFC 3629
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0; 
 l:
-for (index = 0x0080; index <= 0x07FF; index++) {
+for (var index = 0x0080; index <= 0x07FF; index++) {
   count++;  
-  hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
-  hex2 = decimalToHexString(0x00C0 + (index & 0x07C0) / 0x0040).substring(2);    
-  str = String.fromCharCode(index);
+  var hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
+  var hex2 = decimalToHexString(0x00C0 + (index & 0x07C0) / 0x0040).substring(2);
+  var str = String.fromCharCode(index);
   try {
     if (encodeURI(str).toUpperCase() === "%" + hex2 + "%" + hex1) continue;
   } catch(e) {}  

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.3_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.3_T1.js
@@ -9,16 +9,16 @@ es5id: 15.1.3.3_A2.3_T1
 description: Complex tests, use RFC 3629
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0; 
-for (index = 0x0800; index <= 0xD7FF; index++) {
+for (var index = 0x0800; index <= 0xD7FF; index++) {
   count++; 
-  hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
-  hex2 = decimalToHexString(0x0080 + (index & 0x0FC0) / 0x0040).substring(2);
-  hex3 = decimalToHexString(0x00E0 + (index & 0xF000) / 0x1000).substring(2);
-  str = String.fromCharCode(index);
+  var hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
+  var hex2 = decimalToHexString(0x0080 + (index & 0x0FC0) / 0x0040).substring(2);
+  var hex3 = decimalToHexString(0x00E0 + (index & 0xF000) / 0x1000).substring(2);
+  var str = String.fromCharCode(index);
   try {
     if (encodeURI(str).toUpperCase() === "%" + hex3 + "%" + hex2 + "%" + hex1) continue;
   } catch(e) {}      

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.4_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.4_T1.js
@@ -12,20 +12,20 @@ description: >
     0xDDFF, 0xDFFF]
 ---*/
 
-chars = [0xDC00, 0xDDFF, 0xDFFF]; 
-errorCount = 0;
-count = 0;
+var chars = [0xDC00, 0xDDFF, 0xDFFF];
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0; 
-for (index = 0xD800; index <= 0xDBFF; index++) {
-  res = true;
-  for (indexC = 0; indexC < chars.length; indexC++) {
-    index1 = (index - 0xD800) * 0x400 + (chars[indexC] - 0xDC00) + 0x10000; 
-    hex1 = decimalToHexString(0x0080 + (index1 & 0x003F)).substring(2);
-    hex2 = decimalToHexString(0x0080 + (index1 & 0x0FC0) / 0x0040).substring(2);
-    hex3 = decimalToHexString(0x0080 + (index1 & 0x3F000) / 0x1000).substring(2);
-    hex4 = decimalToHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000).substring(2);
-    str = String.fromCharCode(index, chars[indexC]);
+for (var index = 0xD800; index <= 0xDBFF; index++) {
+  var res = true;
+  for (var indexC = 0; indexC < chars.length; indexC++) {
+    var index1 = (index - 0xD800) * 0x400 + (chars[indexC] - 0xDC00) + 0x10000;
+    var hex1 = decimalToHexString(0x0080 + (index1 & 0x003F)).substring(2);
+    var hex2 = decimalToHexString(0x0080 + (index1 & 0x0FC0) / 0x0040).substring(2);
+    var hex3 = decimalToHexString(0x0080 + (index1 & 0x3F000) / 0x1000).substring(2);
+    var hex4 = decimalToHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000).substring(2);
+    var str = String.fromCharCode(index, chars[indexC]);
     try {
       if (encodeURI(str).toUpperCase() !== "%" + hex4 + "%" + hex3 + "%" + hex2 + "%" + hex1) {
         res = false;

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.4_T2.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.4_T2.js
@@ -12,20 +12,20 @@ description: >
     0xD9FF]
 ---*/
 
-chars = [0xD800, 0xDBFF, 0xD9FF]; 
-errorCount = 0;
-count = 0;
+var chars = [0xD800, 0xDBFF, 0xD9FF];
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0; 
-for (index = 0xDC00; index <= 0xDFFF; index++) {
-  res = true;
-  for (indexC = 0; indexC < chars.length; indexC++) {
-    index1 = (chars[indexC] - 0xD800) * 0x400 + (index - 0xDC00) + 0x10000; 
-    hex1 = decimalToHexString(0x0080 + (index1 & 0x003F)).substring(2);
-    hex2 = decimalToHexString(0x0080 + (index1 & 0x0FC0) / 0x0040).substring(2);
-    hex3 = decimalToHexString(0x0080 + (index1 & 0x3F000) / 0x1000).substring(2);
-    hex4 = decimalToHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000).substring(2);
-    str = String.fromCharCode(chars[indexC], index);
+for (var index = 0xDC00; index <= 0xDFFF; index++) {
+  var res = true;
+  for (var indexC = 0; indexC < chars.length; indexC++) {
+    var index1 = (chars[indexC] - 0xD800) * 0x400 + (index - 0xDC00) + 0x10000;
+    var hex1 = decimalToHexString(0x0080 + (index1 & 0x003F)).substring(2);
+    var hex2 = decimalToHexString(0x0080 + (index1 & 0x0FC0) / 0x0040).substring(2);
+    var hex3 = decimalToHexString(0x0080 + (index1 & 0x3F000) / 0x1000).substring(2);
+    var hex4 = decimalToHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000).substring(2);
+    var str = String.fromCharCode(chars[indexC], index);
     try {
       if (encodeURI(str).toUpperCase() !== "%" + hex4 + "%" + hex3 + "%" + hex2 + "%" + hex1) {
         res = false;

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.5_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.5_T1.js
@@ -9,16 +9,16 @@ es5id: 15.1.3.3_A2.5_T1
 description: Complex tests, use RFC 3629
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0; 
-for (index = 0xE000; index <= 0xFFFF; index++) {
+for (var index = 0xE000; index <= 0xFFFF; index++) {
   count++;  
-  hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
-  hex2 = decimalToHexString(0x0080 + (index & 0x0FC0) / 0x0040).substring(2);
-  hex3 = decimalToHexString(0x00E0 + (index & 0xF000) / 0x1000).substring(2);
-  str = String.fromCharCode(index);
+  var hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
+  var hex2 = decimalToHexString(0x0080 + (index & 0x0FC0) / 0x0040).substring(2);
+  var hex3 = decimalToHexString(0x00E0 + (index & 0xF000) / 0x1000).substring(2);
+  var str = String.fromCharCode(index);
   try {
     if (encodeURI(str).toUpperCase() === "%" + hex3 + "%" + hex2 + "%" + hex1) continue;
   } catch(e) {}      

--- a/test/built-ins/encodeURI/S15.1.3.3_A3.1_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A3.1_T1.js
@@ -9,8 +9,8 @@ es5id: 15.1.3.3_A3.1_T1
 description: Complex tests
 ---*/
 
-uriReserved = [";", "/", "?", ":", "@", "&", "=", "+", "$", ","];
-for (indexC = 0; indexC < uriReserved.length; indexC++) {
+var uriReserved = [";", "/", "?", ":", "@", "&", "=", "+", "$", ","];
+for (var indexC = 0; indexC < uriReserved.length; indexC++) {
   var str = uriReserved[indexC];    
   if (encodeURI(str) !== str) {
     $ERROR('#' + (indexC + 1) + ': unescapedURISet containing' + str);

--- a/test/built-ins/encodeURI/S15.1.3.3_A3.2_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A3.2_T1.js
@@ -9,8 +9,8 @@ es5id: 15.1.3.3_A3.2_T1
 description: "Complex tests, uriUnescaped :: uriAlpha"
 ---*/
 
-uriAlpha = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"];
-for (indexC = 0; indexC < uriAlpha.length; indexC++) {
+var uriAlpha = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"];
+for (var indexC = 0; indexC < uriAlpha.length; indexC++) {
   var str = uriAlpha[indexC];    
   if (encodeURI(str) !== str) {
     $ERROR('#' + (indexC + 1) + ': unescapedURISet containing ' + str);

--- a/test/built-ins/encodeURI/S15.1.3.3_A3.2_T2.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A3.2_T2.js
@@ -9,8 +9,8 @@ es5id: 15.1.3.3_A3.2_T2
 description: "Complex tests, uriUnescaped :: DecimalDigit"
 ---*/
 
-DecimalDigit = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
-for (indexC = 0; indexC < DecimalDigit.length; indexC++) {
+var DecimalDigit = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+for (var indexC = 0; indexC < DecimalDigit.length; indexC++) {
   var str = DecimalDigit[indexC];    
   if (encodeURI(str) !== str) {
     $ERROR('#' + (indexC + 1) + ': unescapedURISet containing' + str);

--- a/test/built-ins/encodeURI/S15.1.3.3_A3.2_T3.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A3.2_T3.js
@@ -9,8 +9,8 @@ es5id: 15.1.3.3_A3.2_T3
 description: "Complex tests, uriUnescaped :: uriMark"
 ---*/
 
-uriMark = ["-", "_", ".", "!", "~", "*", "'", "(", ")"];
-for (indexC = 0; indexC < uriMark.length; indexC++) {
+var uriMark = ["-", "_", ".", "!", "~", "*", "'", "(", ")"];
+for (var indexC = 0; indexC < uriMark.length; indexC++) {
   var str = uriMark[indexC];    
   if (encodeURI(str) !== str) {
     $ERROR('#' + (indexC + 1) + ': unescapedURISet containing' + str);

--- a/test/built-ins/encodeURI/S15.1.3.3_A5.1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A5.1.js
@@ -13,8 +13,8 @@ if (encodeURI.propertyIsEnumerable('length') !== false) {
 }
 
 //CHECK#2
-result = true;
-for (p in encodeURI){
+var result = true;
+for (var p in encodeURI){
   if (p === "length") {
     result = false;
   }  

--- a/test/built-ins/encodeURI/S15.1.3.3_A5.3.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A5.3.js
@@ -5,6 +5,7 @@
 info: The length property of encodeURI has the attribute ReadOnly
 es5id: 15.1.3.3_A5.3
 description: Checking if varying the length property fails
+flags: [noStrict]
 ---*/
 
 //CHECK#1

--- a/test/built-ins/encodeURI/S15.1.3.3_A5.5.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A5.5.js
@@ -13,8 +13,8 @@ if (this.propertyIsEnumerable('encodeURI') !== false) {
 }
 
 //CHECK#2
-result = true;
-for (p in this){
+var result = true;
+for (var p in this){
   if (p === "encodeURI") {
     result = false;
   }  

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.1_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.1_T1.js
@@ -7,14 +7,14 @@ es5id: 15.1.3.4_A1.1_T1
 description: Complex tests
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xDC00; index <= 0xDFFF; index++) {
+for (var index = 0xDC00; index <= 0xDFFF; index++) {
   count++; 
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     encodeURIComponent(String.fromCharCode(index));
   } catch (e) { 

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.1_T2.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.1_T2.js
@@ -7,14 +7,14 @@ es5id: 15.1.3.4_A1.1_T2
 description: Complex tests
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xDC00; index <= 0xDFFF; index++) { 
+for (var index = 0xDC00; index <= 0xDFFF; index++) {
   count++; 
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     encodeURIComponent(String.fromCharCode(index, 0x0041));
   } catch (e) { 

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.2_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.2_T1.js
@@ -9,14 +9,14 @@ es5id: 15.1.3.4_A1.2_T1
 description: Complex tests
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xD800; index <= 0xDBFF; index++) {
+for (var index = 0xD800; index <= 0xDBFF; index++) {
   count++;   
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     encodeURIComponent(String.fromCharCode(index));
   } catch (e) { 

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.2_T2.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.2_T2.js
@@ -9,14 +9,14 @@ es5id: 15.1.3.4_A1.2_T2
 description: Complex tests
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xD800; index <= 0xDBFF; index++) { 
+for (var index = 0xD800; index <= 0xDBFF; index++) {
   count++; 
-  hex = decimalToHexString(index);
+  var hex = decimalToHexString(index);
   try {
     encodeURIComponent(String.fromCharCode(0x0041, index));
   } catch (e) { 

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.3_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.3_T1.js
@@ -11,17 +11,17 @@ description: >
     0xDBFE, 0xDBFF, 0xE000, 0xFFFF]
 ---*/
 
-chars = [0x0000, 0xD7FF, 0xD800, 0xDBFE, 0xDBFF, 0xE000, 0xFFFF];
-errorCount = 0;
-count = 0;
+var chars = [0x0000, 0xD7FF, 0xD800, 0xDBFE, 0xDBFF, 0xE000, 0xFFFF];
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
-for (index = 0xD800; index <= 0xDBFF; index++) {
+for (var index = 0xD800; index <= 0xDBFF; index++) {
   count++; 
-  res = true;
-  for (indexC = 0; indexC < chars.length; indexC++) {  
-    hex = decimalToHexString(index);
+  var res = true;
+  for (var indexC = 0; indexC < chars.length; indexC++) {
+    var hex = decimalToHexString(index);
     try {
       encodeURIComponent(String.fromCharCode(index, chars[indexC]));    
     } catch (e) { 

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.1_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.1_T1.js
@@ -9,17 +9,17 @@ es5id: 15.1.3.4_A2.1_T1
 description: Complex tests, use RFC 3629
 ---*/
 
-uriUnescaped = ["-", "_", ".", "!", "~", "*", "'", "(", ")", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]; 
-errorCount = 0;
-count = 0;
+var uriUnescaped = ["-", "_", ".", "!", "~", "*", "'", "(", ")", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0;
 
 l : 
-for (index = 0x0000; index <= 0x007F; index++) {
+for (var index = 0x0000; index <= 0x007F; index++) {
   count++;
-  str = String.fromCharCode(index);
-    for (indexC = 0; indexC < uriUnescaped.length; indexC++) {
+  var str = String.fromCharCode(index);
+    for (var indexC = 0; indexC < uriUnescaped.length; indexC++) {
     if (uriUnescaped[indexC] === str) continue l;
   }    
   try {

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.2_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.2_T1.js
@@ -9,16 +9,16 @@ es5id: 15.1.3.4_A2.2_T1
 description: Complex tests, use RFC 3629
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0; 
 l:
-for (index = 0x0080; index <= 0x07FF; index++) {
+for (var index = 0x0080; index <= 0x07FF; index++) {
   count++;  
-  hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
-  hex2 = decimalToHexString(0x00C0 + (index & 0x07C0) / 0x0040).substring(2);    
-  str = String.fromCharCode(index);
+  var hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
+  var hex2 = decimalToHexString(0x00C0 + (index & 0x07C0) / 0x0040).substring(2);
+  var str = String.fromCharCode(index);
   try {
     if (encodeURIComponent(str).toUpperCase() === "%" + hex2 + "%" + hex1) continue;
   } catch(e) {}  

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.3_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.3_T1.js
@@ -9,16 +9,16 @@ es5id: 15.1.3.4_A2.3_T1
 description: Complex tests, use RFC 3629
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0; 
-for (index = 0x0800; index <= 0xD7FF; index++) {
+for (var index = 0x0800; index <= 0xD7FF; index++) {
   count++; 
-  hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
-  hex2 = decimalToHexString(0x0080 + (index & 0x0FC0) / 0x0040).substring(2);
-  hex3 = decimalToHexString(0x00E0 + (index & 0xF000) / 0x1000).substring(2);
-  str = String.fromCharCode(index);
+  var hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
+  var hex2 = decimalToHexString(0x0080 + (index & 0x0FC0) / 0x0040).substring(2);
+  var hex3 = decimalToHexString(0x00E0 + (index & 0xF000) / 0x1000).substring(2);
+  var str = String.fromCharCode(index);
   try {
     if (encodeURIComponent(str).toUpperCase() === "%" + hex3 + "%" + hex2 + "%" + hex1) continue;
   } catch(e) {}      

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T1.js
@@ -12,20 +12,20 @@ description: >
     0xDDFF, 0xDFFF]
 ---*/
 
-chars = [0xDC00, 0xDDFF, 0xDFFF]; 
-errorCount = 0;
-count = 0;
+var chars = [0xDC00, 0xDDFF, 0xDFFF];
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0; 
-for (index = 0xD800; index <= 0xDBFF; index++) {
-  res = true;
-  for (indexC = 0; indexC < chars.length; indexC++) {
-    index1 = (index - 0xD800) * 0x400 + (chars[indexC] - 0xDC00) + 0x10000; 
-    hex1 = decimalToHexString(0x0080 + (index1 & 0x003F)).substring(2);
-    hex2 = decimalToHexString(0x0080 + (index1 & 0x0FC0) / 0x0040).substring(2);
-    hex3 = decimalToHexString(0x0080 + (index1 & 0x3F000) / 0x1000).substring(2);
-    hex4 = decimalToHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000).substring(2);
-    str = String.fromCharCode(index, chars[indexC]);
+for (var index = 0xD800; index <= 0xDBFF; index++) {
+  var res = true;
+  for (var indexC = 0; indexC < chars.length; indexC++) {
+    var index1 = (index - 0xD800) * 0x400 + (chars[indexC] - 0xDC00) + 0x10000;
+    var hex1 = decimalToHexString(0x0080 + (index1 & 0x003F)).substring(2);
+    var hex2 = decimalToHexString(0x0080 + (index1 & 0x0FC0) / 0x0040).substring(2);
+    var hex3 = decimalToHexString(0x0080 + (index1 & 0x3F000) / 0x1000).substring(2);
+    var hex4 = decimalToHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000).substring(2);
+    var str = String.fromCharCode(index, chars[indexC]);
     try {
       if (encodeURIComponent(str).toUpperCase() !== "%" + hex4 + "%" + hex3 + "%" + hex2 + "%" + hex1) {
         res = false;

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T2.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T2.js
@@ -12,20 +12,20 @@ description: >
     0xD9FF]
 ---*/
 
-chars = [0xD800, 0xDBFF, 0xD9FF]; 
-errorCount = 0;
-count = 0;
+var chars = [0xD800, 0xDBFF, 0xD9FF];
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0; 
-for (index = 0xDC00; index <= 0xDFFF; index++) {
-  res = true;
-  for (indexC = 0; indexC < chars.length; indexC++) {
-    index1 = (chars[indexC] - 0xD800) * 0x400 + (index - 0xDC00) + 0x10000; 
-    hex1 = decimalToHexString(0x0080 + (index1 & 0x003F)).substring(2);
-    hex2 = decimalToHexString(0x0080 + (index1 & 0x0FC0) / 0x0040).substring(2);
-    hex3 = decimalToHexString(0x0080 + (index1 & 0x3F000) / 0x1000).substring(2);
-    hex4 = decimalToHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000).substring(2);
-    str = String.fromCharCode(chars[indexC], index);
+for (var index = 0xDC00; index <= 0xDFFF; index++) {
+  var res = true;
+  for (var indexC = 0; indexC < chars.length; indexC++) {
+    var index1 = (chars[indexC] - 0xD800) * 0x400 + (index - 0xDC00) + 0x10000;
+    var hex1 = decimalToHexString(0x0080 + (index1 & 0x003F)).substring(2);
+    var hex2 = decimalToHexString(0x0080 + (index1 & 0x0FC0) / 0x0040).substring(2);
+    var hex3 = decimalToHexString(0x0080 + (index1 & 0x3F000) / 0x1000).substring(2);
+    var hex4 = decimalToHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000).substring(2);
+    var str = String.fromCharCode(chars[indexC], index);
     try {
       if (encodeURIComponent(str).toUpperCase() !== "%" + hex4 + "%" + hex3 + "%" + hex2 + "%" + hex1) {
         res = false;

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.5_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.5_T1.js
@@ -9,16 +9,16 @@ es5id: 15.1.3.4_A2.5_T1
 description: Complex tests, use RFC 3629
 ---*/
 
-errorCount = 0;
-count = 0;
+var errorCount = 0;
+var count = 0;
 var indexP;
 var indexO = 0; 
-for (index = 0xE000; index <= 0xFFFF; index++) {
+for (var index = 0xE000; index <= 0xFFFF; index++) {
   count++;  
-  hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
-  hex2 = decimalToHexString(0x0080 + (index & 0x0FC0) / 0x0040).substring(2);
-  hex3 = decimalToHexString(0x00E0 + (index & 0xF000) / 0x1000).substring(2);
-  str = String.fromCharCode(index);
+  var hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
+  var hex2 = decimalToHexString(0x0080 + (index & 0x0FC0) / 0x0040).substring(2);
+  var hex3 = decimalToHexString(0x00E0 + (index & 0xF000) / 0x1000).substring(2);
+  var str = String.fromCharCode(index);
   try {
     if (encodeURIComponent(str).toUpperCase() === "%" + hex3 + "%" + hex2 + "%" + hex1) continue;
   } catch(e) {}      

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A3.1_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A3.1_T1.js
@@ -7,9 +7,9 @@ es5id: 15.1.3.4_A3.1_T1
 description: Complex tests
 ---*/
 
-uriReserved = ["%3B", "%2F", "%3F", "%3A", "%40", "%26", "%3D", "%2B", "%24", "%2C"];
-uriReserved_ = [";", "/", "?", ":", "@", "&", "=", "+", "$", ","];                  
-for (indexC = 0; indexC < 10; indexC++) {    
+var uriReserved = ["%3B", "%2F", "%3F", "%3A", "%40", "%26", "%3D", "%2B", "%24", "%2C"];
+var uriReserved_ = [";", "/", "?", ":", "@", "&", "=", "+", "$", ","];
+for (var indexC = 0; indexC < 10; indexC++) {
   var str = uriReserved_[indexC];
   if (encodeURIComponent(str) !== uriReserved[indexC]) {
     $ERROR('#' + (indexC + 1) + ': unescapedURIComponentSet not containing' + str);

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A3.2_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A3.2_T1.js
@@ -9,8 +9,8 @@ es5id: 15.1.3.4_A3.2_T1
 description: "Complex tests, uriUnescaped :: uriAlpha"
 ---*/
 
-uriAlpha = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"];
-for (indexC = 0; indexC < uriAlpha.length; indexC++) {
+var uriAlpha = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"];
+for (var indexC = 0; indexC < uriAlpha.length; indexC++) {
   var str = uriAlpha[indexC];    
   if (encodeURIComponent(str) !== str) {
     $ERROR('#' + (indexC + 1) + ': unescapedURISet containing ' + str);

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A3.2_T2.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A3.2_T2.js
@@ -9,8 +9,8 @@ es5id: 15.1.3.4_A3.2_T2
 description: "Complex tests, uriUnescaped :: DecimalDigit"
 ---*/
 
-DecimalDigit = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
-for (indexC = 0; indexC < DecimalDigit.length; indexC++) {
+var DecimalDigit = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+for (var indexC = 0; indexC < DecimalDigit.length; indexC++) {
   var str = DecimalDigit[indexC];    
   if (encodeURIComponent(str) !== str) {
     $ERROR('#' + (indexC + 1) + ': unescapedURISet containing' + str);

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A3.2_T3.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A3.2_T3.js
@@ -9,8 +9,8 @@ es5id: 15.1.3.4_A3.2_T3
 description: "Complex tests, uriUnescaped :: uriMark"
 ---*/
 
-uriMark = ["-", "_", ".", "!", "~", "*", "'", "(", ")"];
-for (indexC = 0; indexC < uriMark.length; indexC++) {
+var uriMark = ["-", "_", ".", "!", "~", "*", "'", "(", ")"];
+for (var indexC = 0; indexC < uriMark.length; indexC++) {
   var str = uriMark[indexC];    
   if (encodeURIComponent(str) !== str) {
     $ERROR('#' + (indexC + 1) + ': unescapedURISet containing' + str);

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A5.1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A5.1.js
@@ -13,8 +13,8 @@ if (encodeURIComponent.propertyIsEnumerable('length') !== false) {
 }
 
 //CHECK#2
-result = true;
-for (p in encodeURIComponent){
+var result = true;
+for (var p in encodeURIComponent){
   if (p === "length") {
     result = false;
   }  

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A5.3.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A5.3.js
@@ -5,6 +5,7 @@
 info: The length property of encodeURIComponent has the attribute ReadOnly
 es5id: 15.1.3.4_A5.3
 description: Checking if varying the length property fails
+flags: [noStrict]
 ---*/
 
 //CHECK#1

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A5.5.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A5.5.js
@@ -13,8 +13,8 @@ if (this.propertyIsEnumerable('encodeURIComponent') !== false) {
 }
 
 //CHECK#2
-result = true;
-for (p in this){
+var result = true;
+for (var p in this){
   if (p === "encodeURIComponent") {
     result = false;
   }  


### PR DESCRIPTION
Add missing "var" declarations and noStrict flags.

Part of issue #35.