### PR TITLE
rewrite tests to work in strict mode, use helpers

### DIFF
--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-174.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-174.js
@@ -12,19 +12,14 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperties(obj, {
-            property: {
-                writable: ""
-            }
-        });
-
-        obj.property = "isWritable";
-
-        return obj.hasOwnProperty("property") && typeof (obj.property) === "undefined";
-
+Object.defineProperties(obj, {
+    property: {
+        writable: ""
     }
+});
+
 assert(obj.hasOwnProperty("property"));
 verifyNotWritable(obj, "property");
-assert(obj.hasOwnProperty("property"));
+

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-68.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-68.js
@@ -14,30 +14,28 @@ includes: [propertyHelper.js]
 ---*/
 
 
-        var obj = {};
-        var proto = {};
-        Object.defineProperty(proto, "configurable", {
-            get: function () {
-                return true;
-            }
-        });
-
-        var Con = function () { };
-        Con.prototype = proto;
-        var descObj = new Con();
-
-        Object.defineProperty(descObj, "configurable", {
-            get: function () {
-                return false;
-            }
-        });
-
-        Object.defineProperties(obj, {
-            prop: descObj
-        });
-        var result1 = obj.hasOwnProperty("prop");
-        delete obj.prop;
-        var result2 = obj.hasOwnProperty("prop");
-
-        return result1 === true && result2 === true;
+var obj = {};
+var proto = {};
+Object.defineProperty(proto, "configurable", {
+    get: function () {
+        return true;
     }
+});
+
+var Con = function () { };
+Con.prototype = proto;
+var descObj = new Con();
+
+Object.defineProperty(descObj, "configurable", {
+    get: function () {
+        return false;
+    }
+});
+
+Object.defineProperties(obj, {
+    prop: descObj
+});
+
+assert(obj.hasOwnProperty("prop"));
+verifyNotConfigurable(obj, "prop");
+assert(obj.hasOwnProperty("prop"));

--- a/test/built-ins/Object/defineProperties/15.2.3.7-6-a-44.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-6-a-44.js
@@ -13,31 +13,18 @@ includes: [propertyHelper.js]
 ---*/
 
 
-        var obj = {};
+var obj = {};
 
-        var desc = { value: NaN };
-        Object.defineProperty(obj, "foo", desc);
+var desc = { value: NaN };
+Object.defineProperty(obj, "foo", desc);
 
-        Object.defineProperties(obj, {
-            foo: {
-                value: NaN
-            }
-        });
-
-        var verifyEnumerable = false;
-        for (var p in obj) {
-            if (p === "foo") {
-                verifyEnumerable = true;
-            }
-        }
-
-        var verifyValue = false;
-        obj.prop = "overrideData";
-        verifyValue = obj.foo !== obj.foo && isNaN(obj.foo);
-
-        var verifyConfigurable = false;
-        delete obj.foo;
-        verifyConfigurable = obj.hasOwnProperty("foo");
-
-        return verifyConfigurable && !verifyEnumerable && verifyValue;
+Object.defineProperties(obj, {
+    foo: {
+        value: NaN
     }
+});
+
+verifyNotEnumerable(obj, "foo");
+verifyNotWritable(obj, "foo");
+verifyNotConfigurable(obj, "foo");
+

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-100.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-100.js
@@ -12,15 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        Object.defineProperty(obj, "property", { configurable: null });
+Object.defineProperty(obj, "property", { configurable: null });
 
-        var beforeDeleted = obj.hasOwnProperty("property");
-
-        delete obj.property;
-
-        var afterDeleted = obj.hasOwnProperty("property") && typeof (obj.property) === "undefined";
-
-        return beforeDeleted === true && afterDeleted === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotConfigurable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-102.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-102.js
@@ -12,15 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        Object.defineProperty(obj, "property", { configurable: false });
+Object.defineProperty(obj, "property", { configurable: false });
 
-        var beforeDeleted = obj.hasOwnProperty("property");
-
-        delete obj.property;
-
-        var afterDeleted = obj.hasOwnProperty("property") && typeof (obj.property) === "undefined";
-
-        return beforeDeleted === true && afterDeleted === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotConfigurable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-103.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-103.js
@@ -12,15 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        Object.defineProperty(obj, "property", { configurable: 0 });
+Object.defineProperty(obj, "property", { configurable: 0 });
 
-        var beforeDeleted = obj.hasOwnProperty("property");
-
-        delete obj.property;
-
-        var afterDeleted = obj.hasOwnProperty("property") && typeof (obj.property) === "undefined";
-
-        return beforeDeleted === true && afterDeleted === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotConfigurable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-104.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-104.js
@@ -12,15 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "property", { configurable: +0 });
+Object.defineProperty(obj, "property", { configurable: +0 });
 
-        var beforeDeleted = obj.hasOwnProperty("property");
-
-        delete obj.property;
-
-        var afterDeleted = obj.hasOwnProperty("property") && typeof (obj.property) === "undefined";
-
-        return beforeDeleted === true && afterDeleted === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotConfigurable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-105.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-105.js
@@ -12,15 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        Object.defineProperty(obj, "property", { configurable: -0 });
+Object.defineProperty(obj, "property", { configurable: -0 });
 
-        var beforeDeleted = obj.hasOwnProperty("property");
-
-        delete obj.property;
-
-        var afterDeleted = obj.hasOwnProperty("property") && typeof (obj.property) === "undefined";
-
-        return beforeDeleted === true && afterDeleted === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotConfigurable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-106.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-106.js
@@ -12,15 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        Object.defineProperty(obj, "property", { configurable: NaN });
+Object.defineProperty(obj, "property", { configurable: NaN });
 
-        var beforeDeleted = obj.hasOwnProperty("property");
-
-        delete obj.property;
-
-        var afterDeleted = obj.hasOwnProperty("property") && typeof (obj.property) === "undefined";
-
-        return beforeDeleted === true && afterDeleted === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotConfigurable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-109.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-109.js
@@ -12,15 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        Object.defineProperty(obj, "property", { configurable: "" });
+Object.defineProperty(obj, "property", { configurable: "" });
 
-        var beforeDeleted = obj.hasOwnProperty("property");
-
-        delete obj.property;
-
-        var afterDeleted = obj.hasOwnProperty("property") && typeof (obj.property) === "undefined";
-
-        return beforeDeleted === true && afterDeleted === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotConfigurable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-152.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-152.js
@@ -12,19 +12,15 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var attr = {
-            writable: false
-        };
+var attr = {
+    writable: false
+};
 
-        Object.defineProperty(obj, "property", attr);
+Object.defineProperty(obj, "property", attr);
 
-        var beforeWrite = obj.hasOwnProperty("property");
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");
+verifyNotConfigurable(obj, "property");
 
-        obj.property = "isWritable";
-
-        var afterWrite = (obj.property === "isWritable");
-
-        return beforeWrite === true && afterWrite === false;
-    }

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-153.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-153.js
@@ -12,19 +12,13 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var attr = {
-            value: 100
-        };
+var attr = {
+    value: 100
+};
 
-        Object.defineProperty(obj, "property", attr);
+Object.defineProperty(obj, "property", attr);
 
-        var beforeWrite = obj.hasOwnProperty("property");
-
-        obj.property = "isWritable";
-
-        var afterWrite = (obj.property === "isWritable");
-
-        return beforeWrite === true && afterWrite === false;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-162.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-162.js
@@ -12,20 +12,15 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var attr = {};
-        Object.defineProperty(attr, "writable", {
-            set: function () { }
-        });
+var attr = {};
+Object.defineProperty(attr, "writable", {
+    set: function () { }
+});
 
-        Object.defineProperty(obj, "property", attr);
+Object.defineProperty(obj, "property", attr);
 
-        var beforeWrite = obj.hasOwnProperty("property");
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");
 
-        obj.property = "isWritable";
-
-        var afterWrite = (typeof (obj.property) === "undefined");
-
-        return beforeWrite === true && afterWrite === true;
-    }

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-163.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-163.js
@@ -13,30 +13,24 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var proto = {};
-        Object.defineProperty(proto, "writable", {
-            get: function () {
-                return true;
-            }
-        });
-
-        var ConstructFun = function () { };
-        ConstructFun.prototype = proto;
-
-        var child = new ConstructFun();
-        Object.defineProperty(child, "writable", {
-            set: function () { }
-        });
-
-        Object.defineProperty(obj, "property", child);
-
-        var beforeWrite = obj.hasOwnProperty("property");
-
-        obj.property = "isWritable";
-
-        var afterWrite = (typeof (obj.property) === "undefined");
-
-        return beforeWrite === true && afterWrite === true;
+var proto = {};
+Object.defineProperty(proto, "writable", {
+    get: function () {
+        return true;
     }
+});
+
+var ConstructFun = function () { };
+ConstructFun.prototype = proto;
+
+var child = new ConstructFun();
+Object.defineProperty(child, "writable", {
+    set: function () { }
+});
+
+Object.defineProperty(obj, "property", child);
+
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-164.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-164.js
@@ -13,25 +13,19 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var proto = {};
-        Object.defineProperty(proto, "writable", {
-            set: function () { }
-        });
+var proto = {};
+Object.defineProperty(proto, "writable", {
+    set: function () { }
+});
 
-        var ConstructFun = function () { };
-        ConstructFun.prototype = proto;
+var ConstructFun = function () { };
+ConstructFun.prototype = proto;
 
-        var child = new ConstructFun();
+var child = new ConstructFun();
 
-        Object.defineProperty(obj, "property", child);
+Object.defineProperty(obj, "property", child);
 
-        var beforeWrite = obj.hasOwnProperty("property");
-
-        obj.property = "isWritable";
-
-        var afterWrite = (typeof (obj.property) === "undefined");
-
-        return beforeWrite === true && afterWrite === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-171-1.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-171-1.js
@@ -13,22 +13,15 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
-        try {
-            Date.prototype.writable = true;
+var obj = {};
+try {
+    Date.prototype.writable = true;
 
-            dateObj = new Date();
+    var dateObj = new Date();
 
-            Object.defineProperty(obj, "property", dateObj);
+    Object.defineProperty(obj, "property", dateObj);
+    verifyWritable(obj, "property");
 
-            var beforeWrite = obj.hasOwnProperty("property");
-
-            obj.property = "isWritable";
-
-            var afterWrite = (obj.property === "isWritable");
-
-            return beforeWrite === true && afterWrite === true;
-        } finally {
-            delete Date.prototype.writable;
-        }
-    }
+} finally {
+    delete Date.prototype.writable;
+}

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-178.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-178.js
@@ -12,17 +12,11 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "property", {
-            writable: undefined
-        });
+Object.defineProperty(obj, "property", {
+    writable: undefined
+});
 
-        var beforeWrite = obj.hasOwnProperty("property");
-
-        obj.property = "isWritable";
-
-        var afterWrite = (typeof (obj.property) === "undefined");
-
-        return beforeWrite === true && afterWrite === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-179.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-179.js
@@ -12,15 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        Object.defineProperty(obj, "property", { writable: null });
+Object.defineProperty(obj, "property", { writable: null });
 
-        var beforeWrite = obj.hasOwnProperty("property");
-
-        obj.property = "isWritable";
-
-        var afterWrite = (typeof (obj.property) === "undefined");
-
-        return beforeWrite === true && afterWrite === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-181.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-181.js
@@ -12,15 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        Object.defineProperty(obj, "property", { writable: false });
+Object.defineProperty(obj, "property", { writable: false });
 
-        var beforeWrite = obj.hasOwnProperty("property");
-
-        obj.property = "isWritable";
-
-        var afterWrite = (typeof (obj.property) === "undefined");
-
-        return beforeWrite === true && afterWrite === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-182.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-182.js
@@ -12,15 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        Object.defineProperty(obj, "property", { writable: 0 });
+Object.defineProperty(obj, "property", { writable: 0 });
 
-        var beforeWrite = obj.hasOwnProperty("property");
-
-        obj.property = "isWritable";
-
-        var afterWrite = (typeof (obj.property) === "undefined");
-
-        return beforeWrite === true && afterWrite === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-183.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-183.js
@@ -12,15 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "property", { writable: +0 });
+Object.defineProperty(obj, "property", { writable: +0 });
 
-        var beforeWrite = obj.hasOwnProperty("property");
-
-        obj.property = "isWritable";
-
-        var afterWrite = (typeof (obj.property) === "undefined");
-
-        return beforeWrite === true && afterWrite === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-184.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-184.js
@@ -12,15 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        Object.defineProperty(obj, "property", { writable: -0 });
+Object.defineProperty(obj, "property", { writable: -0 });
 
-        var beforeWrite = obj.hasOwnProperty("property");
-
-        obj.property = "isWritable";
-
-        var afterWrite = (typeof (obj.property) === "undefined");
-
-        return beforeWrite === true && afterWrite === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-185.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-185.js
@@ -12,15 +12,13 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        Object.defineProperty(obj, "property", { writable:  NaN});
+Object.defineProperty(obj, "property", { writable:  NaN});
 
-        var beforeWrite = obj.hasOwnProperty("property");
+assert(obj.hasOwnProperty("property"));
 
-        obj.property = "isWritable";
+verifyNotWritable(obj, "property");
 
-        var afterWrite = (typeof (obj.property) === "undefined");
+assert.sameValue(typeof (obj.property), "undefined");
 
-        return beforeWrite === true && afterWrite === true;
-    }

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-188.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-188.js
@@ -12,15 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "property", { writable: "" });
+Object.defineProperty(obj, "property", { writable: "" });
 
-        var beforeWrite = obj.hasOwnProperty("property");
-
-        obj.property = "isWritable";
-
-        var afterWrite = (typeof (obj.property) === "undefined");
-
-        return beforeWrite === true && afterWrite === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-236.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-236.js
@@ -12,15 +12,13 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "property", {
-            get: function () {
-                return 11;
-            }
-        });
-
-        obj.property = 14;
-        var desc = Object.getOwnPropertyDescriptor(obj, "property");
-        return obj.hasOwnProperty("property") && obj.property === 11 && typeof desc.set === "undefined";
+Object.defineProperty(obj, "property", {
+    get: function () {
+        return 11;
     }
+});
+
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-245.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-245.js
@@ -12,18 +12,20 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var attributes = {};
-        Object.defineProperty(attributes, "set", {
-            set: function () { }
-        });
+var attributes = {};
+Object.defineProperty(attributes, "set", {
+    set: function () { }
+});
 
-        Object.defineProperty(obj, "property", attributes);
+Object.defineProperty(obj, "property", attributes);
 
-        obj.property = "overrideOwnData";
+verifyNotWritable(obj, "property");
 
-        var desc = Object.getOwnPropertyDescriptor(obj, "property");
-        return obj.hasOwnProperty("property") && typeof obj.property === "undefined" &&
-            typeof desc.set === "undefined";
-    }
+var desc = Object.getOwnPropertyDescriptor(obj, "property");
+
+assert(obj.hasOwnProperty("property"));
+assert.sameValue(typeof obj.property, "undefined");
+assert.sameValue(typeof desc.set, "undefined");
+

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-246.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-246.js
@@ -13,27 +13,30 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
-        var proto = {};
-        var data = "data";
-        Object.defineProperty(proto, "set", {
-            get: function () {
-                return function (value) {
-                    data = value;
-                };
-            }
-        });
-
-        var ConstructFun = function () { };
-        ConstructFun.prototype = proto;
-
-        var child = new ConstructFun();
-        Object.defineProperty(child, "set", {
-            set: function () { }
-        });
-
-        Object.defineProperty(obj, "property", child);
-
-        obj.property = "overrideData";
-        return obj.hasOwnProperty("property") && typeof obj.property === "undefined" && data === "data";
+var obj = {};
+var proto = {};
+var data = "data";
+Object.defineProperty(proto, "set", {
+    get: function () {
+        return function (value) {
+            data = value;
+        };
     }
+});
+
+var ConstructFun = function () { };
+ConstructFun.prototype = proto;
+
+var child = new ConstructFun();
+Object.defineProperty(child, "set", {
+    set: function () { }
+});
+
+Object.defineProperty(obj, "property", child);
+
+verifyNotWritable(obj, "property");
+
+assert.sameValue(typeof obj.property, "undefined");
+assert.sameValue(data, "data");
+
+assert(obj.hasOwnProperty("property"));

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-247.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-247.js
@@ -13,19 +13,18 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
-        var proto = {};
-        Object.defineProperty(proto, "set", {
-            set: function () { }
-        });
+var obj = {};
+var proto = {};
+Object.defineProperty(proto, "set", {
+    set: function () { }
+});
 
-        var ConstructFun = function () { };
-        ConstructFun.prototype = proto;
+var ConstructFun = function () { };
+ConstructFun.prototype = proto;
 
-        var child = new ConstructFun();
+var child = new ConstructFun();
 
-        Object.defineProperty(obj, "property", child);
+Object.defineProperty(obj, "property", child);
 
-        obj.property = "overrideData";
-        return obj.hasOwnProperty("property") && typeof obj.property === "undefined";
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-261.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-261.js
@@ -12,14 +12,13 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "property", {
-            set: undefined
-        });
+Object.defineProperty(obj, "property", {
+    set: undefined
+});
 
-        obj.property = "overrideData";
-        var desc = Object.getOwnPropertyDescriptor(obj, "property");
-        return obj.hasOwnProperty("property") && typeof obj.property === "undefined" &&
-            typeof desc.set === "undefined";
-    }
+var desc = Object.getOwnPropertyDescriptor(obj, "property");
+
+assert(obj.hasOwnProperty("property"));
+verifyNotWritable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-73.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-73.js
@@ -12,17 +12,11 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "property", {
-            configurable: false
-        });
+Object.defineProperty(obj, "property", {
+    configurable: false
+});
 
-        var beforeDeleted = obj.hasOwnProperty("property");
-
-        delete obj.property;
-
-        var afterDeleted = obj.hasOwnProperty("property");
-
-        return beforeDeleted === true && afterDeleted === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotConfigurable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-74.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-74.js
@@ -12,16 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        Object.defineProperty(obj, "property", { value: 100 });
+Object.defineProperty(obj, "property", { value: 100 });
 
-        var beforeDeleted = obj.hasOwnProperty("property");
-
-        delete obj.property;
-
-        var afterDeleted = (obj.property === 100);
-
-        return beforeDeleted === true && afterDeleted === true;
-
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotConfigurable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-76.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-76.js
@@ -12,23 +12,23 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        var proto = {
-            configurable: false
-        };
+var proto = {
+    configurable: false
+};
 
-        var ConstructFun = function () { };
-        ConstructFun.prototype = proto;
+var ConstructFun = function () { };
+ConstructFun.prototype = proto;
 
-        var child = new ConstructFun();
+var child = new ConstructFun();
 
-        Object.defineProperty(obj, "property", child);
+Object.defineProperty(obj, "property", child);
 
-        var beforeDeleted = obj.hasOwnProperty("property");
+assert(obj.hasOwnProperty("property"));
 
-        delete obj.property;
+verifyNotConfigurable(obj, "property");
 
-        var afterDeleted = obj.hasOwnProperty("property");
-        return beforeDeleted && afterDeleted && typeof (obj.property) === "undefined";
-    }
+assert(obj.hasOwnProperty("property"));
+
+assert.sameValue(typeof (obj.property), "undefined");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-83.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-83.js
@@ -12,20 +12,14 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        var attr = {};
-        Object.defineProperty(attr, "configurable", {
-            set : function () { }
-        });
+var attr = {};
+Object.defineProperty(attr, "configurable", {
+    set : function () { }
+});
 
-        Object.defineProperty(obj, "property", attr);
+Object.defineProperty(obj, "property", attr);
 
-        var beforeDeleted = obj.hasOwnProperty("property");
-
-        delete obj.property;
-
-        var afterDeleted = obj.hasOwnProperty("property") && typeof (obj.property) === "undefined";
-
-        return beforeDeleted === true && afterDeleted === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotConfigurable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-84.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-84.js
@@ -13,30 +13,24 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var proto = {};
-        Object.defineProperty(proto, "configurable", {
-            get: function () {
-                return true;
-            }
-        });
-
-        var ConstructFun = function () { };
-        ConstructFun.prototype = proto;
-
-        var child = new ConstructFun();
-        Object.defineProperty(child, "configurable", {
-            set: function () { }
-        });
-
-        Object.defineProperty(obj, "property", child);
-
-        var beforeDeleted = obj.hasOwnProperty("property");
-
-        delete obj.property;
-
-        var afterDeleted = obj.hasOwnProperty("property") && typeof (obj.property) === "undefined";
-
-        return beforeDeleted === true && afterDeleted === true;
+var proto = {};
+Object.defineProperty(proto, "configurable", {
+    get: function () {
+        return true;
     }
+});
+
+var ConstructFun = function () { };
+ConstructFun.prototype = proto;
+
+var child = new ConstructFun();
+Object.defineProperty(child, "configurable", {
+    set: function () { }
+});
+
+Object.defineProperty(obj, "property", child);
+
+assert(obj.hasOwnProperty("property"));
+verifyNotConfigurable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-85.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-85.js
@@ -13,25 +13,25 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var proto = {};
-        Object.defineProperty(proto, "configurable", {
-            set: function () { }
-        });
+var proto = {};
+Object.defineProperty(proto, "configurable", {
+    set: function () { }
+});
 
-        var ConstructFun = function () { };
-        ConstructFun.prototype = proto;
+var ConstructFun = function () { };
+ConstructFun.prototype = proto;
 
-        var child = new ConstructFun();
+var child = new ConstructFun();
 
-        Object.defineProperty(obj, "property", child);
+Object.defineProperty(obj, "property", child);
 
-        var beforeDeleted = obj.hasOwnProperty("property");
+assert(obj.hasOwnProperty("property"));
 
-        delete obj.property;
+verifyNotConfigurable(obj, "property");
 
-        var afterDeleted = obj.hasOwnProperty("property") && typeof (obj.property) === "undefined";
+assert(obj.hasOwnProperty("property"));
+assert.sameValue(typeof (obj.property), "undefined");
 
-        return beforeDeleted === true && afterDeleted === true;
-    }
+

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-99.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-99.js
@@ -12,15 +12,9 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = { };
+var obj = { };
 
-        Object.defineProperty(obj, "property", { configurable: undefined });
+Object.defineProperty(obj, "property", { configurable: undefined });
 
-        var beforeDeleted = obj.hasOwnProperty("property");
-
-        delete obj.property;
-
-        var afterDeleted = obj.hasOwnProperty("property") && typeof (obj.property) === "undefined";
-
-        return beforeDeleted === true && afterDeleted === true;
-    }
+assert(obj.hasOwnProperty("property"));
+verifyNotConfigurable(obj, "property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-118.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-118.js
@@ -13,27 +13,12 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var arrObj = [];
+var arrObj = [];
 
-        Object.defineProperty(arrObj, "length", {});
+Object.defineProperty(arrObj, "length", {});
 
-        var verifyValue = false;
-        if (arrObj.length === 0) {
-            verifyValue = true;
-        }
-
-        arrObj.length = 2;
-        var verifyWritable = arrObj.length === 2;
-
-        var verifyEnumerable = false;
-        for (var p in arrObj) {
-            if (p === "length" && arrObj.hasOwnProperty(p)) {
-                verifyEnumerable = true;
-            }
-        }
-
-        delete arrObj.length;
-        var verifyConfigurable = arrObj.hasOwnProperty("length");
-
-        return verifyValue && verifyWritable && !verifyEnumerable && verifyConfigurable;
-    }
+assert.sameValue(arrObj.length, 0);
+arrObj.length = 2;
+assert.sameValue(arrObj.length, 2);
+verifyNotEnumerable(arrObj, "length");
+verifyNotConfigurable(arrObj, "length");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-119.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-119.js
@@ -15,30 +15,15 @@ includes: [propertyHelper.js]
 ---*/
 
 
-        var arrObj = [];
-        Object.defineProperty(arrObj, "length", {
-            writable: true,
-            enumerable: false,
-            configurable: false
-        });
+var arrObj = [];
+Object.defineProperty(arrObj, "length", {
+    writable: true,
+    enumerable: false,
+    configurable: false
+});
 
-        var verifyValue = false;
-        if (arrObj.length === 0) {
-            verifyValue = true;
-        }
-
-        arrObj.length = 2;
-        var verifyWritable = arrObj.length === 2 ? true : false;
-
-        var verifyEnumerable = false;
-        for (var p in arrObj) {
-            if (p === "length" && arrObj.hasOwnProperty(p)) {
-                verifyEnumerable = true;
-            }
-        }
-
-        delete arrObj.length;
-        var verifyConfigurable = arrObj.hasOwnProperty("length");
-
-        return verifyValue && verifyWritable && !verifyEnumerable && verifyConfigurable;
-    }
+assert.sameValue(arrObj.length, 0);
+arrObj.length = 2;
+assert.sameValue(arrObj.length, 2);
+verifyNotEnumerable(arrObj, "length");
+verifyNotConfigurable(arrObj, "length");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-167.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-167.js
@@ -17,16 +17,13 @@ includes: [propertyHelper.js]
 ---*/
 
 
-        var arrObj = [0, 1];
+var arrObj = [0, 1];
 
-        Object.defineProperty(arrObj, "length", {
-            value: 1,
-            writable: false
-        });
+Object.defineProperty(arrObj, "length", {
+    value: 1,
+    writable: false
+});
 
-        var indexDeleted = !arrObj.hasOwnProperty("1");
-
-        arrObj.length = 10;
-
-        return indexDeleted && arrObj.length === 1;
-    }
+assert(!arrObj.hasOwnProperty("1"))
+assert.sameValue(arrObj.length, 1);
+verifyNotWritable(arrObj, "length");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-181.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-181.js
@@ -17,13 +17,14 @@ includes: [propertyHelper.js]
 ---*/
 
 
-        var arrObj = [0, 1];
+var arrObj = [0, 1];
 
-        Object.defineProperty(arrObj, "length", {
-            value: 0,
-            writable: false
-        });
-            
-        arrObj.length = 10; //try to overwrite length value of arr
-        return !arrObj.hasOwnProperty("1") && arrObj.length === 0;
-    }
+Object.defineProperty(arrObj, "length", {
+    value: 0,
+    writable: false
+});
+
+verifyNotWritable(arrObj, "length");
+
+assert(!arrObj.hasOwnProperty("1"));
+assert.sameValue(arrObj.length, 0);

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-217.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-217.js
@@ -13,29 +13,15 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var arrObj = [];
+var arrObj = [];
 
-        Object.defineProperty(arrObj, "0", { value: NaN });
+Object.defineProperty(arrObj, "0", { value: NaN });
 
-        Object.defineProperty(arrObj, "0", { value: NaN });
+Object.defineProperty(arrObj, "0", { value: NaN });
 
-        var hasProperty = arrObj.hasOwnProperty("0");
-        var verifyValue = (arrObj[0] !== arrObj[0]);
+assert(arrObj.hasOwnProperty("0"));
+assert(arrObj[0] !== arrObj[0]);
 
-        var verifyWritable = false;
-        arrObj[0] = 1001;
-        verifyWritable = arrObj[0] !== 1001 && arrObj[0] !== arrObj[0];
-
-        var verifyEnumerable = false;
-        for (var p in arrObj) {
-            if (p === "0") {
-                verifyEnumerable = true;
-            }
-        }
-
-        var verifyConfigurable = false;
-        delete arrObj[0];
-        verifyConfigurable = arrObj.hasOwnProperty("0");
-
-        return hasProperty && verifyValue && verifyWritable && !verifyEnumerable && verifyConfigurable;
-    }
+verifyNotWritable(arrObj, "0");
+verifyNotEnumerable(arrObj, "0");
+verifyNotWritable(arrObj, "0");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-254.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-254.js
@@ -16,33 +16,22 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var arrObj = [];
+var arrObj = [];
 
-        Object.defineProperty(arrObj, "1", {
-            set: undefined
-        });
-        var hasProperty = arrObj.hasOwnProperty("1");
+Object.defineProperty(arrObj, "1", {
+    set: undefined
+});
+assert(arrObj.hasOwnProperty("1"));
 
-        Object.defineProperty(arrObj, "1", {
-            set: undefined
-        });
+Object.defineProperty(arrObj, "1", {
+    set: undefined
+});
 
-        var desc = Object.getOwnPropertyDescriptor(arrObj, "1");
+var desc = Object.getOwnPropertyDescriptor(arrObj, "1");
 
-        var verifyGet = desc.hasOwnProperty("get") && typeof desc.get === "undefined";
+assert(desc.hasOwnProperty("get") && typeof desc.get === "undefined");
+assert(desc.hasOwnProperty("set") && typeof desc.set === "undefined");
 
-        var verifySet = desc.hasOwnProperty("set") && typeof desc.set === "undefined";
+verifyNotEnumerable(arrObj, "1");
+verifyNotConfigurable(arrObj, "1");
 
-        var verifyEnumerable = false;
-        for (var p in arrObj) {
-            if (p === "1") {
-                verifyEnumerable = true
-            }
-        }
-
-        var verifyConfigurable = false;
-        delete arrObj[1];
-        verifyConfigurable = arrObj.hasOwnProperty("1");
-
-        return hasProperty && verifyGet && verifySet && !verifyEnumerable && verifyConfigurable;
-    }

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-255.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-255.js
@@ -17,43 +17,34 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var arrObj = [];
+var arrObj = [];
 
-        function getFunc() {
-            return 12;
+function getFunc() {
+    return 12;
+}
+Object.defineProperty(arrObj, "1", {
+    get: getFunc
+});
+
+try {
+    Object.defineProperty(arrObj, "1", {
+        get: function () {
+            return 14;
         }
-        Object.defineProperty(arrObj, "1", {
-            get: getFunc
-        });
+    });
 
-        try {
-            Object.defineProperty(arrObj, "1", {
-                get: function () {
-                    return 14;
-                }
-            });
+    $ERROR("Expected TypeError");
+} catch (e) {
+    assert(e instanceof TypeError);
+    assert(arrObj.hasOwnProperty("1"));
 
-            return false;
-        } catch (e) {
-            var hasProperty = arrObj.hasOwnProperty("1");
-            var desc = Object.getOwnPropertyDescriptor(arrObj, "1");
+    var desc = Object.getOwnPropertyDescriptor(arrObj, "1");
 
-            var verifyGet = arrObj[1] === getFunc();
+    assert(arrObj[1] === getFunc());
 
-            var verifySet = desc.hasOwnProperty("set") && typeof desc.set === "undefined";
+    assert(desc.hasOwnProperty("set") && typeof desc.set === "undefined");
 
-            var verifyEnumerable = false;
-            for (var p in arrObj) {
-                if (p === "1") {
-                    verifyEnumerable = true
-                }
-            }
+    verifyNotEnumerable(arrObj, "1");
+    verifyNotConfigurable(arrObj, "1");
+}
 
-            var verifyConfigurable = false;
-            delete arrObj[1];
-            verifyConfigurable = arrObj.hasOwnProperty("1");
-
-            return e instanceof TypeError && hasProperty && verifyGet &&
-                verifySet && !verifyEnumerable && verifyConfigurable;
-        }
-    }

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-256.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-256.js
@@ -16,40 +16,31 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var arrObj = [];
-        function getFunc() {
-            return 12;
-        }
+var arrObj = [];
+function getFunc() {
+    return 12;
+}
 
-        Object.defineProperty(arrObj, "1", {
-            get: getFunc
-        });
+Object.defineProperty(arrObj, "1", {
+    get: getFunc
+});
 
-        try {
-            Object.defineProperty(arrObj, "1", {
-                get: undefined
-            });
-            return false;
-        } catch (e) {
-            var hasProperty = arrObj.hasOwnProperty("1");
-            var desc = Object.getOwnPropertyDescriptor(arrObj, "1");
+try {
+    Object.defineProperty(arrObj, "1", {
+        get: undefined
+    });
+    $ERROR("Expected TypeError");
+} catch (e) {
+    assert(e instanceof TypeError);
+    assert(arrObj.hasOwnProperty("1"));
 
-            var verifyGet = arrObj[1] === getFunc();
+    var desc = Object.getOwnPropertyDescriptor(arrObj, "1");
 
-            var verifySet = desc.hasOwnProperty("set") && typeof desc.set === "undefined";
+    assert(arrObj[1] === getFunc());
+    assert(desc.hasOwnProperty("set") && typeof desc.set === "undefined");
 
-            var verifyEnumerable = false;
-            for (var p in arrObj) {
-                if (p === "1") {
-                    verifyEnumerable = true
-                }
-            }
+    verifyNotWritable(arrObj, "1");
 
-            var verifyConfigurable = false;
-            delete arrObj[1];
-            verifyConfigurable = arrObj.hasOwnProperty("1");
+    verifyNotWritable(arrObj, "1");
+}
 
-            return e instanceof TypeError && hasProperty && verifyGet &&
-                verifySet && !verifyEnumerable && verifyConfigurable;
-        }
-    }

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-335.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-335.js
@@ -12,16 +12,15 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "prop", {
-            value: 2010,
-            writable: true,
-            enumerable: true,
-            configurable: false
-        });
-        var beforeDelete = obj.hasOwnProperty("prop");
-        delete obj.prop;
-        var afterDelete = obj.hasOwnProperty("prop");
-        return beforeDelete && obj.prop === 2010 && afterDelete;
-    }
+Object.defineProperty(obj, "prop", {
+    value: 2010,
+    writable: true,
+    enumerable: true,
+    configurable: false
+});
+
+assert(obj.hasOwnProperty("prop"));
+verifyNotConfigurable(obj, "prop");
+assert.sameValue(obj.prop, 2010);

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-349.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-349.js
@@ -12,16 +12,15 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "prop", {
-            value: 2010,
-            writable: true,
-            enumerable: false,
-            configurable: false
-        });
-        var beforeDelete = obj.hasOwnProperty("prop");
-        delete obj.prop;
-        var afterDelete = obj.hasOwnProperty("prop");
-        return beforeDelete && obj.prop === 2010 && afterDelete;
-    }
+Object.defineProperty(obj, "prop", {
+    value: 2010,
+    writable: true,
+    enumerable: false,
+    configurable: false
+});
+
+assert(obj.hasOwnProperty("prop"));
+verifyNotConfigurable(obj, "prop");
+assert.sameValue(obj.prop, 2010);

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-354-15.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-354-15.js
@@ -13,16 +13,15 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = [];
+var obj = [];
 
-        Object.defineProperty(obj, "prop", {
-            value: 2010,
-            writable: false,
-            enumerable: true,
-            configurable: true
-        });
-        var verifyValue = (obj.prop === 2010);
-        obj.prop = 1001;
+Object.defineProperty(obj, "prop", {
+    value: 2010,
+    writable: false,
+    enumerable: true,
+    configurable: true
+});
 
-        return verifyValue && obj.prop === 2010;
-    }
+assert.sameValue(obj.prop, 2010);
+verifyNotWritable(obj, "prop");
+

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-354-16.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-354-16.js
@@ -14,18 +14,16 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = (function () {
-            return arguments;
-        }());
+var obj = (function () {
+    return arguments;
+}());
 
-        Object.defineProperty(obj, "0", {
-            value: 2010,
-            writable: false,
-            enumerable: true,
-            configurable: true
-        });
-        var valueVerify = (obj[0] === 2010);
-        obj[0] = 1001;
+Object.defineProperty(obj, "0", {
+    value: 2010,
+    writable: false,
+    enumerable: true,
+    configurable: true
+});
 
-        return valueVerify && obj[0] === 2010;
-    }
+assert.sameValue(obj[0], 2010);
+verifyNotWritable(obj, "0");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-354-6.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-354-6.js
@@ -13,16 +13,14 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = [];
+var obj = [];
 
-        Object.defineProperty(obj, "0", {
-            value: 2010,
-            writable: false,
-            enumerable: true,
-            configurable: true
-        });
-        var verifyValue = (obj[0] === 2010);
-        obj[0] = 1001;
+Object.defineProperty(obj, "0", {
+    value: 2010,
+    writable: false,
+    enumerable: true,
+    configurable: true
+});
 
-        return verifyValue && obj[0] === 2010;
-    }
+assert.sameValue(obj[0], 2010);
+verifyNotWritable(obj, "0");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-354-7.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-354-7.js
@@ -13,18 +13,16 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = (function () {
-            return arguments;
-        }());
+var obj = (function () {
+    return arguments;
+}());
 
-        Object.defineProperty(obj, "prop", {
-            value: 2010,
-            writable: false,
-            enumerable: true,
-            configurable: true
-        });
-        var valueVerify = (obj.prop === 2010);
-        obj.prop = 1001;
+Object.defineProperty(obj, "prop", {
+    value: 2010,
+    writable: false,
+    enumerable: true,
+    configurable: true
+});
 
-        return valueVerify && obj.prop === 2010;
-    }
+assert.sameValue(obj.prop, 2010);
+verifyNotWritable(obj, "prop");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-354-8.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-354-8.js
@@ -15,19 +15,19 @@ includes:
     - fnGlobalObject.js
 ---*/
 
-        var obj = fnGlobalObject();
-        try {
-            Object.defineProperty(obj, "prop", {
-                value: 2010,
-                writable: false,
-                enumerable: true,
-                configurable: true
-            });
-            var valueVerify = (obj.prop === 2010);
-            obj.prop = 1001;
+var obj = fnGlobalObject();
+try {
+    Object.defineProperty(obj, "prop", {
+        value: 2010,
+        writable: false,
+        enumerable: true,
+        configurable: true
+    });
 
-            return valueVerify && obj.prop === 2010;
-        } finally {
-            delete obj.prop;
-        }
-    }
+    assert.sameValue(obj.prop, 2010);
+    verifyNotWritable(obj, "prop");
+
+} finally {
+    delete obj.prop;
+}
+

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-354.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-354.js
@@ -12,16 +12,14 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "prop", {
-            value: 2010,
-            writable: false,
-            enumerable: true,
-            configurable: true
-        });
-        var propertyDefineCorrect = (obj.prop === 2010);
-        obj.prop = 1001;
+Object.defineProperty(obj, "prop", {
+    value: 2010,
+    writable: false,
+    enumerable: true,
+    configurable: true
+});
 
-        return propertyDefineCorrect && obj.prop === 2010;
-    }
+assert.sameValue(obj.prop, 2010);
+verifyNotWritable(obj, "prop");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-361.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-361.js
@@ -12,16 +12,14 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "prop", {
-            value: 2010,
-            writable: false,
-            enumerable: true,
-            configurable: false
-        });
-        var propertyDefineCorrect = (obj.prop === 2010);
-        obj.prop = 1001;
+Object.defineProperty(obj, "prop", {
+    value: 2010,
+    writable: false,
+    enumerable: true,
+    configurable: false
+});
 
-        return propertyDefineCorrect && obj.prop === 2010;
-    }
+assert.sameValue(obj.prop, 2010);
+verifyNotWritable(obj, "prop");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-363.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-363.js
@@ -12,16 +12,14 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "prop", {
-            value: 2010,
-            writable: false,
-            enumerable: true,
-            configurable: false
-        });
-        var beforeDelete = obj.hasOwnProperty("prop");
-        delete obj.prop;
-        var afterDelete = obj.hasOwnProperty("prop");
-        return beforeDelete && obj.prop === 2010 && afterDelete;
-    }
+Object.defineProperty(obj, "prop", {
+    value: 2010,
+    writable: false,
+    enumerable: true,
+    configurable: false
+});
+
+assert(obj.hasOwnProperty("prop"));
+verifyNotConfigurable(obj, "prop");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-368.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-368.js
@@ -12,16 +12,14 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "prop", {
-            value: 2010,
-            writable: false,
-            enumerable: false,
-            configurable: true
-        });
-        var propertyDefineCorrect = (obj.prop === 2010);
-        obj.prop = 1001;
+Object.defineProperty(obj, "prop", {
+    value: 2010,
+    writable: false,
+    enumerable: false,
+    configurable: true
+});
 
-        return propertyDefineCorrect && obj.prop === 2010;
-    }
+assert.sameValue(obj.prop, 2010);
+verifyNotWritable(obj, "prop");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-375.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-375.js
@@ -12,16 +12,14 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "prop", {
-            value: 2010,
-            writable: false,
-            enumerable: false,
-            configurable: false
-        });
-        var propertyDefineCorrect = (obj.prop === 2010);
-        obj.prop = 1001;
+Object.defineProperty(obj, "prop", {
+    value: 2010,
+    writable: false,
+    enumerable: false,
+    configurable: false
+});
 
-        return propertyDefineCorrect && obj.prop === 2010;
-    }
+assert.sameValue(obj.prop, 2010);
+verifyNotWritable(obj, "prop");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-377.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-377.js
@@ -12,16 +12,14 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "prop", {
-            value: 2010,
-            writable: false,
-            enumerable: false,
-            configurable: false
-        });
-        var beforeDelete = obj.hasOwnProperty("prop");
-        delete obj.prop;
-        var afterDelete = obj.hasOwnProperty("prop");
-        return beforeDelete && obj.prop === 2010 && afterDelete;
-    }
+Object.defineProperty(obj, "prop", {
+    value: 2010,
+    writable: false,
+    enumerable: false,
+    configurable: false
+});
+
+assert(obj.hasOwnProperty("prop"));
+verifyNotConfigurable(obj, "prop");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-405.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-405.js
@@ -13,18 +13,19 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        try {
-            Object.defineProperty(Number.prototype, "prop", {
-                value: 1001,
-                writable: false,
-                enumerable: false,
-                configurable: true
-            });
-            var numObj = new Number();
-            numObj.prop = 1002;
+try {
+    Object.defineProperty(Number.prototype, "prop", {
+        value: 1001,
+        writable: false,
+        enumerable: false,
+        configurable: true
+    });
+    
+    var numObj = new Number();
 
-            return !numObj.hasOwnProperty("prop") && numObj.prop === 1001;
-        } finally {
-            delete Number.prototype.prop;
-        }
-    }
+    assert(!numObj.hasOwnProperty("prop"));
+    verifyNotWritable(numObj, "prop", "noCheckOwnProp");
+} finally {
+    delete Number.prototype.prop;
+}
+

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-410.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-410.js
@@ -13,17 +13,19 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        try {
-            Object.defineProperty(Object.prototype, "prop", {
-                value: 1001,
-                writable: false,
-                enumerable: false,
-                configurable: true
-            });
-            JSON.prop = 1002;
+try {
+    Object.defineProperty(Object.prototype, "prop", {
+        value: 1001,
+        writable: false,
+        enumerable: false,
+        configurable: true
+    });
 
-            return !JSON.hasOwnProperty("prop") && JSON.prop === 1001;
-        } finally {
-            delete Object.prototype.prop;
-        }
-    }
+    assert(!JSON.hasOwnProperty("prop"));
+    verifyNotWritable(JSON, "prop", "noCheckOwnProp");
+    assert.sameValue(JSON.prop, 1001);
+
+} finally {
+    delete Object.prototype.prop;
+}
+

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-415.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-415.js
@@ -13,40 +13,45 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var appointment = new Object();
+var appointment = new Object();
 
-        Object.defineProperty(appointment, "startTime", {
-            value: 1001,
-            writable: false,
-            enumerable: false,
-            configurable: true
-        });
-        Object.defineProperty(appointment, "name", {
-            value: "NAME",
-            writable: false,
-            enumerable: false,
-            configurable: true
-        });
+Object.defineProperty(appointment, "startTime", {
+    value: 1001,
+    writable: false,
+    enumerable: false,
+    configurable: true
+});
+Object.defineProperty(appointment, "name", {
+    value: "NAME",
+    writable: false,
+    enumerable: false,
+    configurable: true
+});
 
-        var meeting = Object.create(appointment);
-        Object.defineProperty(meeting, "conferenceCall", {
-            value: "In-person meeting",
-            writable: false,
-            enumerable: false,
-            configurable: true
-        });
+var meeting = Object.create(appointment);
+Object.defineProperty(meeting, "conferenceCall", {
+    value: "In-person meeting",
+    writable: false,
+    enumerable: false,
+    configurable: true
+});
 
-        var teamMeeting = Object.create(meeting);
-        teamMeeting.name = "Team Meeting";
-        var dateObj = new Date("10/31/2010 08:00");
-        teamMeeting.startTime = dateObj;
-        teamMeeting.conferenceCall = "4255551212";
+var teamMeeting = Object.create(meeting);
 
-        var hasOwnProperty = !teamMeeting.hasOwnProperty("name") &&
-            !teamMeeting.hasOwnProperty("startTime") &&
-            !teamMeeting.hasOwnProperty('conferenceCall');
+//teamMeeting.name = "Team Meeting";
+verifyNotWritable(teamMeeting, "name", "noCheckOwnProp");
 
-        return hasOwnProperty && teamMeeting.name === "NAME" &&
-            teamMeeting.startTime === 1001 &&
-            teamMeeting.conferenceCall === "In-person meeting";
-    }
+var dateObj = new Date("10/31/2010 08:00");
+//teamMeeting.startTime = dateObj;
+verifyNotWritable(teamMeeting, "startTime", "noCheckOwnProp");
+
+//teamMeeting.conferenceCall = "4255551212";
+verifyNotWritable(teamMeeting, "conferenceCall", "noCheckOwnProp");
+
+assert(!teamMeeting.hasOwnProperty("name"));
+assert(!teamMeeting.hasOwnProperty("startTime"));
+assert(!teamMeeting.hasOwnProperty('conferenceCall'));
+
+assert.sameValue(teamMeeting.name, "NAME");
+assert.sameValue(teamMeeting.startTime, 1001);
+assert.sameValue(teamMeeting.conferenceCall, "In-person meeting");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-420.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-420.js
@@ -13,20 +13,19 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var foo = function () { };
-        try {
-            Object.defineProperty(Function.prototype, "prop", {
-                value: 1001,
-                writable: false,
-                enumerable: false,
-                configurable: true
-            });
+var foo = function () { };
+try {
+    Object.defineProperty(Function.prototype, "prop", {
+        value: 1001,
+        writable: false,
+        enumerable: false,
+        configurable: true
+    });
 
-            var obj = foo.bind({});
-            obj.prop = 1002;
+    var obj = foo.bind({});
+    assert(!obj.hasOwnProperty("prop"));
+    verifyNotWritable(foo, "prop", "noCheckOwnProp");
+} finally {
+    delete Function.prototype.prop;
+}
 
-            return !obj.hasOwnProperty("prop") && obj.prop === 1001;
-        } finally {
-            delete Function.prototype.prop;
-        }
-    }

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-429.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-429.js
@@ -14,21 +14,22 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "prop", {
-            get: undefined,
-            set: undefined,
-            enumerable: true,
-            configurable: true
-        });
-        var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
+Object.defineProperty(obj, "prop", {
+    get: undefined,
+    set: undefined,
+    enumerable: true,
+    configurable: true
+});
+var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        Object.defineProperty(obj, "prop", {
-            configurable: false
-        });
-        var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
-        delete obj.prop;
+Object.defineProperty(obj, "prop", {
+    configurable: false
+});
+var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        return desc1.configurable === true && desc2.configurable === false && obj.hasOwnProperty("prop");
-    }
+verifyNotConfigurable(obj, "prop");
+assert.sameValue(desc1.configurable, true);
+assert.sameValue(desc2.configurable, false);
+assert(obj.hasOwnProperty("prop"));

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-434.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-434.js
@@ -13,19 +13,19 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "prop", {
-            get: undefined,
-            set: undefined,
-            enumerable: true,
-            configurable: false
-        });
+Object.defineProperty(obj, "prop", {
+    get: undefined,
+    set: undefined,
+    enumerable: true,
+    configurable: false
+});
 
-        var propertyDefineCorrect = obj.hasOwnProperty("prop");
-        var desc = Object.getOwnPropertyDescriptor(obj, "prop");
+assert(obj.hasOwnProperty("prop"));
 
-        delete obj.prop;
+var desc = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        return propertyDefineCorrect && desc.configurable === false && obj.hasOwnProperty("prop");
-    }
+assert.sameValue(desc.configurable, false);
+
+verifyNotConfigurable(obj, "prop");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-438.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-438.js
@@ -14,26 +14,31 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "prop", {
-            get: undefined,
-            set: undefined,
-            enumerable: true,
-            configurable: false
-        });
-        var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
+Object.defineProperty(obj, "prop", {
+    get: undefined,
+    set: undefined,
+    enumerable: true,
+    configurable: false
+});
+var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        try {
-            Object.defineProperty(obj, "prop", {
-                configurable: true
-            });
+try {
+    Object.defineProperty(obj, "prop", {
+        configurable: true
+    });
 
-            return false;
-        } catch (e) {
-            var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
-            delete obj.prop;
+    $ERROR("Expected TypeError");
+} catch (e) {
+    assert(e instanceof TypeError);
 
-            return desc1.configurable === false && desc2.configurable === false && obj.hasOwnProperty("prop") && e instanceof TypeError;
-        }
-    }
+    var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
+
+    assert.sameValue(desc1.configurable, false);
+    assert.sameValue(desc2.configurable, false);
+
+    verifyNotConfigurable(obj, "prop");
+
+    assert(obj.hasOwnProperty("prop"));
+}

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-447.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-447.js
@@ -14,21 +14,24 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "prop", {
-            get: undefined,
-            set: undefined,
-            enumerable: false,
-            configurable: true
-        });
-        var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
+Object.defineProperty(obj, "prop", {
+    get: undefined,
+    set: undefined,
+    enumerable: false,
+    configurable: true
+});
+var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        Object.defineProperty(obj, "prop", {
-            configurable: false
-        });
-        var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
-        delete obj.prop;
+Object.defineProperty(obj, "prop", {
+    configurable: false
+});
 
-        return desc1.configurable === true && desc2.configurable === false && obj.hasOwnProperty("prop");
-    }
+var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
+
+assert.sameValue(desc1.configurable, true);
+assert.sameValue(desc2.configurable, false);
+
+verifyNotConfigurable(obj, "prop");
+assert(obj.hasOwnProperty("prop"));

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-452.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-452.js
@@ -13,19 +13,19 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "prop", {
-            get: undefined,
-            set: undefined,
-            enumerable: false,
-            configurable: false
-        });
+Object.defineProperty(obj, "prop", {
+    get: undefined,
+    set: undefined,
+    enumerable: false,
+    configurable: false
+});
 
-        var propertyDefineCorrect = obj.hasOwnProperty("prop");
-        var desc = Object.getOwnPropertyDescriptor(obj, "prop");
+assert(obj.hasOwnProperty("prop"));
 
-        delete obj.prop;
+var desc = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        return propertyDefineCorrect && desc.configurable === false && obj.hasOwnProperty("prop");
-    }
+assert.sameValue(desc.configurable, false);
+
+verifyNotConfigurable(obj, "prop");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-456.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-456.js
@@ -14,26 +14,31 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "prop", {
-            get: undefined,
-            set: undefined,
-            enumerable: false,
-            configurable: false
-        });
-        var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
+Object.defineProperty(obj, "prop", {
+    get: undefined,
+    set: undefined,
+    enumerable: false,
+    configurable: false
+});
+var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        try {
-            Object.defineProperty(obj, "prop", {
-                configurable: true
-            });
+try {
+    Object.defineProperty(obj, "prop", {
+        configurable: true
+    });
 
-            return false;
-        } catch (e) {
-            var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
-            delete obj.prop;
+    $ERROR("Expected TypeError");
+} catch (e) {
+    assert(e instanceof TypeError);
+    
+    var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
 
-            return desc1.configurable === false && desc2.configurable === false && obj.hasOwnProperty("prop") && e instanceof TypeError;
-        }
-    }
+    assert.sameValue(desc1.configurable, false);
+    assert.sameValue(desc2.configurable, false);
+
+    verifyNotConfigurable(obj, "prop");
+
+    assert(obj.hasOwnProperty("prop"));
+}

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-465.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-465.js
@@ -14,26 +14,29 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var verifySetFunc = "data";
-        var setFunc = function (value) {
-            verifySetFunc = value;
-        };
+var verifySetFunc = "data";
+var setFunc = function (value) {
+    verifySetFunc = value;
+};
 
-        Object.defineProperty(obj, "prop", {
-            get: undefined,
-            set: setFunc,
-            enumerable: true,
-            configurable: true
-        });
-        var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
+Object.defineProperty(obj, "prop", {
+    get: undefined,
+    set: setFunc,
+    enumerable: true,
+    configurable: true
+});
+var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        Object.defineProperty(obj, "prop", {
-            configurable: false
-        });
-        var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
-        delete obj.prop;
+Object.defineProperty(obj, "prop", {
+    configurable: false
+});
 
-        return desc1.configurable === true && desc2.configurable === false && obj.hasOwnProperty("prop");
-    }
+var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
+
+assert.sameValue(desc1.configurable, true);
+assert.sameValue(desc2.configurable, false);
+
+verifyNotConfigurable(obj, "prop");
+assert(obj.hasOwnProperty("prop"));

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-470.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-470.js
@@ -13,24 +13,26 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var verifySetFunc = "data";
-        var setFunc = function (value) {
-            verifySetFunc = value;
-        };
+var verifySetFunc = "data";
+var setFunc = function (value) {
+    verifySetFunc = value;
+};
 
-        Object.defineProperty(obj, "prop", {
-            get: undefined,
-            set: setFunc,
-            enumerable: true,
-            configurable: false
-        });
+Object.defineProperty(obj, "prop", {
+    get: undefined,
+    set: setFunc,
+    enumerable: true,
+    configurable: false
+});
 
-        var propertyDefineCorrect = obj.hasOwnProperty("prop");
-        var desc = Object.getOwnPropertyDescriptor(obj, "prop");
+assert(obj.hasOwnProperty("prop"));
 
-        delete obj.prop;
+var desc = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        return propertyDefineCorrect && desc.configurable === false && obj.hasOwnProperty("prop");
-    }
+verifyNotWritable(obj, "prop");
+
+assert.sameValue(desc.configurable, false);
+
+assert(obj.hasOwnProperty("prop"));

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-474.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-474.js
@@ -14,31 +14,36 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var verifySetFunc = "data";
-        var setFunc = function (value) {
-            verifySetFunc = value;
-        };
+var verifySetFunc = "data";
+var setFunc = function (value) {
+    verifySetFunc = value;
+};
 
-        Object.defineProperty(obj, "prop", {
-            get: undefined,
-            set: setFunc,
-            enumerable: true,
-            configurable: false
-        });
-        var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
+Object.defineProperty(obj, "prop", {
+    get: undefined,
+    set: setFunc,
+    enumerable: true,
+    configurable: false
+});
+var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        try {
-            Object.defineProperty(obj, "prop", {
-                configurable: true
-            });
+try {
+    Object.defineProperty(obj, "prop", {
+        configurable: true
+    });
 
-            return false;
-        } catch (e) {
-            var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
-            delete obj.prop;
+    $ERROR("Expected TypeError");
+} catch (e) {
+    assert(e instanceof TypeError);
 
-            return desc1.configurable === false && desc2.configurable === false && obj.hasOwnProperty("prop") && e instanceof TypeError;
-        }
-    }
+    var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
+
+    assert.sameValue(desc1.configurable, false);
+    assert.sameValue(desc2.configurable, false);
+
+    verifyNotConfigurable(obj, "prop");
+
+    assert(obj.hasOwnProperty("prop"));
+}

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-483.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-483.js
@@ -14,26 +14,30 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var verifySetFunc = "data";
-        var setFunc = function (value) {
-            verifySetFunc = value;
-        };
+var verifySetFunc = "data";
+var setFunc = function (value) {
+    verifySetFunc = value;
+};
 
-        Object.defineProperty(obj, "prop", {
-            get: undefined,
-            set: setFunc,
-            enumerable: false,
-            configurable: true
-        });
-        var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
+Object.defineProperty(obj, "prop", {
+    get: undefined,
+    set: setFunc,
+    enumerable: false,
+    configurable: true
+});
+var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        Object.defineProperty(obj, "prop", {
-            configurable: false
-        });
-        var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
-        delete obj.prop;
+Object.defineProperty(obj, "prop", {
+    configurable: false
+});
 
-        return desc1.configurable === true && desc2.configurable === false && obj.hasOwnProperty("prop");
-    }
+var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
+
+assert.sameValue(desc1.configurable, true);
+assert.sameValue(desc2.configurable, false);
+
+verifyNotConfigurable(obj, "prop");
+
+assert(obj.hasOwnProperty("prop"));

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-488.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-488.js
@@ -13,24 +13,25 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var verifySetFunc = "data";
-        var setFunc = function (value) {
-            verifySetFunc = value;
-        };
+var verifySetFunc = "data";
+var setFunc = function (value) {
+    verifySetFunc = value;
+};
 
-        Object.defineProperty(obj, "prop", {
-            get: undefined,
-            set: setFunc,
-            enumerable: false,
-            configurable: false
-        });
+Object.defineProperty(obj, "prop", {
+    get: undefined,
+    set: setFunc,
+    enumerable: false,
+    configurable: false
+});
 
-        var propertyDefineCorrect = obj.hasOwnProperty("prop");
-        var desc = Object.getOwnPropertyDescriptor(obj, "prop");
+assert(obj.hasOwnProperty("prop"));
 
-        delete obj.prop;
+var desc = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        return propertyDefineCorrect && desc.configurable === false && obj.hasOwnProperty("prop");
-    }
+verifyNotConfigurable(obj, "prop");
+assert.sameValue(desc.configurable, false);
+
+assert(obj.hasOwnProperty("prop"));

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-492.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-492.js
@@ -14,31 +14,36 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var verifySetFunc = "data";
-        var setFunc = function (value) {
-            verifySetFunc = value;
-        };
+var verifySetFunc = "data";
+var setFunc = function (value) {
+    verifySetFunc = value;
+};
 
-        Object.defineProperty(obj, "prop", {
-            get: undefined,
-            set: setFunc,
-            enumerable: false,
-            configurable: false
-        });
-        var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
+Object.defineProperty(obj, "prop", {
+    get: undefined,
+    set: setFunc,
+    enumerable: false,
+    configurable: false
+});
+var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        try {
-            Object.defineProperty(obj, "prop", {
-                configurable: true
-            });
+try {
+    Object.defineProperty(obj, "prop", {
+        configurable: true
+    });
 
-            return false;
-        } catch (e) {
-            var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
-            delete obj.prop;
+    $ERROR("Expected TypeError");
+} catch (e) {
+    assert(e instanceof TypeError);
 
-            return desc1.configurable === false && desc2.configurable === false && obj.hasOwnProperty("prop") && e instanceof TypeError;
-        }
-    }
+    var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
+
+    verifyNotConfigurable(obj, "prop");
+
+    assert.sameValue(desc1.configurable, false);
+    assert.sameValue(desc2.configurable, false);
+
+    assert(obj.hasOwnProperty("prop"));
+}

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-501.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-501.js
@@ -14,25 +14,29 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var getFunc = function () {
-            return 1001;
-        };
+var getFunc = function () {
+    return 1001;
+};
 
-        Object.defineProperty(obj, "prop", {
-            get: getFunc,
-            set: undefined,
-            enumerable: true,
-            configurable: true
-        });
-        var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
+Object.defineProperty(obj, "prop", {
+    get: getFunc,
+    set: undefined,
+    enumerable: true,
+    configurable: true
+});
+var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        Object.defineProperty(obj, "prop", {
-            configurable: false
-        });
-        var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
-        delete obj.prop;
+Object.defineProperty(obj, "prop", {
+    configurable: false
+});
 
-        return desc1.configurable === true && desc2.configurable === false && obj.hasOwnProperty("prop");
-    }
+var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
+
+assert.sameValue(desc1.configurable, true);
+assert.sameValue(desc2.configurable, false);
+
+verifyNotWritable(obj, "prop");
+
+assert(obj.hasOwnProperty("prop"));

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-506.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-506.js
@@ -13,23 +13,25 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var getFunc = function () {
-            return 1001;
-        };
+var getFunc = function () {
+    return 1001;
+};
 
-        Object.defineProperty(obj, "prop", {
-            get: getFunc,
-            set: undefined,
-            enumerable: true,
-            configurable: false
-        });
+Object.defineProperty(obj, "prop", {
+    get: getFunc,
+    set: undefined,
+    enumerable: true,
+    configurable: false
+});
 
-        var propertyDefineCorrect = obj.hasOwnProperty("prop");
-        var desc = Object.getOwnPropertyDescriptor(obj, "prop");
+assert(obj.hasOwnProperty("prop"));
 
-        delete obj.prop;
+var desc = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        return propertyDefineCorrect && desc.configurable === false && obj.hasOwnProperty("prop");
-    }
+assert.sameValue(desc.configurable, false);
+
+verifyNotConfigurable(obj, "prop");
+
+assert(obj.hasOwnProperty("prop"));

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-510.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-510.js
@@ -14,30 +14,35 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var getFunc = function () {
-            return 1001;
-        };
+var getFunc = function () {
+    return 1001;
+};
 
-        Object.defineProperty(obj, "prop", {
-            get: getFunc,
-            set: undefined,
-            enumerable: true,
-            configurable: false
-        });
-        var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
+Object.defineProperty(obj, "prop", {
+    get: getFunc,
+    set: undefined,
+    enumerable: true,
+    configurable: false
+});
+var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        try {
-            Object.defineProperty(obj, "prop", {
-                configurable: true
-            });
+try {
+    Object.defineProperty(obj, "prop", {
+        configurable: true
+    });
 
-            return false;
-        } catch (e) {
-            var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
-            delete obj.prop;
+    $ERROR("Expected TypeError");
+} catch (e) {
+    assert(e instanceof TypeError);
 
-            return desc1.configurable === false && desc2.configurable === false && obj.hasOwnProperty("prop") && e instanceof TypeError;
-        }
-    }
+    var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
+
+    assert.sameValue(desc1.configurable, false);
+    assert.sameValue(desc2.configurable, false);
+
+    verifyNotConfigurable(obj, "prop");
+
+    assert(obj.hasOwnProperty("prop"));
+}

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-519.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-519.js
@@ -14,25 +14,29 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var getFunc = function () {
-            return 1001;
-        };
+var getFunc = function () {
+    return 1001;
+};
 
-        Object.defineProperty(obj, "prop", {
-            get: getFunc,
-            set: undefined,
-            enumerable: false,
-            configurable: true
-        });
-        var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
+Object.defineProperty(obj, "prop", {
+    get: getFunc,
+    set: undefined,
+    enumerable: false,
+    configurable: true
+});
+var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        Object.defineProperty(obj, "prop", {
-            configurable: false
-        });
-        var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
-        delete obj.prop;
+Object.defineProperty(obj, "prop", {
+    configurable: false
+});
 
-        return desc1.configurable === true && desc2.configurable === false && obj.hasOwnProperty("prop");
-    }
+var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
+
+assert.sameValue(desc1.configurable, true);
+assert.sameValue(desc2.configurable, false);
+
+verifyNotConfigurable(obj, "prop");
+
+assert(obj.hasOwnProperty("prop"));

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-524.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-524.js
@@ -13,23 +13,24 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var getFunc = function () {
-            return 1001;
-        };
+var getFunc = function () {
+    return 1001;
+};
 
-        Object.defineProperty(obj, "prop", {
-            get: getFunc,
-            set: undefined,
-            enumerable: false,
-            configurable: false
-        });
+Object.defineProperty(obj, "prop", {
+    get: getFunc,
+    set: undefined,
+    enumerable: false,
+    configurable: false
+});
 
-        var propertyDefineCorrect = obj.hasOwnProperty("prop");
-        var desc = Object.getOwnPropertyDescriptor(obj, "prop");
+assert(obj.hasOwnProperty("prop"));
+var desc = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        delete obj.prop;
+assert.sameValue(desc.configurable, false);
 
-        return propertyDefineCorrect && desc.configurable === false && obj.hasOwnProperty("prop");
-    }
+verifyNotConfigurable(obj, "prop");
+
+assert(obj.hasOwnProperty("prop"));

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-528.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-528.js
@@ -14,30 +14,35 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = {};
+var obj = {};
 
-        var getFunc = function () {
-            return 1001;
-        };
+var getFunc = function () {
+    return 1001;
+};
 
-        Object.defineProperty(obj, "prop", {
-            get: getFunc,
-            set: undefined,
-            enumerable: false,
-            configurable: false
-        });
-        var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
+Object.defineProperty(obj, "prop", {
+    get: getFunc,
+    set: undefined,
+    enumerable: false,
+    configurable: false
+});
+var desc1 = Object.getOwnPropertyDescriptor(obj, "prop");
 
-        try {
-            Object.defineProperty(obj, "prop", {
-                configurable: true
-            });
+try {
+    Object.defineProperty(obj, "prop", {
+        configurable: true
+    });
 
-            return false;
-        } catch (e) {
-            var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
-            delete obj.prop;
+    $ERROR("Expected TypeError");
+} catch (e) {
+    assert(e instanceof TypeError);
 
-            return desc1.configurable === false && desc2.configurable === false && obj.hasOwnProperty("prop") && e instanceof TypeError;
-        }
-    }
+    var desc2 = Object.getOwnPropertyDescriptor(obj, "prop");
+
+    assert.sameValue(desc1.configurable, false);
+    assert.sameValue(desc2.configurable, false);
+    
+    verifyNotConfigurable(obj, "prop");
+
+    assert(obj.hasOwnProperty("prop"));
+}

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-531-6.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-531-6.js
@@ -13,22 +13,23 @@ description: >
 includes: [propertyHelper.js]
 ---*/
 
-        var obj = [];
+var obj = [];
 
-        var verifySetFunc = "data";
-        var getFunc = function () {
-            return verifySetFunc;
-        };
+var verifySetFunc = "data";
+var getFunc = function () {
+    return verifySetFunc;
+};
 
-        Object.defineProperty(obj, "0", {
-            get: getFunc,
-            enumerable: true,
-            configurable: true
-        });
+Object.defineProperty(obj, "0", {
+    get: getFunc,
+    enumerable: true,
+    configurable: true
+});
 
-        obj[0] = "overrideData";
-        var propertyDefineCorrect = obj.hasOwnProperty("0");
-        var desc = Object.getOwnPropertyDescriptor(obj, "0");
+verifyNotWritable(obj, "0");
 
-        return propertyDefineCorrect && typeof desc.set === "undefined" && obj[0] === "data";
-    }
+assert(obj.hasOwnProperty("0"));
+var desc = Object.getOwnPropertyDescriptor(obj, "0");
+
+assert.sameValue(typeof desc.set, "undefined");
+


### PR DESCRIPTION
use helper fn; need to remove writeable test for non-own properties

Here are the rest of them.  The PR is messed up because I squashed it on top of the other one, #254 .  I don't know what's the best way to proceed with this - is there an easy way to drop the doubly-applied ones?

