### PR TITLE
strict mode: use new property helpers

### DIFF
--- a/test/built-ins/Object/freeze/15.2.3.9-2-4.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-4.js
@@ -7,26 +7,18 @@
 /*---
 es5id: 15.2.3.9-2-4
 description: Object.freeze - Non-enumerable own properties of 'O' are frozen
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "foo", {
-            value: 10,
-            enumerable: false,
-            configurable: true
-        });
+Object.defineProperty(obj, "foo", {
+    value: 10,
+    enumerable: false,
+    configurable: true
+});
 
-        Object.freeze(obj);
+Object.freeze(obj);
 
-        var desc = Object.getOwnPropertyDescriptor(obj, "foo");
-
-        var beforeDeleted = obj.hasOwnProperty("foo");
-        delete obj.foo;
-        var afterDeleted = obj.hasOwnProperty("foo");
-
-        return beforeDeleted && afterDeleted && desc.configurable === false && desc.writable === false;
-    }
-runTestCase(testcase);
+assert(obj.hasOwnProperty("foo"));
+verifyNotConfigurable(obj, "foo");

--- a/test/built-ins/Object/freeze/15.2.3.9-2-4.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-4.js
@@ -21,4 +21,5 @@ Object.defineProperty(obj, "foo", {
 Object.freeze(obj);
 
 assert(obj.hasOwnProperty("foo"));
+verifyNotWritable(obj, "foo");
 verifyNotConfigurable(obj, "foo");

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-1.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-1.js
@@ -7,19 +7,16 @@
 /*---
 es5id: 15.2.3.9-2-a-1
 description: Object.freeze - 'P' is own data property
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var obj = {};
+var obj = {};
 
-        obj.foo = 10; // default [[Configurable]] attribute value of foo: true
+obj.foo = 10; // default [[Configurable]] attribute value of foo: true
 
-        Object.freeze(obj);
+Object.freeze(obj);
 
-        var desc = Object.getOwnPropertyDescriptor(obj, "foo");
+verifyNotWritable(obj, "foo");
+verifyNotConfigurable(obj, "foo");
 
-        delete obj.foo;
-        return obj.foo === 10 && desc.configurable === false && desc.writable === false;
-    }
-runTestCase(testcase);
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-10.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-10.js
@@ -9,19 +9,16 @@ es5id: 15.2.3.9-2-a-10
 description: >
     Object.freeze - 'P' is own named property of an Array object that
     uses Object's [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var arrObj = [];
+var arrObj = [];
 
-        arrObj.foo = 10; // default [[Configurable]] attribute value of foo: true
+arrObj.foo = 10; // default [[Configurable]] attribute value of foo: true
 
-        Object.freeze(arrObj);
+Object.freeze(arrObj);
 
-        var desc = Object.getOwnPropertyDescriptor(arrObj, "foo");
+verifyNotWritable(arrObj, "foo");
+verifyNotConfigurable(arrObj, "foo");
 
-        delete arrObj.foo;
-        return arrObj.foo === 10 && desc.configurable === false && desc.writable === false;
-    }
-runTestCase(testcase);
+assert.sameValue(arrObj.foo, 10);

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-11.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-11.js
@@ -9,19 +9,17 @@ es5id: 15.2.3.9-2-a-11
 description: >
     Object.freeze - 'P' is own index property of the Arguments object
     that implements its own [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
 
-        // default [[Configurable]] attribute value of "0": true
-        var argObj = (function () { return arguments; }(1, 2, 3));
+// default [[Configurable]] attribute value of "0": true
+var argObj = (function () { return arguments; }(1, 2, 3));
 
-        Object.freeze(argObj);
+Object.freeze(argObj);
 
-        var desc = Object.getOwnPropertyDescriptor(argObj, "0");
+var desc = Object.getOwnPropertyDescriptor(argObj, "0");
 
-        delete argObj[0];
-        return argObj[0] === 1 && desc.configurable === false && desc.writable === false;
-    }
-runTestCase(testcase);
+verifyNotWritable(argObj, "0");
+verifyNotConfigurable(argObj, "0");
+

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-11.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-11.js
@@ -22,4 +22,5 @@ var desc = Object.getOwnPropertyDescriptor(argObj, "0");
 
 verifyNotWritable(argObj, "0");
 verifyNotConfigurable(argObj, "0");
+assert.sameValue(argObj[0], 1);
 

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-12.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-12.js
@@ -20,3 +20,5 @@ Object.freeze(strObj);
 
 verifyNotWritable(strObj, "0");
 verifyNotConfigurable(strObj, "0");
+
+assert.sameValue(strObj[0], "a");

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-12.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-12.js
@@ -9,19 +9,14 @@ es5id: 15.2.3.9-2-a-12
 description: >
     Object.freeze - 'P' is own index property of a String object that
     implements its own [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
 
-        // default [[Configurable]] attribute value of "0": true
-        var strObj = new String("abc");
+// default [[Configurable]] attribute value of "0": true
+var strObj = new String("abc");
 
-        Object.freeze(strObj);
+Object.freeze(strObj);
 
-        var desc = Object.getOwnPropertyDescriptor(strObj, "0");
-
-        delete strObj[0];
-        return strObj[0] === "a" && desc.configurable === false && desc.writable === false;
-    }
-runTestCase(testcase);
+verifyNotWritable(strObj, "0");
+verifyNotConfigurable(strObj, "0");

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-13.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-13.js
@@ -18,3 +18,5 @@ Object.freeze(obj);
 
 verifyNotWritable(obj, "0");
 verifyNotConfigurable(obj, "0");
+
+assert.sameValue(obj[0], 0);

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-13.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-13.js
@@ -7,19 +7,14 @@
 /*---
 es5id: 15.2.3.9-2-a-13
 description: Object.freeze - 'P' is own index property of the Object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
 
-        // default [[Configurable]] attribute value of "0": true
-        var obj = { 0: 0, 1: 1, length: 2};
+// default [[Configurable]] attribute value of "0": true
+var obj = { 0: 0, 1: 1, length: 2};
 
-        Object.freeze(obj);
+Object.freeze(obj);
 
-        var desc = Object.getOwnPropertyDescriptor(obj, "0");
-
-        delete obj[0];
-        return obj[0] === 0 && desc.configurable === false && desc.writable === false;
-    }
-runTestCase(testcase);
+verifyNotWritable(obj, "0");
+verifyNotConfigurable(obj, "0");

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-14.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-14.js
@@ -9,19 +9,14 @@ es5id: 15.2.3.9-2-a-14
 description: >
     Object.freeze - 'P' is own index property of an Array object that
     uses Object's [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
+// default [[Configurable]] attribute value of "0": true
+var arrObj = [0, 1, 2];
 
-        // default [[Configurable]] attribute value of "0": true
-        var arrObj = [0, 1, 2];
+Object.freeze(arrObj);
 
-        Object.freeze(arrObj);
-
-        var desc = Object.getOwnPropertyDescriptor(arrObj, "0");
-
-        delete arrObj[0];
-        return arrObj[0] === 0 && desc.configurable === false && desc.writable === false;
-    }
-runTestCase(testcase);
+verifyNotWritable(arrObj, "0");
+verifyNotConfigurable(arrObj, "0");
+assert.sameValue(arrObj[0], 0);

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-2.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-2.js
@@ -9,25 +9,20 @@ es5id: 15.2.3.9-2-a-2
 description: >
     Object.freeze - 'P' is own data property that overrides an
     inherited data property
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
 
-        var proto = { foo: 0 }; // default [[Configurable]] attribute value of foo: true
+var proto = { foo: 0 }; // default [[Configurable]] attribute value of foo: true
 
-        var Con = function () { };
-        Con.prototype = proto;
+var Con = function () { };
+Con.prototype = proto;
 
-        var child = new Con();
+var child = new Con();
 
-        child.foo = 10; // default [[Configurable]] attribute value of foo: true
- 
-        Object.freeze(child);
+child.foo = 10; // default [[Configurable]] attribute value of foo: true
 
-        var desc = Object.getOwnPropertyDescriptor(child, "foo");
+Object.freeze(child);
 
-        delete child.foo;
-        return child.foo === 10 && desc.configurable === false && desc.writable === false;
-    }
-runTestCase(testcase);
+verifyNotWritable(child, "foo");
+verifyNotConfigurable(child, "foo");

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-2.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-2.js
@@ -26,3 +26,5 @@ Object.freeze(child);
 
 verifyNotWritable(child, "foo");
 verifyNotConfigurable(child, "foo");
+
+assert.sameValue(child.foo, 10);

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-3.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-3.js
@@ -9,33 +9,29 @@ es5id: 15.2.3.9-2-a-3
 description: >
     Object.freeze - 'P' is own data property that overrides an
     inherited accessor property
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var proto = {};
+var proto = {};
 
-        Object.defineProperty(proto, "foo", {
-            get: function () {
-                return 0;
-            },
-            configurable: true
-        });
+Object.defineProperty(proto, "foo", {
+    get: function () {
+        return 0;
+    },
+    configurable: true
+});
 
-        var Con = function () { };
-        Con.prototype = proto;
+var Con = function () { };
+Con.prototype = proto;
 
-        var child = new Con();
-        Object.defineProperty(child, "foo", {
-            value: 10,
-            configurable: true
-        });
+var child = new Con();
+Object.defineProperty(child, "foo", {
+    value: 10,
+    configurable: true
+});
 
-        Object.freeze(child);
+Object.freeze(child);
 
-        var desc = Object.getOwnPropertyDescriptor(child, "foo");
-
-        delete child.foo;
-        return child.foo === 10 && desc.configurable === false && desc.writable === false;
-    }
-runTestCase(testcase);
+verifyNotWritable(child, "foo");
+verifyNotConfigurable(child, "foo");
+assert.sameValue(child.foo, 10);

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-4.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-4.js
@@ -7,24 +7,19 @@
 /*---
 es5id: 15.2.3.9-2-a-4
 description: Object.freeze - 'P' is own accessor property
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "foo", {
-            get: function () {
-                return 10;
-            },
-            configurable: true
-        });
+Object.defineProperty(obj, "foo", {
+    get: function () {
+        return 10;
+    },
+    configurable: true
+});
 
-        Object.freeze(obj);
+Object.freeze(obj);
 
-        var desc = Object.getOwnPropertyDescriptor(obj, "foo");
-
-        delete obj.foo;
-        return obj.foo === 10 && desc.configurable === false;
-    }
-runTestCase(testcase);
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-5.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-5.js
@@ -9,32 +9,27 @@ es5id: 15.2.3.9-2-a-5
 description: >
     Object.freeze - 'P' is own accessor property that overrides an
     inherited data property
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
 
-        var proto = {};
+var proto = {};
 
-        proto.foo = 0; // default [[Configurable]] attribute value of foo: true
+proto.foo = 0; // default [[Configurable]] attribute value of foo: true
 
-        var Con = function () { };
-        Con.prototype = proto;
+var Con = function () { };
+Con.prototype = proto;
 
-        var child = new Con();
+var child = new Con();
 
-        Object.defineProperty(child, "foo", {
-            get: function () {
-                return 10;
-            },
-            configurable: true
-        });
+Object.defineProperty(child, "foo", {
+    get: function () {
+        return 10;
+    },
+    configurable: true
+});
 
-        Object.freeze(child);
+Object.freeze(child);
 
-        var desc = Object.getOwnPropertyDescriptor(child, "foo");
-
-        delete child.foo;
-        return child.foo === 10 && desc.configurable === false;
-    }
-runTestCase(testcase);
+verifyNotConfigurable(child, "foo");
+assert.sameValue(child.foo, 10);

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-6.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-6.js
@@ -9,36 +9,31 @@ es5id: 15.2.3.9-2-a-6
 description: >
     Object.freeze - 'P' is own accessor property that overrides an
     inherited accessor property
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var proto = {};
+var proto = {};
 
-        Object.defineProperty(proto, "foo", {
-            get: function () {
-                return 0;
-            },
-            configurable: true
-        });
+Object.defineProperty(proto, "foo", {
+    get: function () {
+        return 0;
+    },
+    configurable: true
+});
 
-        var Con = function () { };
-        Con.prototype = proto;
+var Con = function () { };
+Con.prototype = proto;
 
-        var child = new Con();
+var child = new Con();
 
-        Object.defineProperty(child, "foo", {
-            get: function () {
-                return 10;
-            },
-            configurable: true
-        });
+Object.defineProperty(child, "foo", {
+    get: function () {
+        return 10;
+    },
+    configurable: true
+});
 
-        Object.freeze(child);
+Object.freeze(child);
 
-        var desc = Object.getOwnPropertyDescriptor(child, "foo");
-
-        delete child.foo;
-        return child.foo === 10 && desc.configurable === false;
-    }
-runTestCase(testcase);
+verifyNotConfigurable(child, "foo");
+assert.sameValue(child.foo, 10);

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-7.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-7.js
@@ -9,19 +9,15 @@ es5id: 15.2.3.9-2-a-7
 description: >
     Object.freeze - 'P' is own named property of an Arguments object
     that implements its own [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var argObj = (function () { return arguments; }());
+var argObj = (function () { return arguments; }());
 
-        argObj.foo = 10; // default [[Configurable]] attribute value of foo: true
+argObj.foo = 10; // default [[Configurable]] attribute value of foo: true
 
-        Object.freeze(argObj);
+Object.freeze(argObj);
 
-        var desc = Object.getOwnPropertyDescriptor(argObj, "foo");
-
-        delete argObj.foo;
-        return argObj.foo === 10 && desc.configurable === false && desc.writable === false;
-    }
-runTestCase(testcase);
+verifyNotWritable(argObj, "foo");
+verifyNotConfigurable(argObj, "foo");
+assert.sameValue(argObj.foo, 10);

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-8.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-8.js
@@ -9,19 +9,15 @@ es5id: 15.2.3.9-2-a-8
 description: >
     Object.freeze - 'P' is own named property of the String object
     that implements its own [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var strObj = new String("abc");
+var strObj = new String("abc");
 
-        strObj.foo = 10; // default [[Configurable]] attribute value of foo: true
+strObj.foo = 10; // default [[Configurable]] attribute value of foo: true
 
-        Object.freeze(strObj);
+Object.freeze(strObj);
 
-        var desc = Object.getOwnPropertyDescriptor(strObj, "foo");
-
-        delete strObj.foo;
-        return strObj.foo === 10 && desc.configurable === false && desc.writable === false;
-    }
-runTestCase(testcase);
+verifyNotWritable(strObj, "foo");
+verifyNotConfigurable(strObj, "foo");
+assert.sameValue(strObj.foo, 10);

--- a/test/built-ins/Object/freeze/15.2.3.9-2-a-9.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-a-9.js
@@ -9,19 +9,16 @@ es5id: 15.2.3.9-2-a-9
 description: >
     Object.freeze - 'P' is own property of the Function object that
     uses Object's [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var funObj = function () { };
+var funObj = function () { };
 
-        funObj.foo = 10; // default [[Configurable]] attribute value of foo: true
+funObj.foo = 10; // default [[Configurable]] attribute value of foo: true
 
-        Object.freeze(funObj);
+Object.freeze(funObj);
 
-        var desc = Object.getOwnPropertyDescriptor(funObj, "foo");
+verifyNotWritable(funObj, "foo");
+verifyNotConfigurable(funObj, "foo");
 
-        delete funObj.foo;
-        return funObj.foo === 10 && desc.configurable === false && desc.writable === false;
-    }
-runTestCase(testcase);
+assert.sameValue(funObj.foo, 10);

--- a/test/built-ins/Object/freeze/15.2.3.9-2-c-2.js
+++ b/test/built-ins/Object/freeze/15.2.3.9-2-c-2.js
@@ -10,47 +10,38 @@ description: >
     Object.freeze - The [[Configurable]] attribute of own accessor
     property of 'O' is set to false while other attributes are
     unchanged
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var obj = {};
+var obj = {};
 
-        function get_func() {
-            return 10;
-        }
+function get_func() {
+    return 10;
+}
 
-        var resultSetFun = false;
-        function set_func() {
-            resultSetFun = true;
-        }
+var set_funcCalled = false;
+function set_func() {
+    set_funcCalled = true;
+}
 
-        Object.defineProperty(obj, "foo", {
-            get: get_func,
-            set: set_func,
-            enumerable: true,
-            configurable: true
-        });
+Object.defineProperty(obj, "foo", {
+    get: get_func,
+    set: set_func,
+    enumerable: true,
+    configurable: true
+});
 
-        Object.freeze(obj);
-        var res1 = obj.hasOwnProperty("foo");
-        delete obj.foo;
-        var res2 = obj.hasOwnProperty("foo");
-        var resultConfigurable = (res1 && res2);
+Object.freeze(obj);
 
-        var resultGetFun = (obj.foo === 10);
-        obj.foo = 12;
+assert(obj.hasOwnProperty("foo"));
+verifyNotConfigurable(obj, "foo");
 
-        var resultEnumerable = false;
-        for (var prop in obj) {
-            if (prop === "foo") {
-                resultEnumerable = true;
-            }
-        }
+assert.sameValue(obj.foo, 10);
 
-        var desc = Object.getOwnPropertyDescriptor(obj, "foo");
-        var result = resultConfigurable && resultEnumerable && resultGetFun && resultSetFun;
+obj.foo = 12;
+assert(set_funcCalled);
 
-        return desc.configurable === false && result;
-    }
-runTestCase(testcase);
+verifyEnumerable(obj, "foo");
+
+var desc = Object.getOwnPropertyDescriptor(obj, "foo");
+assert.sameValue(desc.configurable, false);

--- a/test/built-ins/Object/isExtensible/15.2.3.13-2-1.js
+++ b/test/built-ins/Object/isExtensible/15.2.3.13-2-1.js
@@ -7,15 +7,11 @@
 /*---
 es5id: 15.2.3.13-2-1
 description: Object.isExtensible returns true for all built-in objects (Global)
-includes: [runTestCase.js]
+flags: [noStrict]
 ---*/
 
 var global = this;
-function testcase() {
-  // in non-strict mode, 'this' is bound to the global object.
-  var e = Object.isExtensible(this);
-  if (e === true) {
-    return true;
-  }
- }
-runTestCase(testcase);
+
+// in non-strict mode, 'this' is bound to the global object.
+assert(Object.isExtensible(this));
+

--- a/test/built-ins/Object/isExtensible/15.2.3.13-2-1.js
+++ b/test/built-ins/Object/isExtensible/15.2.3.13-2-1.js
@@ -7,11 +7,10 @@
 /*---
 es5id: 15.2.3.13-2-1
 description: Object.isExtensible returns true for all built-in objects (Global)
-flags: [noStrict]
+includes: [fnGlobalObject.js]
 ---*/
 
-var global = this;
+var global = fnGlobalObject();
 
-// in non-strict mode, 'this' is bound to the global object.
-assert(Object.isExtensible(this));
+assert(Object.isExtensible(global));
 

--- a/test/built-ins/Object/isFrozen/15.2.3.12-3-1.js
+++ b/test/built-ins/Object/isFrozen/15.2.3.12-3-1.js
@@ -7,8 +7,7 @@
 /*---
 es5id: 15.2.3.12-3-1
 description: Object.isFrozen returns false for all built-in objects (Global)
-flags: [noStrict]
+includes: [fnGlobalObject.js]
 ---*/
 
-// in non-strict mode, 'this' is bound to the global object.
-assert(!Object.isFrozen(this));
+assert(!Object.isFrozen(fnGlobalObject()));

--- a/test/built-ins/Object/isFrozen/15.2.3.12-3-1.js
+++ b/test/built-ins/Object/isFrozen/15.2.3.12-3-1.js
@@ -7,14 +7,8 @@
 /*---
 es5id: 15.2.3.12-3-1
 description: Object.isFrozen returns false for all built-in objects (Global)
-includes: [runTestCase.js]
+flags: [noStrict]
 ---*/
 
-function testcase() {
-  // in non-strict mode, 'this' is bound to the global object.
-  var b = Object.isFrozen(this);
-  if (b === false) {
-    return true;
-  }
- }
-runTestCase(testcase);
+// in non-strict mode, 'this' is bound to the global object.
+assert(!Object.isFrozen(this));

--- a/test/built-ins/Object/isSealed/15.2.3.11-4-1.js
+++ b/test/built-ins/Object/isSealed/15.2.3.11-4-1.js
@@ -7,8 +7,7 @@
 /*---
 es5id: 15.2.3.11-4-1
 description: Object.isSealed returns false for all built-in objects (Global)
-flags: [noStrict]
+includes: [fnGlobalObject.js]
 ---*/
 
-// in non-strict mode, 'this' is bound to the global object.
-assert(!Object.isSealed(this));
+assert(!Object.isSealed(fnGlobalObject()));

--- a/test/built-ins/Object/isSealed/15.2.3.11-4-1.js
+++ b/test/built-ins/Object/isSealed/15.2.3.11-4-1.js
@@ -7,14 +7,8 @@
 /*---
 es5id: 15.2.3.11-4-1
 description: Object.isSealed returns false for all built-in objects (Global)
-includes: [runTestCase.js]
+flags: [noStrict]
 ---*/
 
-function testcase() {
-  // in non-strict mode, 'this' is bound to the global object.
-  var b = Object.isSealed(this);
-  if (b === false) {
-    return true;
-  }
- }
-runTestCase(testcase);
+// in non-strict mode, 'this' is bound to the global object.
+assert(!Object.isSealed(this));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-10.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-10.js
@@ -9,15 +9,16 @@ es5id: 15.2.3.10-3-10
 description: >
     Object.preventExtensions - indexed properties cannot be added into
     an Error object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var errObj = new Error();
-        var preCheck = Object.isExtensible(errObj);
-        Object.preventExtensions(errObj);
+var errObj = new Error();
 
-        errObj[0] = 12;
-        return preCheck && !errObj.hasOwnProperty("0");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(errObj));
+Object.preventExtensions(errObj);
+assert(!Object.isExtensible(errObj));
+
+verifyNotWritable(errObj, "0", "nocheck");
+
+assert(!errObj.hasOwnProperty("0"));
+

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-11.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-11.js
@@ -9,18 +9,18 @@ es5id: 15.2.3.10-3-11
 description: >
     Object.preventExtensions - indexed properties cannot be added into
     an Arguments object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var argObj;
-        (function () {
-            argObj = arguments;
-        }());
-        var preCheck = Object.isExtensible(argObj);
-        Object.preventExtensions(argObj);
+var argObj;
+(function () {
+    argObj = arguments;
+}());
 
-        argObj[0] = 12;
-        return preCheck && !argObj.hasOwnProperty("0");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(argObj));
+Object.preventExtensions(argObj);
+assert(!Object.isExtensible(argObj));
+
+verifyNotWritable(argObj, "0", "nocheck");
+
+assert(!argObj.hasOwnProperty("0"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-12.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-12.js
@@ -9,15 +9,16 @@ es5id: 15.2.3.10-3-12
 description: >
     Object.preventExtensions - named properties cannot be added into
     the returned object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var obj = {};
-        var preCheck = Object.isExtensible(obj);
-        Object.preventExtensions(obj);
+var obj = {};
 
-        obj.exName = 2;
-        return preCheck && !Object.hasOwnProperty("exName");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "exName", "nocheck");
+
+assert(!obj.hasOwnProperty("exName"));
+

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-13.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-13.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-13
 description: >
     Object.preventExtensions - named properties cannot be added into a
     Function object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var funObj = function () { };
-        var preCheck = Object.isExtensible(funObj);
-        Object.preventExtensions(funObj);
+var obj = function () { };
 
-        funObj.exName = 2;
-        return preCheck && !funObj.hasOwnProperty("exName");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "exName", "nocheck");
+
+assert(!obj.hasOwnProperty("exName"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-14.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-14.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-14
 description: >
     Object.preventExtensions - named properties cannot be added into
     an Array object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var arrObj = [];
-        var preCheck = Object.isExtensible(arrObj);
-        Object.preventExtensions(arrObj);
+var obj = [];
 
-        arrObj.exName = 2;
-        return preCheck && !arrObj.hasOwnProperty("exName");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "exName", "nocheck");
+
+assert(!obj.hasOwnProperty("exName"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-15.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-15.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-15
 description: >
     Object.preventExtensions - named properties cannot be added into a
     String object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var strObj = new String("bbq");
-        var preCheck = Object.isExtensible(strObj);
-        Object.preventExtensions(strObj);
+var obj = new String("bbq");
 
-        strObj.exName = 2;
-        return preCheck && !strObj.hasOwnProperty("exName");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "exName", "nocheck");
+
+assert(!obj.hasOwnProperty("exName"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-16.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-16.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-16
 description: >
     Object.preventExtensions - named properties cannot be added into a
     Boolean object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var boolObj = new Boolean(true);
-        var preCheck = Object.isExtensible(boolObj);
-        Object.preventExtensions(boolObj);
+var obj = new Boolean(true);
 
-        boolObj.exName = 2;
-        return preCheck && !boolObj.hasOwnProperty("exName");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "exName", "nocheck");
+
+assert(!obj.hasOwnProperty("exName"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-17.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-17.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-17
 description: >
     Object.preventExtensions - named properties cannot be added into a
     Number object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var numObj = new Number(123);
-        var preCheck = Object.isExtensible(numObj);
-        Object.preventExtensions(numObj);
+var obj = new Number(123);
 
-        numObj.exName = 2;
-        return preCheck && !numObj.hasOwnProperty("exName");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "exName", "nocheck");
+
+assert(!obj.hasOwnProperty("exName"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-18.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-18.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-18
 description: >
     Object.preventExtensions - named properties cannot be added into a
     Date object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var dateObj = new Date();
-        var preCheck = Object.isExtensible(dateObj);
-        Object.preventExtensions(dateObj);
+var obj = new Date();
 
-        dateObj.exName = 2;
-        return preCheck && !dateObj.hasOwnProperty("exName");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "exName", "nocheck");
+
+assert(!obj.hasOwnProperty("exName"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-19.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-19.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-19
 description: >
     Object.preventExtensions - named properties cannot be added into a
     RegExp object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var regObj = new RegExp();
-        var preCheck = Object.isExtensible(regObj);
-        Object.preventExtensions(regObj);
+var obj = new RegExp();
 
-        regObj.exName = 2;
-        return preCheck && !regObj.hasOwnProperty("exName");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "exName", "nocheck");
+
+assert(!obj.hasOwnProperty("exName"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-2.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-2.js
@@ -9,16 +9,15 @@ es5id: 15.2.3.10-3-2
 description: >
     Object.preventExtensions - indexed properties cannot be added into
     the returned object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
+var obj = {};
 
-        var obj = {};
-        var preCheck = Object.isExtensible(obj);
-        Object.preventExtensions(obj);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
 
-        obj[0] = 12;
-        return preCheck && !obj.hasOwnProperty("0");
-    }
-runTestCase(testcase);
+verifyNotWritable(obj, "0", "nocheck");
+
+assert(!obj.hasOwnProperty("0"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-20.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-20.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-20
 description: >
     Object.preventExtensions - named properties cannot be added into
     an Error object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var errObj = new Error();
-        var preCheck = Object.isExtensible(errObj);
-        Object.preventExtensions(errObj);
+var obj = new Error();
 
-        errObj.exName = 2;
-        return preCheck && !errObj.hasOwnProperty("exName");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "exName", "nocheck");
+
+assert(!obj.hasOwnProperty("exName"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-21.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-21.js
@@ -9,18 +9,18 @@ es5id: 15.2.3.10-3-21
 description: >
     Object.preventExtensions - named properties cannot be added into
     an Arguments object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var argObj;
-        (function () {
-            argObj = arguments;
-        }());
-        var preCheck = Object.isExtensible(argObj);
-        Object.preventExtensions(argObj);
+var obj;
+(function () {
+    obj = arguments;
+}());
 
-        argObj.exName = 2;
-        return preCheck && !argObj.hasOwnProperty("exName");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "exName", "nocheck");
+
+assert(!obj.hasOwnProperty("exName"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-3.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-3.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-3
 description: >
     Object.preventExtensions - indexed properties cannot be added into
     a Function object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var funObj = function () { };
-        var preCheck = Object.isExtensible(funObj);
-        Object.preventExtensions(funObj);
+var obj = function () { };
 
-        funObj[0] = 12;
-        return preCheck && !funObj.hasOwnProperty("0");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "0", "nocheck");
+
+assert(!obj.hasOwnProperty("0"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-4.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-4.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-4
 description: >
     Object.preventExtensions - indexed properties cannot be added into
     an Array object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var arrObj = [];
-        var preCheck = Object.isExtensible(arrObj);
-        Object.preventExtensions(arrObj);
+var obj = [];
 
-        arrObj[0] = 12;
-        return preCheck && !arrObj.hasOwnProperty("0");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "0", "nocheck");
+
+assert(!obj.hasOwnProperty("0"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-5-1.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-5-1.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-5-1
 description: >
     Object.preventExtensions - indexed properties cannot be added into
     a String object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var strObj = new String("bbq");
-        var preCheck = Object.isExtensible(strObj);
-        Object.preventExtensions(strObj);
+var obj = new String("bbq");
 
-        strObj[10] = 12;
-        return preCheck && !strObj.hasOwnProperty("10");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "10", "nocheck");
+
+assert(!obj.hasOwnProperty("10"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-6.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-6.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-6
 description: >
     Object.preventExtensions - indexed properties cannot be added into
     a Boolean object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var boolObj = new Boolean(true);
-        var preCheck = Object.isExtensible(boolObj);
-        Object.preventExtensions(boolObj);
+var obj = new Boolean(true);
 
-        boolObj[0] = 12;
-        return preCheck && !boolObj.hasOwnProperty("0");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "0", "nocheck");
+
+assert(!obj.hasOwnProperty("0"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-7.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-7.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-7
 description: >
     Object.preventExtensions - indexed properties cannot be added into
     a Number object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var numObj = new Number(123);
-        var preCheck = Object.isExtensible(numObj);
-        Object.preventExtensions(numObj);
+var obj = new Number(123);
 
-        numObj[0] = 12;
-        return preCheck && !numObj.hasOwnProperty("0");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "0", "nocheck");
+
+assert(!obj.hasOwnProperty("0"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-8.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-8.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-8
 description: >
     Object.preventExtensions - indexed properties cannot be added into
     a Date object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var dateObj = new Date();
-        var preCheck = Object.isExtensible(dateObj);
-        Object.preventExtensions(dateObj);
+var obj = new Date();
 
-        dateObj[0] = 12;
-        return preCheck && !dateObj.hasOwnProperty("0");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "0", "nocheck");
+
+assert(!obj.hasOwnProperty("0"));

--- a/test/built-ins/Object/preventExtensions/15.2.3.10-3-9.js
+++ b/test/built-ins/Object/preventExtensions/15.2.3.10-3-9.js
@@ -9,15 +9,15 @@ es5id: 15.2.3.10-3-9
 description: >
     Object.preventExtensions - indexed properties cannot be added into
     a RegExp object
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var regObj = new RegExp();
-        var preCheck = Object.isExtensible(regObj);
-        Object.preventExtensions(regObj);
+var obj = new RegExp();
 
-        regObj[0] = 12;
-        return preCheck && !regObj.hasOwnProperty("0");
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.preventExtensions(obj);
+assert(!Object.isExtensible(obj));
+
+verifyNotWritable(obj, "0", "nocheck");
+
+assert(!obj.hasOwnProperty("0"));

--- a/test/built-ins/Object/seal/15.2.3.8-2-4.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-4.js
@@ -7,24 +7,20 @@
 /*---
 es5id: 15.2.3.8-2-4
 description: Object.seal - non-enumerable own property of 'O' is sealed
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "foo", {
-            value: 10,
-            enumerable: false,
-            configurable: true
-        });
-        var preCheck = Object.isExtensible(obj);
-        Object.seal(obj);
+Object.defineProperty(obj, "foo", {
+    value: 10,
+    enumerable: false,
+    configurable: true
+});
 
-        var beforeDeleted = obj.hasOwnProperty("foo");
-        delete obj.foo;
-        var afterDeleted = obj.hasOwnProperty("foo");
+assert(Object.isExtensible(obj));
+Object.seal(obj);
 
-        return preCheck && beforeDeleted && afterDeleted;
-    }
-runTestCase(testcase);
+assert(obj.hasOwnProperty("foo"));
+verifyNotConfigurable(obj, "foo");
+

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-1.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-1.js
@@ -7,17 +7,15 @@
 /*---
 es5id: 15.2.3.8-2-a-1
 description: Object.seal - 'P' is own data property
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var obj = {};
+var obj = {};
 
-        obj.foo = 10; // default [[Configurable]] attribute value of foo: true
-        var preCheck = Object.isExtensible(obj);
-        Object.seal(obj);
+obj.foo = 10; // default [[Configurable]] attribute value of foo: true
 
-        delete obj.foo;
-        return preCheck && obj.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-10.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-10.js
@@ -9,17 +9,15 @@ es5id: 15.2.3.8-2-a-10
 description: >
     Object.seal - 'P' is own property of a Boolean object that uses
     Object's [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var boolObj = new Boolean(false);
+var obj = new Boolean(false);
 
-        boolObj.foo = 10;
-        var preCheck = Object.isExtensible(boolObj);
-        Object.seal(boolObj);
+obj.foo = 10;
 
-        delete boolObj.foo;
-        return preCheck && boolObj.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-11.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-11.js
@@ -9,17 +9,15 @@ es5id: 15.2.3.8-2-a-11
 description: >
     Object.seal - 'P' is own property of a Number object that uses
     Object's [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var numObj = new Number(-1);
+var obj = new Number(-1);
 
-        numObj.foo = 10;
-        var preCheck = Object.isExtensible(numObj);
-        Object.seal(numObj);
+obj.foo = 10;
 
-        delete numObj.foo;
-        return preCheck && numObj.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-12.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-12.js
@@ -9,17 +9,15 @@ es5id: 15.2.3.8-2-a-12
 description: >
     Object.seal - 'P' is own property of a Date object that uses
     Object's [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var dateObj = new Date();
+var obj = new Date();
 
-        dateObj.foo = 10;
-        var preCheck = Object.isExtensible(dateObj);
-        Object.seal(dateObj);
+obj.foo = 10;
 
-        delete dateObj.foo;
-        return preCheck && dateObj.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-13.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-13.js
@@ -9,17 +9,15 @@ es5id: 15.2.3.8-2-a-13
 description: >
     Object.seal - 'P' is own property of a RegExp object that uses
     Object's [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var regObj = new RegExp();
+var obj = new RegExp();
 
-        regObj.foo = 10;
-        var preCheck = Object.isExtensible(regObj);
-        Object.seal(regObj);
+obj.foo = 10;
 
-        delete regObj.foo;
-        return preCheck && regObj.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-14.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-14.js
@@ -9,17 +9,15 @@ es5id: 15.2.3.8-2-a-14
 description: >
     Object.seal - 'P' is own property of an Error object that uses
     Object's [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var errObj = new Error();
+var obj = new Error();
 
-        errObj.foo = 10;
-        var preCheck = Object.isExtensible(errObj);
-        Object.seal(errObj);
+obj.foo = 10;
 
-        delete errObj.foo;
-        return preCheck && errObj.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-15.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-15.js
@@ -9,17 +9,15 @@ es5id: 15.2.3.8-2-a-15
 description: >
     Object.seal - 'P' is own property of an Arguments object which
     implements its own [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var argObj = (function () { return arguments; })();
+var obj = (function () { return arguments; })();
 
-        argObj.foo = 10; // default [[Configurable]] attribute value of foo: true
-        var preCheck = Object.isExtensible(argObj);
-        Object.seal(argObj);
+obj.foo = 10;
 
-        delete argObj.foo;
-        return preCheck && argObj.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-2.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-2.js
@@ -9,24 +9,22 @@ es5id: 15.2.3.8-2-a-2
 description: >
     Object.seal - 'P' is own data property that overrides an inherited
     data property
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var proto = { foo: 0 };
+var proto = { foo: 0 };
 
-        var ConstructFun = function () { };
-        ConstructFun.prototype = proto;
+var ConstructFun = function () { };
+ConstructFun.prototype = proto;
 
-        var child = new ConstructFun();
-        Object.defineProperty(child, "foo", {
-            value: 10,
-            configurable: true
-        });
-        var preCheck = Object.isExtensible(child);
-        Object.seal(child);
+var obj = new ConstructFun();
+Object.defineProperty(obj, "foo", {
+    value: 10,
+    configurable: true
+});
 
-        delete child.foo;
-        return preCheck && child.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-3.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-3.js
@@ -9,31 +9,29 @@ es5id: 15.2.3.8-2-a-3
 description: >
     Object.seal - 'P' is own data property that overrides an inherited
     accessor property
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var proto = {};
+var proto = {};
 
-        Object.defineProperty(proto, "foo", {
-            get: function () {
-                return 0;
-            },
-            configurable: true
-        });
+Object.defineProperty(proto, "foo", {
+    get: function () {
+        return 0;
+    },
+    configurable: true
+});
 
-        var ConstructFun = function () { };
-        ConstructFun.prototype = proto;
+var ConstructFun = function () { };
+ConstructFun.prototype = proto;
 
-        var child = new ConstructFun();
-        Object.defineProperty(child, "foo", {
-            value: 10,
-            configurable: true
-        });
-        var preCheck = Object.isExtensible(child);
-        Object.seal(child);
+var obj = new ConstructFun();
+Object.defineProperty(obj, "foo", {
+    value: 10,
+    configurable: true
+});
 
-        delete child.foo;
-        return preCheck && child.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-4.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-4.js
@@ -7,22 +7,20 @@
 /*---
 es5id: 15.2.3.8-2-a-4
 description: Object.seal - 'P' is own accessor property
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var obj = {};
+var obj = {};
 
-        Object.defineProperty(obj, "foo", {
-            get: function () {
-                return 10;
-            },
-            configurable: true
-        });
-        var preCheck = Object.isExtensible(obj);
-        Object.seal(obj);
+Object.defineProperty(obj, "foo", {
+    get: function () {
+        return 10;
+    },
+    configurable: true
+});
 
-        delete obj.foo;
-        return preCheck && obj.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-5.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-5.js
@@ -9,32 +9,30 @@ es5id: 15.2.3.8-2-a-5
 description: >
     Object.seal - 'P' is own accessor property that overrides an
     inherited data property
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var proto = {};
+var proto = {};
 
-        Object.defineProperty(proto, "foo", {
-            value: 0,
-            configurable: true
-        });
+Object.defineProperty(proto, "foo", {
+    value: 0,
+    configurable: true
+});
 
-        var ConstructFun = function () { };
-        ConstructFun.prototype = proto;
+var ConstructFun = function () { };
+ConstructFun.prototype = proto;
 
-        var child = new ConstructFun();
+var obj = new ConstructFun();
         
-        Object.defineProperty(child, "foo", {
-            get: function () {
-                return 10;
-            },
-            configurable: true
-        });
-        var preCheck = Object.isExtensible(child);
-        Object.seal(child);
+Object.defineProperty(obj, "foo", {
+    get: function () {
+        return 10;
+    },
+    configurable: true
+});
 
-        delete child.foo;
-        return preCheck && child.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-6.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-6.js
@@ -9,34 +9,32 @@ es5id: 15.2.3.8-2-a-6
 description: >
     Object.seal - 'P' is own accessor property that overrides an
     inherited accessor property
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var proto = {};
+var proto = {};
 
-        Object.defineProperty(proto, "foo", {
-            get: function () {
-                return 0;
-            },
-            configurable: true
-        });
+Object.defineProperty(proto, "foo", {
+    get: function () {
+        return 0;
+    },
+    configurable: true
+});
 
-        var ConstructFun = function () { };
-        ConstructFun.prototype = proto;
+var ConstructFun = function () { };
+ConstructFun.prototype = proto;
 
-        var child = new ConstructFun();
+var obj = new ConstructFun();
 
-        Object.defineProperty(child, "foo", {
-            get: function () {
-                return 10;
-            },
-            configurable: true
-        });
-        var preCheck = Object.isExtensible(child);
-        Object.seal(child);
+Object.defineProperty(obj, "foo", {
+    get: function () {
+        return 10;
+    },
+    configurable: true
+});
 
-        delete child.foo;
-        return preCheck && child.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-7.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-7.js
@@ -9,17 +9,15 @@ es5id: 15.2.3.8-2-a-7
 description: >
     Object.seal - 'P' is own property of a Function object that uses
     Object's [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var funObj = function () { };
+var obj = function () { };
 
-        funObj.foo = 10; // default [[Configurable]] attribute value of foo: true
-        var preCheck = Object.isExtensible(funObj);
-        Object.seal(funObj);
+obj.foo = 10;
 
-        delete funObj.foo;
-        return preCheck && funObj.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-8.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-8.js
@@ -9,17 +9,15 @@ es5id: 15.2.3.8-2-a-8
 description: >
     Object.seal - 'P' is own property of an Array object that uses
     Object's [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var arrObj = [];
+var obj = [];
 
-        arrObj.foo = 10;
-        var preCheck = Object.isExtensible(arrObj);
-        Object.seal(arrObj);
+obj.foo = 10;
 
-        delete arrObj.foo;
-        return preCheck && arrObj.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);

--- a/test/built-ins/Object/seal/15.2.3.8-2-a-9.js
+++ b/test/built-ins/Object/seal/15.2.3.8-2-a-9.js
@@ -9,17 +9,15 @@ es5id: 15.2.3.8-2-a-9
 description: >
     Object.seal - 'P' is own property of a String object which
     implements its own [[GetOwnProperty]]
-includes: [runTestCase.js]
+includes: [propertyHelper.js]
 ---*/
 
-function testcase() {
-        var strObj = new String("abc");
+var obj = new String("abc");
 
-        strObj.foo = 10; // default [[Configurable]] attribute value of foo: true
-        var preCheck = Object.isExtensible(strObj);
-        Object.seal(strObj);
+obj.foo = 10;
 
-        delete strObj.foo;
-        return preCheck && strObj.foo === 10;
-    }
-runTestCase(testcase);
+assert(Object.isExtensible(obj));
+Object.seal(obj);
+
+verifyNotConfigurable(obj, "foo");
+assert.sameValue(obj.foo, 10);


### PR DESCRIPTION
Fixes tests noted in #260

Object.freeze fixes
global object tests: noStrict
preventExtensions tests
Object.seal tests
one more freeze test