### PR TITLE
Candidate fix of empty catch{}

### DIFF
--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-591.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-591.js
@@ -49,16 +49,23 @@ verifyNotWritable(teamMeeting, "conferenceCall", "nocheck");
 
 try {
     teamMeeting.name = "IE Team Meeting";
-} catch (e) {}
+} catch (e) {
+    assert(e instanceof TypeError);
+}
 
 try {
     var dateObj = new Date("10/31/2010 08:00");
     teamMeeting.startTime = dateObj;
-} catch (e) {}
+} catch (e) {
+    assert(e instanceof TypeError);
+}
 
 try {
     teamMeeting.conferenceCall = "4255551212";
-} catch (e) {}
+} catch (e) {
+    assert(e instanceof TypeError);
+}
+
 
 assert(!teamMeeting.hasOwnProperty("name"));
 assert(!teamMeeting.hasOwnProperty("startTime"));


### PR DESCRIPTION
This is a candidate fix to the line note on #259
https://github.com/tc39/test262/pull/259#discussion_r29866745