### PR TITLE
Fix strict mode errors in language

### DIFF
--- a/test/language/arguments-object/10.6-10-c-ii-1.js
+++ b/test/language/arguments-object/10.6-10-c-ii-1.js
@@ -7,6 +7,7 @@
 /*---
 es5id: 10.6-10-c-ii-1
 description: arguments[i] change with actual parameters
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/language/arguments-object/10.6-10-c-ii-2.js
+++ b/test/language/arguments-object/10.6-10-c-ii-2.js
@@ -7,6 +7,7 @@
 /*---
 es5id: 10.6-10-c-ii-2
 description: arguments[i] map to actual parameter
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/language/arguments-object/10.6-12-1.js
+++ b/test/language/arguments-object/10.6-12-1.js
@@ -7,6 +7,7 @@
 /*---
 es5id: 10.6-12-1
 description: Accessing callee property of Arguments object is allowed
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/language/arguments-object/10.6-13-1.js
+++ b/test/language/arguments-object/10.6-13-1.js
@@ -7,6 +7,7 @@
 /*---
 es5id: 10.6-13-1
 description: Accessing caller property of Arguments object is allowed
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/language/arguments-object/10.6-13-a-1.js
+++ b/test/language/arguments-object/10.6-13-a-1.js
@@ -9,6 +9,7 @@ es5id: 10.6-13-a-1
 description: >
     In non-strict mode, arguments object should have its own 'callee'
     property defined (Step 13.a)
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/language/arguments-object/10.6-13-a-2.js
+++ b/test/language/arguments-object/10.6-13-a-2.js
@@ -7,6 +7,7 @@
 /*---
 es5id: 10.6-13-a-2
 description: A direct call to arguments.callee.caller should work
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/language/arguments-object/10.6-13-a-3.js
+++ b/test/language/arguments-object/10.6-13-a-3.js
@@ -7,6 +7,7 @@
 /*---
 es5id: 10.6-13-a-3
 description: An indirect call to arguments.callee.caller should work
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/language/arguments-object/10.6-6-3-s.js
+++ b/test/language/arguments-object/10.6-6-3-s.js
@@ -5,20 +5,16 @@
 // copyright and this notice and otherwise comply with the Use Terms.
 
 /*---
-es5id: 10.6-12-2
-description: arguments.callee has correct attributes
-flags: [noStrict]
+es5id: 10.6-6-3
+description: >
+    'length' property of arguments object for 0 argument function
+    exists
+flags: [onlyStrict]
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  
-  var desc = Object.getOwnPropertyDescriptor(arguments,"callee");
-  if(desc.configurable === true &&
-     desc.enumerable === false &&
-     desc.writable === true &&
-     desc.hasOwnProperty('get') == false &&
-     desc.hasOwnProperty('put') == false)
-    return true;   
+  'use strict';
+	return (function () {return arguments.length !== undefined})();
  }
 runTestCase(testcase);

--- a/test/language/arguments-object/10.6-6-3.js
+++ b/test/language/arguments-object/10.6-6-3.js
@@ -9,6 +9,7 @@ es5id: 10.6-6-3
 description: >
     'length' property of arguments object for 0 argument function
     exists
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/language/arguments-object/10.6-6-4-s.js
+++ b/test/language/arguments-object/10.6-6-4-s.js
@@ -5,20 +5,16 @@
 // copyright and this notice and otherwise comply with the Use Terms.
 
 /*---
-es5id: 10.6-12-2
-description: arguments.callee has correct attributes
-flags: [noStrict]
+es5id: 10.6-6-4
+description: >
+    'length' property of arguments object for 0 argument function call
+    is 0 even with formal parameters
+flags: [onlyStrict]
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  
-  var desc = Object.getOwnPropertyDescriptor(arguments,"callee");
-  if(desc.configurable === true &&
-     desc.enumerable === false &&
-     desc.writable === true &&
-     desc.hasOwnProperty('get') == false &&
-     desc.hasOwnProperty('put') == false)
-    return true;   
+  'use strict';
+	return (function (a,b,c) {return arguments.length === 0})();
  }
 runTestCase(testcase);

--- a/test/language/arguments-object/10.6-6-4.js
+++ b/test/language/arguments-object/10.6-6-4.js
@@ -9,6 +9,7 @@ es5id: 10.6-6-4
 description: >
     'length' property of arguments object for 0 argument function call
     is 0 even with formal parameters
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/language/eval-code/10.4.2-1-1.js
+++ b/test/language/eval-code/10.4.2-1-1.js
@@ -12,8 +12,6 @@ includes: [runTestCase.js]
 
 var __10_4_2_1_1_1 = "str";
 function testcase() {
-  try {
-
     var _eval = eval;
     var __10_4_2_1_1_1 = "str1";
     if(_eval("\'str\' === __10_4_2_1_1_1") === true &&  // indirect eval
@@ -21,8 +19,5 @@ function testcase() {
        return true;
     }
     return false;
-  } finally {
-    delete this.__10_4_2_1_1_1;
-  }
 }
 runTestCase(testcase);

--- a/test/language/eval-code/10.4.2-1-2.js
+++ b/test/language/eval-code/10.4.2-1-2.js
@@ -14,8 +14,6 @@ includes: [runTestCase.js]
 
 var __10_4_2_1_2 = "str";
 function testcase() {
-        try {
-
             var _eval = eval;
             var __10_4_2_1_2 = "str1";
             function foo() {
@@ -28,8 +26,5 @@ function testcase() {
                 }
             }
             return foo();
-        } finally {
-            delete this.__10_4_2_1_1_2;
-        }
     }
 runTestCase(testcase);

--- a/test/language/eval-code/10.4.2-1-3.js
+++ b/test/language/eval-code/10.4.2-1-3.js
@@ -14,9 +14,6 @@ includes: [runTestCase.js]
 
 var __10_4_2_1_3 = "str";
 function testcase() {
-
-        try {
-
             var _eval = eval;
             var __10_4_2_1_3 = "str1";
             try {
@@ -31,8 +28,5 @@ function testcase() {
                     return false;
                 }
             }
-        } finally {
-            delete this.__10_4_2_1_3;
-        }
     }
 runTestCase(testcase);

--- a/test/language/eval-code/10.4.2-1-4.js
+++ b/test/language/eval-code/10.4.2-1-4.js
@@ -9,12 +9,12 @@ es5id: 10.4.2-1-4
 description: >
     Indirect call to eval has context set to global context (with
     block)
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 
 var __10_4_2_1_4 = "str";
 function testcase() {
-        try {
             var o = new Object();
             o.__10_4_2_1_4 = "str2";
             var _eval = eval;
@@ -26,8 +26,5 @@ function testcase() {
                 }
             }
             return false;
-        } finally {
-            delete this.__10_4_2_1_4;
-        }
     }
 runTestCase(testcase);

--- a/test/language/eval-code/10.4.2-1-5.js
+++ b/test/language/eval-code/10.4.2-1-5.js
@@ -14,8 +14,6 @@ includes: [runTestCase.js]
 
 var __10_4_2_1_5 = "str";
 function testcase() {
-        try {
-
             var __10_4_2_1_5 = "str1";
             var r = eval("\
                           var _eval = eval; \
@@ -24,8 +22,5 @@ function testcase() {
                           eval(\"\'str2\' === __10_4_2_1_5\")\
                         ");
             return r;
-        } finally {
-            delete this.__10_4_2_1_5;
-        }
     }
 runTestCase(testcase);

--- a/test/language/eval-code/10.4.2-2-c-1.js
+++ b/test/language/eval-code/10.4.2-2-c-1.js
@@ -9,6 +9,7 @@ es5id: 10.4.2-2-c-1
 description: >
     Direct val code in non-strict mode - can instantiate variable in
     calling context
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/language/eval-code/S10.4.2_A1.1_T1.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T1.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.1_T1
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 var i;

--- a/test/language/eval-code/S10.4.2_A1.1_T10.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T10.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.1_T10
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 var i;

--- a/test/language/eval-code/S10.4.2_A1.1_T11.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T11.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.1_T11
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 var i;

--- a/test/language/eval-code/S10.4.2_A1.1_T12.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T12.js
@@ -5,16 +5,14 @@
 info: >
     The scope chain is initialised to contain the same objects,
     in the same order, as the calling context's scope chain
-es5id: 10.4.2_A1.1_T8
+es5id: 10.4.2_A1.1_T12
 description: eval within global execution context
-flags: [noStrict]
 ---*/
 
 var i;
 var j;
-str1 = '';
-str2 = '';
-this.x = 1;
+var str1 = '';
+var str2 = '';
 
 for(i in this){
   str1+=i;
@@ -26,4 +24,5 @@ if(!(str1 === str2)){
   $ERROR("#1: scope chain must contain same objects in the same order as the calling context");
 }
 
+var x = 1;
 var y = 2;

--- a/test/language/eval-code/S10.4.2_A1.1_T13.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T13.js
@@ -5,16 +5,16 @@
 info: >
     The scope chain is initialised to contain the same objects,
     in the same order, as the calling context's scope chain
-es5id: 10.4.2_A1.1_T8
+es5id: 10.4.2_A1.1_T13
 description: eval within global execution context
-flags: [noStrict]
 ---*/
 
 var i;
 var j;
-str1 = '';
-str2 = '';
+var str1 = '';
+var str2 = '';
 this.x = 1;
+this.y = 2;
 
 for(i in this){
   str1+=i;
@@ -25,5 +25,3 @@ eval('for(j in this){\nstr2+=j;\n}');
 if(!(str1 === str2)){
   $ERROR("#1: scope chain must contain same objects in the same order as the calling context");
 }
-
-var y = 2;

--- a/test/language/eval-code/S10.4.2_A1.1_T14.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T14.js
@@ -5,16 +5,15 @@
 info: >
     The scope chain is initialised to contain the same objects,
     in the same order, as the calling context's scope chain
-es5id: 10.4.2_A1.1_T8
+es5id: 10.4.2_A1.1_T14
 description: eval within global execution context
-flags: [noStrict]
 ---*/
 
 var i;
 var j;
-str1 = '';
-str2 = '';
-this.x = 1;
+var str1 = '';
+var str2 = '';
+var x = 1;
 
 for(i in this){
   str1+=i;

--- a/test/language/eval-code/S10.4.2_A1.1_T15.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T15.js
@@ -5,15 +5,14 @@
 info: >
     The scope chain is initialised to contain the same objects,
     in the same order, as the calling context's scope chain
-es5id: 10.4.2_A1.1_T8
+es5id: 10.4.2_A1.1_T15
 description: eval within global execution context
-flags: [noStrict]
 ---*/
 
 var i;
 var j;
-str1 = '';
-str2 = '';
+var str1 = '';
+var str2 = '';
 this.x = 1;
 
 for(i in this){
@@ -26,4 +25,4 @@ if(!(str1 === str2)){
   $ERROR("#1: scope chain must contain same objects in the same order as the calling context");
 }
 
-var y = 2;
+this.y = 2;

--- a/test/language/eval-code/S10.4.2_A1.1_T16.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T16.js
@@ -5,16 +5,15 @@
 info: >
     The scope chain is initialised to contain the same objects,
     in the same order, as the calling context's scope chain
-es5id: 10.4.2_A1.1_T8
+es5id: 10.4.2_A1.1_T16
 description: eval within global execution context
-flags: [noStrict]
 ---*/
 
 var i;
 var j;
-str1 = '';
-str2 = '';
-this.x = 1;
+var str1 = '';
+var str2 = '';
+var x = 1;
 
 for(i in this){
   str1+=i;
@@ -26,4 +25,4 @@ if(!(str1 === str2)){
   $ERROR("#1: scope chain must contain same objects in the same order as the calling context");
 }
 
-var y = 2;
+this.y = 2;

--- a/test/language/eval-code/S10.4.2_A1.1_T17.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T17.js
@@ -5,15 +5,14 @@
 info: >
     The scope chain is initialised to contain the same objects,
     in the same order, as the calling context's scope chain
-es5id: 10.4.2_A1.1_T8
+es5id: 10.4.2_A1.1_T17
 description: eval within global execution context
-flags: [noStrict]
 ---*/
 
 var i;
 var j;
-str1 = '';
-str2 = '';
+var str1 = '';
+var str2 = '';
 this.x = 1;
 
 for(i in this){

--- a/test/language/eval-code/S10.4.2_A1.1_T18.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T18.js
@@ -5,16 +5,16 @@
 info: >
     The scope chain is initialised to contain the same objects,
     in the same order, as the calling context's scope chain
-es5id: 10.4.2_A1.1_T8
+es5id: 10.4.2_A1.1_T18
 description: eval within global execution context
-flags: [noStrict]
 ---*/
 
 var i;
 var j;
-str1 = '';
-str2 = '';
-this.x = 1;
+var str1 = '';
+var str2 = '';
+var x = 1;
+var y = 2;
 
 for(i in this){
   str1+=i;
@@ -25,5 +25,3 @@ eval('for(j in this){\nstr2+=j;\n}');
 if(!(str1 === str2)){
   $ERROR("#1: scope chain must contain same objects in the same order as the calling context");
 }
-
-var y = 2;

--- a/test/language/eval-code/S10.4.2_A1.1_T19.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T19.js
@@ -5,16 +5,14 @@
 info: >
     The scope chain is initialised to contain the same objects,
     in the same order, as the calling context's scope chain
-es5id: 10.4.2_A1.1_T8
+es5id: 10.4.2_A1.1_T19
 description: eval within global execution context
-flags: [noStrict]
 ---*/
 
 var i;
 var j;
-str1 = '';
-str2 = '';
-this.x = 1;
+var str1 = '';
+var str2 = '';
 
 for(i in this){
   str1+=i;
@@ -26,4 +24,5 @@ if(!(str1 === str2)){
   $ERROR("#1: scope chain must contain same objects in the same order as the calling context");
 }
 
-var y = 2;
+this.x = 1;
+this.y = 2;

--- a/test/language/eval-code/S10.4.2_A1.1_T2.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T2.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.1_T2
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 var i;

--- a/test/language/eval-code/S10.4.2_A1.1_T3.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T3.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.1_T3
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 var i;

--- a/test/language/eval-code/S10.4.2_A1.1_T4.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T4.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.1_T4
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 var i;

--- a/test/language/eval-code/S10.4.2_A1.1_T5.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T5.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.1_T5
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 var i;

--- a/test/language/eval-code/S10.4.2_A1.1_T6.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T6.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.1_T6
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 var i;

--- a/test/language/eval-code/S10.4.2_A1.1_T7.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T7.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.1_T7
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 var i;

--- a/test/language/eval-code/S10.4.2_A1.1_T9.js
+++ b/test/language/eval-code/S10.4.2_A1.1_T9.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.1_T9
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 var i;

--- a/test/language/eval-code/S10.4.2_A1.2_T1.js
+++ b/test/language/eval-code/S10.4.2_A1.2_T1.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.2_T1
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 function f(){

--- a/test/language/eval-code/S10.4.2_A1.2_T10.js
+++ b/test/language/eval-code/S10.4.2_A1.2_T10.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.2_T10
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 function f(){

--- a/test/language/eval-code/S10.4.2_A1.2_T2.js
+++ b/test/language/eval-code/S10.4.2_A1.2_T2.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.2_T2
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 function f(){

--- a/test/language/eval-code/S10.4.2_A1.2_T3.js
+++ b/test/language/eval-code/S10.4.2_A1.2_T3.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.2_T3
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 function f(){

--- a/test/language/eval-code/S10.4.2_A1.2_T4.js
+++ b/test/language/eval-code/S10.4.2_A1.2_T4.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.2_T4
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 function f(){

--- a/test/language/eval-code/S10.4.2_A1.2_T5.js
+++ b/test/language/eval-code/S10.4.2_A1.2_T5.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.2_T5
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 function f(){

--- a/test/language/eval-code/S10.4.2_A1.2_T6.js
+++ b/test/language/eval-code/S10.4.2_A1.2_T6.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.2_T6
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 function f(){

--- a/test/language/eval-code/S10.4.2_A1.2_T7.js
+++ b/test/language/eval-code/S10.4.2_A1.2_T7.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.2_T7
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 function f(){

--- a/test/language/eval-code/S10.4.2_A1.2_T8.js
+++ b/test/language/eval-code/S10.4.2_A1.2_T8.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.2_T8
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 function f(){

--- a/test/language/eval-code/S10.4.2_A1.2_T9.js
+++ b/test/language/eval-code/S10.4.2_A1.2_T9.js
@@ -7,6 +7,7 @@ info: >
     in the same order, as the calling context's scope chain
 es5id: 10.4.2_A1.2_T9
 description: eval within global execution context
+flags: [noStrict]
 ---*/
 
 function f(){

--- a/test/language/expressions/typeof/syntax.js
+++ b/test/language/expressions/typeof/syntax.js
@@ -13,61 +13,61 @@ description: Checking by using eval
 assert.sameValue(
   eval("var x = 0; typeof\u0009x"),
   "number",
-  '#1: var x = 0; typeof\\u0009x; x === "number". Actual: ' + (x)
+  '#1: var x = 0; typeof\\u0009x; x === "number".'
 );
 
 assert.sameValue(
   eval("var x = 0; typeof\u000Bx"),
   "number",
-  '#2: var x = 0; typeof\\u000Bx; x === "number". Actual: ' + (x)
+  '#2: var x = 0; typeof\\u000Bx; x === "number".'
 );
 
 assert.sameValue(
   eval("var x = 0; typeof\u000Cx"),
   "number",
-  '#3: var x = 0; typeof\\u000Cx; x === "number". Actual: ' + (x)
+  '#3: var x = 0; typeof\\u000Cx; x === "number".'
 );
 
 assert.sameValue(
   eval("var x = 0; typeof\u0020x"),
   "number",
-  '#4: var x = 0; typeof\\u0020x; x === "number". Actual: ' + (x)
+  '#4: var x = 0; typeof\\u0020x; x === "number".'
 );
 
 assert.sameValue(
   eval("var x = 0; typeof\u00A0x"),
   "number",
-  '#5: var x = 0; typeof\\u00A0x; x === "number". Actual: ' + (x)
+  '#5: var x = 0; typeof\\u00A0x; x === "number".'
 );
 
 assert.sameValue(
   eval("var x = 0; typeof\u000Ax"),
   "number",
-  '#6: var x = 0; typeof\\u000Ax; x === "number". Actual: ' + (x)
+  '#6: var x = 0; typeof\\u000Ax; x === "number".'
 );
 
 assert.sameValue(
   eval("var x = 0; typeof\u000Dx"),
   "number",
-  '#7: var x = 0; typeof\\u000Dx; x === "number". Actual: ' + (x)
+  '#7: var x = 0; typeof\\u000Dx; x === "number".'
 );
 
 assert.sameValue(
   eval("var x = 0; typeof\u2028x"),
   "number",
-  '#8: var x = 0; typeof\\u2028x; x === "number". Actual: ' + (x)
+  '#8: var x = 0; typeof\\u2028x; x === "number".'
 );
 
 assert.sameValue(
   eval("var x = 0; typeof\u2029x"),
   "number",
-  '#9: var x = 0; typeof\\u2029x; x === "number". Actual: ' + (x)
+  '#9: var x = 0; typeof\\u2029x; x === "number".'
 );
 
 assert.sameValue(
   eval("var x = 0; typeof\u0009\u000B\u000C\u0020\u00A0\u000A\u000D\u2028\u2029x"),
   "number",
-  '#10: var x = 0; typeof\\u0009\\u000B\\u000C\\u0020\\u00A0\\u000A\\u000D\\u2028\\u2029x; x === "number". Actual: ' + (x)
+  '#10: var x = 0; typeof\\u0009\\u000B\\u000C\\u0020\\u00A0\\u000A\\u000D\\u2028\\u2029x; x === "number".'
 );
 
 assert.sameValue(

--- a/test/language/expressions/yield/from-with.js
+++ b/test/language/expressions/yield/from-with.js
@@ -5,6 +5,7 @@ es6id: 25.2
 description: >
     The operand to a `yield` expression should honor the semantics of the
     `with` statement.
+flags: [noStrict]
 ---*/
 
 function* g() {

--- a/test/language/function-code/10.4.3-1-105.js
+++ b/test/language/function-code/10.4.3-1-105.js
@@ -12,6 +12,7 @@ es5id: 10.4.3-1-105
 description: >
     Non strict mode should ToObject thisArg if not an object.  Return
     type should be object and strict equality should fail.
+flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 

--- a/test/language/function-code/S10.2.1_A3.js
+++ b/test/language/function-code/S10.2.1_A3.js
@@ -11,6 +11,7 @@ description: >
     Creating functions with two or more formal parameters,  that have
     the same name. Calling this function excluding a few last
     parameters
+flags: [noStrict]
 ---*/
 
 //CHECK#1

--- a/test/language/punctuators/S7.7_A1.js
+++ b/test/language/punctuators/S7.7_A1.js
@@ -7,14 +7,16 @@ es5id: 7.7_A1
 description: Using all punctuators
 ---*/
 
+this.nan = NaN;
+
 //CHECK#1
   ({});[];
-  this.NaN; 
+  this.nan;
   1 < 2 > 3 <= 4 >= 5 == 6 != 7 === 8 !== 9;
   1 + 2 - 3 * 4 % 5 / 6 << 7 >> 8 >>> 9;
-  this.NaN++; ++this.NaN; this.NaN--; --this.NaN;
+  this.nan++; ++this.nan; this.nan--; --this.nan;
   1 & 2 | 3 ^ 4 && !5 || ~6;
   1 ? 2 : 3;
-  this.NaN = 1; this.NaN += 2; this.NaN -= 3; this.NaN *= 4; this.NaN /= 5;
-  this.NaN %= 6; this.NaN <<= 7; this.NaN >>= 8; this.NaN >>>= 9;
-  this.NaN &= 1; this.NaN |= 2; this.NaN ^= 3;
+  this.nan = 1; this.nan += 2; this.nan -= 3; this.nan *= 4; this.nan /= 5;
+  this.nan %= 6; this.nan <<= 7; this.nan >>= 8; this.nan >>>= 9;
+  this.nan &= 1; this.nan |= 2; this.nan ^= 3;

--- a/test/language/statements/for-of/iterator-next-result-type.js
+++ b/test/language/statements/for-of/iterator-next-result-type.js
@@ -97,7 +97,7 @@ firstIterResult = new Proxy({}, {
     $ERROR('This code is unreachable.');
   }
 });
-i = 0;
+var i = 0;
 for (var x of iterable) {
   assert.sameValue(x, 23);
   i++;

--- a/test/language/types/number/S8.5_A10_T1.js
+++ b/test/language/types/number/S8.5_A10_T1.js
@@ -1,0 +1,10 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Infinity is not a keyword
+es5id: 8.5_A10
+description: Create variable entitled Infinity
+---*/
+
+var Infinity;

--- a/test/language/types/number/S8.5_A10_T2.js
+++ b/test/language/types/number/S8.5_A10_T2.js
@@ -5,6 +5,7 @@
 info: Infinity is not a keyword
 es5id: 8.5_A10
 description: Create variable entitled Infinity
+flags: [noStrict]
 ---*/
 
 var Infinity=1.0;

--- a/test/language/types/number/S8.5_A4_T1.js
+++ b/test/language/types/number/S8.5_A4_T1.js
@@ -1,0 +1,10 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: NaN is not a keyword
+es5id: 8.5_A4
+description: Create variable entitled NaN
+---*/
+
+var NaN;

--- a/test/language/types/number/S8.5_A4_T2.js
+++ b/test/language/types/number/S8.5_A4_T2.js
@@ -5,6 +5,7 @@
 info: NaN is not a keyword
 es5id: 8.5_A4
 description: Create variable entitled NaN
+flags: [noStrict]
 ---*/
 
 var NaN=1.0;

--- a/test/language/types/undefined/S8.1_A3_T1.js
+++ b/test/language/types/undefined/S8.1_A3_T1.js
@@ -1,0 +1,14 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: undefined is not a keyword
+es5id: 8.1_A3
+description: Create variable named undefined
+---*/
+
+//////////////////////////////////////////////////////////
+// CHECK1#
+var undefined;
+//
+//////////////////////////////////////////////////////////

--- a/test/language/types/undefined/S8.1_A3_T2.js
+++ b/test/language/types/undefined/S8.1_A3_T2.js
@@ -5,6 +5,7 @@
 info: undefined is not a keyword
 es5id: 8.1_A3
 description: Create variable named undefined
+flags: [noStrict]
 ---*/
 
 //////////////////////////////////////////////////////////


### PR DESCRIPTION
- Add missing "var" declarations and noStrict flags
- Add strict mode tests for:
 - arguments-object/10.6-6-3 -> arguments-object/10.6-6-3-s
 - arguments-object/10.6-6-4 -> arguments-object/10.6-6-4-s
- Remove try-finally clean-up code
- Add strict mode compatible tests for eval-code/S10.4.2_A1.1_T*
  - No strict mode compatible files added for eval-code/S10.4.2_A1.2_T*, because it doesn't really make sense in this context.
  - (S10.4.2_A1.1 and S10.4.2_A1.2 should probably be removed, because the tested behaviour is not required by the spec.)
- Split S8.5_A10, S8.5_A4 and S8.1_A3 into declaration (both modes) and assignment tests (non-strict only)

Part of issue #35.