### PR TITLE
Fix strict mode errors in language/{identifiers, line-terminators, wh…

### DIFF
--- a/test/language/identifiers/S7.6_A1.2_T3.js
+++ b/test/language/identifiers/S7.6_A1.2_T3.js
@@ -9,9 +9,10 @@ description: The $ as unicode character \u0024
 
 //CHECK#1
 var identifier = String.fromCharCode(0x0024);
-eval("var " + identifier + "=1");
-if (eval(identifier + "===1") !== true) {
-  $ERROR('#1: var identifier = String.fromCharCode(0x0024); eval("var " + identifier + "=1"); eval(identifier + "===1") === true');
+var result;
+eval("var " + identifier + "=1; result = " + identifier);
+if (result !== 1) {
+  $ERROR('#1: var identifier = String.fromCharCode(0x0024); eval("var " + identifier + "=1; result = " + identifier); result === 1');
 }
 
 //CHECK#2

--- a/test/language/identifiers/S7.6_A1.3_T3.js
+++ b/test/language/identifiers/S7.6_A1.3_T3.js
@@ -9,9 +9,10 @@ description: The _ as unicode character \u005F
 
 //CHECK#1
 var identifier = String.fromCharCode(0x005F);
-eval("var " + identifier + "=1");
-if (eval(identifier + "===1") !== true) {
-  $ERROR('#1: var identifier = String.fromCharCode(0x005F); eval("var " + identifier + "=1"); eval(identifier + "===1") === true');
+var result;
+eval("var " + identifier + "=1; result = " + identifier);
+if (result !== 1) {
+  $ERROR('#1: var identifier = String.fromCharCode(0x005F); eval("var " + identifier + "=1; result = " + identifier); result === 1');
 }
 
 //CHECK#2

--- a/test/language/identifiers/S7.6_A2.1_T1.js
+++ b/test/language/identifiers/S7.6_A2.1_T1.js
@@ -7,59 +7,61 @@ es5id: 7.6_A2.1_T1
 description: "IdentifierStart :: UnicodeLetter"
 ---*/
 
+var result;
+
 //CHECK#1
 try {
   var identifier = "x" + "x";     
-  eval("var " + identifier + "=1");
-  if (xx !== 1) {
-    $ERROR('#1.1: var identifier = "x" + "x"; eval("var " + identifier + "=1"); xx === 1. Actual: ' + (xx));
+  eval("var " + identifier + "=1; result = xx");
+  if (result !== 1) {
+    $ERROR('#1.1: var identifier = "x" + "x"; eval("var " + identifier + "=1; result = xx"); result === 1. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#1.2: var identifier = "x" + "x"; eval("var " + identifier + "=1"); xx === 1. Actual: ' + (xx));
+  $ERROR('#1.2: var identifier = "x" + "x"; eval("var " + identifier + "=1; result = xx"); result === 1. Actual: ' + (result));
 }
 
 //CHECK#2
 try {
   var identifier = "x" + String.fromCharCode(0x0078);     
-  eval("var " + identifier + "=2");
-  if (xx !== 2) {
-    $ERROR('#2.1: var identifier = "x" + String.fromCharCode(0x0078); eval("var " + identifier + "=2"); xx === 2. Actual: ' + (xx));
+  eval("var " + identifier + "=2; result = xx");
+  if (result !== 2) {
+    $ERROR('#2.1: var identifier = "x" + String.fromCharCode(0x0078); eval("var " + identifier + "=2; result = xx"); result === 2. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#2.2: var identifier = "x" + String.fromCharCode(0x0078); eval("var " + identifier + "=2"); xx === 2. Actual: ' + (xx));
+  $ERROR('#2.2: var identifier = "x" + String.fromCharCode(0x0078); eval("var " + identifier + "=2; result = xx"); result === 2. Actual: ' + (result));
 }
 
 //CHECK#3
 try {
   var identifier = String.fromCharCode(0x0078) + String.fromCharCode(0x0078);     
-  eval("var " + identifier + "=3");
-  if (xx !== 3) {
-    $ERROR('#3.1: var identifier = String.fromCharCode(0x0078) + String.fromCharCode(0x0078); eval("var " + identifier + "=3"); xx === 3. Actual: ' + (xx));
+  eval("var " + identifier + "=3; result = xx");
+  if (result !== 3) {
+    $ERROR('#3.1: var identifier = String.fromCharCode(0x0078) + String.fromCharCode(0x0078); eval("var " + identifier + "=3; result = xx"); result === 3. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#3.2: var identifier = String.fromCharCode(0x0078) + String.fromCharCode(0x0078); eval("var " + identifier + "=3"); xx === 3. Actual: ' + (xx));
+  $ERROR('#3.2: var identifier = String.fromCharCode(0x0078) + String.fromCharCode(0x0078); eval("var " + identifier + "=3; result = xx"); result === 3. Actual: ' + (result));
 }
 
 //CHECK#4
 try {
   var identifier = "$" + String.fromCharCode(0x0078);     
-  eval("var " + identifier + "=4");
-  if ($x !== 4) {
-    $ERROR('#4.1: var identifier = "$" + String.fromCharCode(0x0078); eval("var " + identifier + "=4"); $x === 4. Actual: ' + ($x));
+  eval("var " + identifier + "=4; result = $x");
+  if (result !== 4) {
+    $ERROR('#4.1: var identifier = "$" + String.fromCharCode(0x0078); eval("var " + identifier + "=4; result = $x"); result === 4. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#4.2: var identifier = "$" + String.fromCharCode(0x0078); eval("var " + identifier + "=4"); $x === 4. Actual: ' + ($x));
+  $ERROR('#4.2: var identifier = "$" + String.fromCharCode(0x0078); eval("var " + identifier + "=4; result = $x"); result === 4. Actual: ' + (result));
 }
 
 //CHECK#5
 try {
   var identifier = "_" + String.fromCharCode(0x0078);     
-  eval("var " + identifier + "=5");
-  if (_x !== 5) {
-    $ERROR('#5.1: var identifier = "_" + String.fromCharCode(0x0078); eval("var " + identifier + "=5"); _x === 5. Actual: ' + (_x));
+  eval("var " + identifier + "=5; result = _x");
+  if (result !== 5) {
+    $ERROR('#5.1: var identifier = "_" + String.fromCharCode(0x0078); eval("var " + identifier + "=5; result = _x"); result === 5. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#5.2: var identifier = "_" + String.fromCharCode(0x0078); eval("var " + identifier + "=5"); _x === 5. Actual: ' + (_x));
+  $ERROR('#5.2: var identifier = "_" + String.fromCharCode(0x0078); eval("var " + identifier + "=5; result = _x"); result === 5. Actual: ' + (result));
 }
 
 //CHECK#6

--- a/test/language/identifiers/S7.6_A2.1_T2.js
+++ b/test/language/identifiers/S7.6_A2.1_T2.js
@@ -7,59 +7,61 @@ es5id: 7.6_A2.1_T2
 description: "IdentifierStart :: $"
 ---*/
 
+var result;
+
 //CHECK#1
 try {
   var identifier = "x" + "$";     
-  eval("var " + identifier + "=1");
-  if (x$ !== 1) {
-    $ERROR('#1.1: var identifier = "x" + "$"; eval("var " + identifier + "=1"); x$ === 1. Actual: ' + (x$));
+  eval("var " + identifier + "=1; result = x$");
+  if (result !== 1) {
+    $ERROR('#1.1: var identifier = "x" + "$"; eval("var " + identifier + "=1; result = x$"); result === 1. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#1.2: var identifier = "x" + "$"; eval("var " + identifier + "=1"); x$ === 1. Actual: ' + (x$));
+  $ERROR('#1.2: var identifier = "x" + "$"; eval("var " + identifier + "=1; result = x$"); result === 1. Actual: ' + (result));
 }
 
 //CHECK#2
 try {
   var identifier = String.fromCharCode(0x0078) + "$";     
-  eval("var " + identifier + "=2");
-  if (x$ !== 2) {
-    $ERROR('#2.1: var identifier = String.fromCharCode(0x0078) + "$"; eval("var " + identifier + "=2"); x$ === 2. Actual: ' + (x$));
+  eval("var " + identifier + "=2; result = x$");
+  if (result !== 2) {
+    $ERROR('#2.1: var identifier = String.fromCharCode(0x0078) + "$"; eval("var " + identifier + "=2; result = x$"); result === 2. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#2.2: var identifier = String.fromCharCode(0x0078) + "$"; eval("var " + identifier + "=2"); x$ === 2. Actual: ' + (x$));
+  $ERROR('#2.2: var identifier = String.fromCharCode(0x0078) + "$"; eval("var " + identifier + "=2; result = x$"); result === 2. Actual: ' + (result));
 }
 
 //CHECK#3
 try {
   var identifier = "$" + "$";     
-  eval("var " + identifier + "=3");
-  if ($$ !== 3) {
-    $ERROR('#3.1: var identifier = "$" + "$"; eval("var " + identifier + "=3"); $$ === 3. Actual: ' + ($$));
+  eval("var " + identifier + "=3; result = $$");
+  if (result !== 3) {
+    $ERROR('#3.1: var identifier = "$" + "$"; eval("var " + identifier + "=3; result = $$"); result === 3. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#3.2: var identifier = "$" + "$"; eval("var " + identifier + "=3"); $$ === 3. Actual: ' + ($$));
+  $ERROR('#3.2: var identifier = "$" + "$"; eval("var " + identifier + "=3; result = $$"); result === 3. Actual: ' + (result));
 }
 
 //CHECK#4
 try {
   var identifier = String.fromCharCode(0x0024) + String.fromCharCode(0x0024);     
-  eval("var " + identifier + "=4");
-  if ($$ !== 4) {
-    $ERROR('#4.1: var identifier = String.fromCharCode(0x0024) + String.fromCharCode(0x0024); eval("var " + identifier + "=4"); $$ === 4. Actual: ' + ($$));
+  eval("var " + identifier + "=4; result = $$");
+  if (result !== 4) {
+    $ERROR('#4.1: var identifier = String.fromCharCode(0x0024) + String.fromCharCode(0x0024); eval("var " + identifier + "=4; result = $$"); result === 4. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#4.2: var identifier = String.fromCharCode(0x0024) + String.fromCharCode(0x0024); eval("var " + identifier + "=4"); $$ === 4. Actual: ' + ($$));
+  $ERROR('#4.2: var identifier = String.fromCharCode(0x0024) + String.fromCharCode(0x0024); eval("var " + identifier + "=4; result = $$"); result === 4. Actual: ' + (result));
 }
 
 //CHECK#5
 try {
   var identifier = "_" + "$";     
-  eval("var " + identifier + "=5");
-  if (_$ !== 5) {
-    $ERROR('#5.1: var identifier = "_" + "$"; eval("var " + identifier + "=5"); _$ === 5. Actual: ' + (_$));
+  eval("var " + identifier + "=5; result = _$");
+  if (result !== 5) {
+    $ERROR('#5.1: var identifier = "_" + "$"; eval("var " + identifier + "=5; result = _$"); result === 5. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#5.2: var identifier = "_" + "$"; eval("var " + identifier + "=5"); _$ === 5. Actual: ' + (_$));
+  $ERROR('#5.2: var identifier = "_" + "$"; eval("var " + identifier + "=5; result = _$"); result === 5. Actual: ' + (result));
 }
 
 //CHECK#6

--- a/test/language/identifiers/S7.6_A2.1_T3.js
+++ b/test/language/identifiers/S7.6_A2.1_T3.js
@@ -7,59 +7,61 @@ es5id: 7.6_A2.1_T3
 description: "IdentifierStart :: _"
 ---*/
 
+var result;
+
 //CHECK#1
 try {
   var identifier = "x" + "_";     
-  eval("var " + identifier + "=1");
-  if (x_ !== 1) {
-    $ERROR('#1.1: var identifier = "x" + "_"; eval("var " + identifier + "=1"); x_ === 1. Actual: ' + (x_));
+  eval("var " + identifier + "=1; result = x_");
+  if (result !== 1) {
+    $ERROR('#1.1: var identifier = "x" + "_"; eval("var " + identifier + "=1; result = x_"); result === 1. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#1.2: var identifier = "x" + "_"; eval("var " + identifier + "=1"); x_ === 1. Actual: ' + (x_));
+  $ERROR('#1.2: var identifier = "x" + "_"; eval("var " + identifier + "=1; result = x_"); result === 1. Actual: ' + (result));
 }
 
 //CHECK#2
 try {
   var identifier = String.fromCharCode(0x0078) + "_";     
-  eval("var " + identifier + "=2");
-  if (x_ !== 2) {
-    $ERROR('#2.1: var identifier = String.fromCharCode(0x0078) + "_"; eval("var " + identifier + "=2"); x_ === 2. Actual: ' + (x_));
+  eval("var " + identifier + "=2; result = x_");
+  if (result !== 2) {
+    $ERROR('#2.1: var identifier = String.fromCharCode(0x0078) + "_"; eval("var " + identifier + "=2; result = x_"); result === 2. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#2.2: var identifier = String.fromCharCode(0x0078) + "_"; eval("var " + identifier + "=2"); x_ === 2. Actual: ' + (x_));
+  $ERROR('#2.2: var identifier = String.fromCharCode(0x0078) + "_"; eval("var " + identifier + "=2; result = x_"); result === 2. Actual: ' + (result));
 }
 
 //CHECK#3
 try {
   var identifier = "_" + "_";     
-  eval("var " + identifier + "=3");
-  if (__ !== 3) {
-    $ERROR('#3.1: var identifier = "_" + "_"; eval("var " + identifier + "=3"); __ === 3. Actual: ' + (__));
+  eval("var " + identifier + "=3; result = __");
+  if (result !== 3) {
+    $ERROR('#3.1: var identifier = "_" + "_"; eval("var " + identifier + "=3; result = __"); result === 3. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#3.2: var identifier = "_" + "_"; eval("var " + identifier + "=3"); __ === 3. Actual: ' + (__));
+  $ERROR('#3.2: var identifier = "_" + "_"; eval("var " + identifier + "=3; result = __"); result === 3. Actual: ' + (result));
 }
 
 //CHECK#4
 try {
   var identifier = String.fromCharCode(0x005F) + String.fromCharCode(0x005F);     
-  eval("var " + identifier + "=4");
-  if (__ !== 4) {
-    $ERROR('#4.1: var identifier = String.fromCharCode(0x005F) + String.fromCharCode(0x005F); eval("var " + identifier + "=4"); __ === 4. Actual: ' + (__));
+  eval("var " + identifier + "=4; result = __");
+  if (result !== 4) {
+    $ERROR('#4.1: var identifier = String.fromCharCode(0x005F) + String.fromCharCode(0x005F); eval("var " + identifier + "=4; result = __"); result === 4. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#4.2: var identifier = String.fromCharCode(0x005F) + String.fromCharCode(0x005F); eval("var " + identifier + "=4"); __ === 4. Actual: ' + (__));
+  $ERROR('#4.2: var identifier = String.fromCharCode(0x005F) + String.fromCharCode(0x005F); eval("var " + identifier + "=4; result = __"); result === 4. Actual: ' + (result));
 }
 
 //CHECK#5
 try {
   var identifier = "_" + "_";     
-  eval("var " + identifier + "=5");
-  if (__ !== 5) {
-    $ERROR('#5.1: var identifier = "_" + "_"; eval("var " + identifier + "=5"); __ === 5. Actual: ' + (__));
+  eval("var " + identifier + "=5; result = __");
+  if (result !== 5) {
+    $ERROR('#5.1: var identifier = "_" + "_"; eval("var " + identifier + "=5; result = __"); result === 5. Actual: ' + (result));
   }
 } catch (e) {
-  $ERROR('#5.2: var identifier = "_" + "_"; eval("var " + identifier + "=5"); __ === 5. Actual: ' + (__));
+  $ERROR('#5.2: var identifier = "_" + "_"; eval("var " + identifier + "=5; result = __"); result === 5. Actual: ' + (result));
 }
 
 //CHECK#6

--- a/test/language/line-terminators/7.3-1.js
+++ b/test/language/line-terminators/7.3-1.js
@@ -13,7 +13,8 @@ includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-        eval("var test7_3_1\u2028prop = 66;");
+        var test7_3_1, prop;
+        eval("test7_3_1\u2028prop = 66;");
         return (prop === 66) && ((typeof test7_3_1) === "undefined");
     }
 runTestCase(testcase);

--- a/test/language/line-terminators/7.3-2.js
+++ b/test/language/line-terminators/7.3-2.js
@@ -13,7 +13,8 @@ includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-        eval("var test7_3_2\u2029prop = 66;");
+        var test7_3_2, prop;
+        eval("test7_3_2\u2029prop = 66;");
         return (prop===66) && ((typeof test7_3_2) === "undefined");
     }
 runTestCase(testcase);

--- a/test/language/line-terminators/7.3-7.js
+++ b/test/language/line-terminators/7.3-7.js
@@ -15,7 +15,6 @@ includes: [runTestCase.js]
 function testcase() {
         try {
             eval("var regExp =  /[\u2028]/");
-            regExp.test("");
             return false;
         } catch (e) {
             return e instanceof SyntaxError;

--- a/test/language/line-terminators/7.3-8.js
+++ b/test/language/line-terminators/7.3-8.js
@@ -15,7 +15,6 @@ includes: [runTestCase.js]
 function testcase() {
         try {
             eval("var regExp =  /[\u2029]/");
-            regExp.test("");
             return false;
         } catch (e) {
             return e instanceof SyntaxError;

--- a/test/language/line-terminators/S7.3_A1.1_T1.js
+++ b/test/language/line-terminators/S7.3_A1.1_T1.js
@@ -7,32 +7,34 @@ es5id: 7.3_A1.1_T1
 description: Insert LINE FEED (\u000A and \n) between tokens of var x=1
 ---*/
 
+var result;
+
 // CHECK#1
-eval("\u000Avar\u000Ax\u000A=\u000A1\u000A");
-if (x !== 1) {
-  $ERROR('#1: eval("\\u000Avar\\u000Ax\\u000A=\\u000A1\\u000A"); x === 1. Actual: ' + (x));
+eval("\u000Avar\u000Ax\u000A=\u000A1\u000A; result = x;");
+if (result !== 1) {
+  $ERROR('#1: eval("\\u000Avar\\u000Ax\\u000A=\\u000A1\\u000A; result = x;"); result === 1. Actual: ' + (result));
 }
 
 //CHECK#2
-eval("\u000A" + "var" + "\u000A" + "x" + "\u000A" + "=" + "\u000A" + "1" + "\u000A");
-if (x !== 1) {
-  $ERROR('#2: eval("\\u000A" + "var" + "\\u000A" + "x" + "\\u000A" + "=" + "\\u000A" + "1" + "\\u000A"); x === 1. Actual: ' + (x));
+eval("\u000A" + "var" + "\u000A" + "x" + "\u000A" + "=" + "\u000A" + "2" + "\u000A; result = x;");
+if (result !== 2) {
+  $ERROR('#2: eval("\\u000A" + "var" + "\\u000A" + "x" + "\\u000A" + "=" + "\\u000A" + "2" + "\\u000A; result = x;"); result === 2. Actual: ' + (result));
 }
 
 //CHECK#3
-eval("\nvar\nx\n=\n1\n");
-if (x !== 1) {
-  $ERROR('#3: eval("\\nvar\\nx\\n=\\n1\\n"); x === 1. Actual: ' + (x));
+eval("\nvar\nx\n=\n3\n; result = x;");
+if (result !== 3) {
+  $ERROR('#3: eval("\\nvar\\nx\\n=\\n3\\n; result = x;"); result === 3. Actual: ' + (result));
 }
 
 //CHECK#4
-eval("\n" + "var" + "\n" + "x" + "\n" + "=" + "\n" + "1" + "\n");
-if (x !== 1) {
-  $ERROR('#4: eval("\\n" + "var" + "\\n" + "x" + "\\n" + "=" + "\\n" + "1" + "\\n"); x === 1. Actual: ' + (x));
+eval("\n" + "var" + "\n" + "x" + "\n" + "=" + "\n" + "4" + "\n; result = x;");
+if (result !== 4) {
+  $ERROR('#4: eval("\\n" + "var" + "\\n" + "x" + "\\n" + "=" + "\\n" + "4" + "\\n; result = x;"); result === 4. Actual: ' + (result));
 }
 
 //CHECK#5
-eval("\u000A" + "var" + "\n" + "x" + "\u000A" + "=" + "\n" + "1" + "\u000A");
-if (x !== 1) {
-  $ERROR('#5: eval("\\u000A" + "var" + "\\n" + "x" + "\\u000A" + "=" + "\\n" + "1" + "\\u000A"); x === 1. Actual: ' + (x));
+eval("\u000A" + "var" + "\n" + "x" + "\u000A" + "=" + "\n" + "5" + "\u000A; result = x;");
+if (result !== 5) {
+  $ERROR('#5: eval("\\u000A" + "var" + "\\n" + "x" + "\\u000A" + "=" + "\\n" + "5" + "\\u000A; result = x;"); result === 5. Actual: ' + (result));
 }

--- a/test/language/line-terminators/S7.3_A1.2_T1.js
+++ b/test/language/line-terminators/S7.3_A1.2_T1.js
@@ -7,32 +7,34 @@ es5id: 7.3_A1.2_T1
 description: Insert CARRIAGE RETURN (\u000D and \r) between tokens of var x=1
 ---*/
 
+var result;
+
 // CHECK#1
-eval("\u000Dvar\u000Dx\u000D=\u000D1\u000D");
-if (x !== 1) {
-  $ERROR('#1: eval("\\u000Dvar\\u000Dx\\u000D=\\u000D1\\u000D"); x === 1. Actual: ' + (x));
+eval("\u000Dvar\u000Dx\u000D=\u000D1\u000D; result = x;");
+if (result !== 1) {
+  $ERROR('#1: eval("\\u000Dvar\\u000Dx\\u000D=\\u000D1\\u000D"); result === 1. Actual: ' + (result));
 }
 
 //CHECK#2
-eval("\u000D" + "var" + "\u000D" + "x" + "\u000D" + "=" + "\u000D" + "1" + "\u000D");
-if (x !== 1) {
-  $ERROR('#2: eval("\\u000D" + "var" + "\\u000D" + "x" + "\\u000D" + "=" + "\\u000D" + "1" + "\\u000D"); x === 1. Actual: ' + (x));
+eval("\u000D" + "var" + "\u000D" + "x" + "\u000D" + "=" + "\u000D" + "2" + "\u000D; result = x;");
+if (result !== 2) {
+  $ERROR('#2: eval("\\u000D" + "var" + "\\u000D" + "x" + "\\u000D" + "=" + "\\u000D" + "2" + "\\u000D"); result === 2. Actual: ' + (result));
 }
 
 //CHECK#3
-eval("\rvar\rx\r=\r1\r");
-if (x !== 1) {
-  $ERROR('#3: eval("\\rvar\\rx\\r=\\r1\\r"); x === 1. Actual: ' + (x));
+eval("\rvar\rx\r=\r3\r; result = x;");
+if (result !== 3) {
+  $ERROR('#3: eval("\\rvar\\rx\\r=\\r3\\r"); result === 3. Actual: ' + (result));
 }
 
 //CHECK#4
-eval("\r" + "var" + "\r" + "x" + "\r" + "=" + "\r" + "1" + "\r");
-if (x !== 1) {
-  $ERROR('#4: eval("\\r" + "var" + "\\r" + "x" + "\\r" + "=" + "\\r" + "1" + "\\r"); x === 1. Actual: ' + (x));
+eval("\r" + "var" + "\r" + "x" + "\r" + "=" + "\r" + "4" + "\r; result = x;");
+if (result !== 4) {
+  $ERROR('#4: eval("\\r" + "var" + "\\r" + "x" + "\\r" + "=" + "\\r" + "4" + "\\r"); result === 4. Actual: ' + (result));
 }
 
 //CHECK#5
-eval("\u000D" + "var" + "\r" + "x" + "\u000D" + "=" + "\r" + "1" + "\u000D");
-if (x !== 1) {
-  $ERROR('#5: eval("\\u000D" + "var" + "\\r" + "x" + "\\u000D" + "=" + "\\r" + "1" + "\\u000D"); x === 1. Actual: ' + (x));
+eval("\u000D" + "var" + "\r" + "x" + "\u000D" + "=" + "\r" + "5" + "\u000D; result = x;");
+if (result !== 5) {
+  $ERROR('#5: eval("\\u000D" + "var" + "\\r" + "x" + "\\u000D" + "=" + "\\r" + "5" + "\\u000D"); result === 5. Actual: ' + (result));
 }

--- a/test/language/line-terminators/S7.3_A1.3.js
+++ b/test/language/line-terminators/S7.3_A1.3.js
@@ -7,14 +7,16 @@ es5id: 7.3_A1.3
 description: Insert LINE SEPARATOR (\u2028) between tokens of var x=1
 ---*/
 
+var result;
+
 // CHECK#1
-eval("\u2028var\u2028x\u2028=\u20281\u2028");
-if (x !== 1) {
-  $ERROR('#1: eval("\\u2028var\\u2028x\\u2028=\\u20281\\u2028"); x === 1. Actual: ' + (x));
+eval("\u2028var\u2028x\u2028=\u20281\u2028; result = x;");
+if (result !== 1) {
+  $ERROR('#1: eval("\\u2028var\\u2028x\\u2028=\\u20281\\u2028"); result === 1. Actual: ' + (result));
 }
 
 //CHECK#2
-eval("\u2028" + "var" + "\u2028" + "x" + "\u2028" + "=" + "\u2028" + "1" + "\u2028");
-if (x !== 1) {
-  $ERROR('#2: eval("\\u2028" + "var" + "\\u2028" + "x" + "\\u2028" + "=" + "\\u2028" + "1" + "\\u2028"); x === 1. Actual: ' + (x));
+eval("\u2028" + "var" + "\u2028" + "x" + "\u2028" + "=" + "\u2028" + "2" + "\u2028; result = x;");
+if (result !== 2) {
+  $ERROR('#2: eval("\\u2028" + "var" + "\\u2028" + "x" + "\\u2028" + "=" + "\\u2028" + "2" + "\\u2028"); result === 2. Actual: ' + (result));
 }

--- a/test/language/line-terminators/S7.3_A1.4.js
+++ b/test/language/line-terminators/S7.3_A1.4.js
@@ -7,14 +7,16 @@ es5id: 7.3_A1.4
 description: Insert PARAGRAPH SEPARATOR (\u2029) between tokens of var x=1
 ---*/
 
+var result;
+
 // CHECK#1
-eval("\u2029var\u2029x\u2029=\u20291\u2029");
-if (x !== 1) {
-  $ERROR('#1: eval("\\u2029var\\u2029x\\u2029=\\u20291\\u2029"); x === 1. Actual: ' + (x));
+eval("\u2029var\u2029x\u2029=\u20291\u2029; result = x;");
+if (result !== 1) {
+  $ERROR('#1: eval("\\u2029var\\u2029x\\u2029=\\u20291\\u2029"); result === 1. Actual: ' + (result));
 }
 
 //CHECK#2
-eval("\u2029" + "var" + "\u2029" + "x" + "\u2029" + "=" + "\u2029" + "1" + "\u2029");
-if (x !== 1) {
-  $ERROR('#2: eval("\\u2029" + "var" + "\\u2029" + "x" + "\\u2029" + "=" + "\\u2029" + "1" + "\\u2029"); x === 1. Actual: ' + (x));
+eval("\u2029" + "var" + "\u2029" + "x" + "\u2029" + "=" + "\u2029" + "2" + "\u2029; result = x;");
+if (result !== 2) {
+  $ERROR('#2: eval("\\u2029" + "var" + "\\u2029" + "x" + "\\u2029" + "=" + "\\u2029" + "2" + "\\u2029"); result === 2. Actual: ' + (result));
 }

--- a/test/language/line-terminators/S7.3_A7_T1.js
+++ b/test/language/line-terminators/S7.3_A7_T1.js
@@ -38,18 +38,19 @@ if (x !== 5) {
 x=0;
 
 // CHECK#3
+var result;
 var y=2;
 var z=3;
-eval("\u2028var\u2028x\u2028=\u2028y\u2028+\u2028z\u2028");
-if (x !== 5) {
-  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028+\\u2028z\\u2028"); x === 5. Actual: ' + (x));
+eval("\u2028var\u2028x\u2028=\u2028y\u2028+\u2028z\u2028; result = x;");
+if (result !== 5) {
+  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028+\\u2028z\\u2028; result = x;"); result === 5. Actual: ' + (result));
 }
-x=0;
+result=0;
 
 // CHECK#4
 var y=2;
 var z=3;
-eval("\u2029var\u2029x\u2029=\u2029y\u2029+\u2029z\u2029");
-if (x !== 5) {
-  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029+\\u2029z\\u2029"); x === 5. Actual: ' + (x));
+eval("\u2029var\u2029x\u2029=\u2029y\u2029+\u2029z\u2029; result = x;");
+if (result !== 5) {
+  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029+\\u2029z\\u2029; result = x;"); result === 5. Actual: ' + (result));
 }

--- a/test/language/line-terminators/S7.3_A7_T2.js
+++ b/test/language/line-terminators/S7.3_A7_T2.js
@@ -38,18 +38,19 @@ if (x !== 1) {
 x=0;
 
 // CHECK#3
+var result;
 var y=3;
 var z=2;
-eval("\u2028var\u2028x\u2028=\u2028y\u2028-\u2028z\u2028");
-if (x !== 1) {
-  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028-\\u2028z\\u2028"); x === 1. Actual: ' + (x));
+eval("\u2028var\u2028x\u2028=\u2028y\u2028-\u2028z\u2028; result = x;");
+if (result !== 1) {
+  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028-\\u2028z\\u2028; result = x;"); result === 1. Actual: ' + (result));
 }
-x=0;
+result=0;
 
 // CHECK#4
 var y=3;
 var z=2;
-eval("\u2029var\u2029x\u2029=\u2029y\u2029-\u2029z\u2029");
-if (x !== 1) {
-  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029-\\u2029z\\u2029"); x === 1. Actual: ' + (x));
+eval("\u2029var\u2029x\u2029=\u2029y\u2029-\u2029z\u2029; result = x;");
+if (result !== 1) {
+  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029-\\u2029z\\u2029; result = x;"); result === 1. Actual: ' + (result));
 }

--- a/test/language/line-terminators/S7.3_A7_T3.js
+++ b/test/language/line-terminators/S7.3_A7_T3.js
@@ -38,18 +38,19 @@ if (x !== 6) {
 x=0;
 
 // CHECK#3
+var result;
 var y=3;
 var z=2;
-eval("\u2028var\u2028x\u2028=\u2028y\u2028*\u2028z\u2028");
-if (x !== 6) {
-  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028*\\u2028z\\u2028"); x === 6. Actual: ' + (x));
+eval("\u2028var\u2028x\u2028=\u2028y\u2028*\u2028z\u2028; result = x;");
+if (result !== 6) {
+  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028*\\u2028z\\u2028; result = x;"); result === 6. Actual: ' + (result));
 }
-x=0;
+result=0;
 
 // CHECK#4
 var y=3;
 var z=2;
-eval("\u2029var\u2029x\u2029=\u2029y\u2029*\u2029z\u2029");
-if (x !== 6) {
-  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029*\\u2029z\\u2029"); x === 6. Actual: ' + (x));
+eval("\u2029var\u2029x\u2029=\u2029y\u2029*\u2029z\u2029; result = x;");
+if (result !== 6) {
+  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029*\\u2029z\\u2029; result = x;"); result === 6. Actual: ' + (result));
 }

--- a/test/language/line-terminators/S7.3_A7_T4.js
+++ b/test/language/line-terminators/S7.3_A7_T4.js
@@ -38,18 +38,19 @@ if (x !== 6) {
 x=0;
 
 // CHECK#3
+var result;
 var y=12;
 var z=2;
-eval("\u2028var\u2028x\u2028=\u2028y\u2028/\u2028z\u2028");
-if (x !== 6) {
-  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028/\\u2028z\\u2028"); x === 6. Actual: ' + (x));
+eval("\u2028var\u2028x\u2028=\u2028y\u2028/\u2028z\u2028; result = x;");
+if (result !== 6) {
+  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028/\\u2028z\\u2028; result = x;"); result === 6. Actual: ' + (result));
 }
-x=0;
+result=0;
 
 // CHECK#4
 var y=12;
 var z=2;
-eval("\u2029var\u2029x\u2029=\u2029y\u2029/\u2029z\u2029");
-if (x !== 6) {
-  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029/\\u2029z\\u2029"); x === 6. Actual: ' + (x));
+eval("\u2029var\u2029x\u2029=\u2029y\u2029/\u2029z\u2029; result = x;");
+if (result !== 6) {
+  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029/\\u2029z\\u2029; result = x;"); result === 6. Actual: ' + (result));
 }

--- a/test/language/line-terminators/S7.3_A7_T5.js
+++ b/test/language/line-terminators/S7.3_A7_T5.js
@@ -38,18 +38,19 @@ if (x !== 6) {
 x=0;
 
 // CHECK#3
+var result;
 var y=16;
 var z=10;
-eval("\u2028var\u2028x\u2028=\u2028y\u2028%\u2028z\u2028");
-if (x !== 6) {
-  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028%\\u2028z\\u2028"); x === 6. Actual: ' + (x));
+eval("\u2028var\u2028x\u2028=\u2028y\u2028%\u2028z\u2028; result = x;");
+if (result !== 6) {
+  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028%\\u2028z\\u2028; result = x;"); result === 6. Actual: ' + (result));
 }
-x=0;
+result=0;
 
 // CHECK#4
 var y=16;
 var z=10;
-eval("\u2029var\u2029x\u2029=\u2029y\u2029%\u2029z\u2029");
-if (x !== 6) {
-  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029%\\u2029z\\u2029"); x === 6. Actual: ' + (x));
+eval("\u2029var\u2029x\u2029=\u2029y\u2029%\u2029z\u2029; result = x;");
+if (result !== 6) {
+  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029%\\u2029z\\u2029; result = x;"); result === 6. Actual: ' + (result));
 }

--- a/test/language/line-terminators/S7.3_A7_T6.js
+++ b/test/language/line-terminators/S7.3_A7_T6.js
@@ -38,18 +38,19 @@ if (x !== 2) {
 x=0;
 
 // CHECK#3
+var result;
 var y=16;
 var z=3;
-eval("\u2028var\u2028x\u2028=\u2028y\u2028>>\u2028z\u2028");
-if (x !== 2) {
-  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028>>\\u2028z\\u2028"); x === 2. Actual: ' + (x));
+eval("\u2028var\u2028x\u2028=\u2028y\u2028>>\u2028z\u2028; result = x;");
+if (result !== 2) {
+  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028>>\\u2028z\\u2028; result = x;"); result === 2. Actual: ' + (result));
 }
-x=0;
+result=0;
 
 // CHECK#4
 var y=16;
 var z=3;
-eval("\u2029var\u2029x\u2029=\u2029y\u2029>>\u2029z\u2029");
-if (x !== 2) {
-  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029>>\\u2029z\\u2029"); x === 2. Actual: ' + (x));
+eval("\u2029var\u2029x\u2029=\u2029y\u2029>>\u2029z\u2029; result = x;");
+if (result !== 2) {
+  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029>>\\u2029z\\u2029; result = x;"); result === 2. Actual: ' + (result));
 }

--- a/test/language/line-terminators/S7.3_A7_T7.js
+++ b/test/language/line-terminators/S7.3_A7_T7.js
@@ -38,18 +38,19 @@ if (x !== 16) {
 x=0;
 
 // CHECK#3
+var result;
 var y=2;
 var z=3;
-eval("\u2028var\u2028x\u2028=\u2028y\u2028<<\u2028z\u2028");
-if (x !== 16) {
-  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028<<\\u2028z\\u2028"); x === 16. Actual: ' + (x));
+eval("\u2028var\u2028x\u2028=\u2028y\u2028<<\u2028z\u2028; result = x;");
+if (result !== 16) {
+  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028<<\\u2028z\\u2028; result = x;"); result === 16. Actual: ' + (result));
 }
-x=0;
+result=0;
 
 // CHECK#4
 var y=2;
 var z=3;
-eval("\u2029var\u2029x\u2029=\u2029y\u2029<<\u2029z\u2029");
-if (x !== 16) {
-  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029<<\\u2029z\\u2029"); x === 16. Actual: ' + (x));
+eval("\u2029var\u2029x\u2029=\u2029y\u2029<<\u2029z\u2029; result = x;");
+if (result !== 16) {
+  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029<<\\u2029z\\u2029; result = x;"); result === 16. Actual: ' + (result));
 }

--- a/test/language/line-terminators/S7.3_A7_T8.js
+++ b/test/language/line-terminators/S7.3_A7_T8.js
@@ -38,18 +38,19 @@ if (x !== true) {
 x=0;
 
 // CHECK#3
+var result;
 var y=2;
 var z=3;
-eval("\u2028var\u2028x\u2028=\u2028y\u2028<\u2028z\u2028");
-if (x !== true) {
-  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028<\\u2028z\\u2028"); x === true. Actual: ' + (x));
+eval("\u2028var\u2028x\u2028=\u2028y\u2028<\u2028z\u2028; result = x;");
+if (result !== true) {
+  $ERROR('#3: eval("\\u2028var\\u2028x\\u2028=\\u2028y\\u2028<\\u2028z\\u2028; result = x;"); result === true. Actual: ' + (result));
 }
-x=0;
+result=0;
 
 // CHECK#4
 var y=2;
 var z=3;
-eval("\u2029var\u2029x\u2029=\u2029y\u2029<\u2029z\u2029");
-if (x !== true) {
-  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029<\\u2029z\\u2029"); x === true. Actual: ' + (x));
+eval("\u2029var\u2029x\u2029=\u2029y\u2029<\u2029z\u2029; result = x;");
+if (result !== true) {
+  $ERROR('#4: eval("\\u2029var\\u2029x\\u2029=\\u2029y\\u2029<\\u2029z\\u2029; result = x;"); result === true. Actual: ' + (result));
 }

--- a/test/language/white-space/S7.2_A1.1_T1.js
+++ b/test/language/white-space/S7.2_A1.1_T1.js
@@ -7,32 +7,34 @@ es5id: 7.2_A1.1_T1
 description: Insert HORIZONTAL TAB(\u0009 and \t) between tokens of var x=1
 ---*/
 
+var result;
+
 // CHECK#1
-eval("\u0009var\u0009x\u0009=\u00091\u0009");
-if (x !== 1) {
-  $ERROR('#1: eval("\\u0009var\\u0009x\\u0009=\\u00091\\u0009"); x === 1. Actual: ' + (x));
+eval("\u0009var\u0009x\u0009=\u00091\u0009; result = x;");
+if (result !== 1) {
+  $ERROR('#1: eval("\\u0009var\\u0009x\\u0009=\\u00091\\u0009; result = x;"); result === 1. Actual: ' + (result));
 }
 
 //CHECK#2
-eval("\u0009" + "var" + "\u0009" + "x" + "\u0009" + "=" + "\u0009" + "1" + "\u0009");
-if (x !== 1) {
-  $ERROR('#2: eval("\\u0009" + "var" + "\\u0009" + "x" + "\\u0009" + "=" + "\\u0009" + "1" + "\\u0009"); x === 1. Actual: ' + (x));
+eval("\u0009" + "var" + "\u0009" + "x" + "\u0009" + "=" + "\u0009" + "2" + "\u0009; result = x;");
+if (result !== 2) {
+  $ERROR('#2: eval("\\u0009" + "var" + "\\u0009" + "x" + "\\u0009" + "=" + "\\u0009" + "2" + "\\u0009; result = x;"); result === 2. Actual: ' + (result));
 }
 
 //CHECK#3
-eval("\tvar\tx\t=\t1\t");
-if (x !== 1) {
-  $ERROR('#3: eval("\\tvar\\tx\\t=\\t1\\t"); x === 1. Actual: ' + (x));
+eval("\tvar\tx\t=\t3\t; result = x;");
+if (result !== 3) {
+  $ERROR('#3: eval("\\tvar\\tx\\t=\\t3\\t; result = x;"); x === 3. Actual: ' + (result));
 }
 
 //CHECK#4
-eval("\t" + "var" + "\t" + "x" + "\t" + "=" + "\t" + "1" + "\t");
-if (x !== 1) {
-  $ERROR('#4: eval("\\t" + "var" + "\\t" + "x" + "\\t" + "=" + "\\t" + "1" + "\\t"); x === 1. Actual: ' + (x));
+eval("\t" + "var" + "\t" + "x" + "\t" + "=" + "\t" + "4" + "\t; result = x;");
+if (result !== 4) {
+  $ERROR('#4: eval("\\t" + "var" + "\\t" + "x" + "\\t" + "=" + "\\t" + "4" + "\\t; result = x;"); result === 4. Actual: ' + (result));
 }
 
 //CHECK#5
-eval("\u0009" + "var" + "\t" + "x" + "\u0009" + "=" + "\t" + "1" + "\u0009");
-if (x !== 1) {
-  $ERROR('#5: eval("\\u0009" + "var" + "\\t" + "x" + "\\u0009" + "=" + "\\t" + "1" + "\\u0009"); x === 1. Actual: ' + (x));
+eval("\u0009" + "var" + "\t" + "x" + "\u0009" + "=" + "\t" + "5" + "\u0009; result = x;");
+if (result !== 5) {
+  $ERROR('#5: eval("\\u0009" + "var" + "\\t" + "x" + "\\u0009" + "=" + "\\t" + "5" + "\\u0009; result = x;"); result === 5. Actual: ' + (result));
 }

--- a/test/language/white-space/S7.2_A1.1_T2.js
+++ b/test/language/white-space/S7.2_A1.1_T2.js
@@ -14,7 +14,8 @@ if (x !== 1) {
 }
 
 //CHECK#2
-eval("	var\tx	=\t2	");
-if (x !== 2) {
-  $ERROR('#2: 	var\\tx	=\\t1	; x === 2. Actual: ' + (x));
+var result;
+eval("	var\tx	=\t2	; result = x;");
+if (result !== 2) {
+  $ERROR('#2: 	var\\tx	=\\t1	; result = x; result === 2. Actual: ' + (result));
 }

--- a/test/language/white-space/S7.2_A1.2_T1.js
+++ b/test/language/white-space/S7.2_A1.2_T1.js
@@ -7,32 +7,34 @@ es5id: 7.2_A1.2_T1
 description: Insert VERTICAL TAB(\u000B and \v) between tokens of var x=1
 ---*/
 
+var result;
+
 // CHECK#1
-eval("\u000Bvar\u000Bx\u000B=\u000B1\u000B");
-if (x !== 1) {
-  $ERROR('#1: eval("\\u000Bvar\\u000Bx\\u000B=\\u000B1\\u000B"); x === 1. Actual: ' + (x));
+eval("\u000Bvar\u000Bx\u000B=\u000B1\u000B; result = x;");
+if (result !== 1) {
+  $ERROR('#1: eval("\\u000Bvar\\u000Bx\\u000B=\\u000B1\\u000B; result = x;"); result === 1. Actual: ' + (result));
 }
 
 //CHECK#2
-eval("\u000B" + "var" + "\u000B" + "x" + "\u000B" + "=" + "\u000B" + "1" + "\u000B");
-if (x !== 1) {
-  $ERROR('#2: eval("\\u000B" + "var" + "\\u000B" + "x" + "\\u000B" + "=" + "\\u000B" + "1" + "\\u000B"); x === 1. Actual: ' + (x));
+eval("\u000B" + "var" + "\u000B" + "x" + "\u000B" + "=" + "\u000B" + "2" + "\u000B; result = x;");
+if (result !== 2) {
+  $ERROR('#2: eval("\\u000B" + "var" + "\\u000B" + "x" + "\\u000B" + "=" + "\\u000B" + "2" + "\\u000B; result = x;"); result === 2. Actual: ' + (result));
 }
 
 //CHECK#3
-eval("\vvar\vx\v=\v1\v");
-if (x !== 1) {
-  $ERROR('#3: eval("\\vvar\\vx\\v=\\v1\\v"); x === 1. Actual: ' + (x));
+eval("\vvar\vx\v=\v3\v; result = x;");
+if (result !== 3) {
+  $ERROR('#3: eval("\\vvar\\vx\\v=\\v3\\v; result = x;"); x === 3. Actual: ' + (result));
 }
 
 //CHECK#4
-eval("\v" + "var" + "\v" + "x" + "\v" + "=" + "\v" + "1" + "\v");
-if (x !== 1) {
-  $ERROR('#4: eval("\\v" + "var" + "\\v" + "x" + "\\v" + "=" + "\\v" + "1" + "\\v"); x === 1. Actual: ' + (x));
+eval("\v" + "var" + "\v" + "x" + "\v" + "=" + "\v" + "4" + "\v; result = x;");
+if (result !== 4) {
+  $ERROR('#4: eval("\\v" + "var" + "\\v" + "x" + "\\v" + "=" + "\\v" + "4" + "\\v; result = x;"); result === 4. Actual: ' + (result));
 }
 
 //CHECK#5
-eval("\u000B" + "var" + "\v" + "x" + "\u000B" + "=" + "\v" + "1" + "\u000B");
-if (x !== 1) {
-  $ERROR('#5: eval("\\u000B" + "var" + "\\v" + "x" + "\\u000B" + "=" + "\\v" + "1" + "\\u000B"); x === 1. Actual: ' + (x));
+eval("\u000B" + "var" + "\v" + "x" + "\u000B" + "=" + "\v" + "5" + "\u000B; result = x;");
+if (result !== 5) {
+  $ERROR('#5: eval("\\u000B" + "var" + "\\v" + "x" + "\\u000B" + "=" + "\\v" + "5" + "\\u000B; result = x;"); result === 5. Actual: ' + (result));
 }

--- a/test/language/white-space/S7.2_A1.3_T1.js
+++ b/test/language/white-space/S7.2_A1.3_T1.js
@@ -7,32 +7,34 @@ es5id: 7.2_A1.3_T1
 description: Insert FORM FEED(\u000C and \f) between tokens of var x=1
 ---*/
 
+var result;
+
 // CHECK#1
-eval("\u000Cvar\u000Cx\u000C=\u000C1\u000C");
-if (x !== 1) {
-  $ERROR('#1: eval("\\u000Cvar\\u000Cx\\u000C=\\u000C1\\u000C"); x === 1. Actual: ' + (x));
+eval("\u000Cvar\u000Cx\u000C=\u000C1\u000C; result = x;");
+if (result !== 1) {
+  $ERROR('#1: eval("\\u000Cvar\\u000Cx\\u000C=\\u000C1\\u000C; result = x;"); result === 1. Actual: ' + (result));
 }
 
 //CHECK#2
-eval("\u000C" + "var" + "\u000C" + "x" + "\u000C" + "=" + "\u000C" + "1" + "\u000C");
-if (x !== 1) {
-  $ERROR('#2: eval("\\u000C" + "var" + "\\u000C" + "x" + "\\u000C" + "=" + "\\u000C" + "1" + "\\u000C"); x === 1. Actual: ' + (x));
+eval("\u000C" + "var" + "\u000C" + "x" + "\u000C" + "=" + "\u000C" + "2" + "\u000C; result = x;");
+if (result !== 2) {
+  $ERROR('#2: eval("\\u000C" + "var" + "\\u000C" + "x" + "\\u000C" + "=" + "\\u000C" + "2" + "\\u000C; result = x;"); result === 2. Actual: ' + (result));
 }
 
 //CHECK#3
-eval("\fvar\fx\f=\f1\f");
-if (x !== 1) {
-  $ERROR('#3: eval("\\fvar\\fx\\f=\\f1\\f"); x === 1. Actual: ' + (x));
+eval("\fvar\fx\f=\f3\f; result = x;");
+if (result !== 3) {
+  $ERROR('#3: eval("\\fvar\\fx\\f=\\f3\\f; result = x;"); result === 3. Actual: ' + (result));
 }
 
 //CHECK#4
-eval("\f" + "var" + "\f" + "x" + "\f" + "=" + "\f" + "1" + "\f");
-if (x !== 1) {
-  $ERROR('#4: eval("\\f" + "var" + "\\f" + "x" + "\\f" + "=" + "\\f" + "1" + "\\f"); x === 1. Actual: ' + (x));
+eval("\f" + "var" + "\f" + "x" + "\f" + "=" + "\f" + "4" + "\f; result = x;");
+if (result !== 4) {
+  $ERROR('#4: eval("\\f" + "var" + "\\f" + "x" + "\\f" + "=" + "\\f" + "4" + "\\f; result = x;"); result === 4. Actual: ' + (result));
 }
 
 //CHECK#5
-eval("\u000C" + "var" + "\f" + "x" + "\u000C" + "=" + "\f" + "1" + "\u000C");
-if (x !== 1) {
-  $ERROR('#5: eval("\\u000C" + "var" + "\\f" + "x" + "\\u000C" + "=" + "\\f" + "1" + "\\u000C"); x === 1. Actual: ' + (x));
+eval("\u000C" + "var" + "\f" + "x" + "\u000C" + "=" + "\f" + "5" + "\u000C; result = x;");
+if (result !== 5) {
+  $ERROR('#5: eval("\\u000C" + "var" + "\\f" + "x" + "\\u000C" + "=" + "\\f" + "5" + "\\u000C; result = x;"); result === 5. Actual: ' + (result));
 }

--- a/test/language/white-space/S7.2_A1.4_T1.js
+++ b/test/language/white-space/S7.2_A1.4_T1.js
@@ -7,14 +7,16 @@ es5id: 7.2_A1.4_T1
 description: Insert SPACE(\u0020) between tokens of var x=1
 ---*/
 
+var result;
+
 // CHECK#1
-eval("\u0020var\u0020x\u0020=\u00201\u0020");
-if (x !== 1) {
-  $ERROR('#1: eval("\\u0020var\\u0020x\\u0020=\\u00201\\u0020"); x === 1;');
+eval("\u0020var\u0020x\u0020=\u00201\u0020; result = x;");
+if (result !== 1) {
+  $ERROR('#1: eval("\\u0020var\\u0020x\\u0020=\\u00201\\u0020; result = x;"); result === 1;');
 }
 
 //CHECK#2
-eval("\u0020" + "var" + "\u0020" + "x" + "\u0020" + "=" + "\u0020" + "1" + "\u0020");
-if (x !== 1) {
-  $ERROR('#2: eval("\\u0020" + "var" + "\\u0020" + "x" + "\\u0020" + "=" + "\\u0020" + "1" + "\\u0020"); x === 1. Actual: ' + (x));
+eval("\u0020" + "var" + "\u0020" + "x" + "\u0020" + "=" + "\u0020" + "2" + "\u0020; result = x;");
+if (result !== 2) {
+  $ERROR('#2: eval("\\u0020" + "var" + "\\u0020" + "x" + "\\u0020" + "=" + "\\u0020" + "2" + "\\u0020; result = x;"); result === 2. Actual: ' + (result));
 }

--- a/test/language/white-space/S7.2_A1.4_T2.js
+++ b/test/language/white-space/S7.2_A1.4_T2.js
@@ -7,14 +7,16 @@ es5id: 7.2_A1.4_T2
 description: Insert real SPACE between tokens of var x=1
 ---*/
 
+var result;
+
 //CHECK#1
-eval("\u0020var x\u0020= 1\u0020");
-if (x !== 1) {
-  $ERROR('#1: eval("\\u0020var x\\u0020= 1\\u0020"); x === 1. Actual: ' + (x));
+eval("\u0020var x\u0020= 1\u0020; result = x;");
+if (result !== 1) {
+  $ERROR('#1: eval("\\u0020var x\\u0020= 1\\u0020; result = x;"); result === 1. Actual: ' + (result));
 }
 
 //CHECK#2
- var x = 1 ;
-if (x !== 1) {
-  $ERROR('#2:  var x = 1 ; x === 1. Actual: ' + (x));
+ var x = 2 ;
+if (x !== 2) {
+  $ERROR('#2:  var x = 2 ; x === 2. Actual: ' + (x));
 }

--- a/test/language/white-space/S7.2_A1.5_T1.js
+++ b/test/language/white-space/S7.2_A1.5_T1.js
@@ -7,14 +7,16 @@ es5id: 7.2_A1.5_T1
 description: Insert NO-BREAK SPACE(\u00A0) between tokens of var x=1
 ---*/
 
+var result;
+
 // CHECK#1
-eval("\u00A0var\u00A0x\u00A0=\u00A01\u00A0");
-if (x !== 1) {
-  $ERROR('#1: eval("\\u00A0var\\u00A0x\\u00A0=\\u00A01\\u00A0"); x === 1. Actual: ' + (x));
+eval("\u00A0var\u00A0x\u00A0=\u00A01\u00A0; result = x;");
+if (result !== 1) {
+  $ERROR('#1: eval("\\u00A0var\\u00A0x\\u00A0=\\u00A01\\u00A0; result = x;"); result === 1. Actual: ' + (result));
 }
 
 //CHECK#2
-eval("\u00A0" + "var" + "\u00A0" + "x" + "\u00A0" + "=" + "\u00A0" + "1" + "\u00A0");
-if (x !== 1) {
-  $ERROR('#2: eval("\\u00A0" + "var" + "\\u00A0" + "x" + "\\u00A0" + "=" + "\\u00A0" + "1" + "\\u00A0"); x === 1. Actual: ' + (x));
+eval("\u00A0" + "var" + "\u00A0" + "x" + "\u00A0" + "=" + "\u00A0" + "2" + "\u00A0; result = x;");
+if (result !== 2) {
+  $ERROR('#2: eval("\\u00A0" + "var" + "\\u00A0" + "x" + "\\u00A0" + "=" + "\\u00A0" + "2" + "\\u00A0; result = x;"); result === 2. Actual: ' + (result));
 }

--- a/test/language/white-space/S7.2_A1.5_T2.js
+++ b/test/language/white-space/S7.2_A1.5_T2.js
@@ -7,14 +7,16 @@ es5id: 7.2_A1.5_T2
 description: Insert real NO-BREAK SPACE between tokens of var x=1
 ---*/
 
+var result;
+
 //CHECK#1
-eval("\u00A0var x\u00A0= 1\u00A0");
-if (x !== 1) {
-  $ERROR('#1: eval("\\u00A0var x\\u00A0= 1\\u00A0"); x === 1. Actual: ' + (x));
+eval("\u00A0var x\u00A0= 1\u00A0; result = x;");
+if (result !== 1) {
+  $ERROR('#1: eval("\\u00A0var x\\u00A0= 1\\u00A0; result = x;"); result === 1. Actual: ' + (result));
 }
 
 //CHECK#2
- var x = 1 ;
-if (x !== 1) {
-  $ERROR('#2:  var x = 1 ; x === 1. Actual: ' + (x));
+ var x = 2 ;
+if (x !== 2) {
+  $ERROR('#2:  var x = 1 ; x === 2. Actual: ' + (x));
 }


### PR DESCRIPTION
…ite-space}

Make tests strict mode compatible by assigning result value to a separate variable.

Part of issue #35.