### PR TITLE
Fix remaining strict mode errors in built-ins

### DIFF
--- a/test/built-ins/Array/S15.4.3_A2.3.js
+++ b/test/built-ins/Array/S15.4.3_A2.3.js
@@ -5,6 +5,7 @@
 info: The length property of Array has the attribute ReadOnly
 es5id: 15.4.3_A2.3
 description: Checking if varying the length property fails
+flags: [noStrict]
 ---*/
 
 //CHECK#1

--- a/test/built-ins/GeneratorPrototype/throw/from-state-completed.js
+++ b/test/built-ins/GeneratorPrototype/throw/from-state-completed.js
@@ -16,7 +16,7 @@ iter.next();
 
 assert.throws(E, function() { iter.throw(new E()); });
 
-result = iter.next();
+var result = iter.next();
 
 assert.sameValue(result.value, undefined, 'Result `value`');
 assert.sameValue(result.done, true, 'Result `done` flag');

--- a/test/built-ins/GeneratorPrototype/throw/from-state-suspended-start.js
+++ b/test/built-ins/GeneratorPrototype/throw/from-state-suspended-start.js
@@ -18,7 +18,7 @@ var iter;
 iter = G();
 assert.throws(E, function() { iter.throw(new E()); });
 
-result = iter.next();
+var result = iter.next();
 
 assert.sameValue(result.value, undefined, 'Result `value`');
 assert.sameValue(result.done, true, 'Result `done` flag');


### PR DESCRIPTION
Add missing noStrict flags and variable declarations.

Part of issue #35.