### PR TITLE
Add tests for destructuring assignment

### DIFF
--- a/test/language/expressions/assignment/destructuring/array-elem-elision.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-elision.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    ArrayAssignmentPattern may include elisions at any position in a
+    AssignmentElementList that does not contain an AssignmentRestElement.
+es6id: 12.14.5
+---*/
+
+var value = [1, 2, 3, 4, 5, 6];
+var x, y;
+var result;
+
+result = [, x, , y, ,] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 2);
+assert.sameValue(y, 4);

--- a/test/language/expressions/assignment/destructuring/array-elem-init-assignment.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-init-assignment.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    If the Initializer is present and v is undefined, the Initializer should be
+    evaluated and the result assigned to the target reference.
+es6id: 12.14.5.3
+---*/
+
+var result, value, x;
+
+value = [];
+result = [ x = 10 ] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 10, 'no element at index');
+
+value = [2];
+result = [ x = 11 ] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 2, 'element at index (truthy value)');
+
+value = [ null ];
+result = [ x = 12 ] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, null, 'element at index (`null`)');
+
+value = [ undefined ];
+result = [ x = 13 ] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 13, 'element at index (`undefined`)');
+
+value = [ , ];
+result = [ x = 14 ] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 14, 'element at index (sparse array)');

--- a/test/language/expressions/assignment/destructuring/array-elem-init-evaluation.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-init-evaluation.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The Initializer should only be evaluated if v is undefined.
+es6id: 12.14.5.3
+---*/
+
+var result, value, x, flag;
+
+value = [];
+flag = false;
+result = [ x = flag = true ] = value;
+assert.sameValue(result, value);
+assert.sameValue(x, true);
+assert.sameValue(flag, true);
+
+value = [14];
+flag = false;
+result = [ x = flag = true ] = value;
+assert.sameValue(result, value);
+assert.sameValue(x, 14);
+assert.sameValue(flag, false);

--- a/test/language/expressions/assignment/destructuring/array-elem-init-in.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-init-in.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The Initializer in an AssignmentElement may be an `in` expression.
+es6id: 12.14.5
+---*/
+
+var value = [];
+var result, x;
+
+result = [ x = 'x' in {} ] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, false);

--- a/test/language/expressions/assignment/destructuring/array-elem-init-let.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-init-let.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Value retrieval of Initializer obeys `let` semantics.
+es6id: 12.14.5.3
+features: [let]
+---*/
+
+var x;
+
+assert.throws(ReferenceError, function() {
+  [ x = y ] = [];
+  let y;
+});

--- a/test/language/expressions/assignment/destructuring/array-elem-init-order.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-init-order.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Initializer values should be assigned in left-to-right order.
+es6id: 12.14.5.3
+---*/
+
+var value = [];
+var x = 0;
+var a, b, result;
+
+result = [ a = x += 1, b = x *= 2 ] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(a, 1);
+assert.sameValue(b, 2);
+assert.sameValue(x, 2);

--- a/test/language/expressions/assignment/destructuring/array-elem-init-simple-no-strict.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-init-simple-no-strict.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Identifiers that appear as the DestructuringAssignmentTarget in an
+    AssignmentElement should take on the iterated value corresponding to their
+    position in the ArrayAssignmentPattern.
+es6id: 12.14.5.3
+flags: [noStrict]
+---*/
+
+var value = [];
+var result, argument, eval;
+
+result = [arguments = 4, eval = 5] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(arguments, 4);
+assert.sameValue(eval, 5);

--- a/test/language/expressions/assignment/destructuring/array-elem-init-simple-strict.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-init-simple-strict.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    It is a Syntax Error if LeftHandSideExpression is neither an
+    ObjectLiteral nor an ArrayLiteral and
+    IsValidSimpleAssignmentTarget(LeftHandSideExpression) is
+    false.
+es6id: 12.14.5.1
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+([arguments] = []);

--- a/test/language/expressions/assignment/destructuring/array-elem-init-yield-expr.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-init-yield-expr.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of an
+    AssignmentElement within a generator function body, it behaves as a
+    YieldExpression.
+es6id: 12.14.5.4
+features: [generators]
+---*/
+
+var value = [];
+var assignmentResult, iterationResult, iter, x;
+
+iter = (function*() {
+  assignmentResult = [ x = yield ] = value;
+})();
+
+iterationResult = iter.next();
+
+assert.sameValue(assignmentResult, undefined);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, false);
+assert.sameValue(x, undefined);
+
+iterationResult = iter.next(86);
+
+assert.sameValue(assignmentResult, value);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, true);
+assert.sameValue(x, 86);

--- a/test/language/expressions/assignment/destructuring/array-elem-init-yield-ident-invalid.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-init-yield-ident-invalid.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of an AssignmentElement
+    outside of a generator function body, it behaves as an IdentifierReference.
+es6id: 12.14.5.4
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+var x;
+[ x = yield ] = [];

--- a/test/language/expressions/assignment/destructuring/array-elem-init-yield-ident-valid.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-init-yield-ident-valid.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of an AssignmentElement
+    outside of a generator function body, it behaves as an IdentifierReference.
+es6id: 12.14.5.4
+flags: [noStrict]
+---*/
+
+var value = [];
+var yield = 4;
+var result, x;
+
+result = [ x = yield ] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 4);

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-array-invalid.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-array-invalid.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    It is a Syntax Error if LeftHandSideExpression is either an ObjectLiteral
+    or an ArrayLiteral and if the lexical token sequence matched by
+    LeftHandSideExpression cannot be parsed with no tokens left over using
+    AssignmentPattern as the goal symbol.
+es6id: 12.14.5.1
+negative: SyntaxError
+---*/
+
+var x, y;
+
+[[(x, y)]] = [[]];

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-array-null.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-array-null.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal and the value is
+    `null`, a TypeError should be thrown.
+es6id: 12.14.5.3
+---*/
+
+var x;
+
+assert.throws(TypeError, function() {
+  [[ x ]] = [null];
+});

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-array-undefined-hole.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-array-undefined-hole.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal and the value is a
+    "hole", a TypeError should be thrown.
+es6id: 12.14.5.3
+---*/
+
+var x;
+
+assert.throws(TypeError, function() {
+  [[ x ]] = [ , ];
+});

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-array-undefined-own.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-array-undefined-own.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal and the value is
+    `undefined`, a TypeError should be thrown.
+es6id: 12.14.5.3
+---*/
+
+var x;
+
+assert.throws(TypeError, function() {
+  [[ x ]] = [undefined];
+});

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-array-undefined.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-array-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal and no value is
+    defined, a TypeError should be thrown.
+es6id: 12.14.5.3
+---*/
+
+var x;
+
+assert.throws(TypeError, function() {
+  [[ x ]] = [];
+});

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-array-yield-expr.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-array-yield-expr.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of a
+    nested destructuring assignment and within a generator function body, it
+    behaves as a YieldExpression.
+es6id: 12.14.5.3
+features: [generators]
+---*/
+
+var value = [[22]];
+var x = {};
+var assignmentResult, iterationResult, iter;
+
+iter = (function*() {
+  assignmentResult = [[x[yield]]] = value;
+}());
+
+iterationResult = iter.next();
+
+assert.sameValue(assignmentResult, undefined);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, false);
+assert.sameValue(x.prop, undefined);
+
+iterationResult = iter.next('prop');
+
+assert.sameValue(assignmentResult, value);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, true);
+assert.sameValue(x.prop, 22);

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-array-yield-ident-invalid.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-array-yield-ident-invalid.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of a
+    nested destructuring assignment outside of strict mode, it behaves as an
+    IdentifierReference.
+es6id: 12.14.5.3
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+[[x[yield]]] = value;

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-array-yield-ident-valid.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-array-yield-ident-valid.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of a
+    nested destructuring assignment outside of strict mode, it behaves as an
+    IdentifierReference.
+es6id: 12.14.5.3
+flags: [noStrict]
+---*/
+
+var value = [[22]];
+var yield = 'prop';
+var x = {};
+var result;
+
+result = [[x[yield]]] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x.prop, 22);

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-array.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-array.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal, it should be parsed
+    parsed as a DestructuringAssignmentPattern and evaluated as a destructuring
+    assignment.
+es6id: 12.14.5.3
+---*/
+
+var value = [[1]];
+var x, result;
+
+result = [[x]] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 1);

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-obj-invalid.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-obj-invalid.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    It is a Syntax Error if LeftHandSideExpression is either an ObjectLiteral
+    or an ArrayLiteral and if the lexical token sequence matched by
+    LeftHandSideExpression cannot be parsed with no tokens left over using
+    AssignmentPattern as the goal symbol.
+es6id: 12.14.5.1
+negative: SyntaxError
+---*/
+
+[{ get x() {} }] = [{}];

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-obj-null.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-obj-null.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an object literal and the value is
+    `null`, a TypeError should be thrown.
+es6id: 12.14.5.3
+---*/
+
+var x;
+
+assert.throws(TypeError, function() {
+  [{ x }] = [null];
+});

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-obj-undefined-hole.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-obj-undefined-hole.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an object literal and the value is a
+    "hole", a TypeError should be thrown.
+es6id: 12.14.5.3
+---*/
+
+var x;
+
+assert.throws(TypeError, function() {
+  [{ x }] = [ , ];
+});

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-obj-undefined-own.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-obj-undefined-own.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an object literal and the value is
+    `undefined`, a TypeError should be thrown.
+es6id: 12.14.5.3
+---*/
+
+var x;
+
+assert.throws(TypeError, function() {
+  [{ x }] = [undefined];
+});

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-obj-undefined.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-obj-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an object literal and no value is
+    defined, a TypeError should be thrown.
+es6id: 12.14.5.3
+---*/
+
+var x;
+
+assert.throws(TypeError, function() {
+  [{ x }] = [];
+});

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-obj-yield-expr.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-obj-yield-expr.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of a nested
+    destructuring assignment and within a generator function body, it behaves
+    as a YieldExpression.
+es6id: 12.14.5.3
+features: [generators]
+---*/
+
+var value = [{}];
+var assignmentResult, iterationResult, iter, x;
+
+iter = (function*() {
+  assignmentResult = [{ x = yield }] = value;
+}());
+
+iterationResult = iter.next();
+
+assert.sameValue(assignmentResult, undefined);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, false);
+assert.sameValue(x, undefined);
+
+iterationResult = iter.next(4);
+
+assert.sameValue(assignmentResult, value);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, true);
+assert.sameValue(x, 4);

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-obj-yield-ident-invalid.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-obj-yield-ident-invalid.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of a nested
+    destructuring assignment outside of a generator function body, it behaves
+    as a IdentifierReference.
+es6id: 12.14.5.3
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+[{ x = yield }] = [{}];

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-obj-yield-ident-valid.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-obj-yield-ident-valid.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of a nested
+    destructuring assignment outside of a generator function body, it behaves
+    as an IdentifierReference.
+es6id: 12.14.5.3
+flags: [noStrict]
+---*/
+
+var value = [{}];
+var yield = 2;
+var result, x;
+
+result = [{ x = yield }] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 2);

--- a/test/language/expressions/assignment/destructuring/array-elem-nested-obj.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-nested-obj.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an object literal, it should be
+    parsed as a DestructuringAssignmentPattern and evaluated as a destructuring
+    assignment.
+es6id: 12.14.5.3
+---*/
+
+var value = [{ x: 2 }];
+var result, x;
+
+result = [{ x }] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 2);

--- a/test/language/expressions/assignment/destructuring/array-elem-put-const.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-put-const.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The assignment target should obey `const` semantics.
+es6id: 12.14.5.3
+features: [const]
+---*/
+
+const c = null;
+
+assert.throws(TypeError, function() {
+  [ c ] = [1];
+});

--- a/test/language/expressions/assignment/destructuring/array-elem-put-let.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-put-let.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The assignment target should obey `let` semantics.
+es6id: 12.14.5.3
+features: [let]
+---*/
+
+assert.throws(ReferenceError, function() {
+  'use strict';
+  [ x ] = [];
+  let x;
+});

--- a/test/language/expressions/assignment/destructuring/array-elem-put-prop-ref-no-get.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-put-prop-ref-no-get.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    If the DestructuringAssignmentTarget of an AssignmentElement is a
+    PropertyReference, it should not be evaluated.
+es6id: 12.14.5.3
+---*/
+
+var value = [23];
+var x, setValue, result;
+x = {
+  get y() {
+    $ERROR('The property should not be accessed.');
+  },
+  set y(val) {
+    setValue = val;
+  }
+};
+
+result = [x.y] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(setValue, 23);

--- a/test/language/expressions/assignment/destructuring/array-elem-put-prop-ref-user-err.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-put-prop-ref-user-err.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Any error raised as a result of setting the value should be forwarded to
+    the runtime.
+es6id: 12.14.5.3
+---*/
+
+var value = [23];
+var x = {
+  set y(val) {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  [x.y] = value;
+});

--- a/test/language/expressions/assignment/destructuring/array-elem-put-prop-ref.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-put-prop-ref.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The DestructuringAssignmentTarget of an AssignmentElement may be a
+    PropertyReference.
+es6id: 12.14.5.3
+---*/
+
+var value = [4];
+var x = {};
+var result;
+
+result = [x.y] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x.y, 4);

--- a/test/language/expressions/assignment/destructuring/array-elem-put-unresolvable-no-strict.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-put-unresolvable-no-strict.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Outside of strict mode, if the the assignment target is an unresolvable
+    reference, a new `var` binding should be created in the environment record.
+es6id: 12.14.5.3
+flags: [noStrict]
+---*/
+
+{
+  [ unresolvable ] = [];
+}
+
+assert.sameValue(unresolvable, undefined);

--- a/test/language/expressions/assignment/destructuring/array-elem-put-unresolvable-strict.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-put-unresolvable-strict.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    In strict mode, if the the assignment target is an unresolvable reference,
+    a ReferenceError should be thrown.
+es6id: 12.14.5.3
+flags: [onlyStrict]
+---*/
+
+assert.throws(ReferenceError, function() {
+  [ unresolvable ] = [];
+});

--- a/test/language/expressions/assignment/destructuring/array-elem-target-identifier.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-target-identifier.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Identifiers that appear as the DestructuringAssignmentTarget in an
+    AssignmentElement should take on the iterated value corresponding to their
+    position in the ArrayAssignmentPattern.
+es6id: 12.14.5.3
+---*/
+
+var value = [1, 2, 3];
+var x, y, z;
+var result;
+
+result = [x, y, z] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 1);
+assert.sameValue(y, 2);
+assert.sameValue(z, 3);

--- a/test/language/expressions/assignment/destructuring/array-elem-target-simple-no-strict.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-target-simple-no-strict.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Identifiers that appear as the DestructuringAssignmentTarget in an
+    AssignmentElement should take on the iterated value corresponding to their
+    position in the ArrayAssignmentPattern.
+es6id: 12.14.5.3
+flags: [noStrict]
+---*/
+
+var value = [2, 3];
+var result, argument, eval;
+
+result = [arguments, eval] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(arguments, 2);
+assert.sameValue(eval, 3);

--- a/test/language/expressions/assignment/destructuring/array-elem-target-simple-strict.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-target-simple-strict.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    It is a Syntax Error if LeftHandSideExpression is neither an
+    ObjectLiteral nor an ArrayLiteral and
+    IsValidSimpleAssignmentTarget(LeftHandSideExpression) is
+    false.
+es6id: 12.14.5.1
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+([arguments] = []);

--- a/test/language/expressions/assignment/destructuring/array-elem-target-yield-expr.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-target-yield-expr.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of an
+    AssignmentElement within a generator function body, it behaves as a
+    YieldExpression.
+es6id: 12.14.5.4
+features: [generators]
+---*/
+
+var value = [33];
+var x = {};
+var assignmentResult, iterationResult, iter;
+
+iter = (function*() {
+  assignmentResult = [ x[yield] ] = value;
+}());
+
+iterationResult = iter.next();
+
+assert.sameValue(assignmentResult, undefined);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, false);
+assert.sameValue(x.prop, undefined);
+
+iterationResult = iter.next('prop');
+
+assert.sameValue(assignmentResult, value);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, true);
+assert.sameValue(x.prop, 33);

--- a/test/language/expressions/assignment/destructuring/array-elem-target-yield-invalid.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-target-yield-invalid.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of an
+    AssignmentElement and outside of a generator function body, it behaves as
+    an IdentifierReference.
+es6id: 12.14.5.4
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+[ x[yield] ] = [];

--- a/test/language/expressions/assignment/destructuring/array-elem-target-yield-valid.js
+++ b/test/language/expressions/assignment/destructuring/array-elem-target-yield-valid.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of an
+    AssignmentElement outside of a generator function body, it behaves as an
+    IdentifierReference.
+es6id: 12.14.5.4
+flags: [noStrict]
+---*/
+
+var value = [33];
+var yield = 'prop';
+var x = {};
+var result;
+
+result = [ x[yield] ] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x.prop, 33);

--- a/test/language/expressions/assignment/destructuring/array-empty.js
+++ b/test/language/expressions/assignment/destructuring/array-empty.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    An ArrayAssignmentPattern without an AssignmentElementList requires
+    iterable values and throws for other values.
+es6id: 12.14.5.2
+---*/
+
+var value, result;
+
+assert.throws(TypeError, function() {
+  [] = undefined;
+});
+
+assert.throws(TypeError, function() {
+  [] = null;
+});
+
+assert.throws(TypeError, function() {
+  [] = true;
+});
+
+assert.throws(TypeError, function() {
+  [] = 1;
+});
+
+result = [] = 'string literal';
+
+assert.sameValue(result, 'string literal');
+
+assert.throws(TypeError, function() {
+  [] = Symbol('s');
+});
+
+value = [];
+result = [] = value;
+
+assert.sameValue(result, value);

--- a/test/language/expressions/assignment/destructuring/array-iteration.js
+++ b/test/language/expressions/assignment/destructuring/array-iteration.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Value iteration only proceeds for the number of elements in the
+    ArrayAssignmentPattern.
+es6id: 12.14.5.3
+features: [generators]
+---*/
+
+var count, iter, result;
+var g = function*() {
+  count += 1;
+  yield;
+  count += 1;
+  yield;
+  count += 1;
+}
+
+count = 0;
+iter = g();
+result = [] = iter;
+
+assert.sameValue(result, iter);
+assert.sameValue(count, 0);
+
+iter = g();
+result = [,] = iter;
+
+assert.sameValue(result, iter);
+assert.sameValue(count, 1);
+
+count = 0;
+iter = g();
+result = [,,] = iter;
+
+assert.sameValue(result, iter);
+assert.sameValue(count, 2);
+
+count = 0;
+iter = g();
+result = [,,,] = iter;
+
+assert.sameValue(result, iter);
+assert.sameValue(count, 3);
+
+count = 0;
+iter = g();
+result = [,,,,] = iter;
+
+assert.sameValue(result, iter);
+assert.sameValue(count, 3);

--- a/test/language/expressions/assignment/destructuring/array-rest-after-element.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-after-element.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    An AssignmentRestElement following an AssignmentElement consumes all
+    remaining iterable values.
+es6id: 12.14.5.3
+---*/
+
+var x, y;
+
+[x, ...y] = [1, 2, 3];
+
+assert.sameValue(x, 1);
+assert.sameValue(y.length, 2);
+assert.sameValue(y[0], 2);
+assert.sameValue(y[1], 3);

--- a/test/language/expressions/assignment/destructuring/array-rest-after-elision.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-after-elision.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    An AssignmentRestElement following an elision consumes all remaining
+    iterable values.
+es6id: 12.14.5.3
+---*/
+
+var x;
+
+[, ...x] = [1, 2, 3];
+
+assert.sameValue(x.length, 2);
+assert.sameValue(x[0], 2);
+assert.sameValue(x[1], 3);

--- a/test/language/expressions/assignment/destructuring/array-rest-before-element.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-before-element.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    An AssignmentElement may not follow an AssignmentRestElement in an
+    AssignmentElementList.
+es6id: 12.14.5
+negative: SyntaxError
+---*/
+
+var x, y;
+
+[...x, y] = [];

--- a/test/language/expressions/assignment/destructuring/array-rest-before-elision.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-before-elision.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    An elision may not follow an AssignmentRestElement in an
+    AssignmentElementList.
+es6id: 12.14.5
+negative: SyntaxError
+---*/
+
+var x;
+
+[...x,] = [];

--- a/test/language/expressions/assignment/destructuring/array-rest-before-rest.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-before-rest.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    An AssignmentRestElement may not follow another AssignmentRestElement in an
+    AssignmentElementList.
+es6id: 12.14.5
+negative: SyntaxError
+---*/
+
+var x, y;
+
+[...x, ...y] = [];

--- a/test/language/expressions/assignment/destructuring/array-rest-elision-invalid.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-elision-invalid.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    ArrayAssignmentPattern may not include elisions following an
+    AssignmentRestElement in a AssignmentElementList.
+es6id: 12.14.5
+negative: SyntaxError
+---*/
+
+[...x,] = [];

--- a/test/language/expressions/assignment/destructuring/array-rest-elision.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-elision.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    ArrayAssignmentPattern may include elisions at any position preceeding a
+    AssignmentRestElement in a AssignmentElementList.
+es6id: 12.14.5
+---*/
+
+var value = [1, 2, 3, 4, 5, 6];
+var x, y;
+var result;
+
+result = [, , x, , ...y] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 3);
+assert.sameValue(y.length, 2);
+assert.sameValue(y[0], 5);
+assert.sameValue(y[1], 6);

--- a/test/language/expressions/assignment/destructuring/array-rest-init.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-init.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The AssignmentRestElement does not support an initializer.
+es6id: 12.14.5
+negative: SyntaxError
+---*/
+
+var x;
+
+[...x = 1] = [];

--- a/test/language/expressions/assignment/destructuring/array-rest-iteration.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-iteration.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    In the presense of an AssignmentRestElement, value iteration exhausts the
+    iterable value;
+es6id: 12.14.5.3
+features: [generators]
+---*/
+
+var count = 0;
+var g = function*() {
+  count += 1;
+  yield;
+  count += 1;
+  yield;
+  count += 1;
+}
+var iter, result, x;
+
+iter = g();
+result = [...x] = iter;
+
+assert.sameValue(result, iter);
+assert.sameValue(count, 3);

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-array-invalid.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-array-invalid.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    It is a Syntax Error if LeftHandSideExpression is either an ObjectLiteral
+    or an ArrayLiteral and if the lexical token sequence matched by
+    LeftHandSideExpression cannot be parsed with no tokens left over using
+    AssignmentPattern as the goal symbol.
+es6id: 12.14.5.1
+negative: SyntaxError
+---*/
+
+var x, y;
+
+[...[(x, y)]] = [[]];

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-array-null.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-array-null.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal and the iterable
+    emits `null` as the only value, an array with a single `null` element
+    should be used as the value of the nested DestructuringAssignment.
+es6id: 12.14.5.3
+---*/
+
+var value = [null];
+var result, x, y;
+
+result = [...[x, y]] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, null);
+assert.sameValue(y, undefined);

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-array-undefined-hole.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-array-undefined-hole.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal and the iterable is
+    an array with a "hole", an array with a single `undefined` element should
+    be used as the value of the nested DestructuringAssignment.
+es6id: 12.14.5.3
+---*/
+
+var value = [ , ];
+var result, x;
+
+result = [...[x]] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, undefined);

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-array-undefined-own.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-array-undefined-own.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal and the iterable
+    emits `undefined` as the only value, an array with a single `undefined`
+    element should be used as the value of the nested DestructuringAssignment.
+es6id: 12.14.5.3
+---*/
+
+var value = [undefined];
+var result, x;
+
+result = [...[x]] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, undefined);

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-array-undefined.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-array-undefined.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal and the iterable is
+    emits no values, an empty array should be used as the value of the nested
+    DestructuringAssignment.
+es6id: 12.14.5.3
+---*/
+
+var value = [];
+var result, x;
+
+result = [...[x]] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, undefined);

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-array-yield-expr.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-array-yield-expr.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of a
+    nested destructuring assignment and within a generator function body, it
+    should behave as a YieldExpression.
+es6id: 12.14.5.3
+features: [generators]
+---*/
+
+var value = [86];
+var x = {};
+var assignmentResult, iterationResult, iter;
+
+iter = (function*() {
+  assignmentResult = [...[x[yield]]] = value;
+}());
+
+iterationResult = iter.next();
+
+assert.sameValue(assignmentResult, undefined);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, false);
+assert.sameValue(x.prop, undefined);
+
+iterationResult = iter.next('prop');
+
+assert.sameValue(assignmentResult, value);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, true);
+assert.sameValue(x.prop, 86);

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-array-yield-ident-invalid.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-array-yield-ident-invalid.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of a
+    nested destructuring assignment and outside of a generator function body,
+    it should behave as an IdentifierExpression.
+es6id: 12.14.5.3
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+var x;
+[...[x[yield]]] = [];

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-array-yield-ident-valid.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-array-yield-ident-valid.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of a
+    nested destructuring assignment and outside of a generator function body,
+    it should behave as an IdentifierExpression.
+es6id: 12.14.5.3
+flags: [noStrict]
+---*/
+
+var value = [86];
+var yield = 'prop';
+var x = {};
+var result;
+
+result = [...[x[yield]]] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x.prop, 86);

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-array.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-array.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal, it should be parsed
+    parsed as a DestructuringAssignmentPattern and evaluated as a destructuring
+    assignment.
+es6id: 12.14.5.3
+---*/
+
+var value = [1, 2, 3];
+var x, result;
+
+result = [...[x]] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 1);

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-obj-invalid.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-obj-invalid.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    It is a Syntax Error if LeftHandSideExpression is either an ObjectLiteral
+    or an ArrayLiteral and if the lexical token sequence matched by
+    LeftHandSideExpression cannot be parsed with no tokens left over using
+    AssignmentPattern as the goal symbol.
+es6id: 12.14.5.1
+negative: SyntaxError
+---*/
+
+[...{ get x() {} }] = [[]];

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-obj-null.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-obj-null.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an object literal and the iterable
+    emits `null` as the only value, an array with a single `null` element
+    should be used as the value of the nested DestructuringAssignment.
+es6id: 12.14.5.3
+---*/
+
+var value = [null];
+var result, x, length;
+
+result = [...{ 0: x, length }] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, null);
+assert.sameValue(length, 1);

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-obj-undefined-hole.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-obj-undefined-hole.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal and the iterable is
+    an array with a "hole", an array with a single `undefined` element should
+    be used as the value of the nested DestructuringAssignment.
+es6id: 12.14.5.3
+---*/
+
+var value = [ , ];
+var result, x, length;
+
+result = [...{ 0: x, length }] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, undefined);
+assert.sameValue(length, 1);

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-obj-undefined-own.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-obj-undefined-own.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal and the iterable
+    emits `undefined` as the only value, an array with a single `undefined`
+    element should be used as the value of the nested DestructuringAssignment.
+es6id: 12.14.5.3
+---*/
+
+var value = [undefined];
+var result, x, length;
+
+result = [...{ 0: x, length }] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, undefined);
+assert.sameValue(length, 1);

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-obj-undefined.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-obj-undefined.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an obect literal and the iterable is
+    emits no values, an empty array should be used as the value of the nested
+    DestructuringAssignment.
+es6id: 12.14.5.3
+---*/
+
+var value = [];
+var result, x, length;
+
+result = [...{ 0: x, length }] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, undefined);
+assert.sameValue(length, 0);

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-obj-yield-expr.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-obj-yield-expr.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of a nested
+    destructuring assignment and within a generator function body, it should
+    behave as a YieldExpression.
+es6id: 12.14.5.3
+features: [generators]
+---*/
+
+var value = [{}];
+var assignmentResult, iterationResult, iter, x;
+
+iter = (function*() {
+  assignmentResult = [...{ x = yield }] = value;
+}());
+
+iterationResult = iter.next();
+
+assert.sameValue(assignmentResult, undefined);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, false);
+assert.sameValue(x, undefined);
+
+iterationResult = iter.next(4);
+
+assert.sameValue(assignmentResult, value);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, true);
+assert.sameValue(x, 4);

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-obj-yield-ident-invalid.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-obj-yield-ident-invalid.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of a nested
+    destructuring assignment and outside of a generator function body, it
+    should behave as an IdentifierExpression.
+es6id: 12.14.5.3
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+var value = [{}];
+[...{ x = yield }] = value;

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-obj-yield-ident-valid.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-obj-yield-ident-valid.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of a nested
+    destructuring assignment and outside of a generator function body, it
+    should behave as an IdentifierExpression.
+es6id: 12.14.5.3
+flags: [noStrict]
+---*/
+
+var value = [{}];
+var yield = 2;
+var result, iterationResult, iter, x;
+
+result = [...{ x = yield }] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 2);

--- a/test/language/expressions/assignment/destructuring/array-rest-nested-obj.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-nested-obj.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an object literal, it should be
+    parsed as a DestructuringAssignmentPattern and evaluated as a destructuring
+    assignment.
+es6id: 12.14.5.3
+---*/
+
+var value = [1, 2, 3];
+var result, x;
+
+result = [...{ 1: x }] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 2);

--- a/test/language/expressions/assignment/destructuring/array-rest-put-const.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-put-const.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The assignment target should obey `const` semantics.
+es6id: 12.14.5.3
+features: [const]
+---*/
+
+const c = null;
+
+assert.throws(TypeError, function() {
+  [ ...c ] = [1];
+});

--- a/test/language/expressions/assignment/destructuring/array-rest-put-let.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-put-let.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The assignment target should obey `let` semantics.
+es6id: 12.14.5.3
+features: [let]
+---*/
+
+assert.throws(ReferenceError, function() {
+  [ ...x ] = [];
+  let x;
+});

--- a/test/language/expressions/assignment/destructuring/array-rest-put-prop-ref-no-get.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-put-prop-ref-no-get.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    If the DestructuringAssignmentTarget of an AssignmentElement is a
+    PropertyReference, it should not be evaluated.
+es6id: 12.14.5.3
+---*/
+
+var value = [23, 45, 99];
+var x, setValue, result;
+x = {
+  get y() {
+    $ERROR('The property should not be accessed.');
+  },
+  set y(val) {
+    setValue = val;
+  }
+};
+
+result = [...x.y] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(setValue.length, 3);
+assert.sameValue(setValue[0], 23);
+assert.sameValue(setValue[1], 45);
+assert.sameValue(setValue[2], 99);

--- a/test/language/expressions/assignment/destructuring/array-rest-put-prop-ref-user-err.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-put-prop-ref-user-err.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Any error raised as a result of setting the value should be forwarded to
+    the runtime.
+es6id: 12.14.5.3
+---*/
+
+var value = [23];
+var x = {
+  set y(val) {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  [...x.y] = value;
+});

--- a/test/language/expressions/assignment/destructuring/array-rest-put-prop-ref.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-put-prop-ref.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The DestructuringAssignmentTarget of an AssignmentElement may be a
+    PropertyReference.
+es6id: 12.14.5.3
+---*/
+
+var value = [4, 3, 2];
+var x = {};
+var result;
+
+result = [...x.y] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x.y.length, 3);
+assert.sameValue(x.y[0], 4);
+assert.sameValue(x.y[1], 3);
+assert.sameValue(x.y[2], 2);

--- a/test/language/expressions/assignment/destructuring/array-rest-put-unresolvable-no-strict.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-put-unresolvable-no-strict.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Outside of strict mode, if the the assignment target is an unresolvable
+    reference, a new `var` binding should be created in the environment record.
+es6id: 12.14.5.3
+flags: [noStrict]
+---*/
+
+{
+  [ ...unresolvable ] = [];
+}
+
+assert.sameValue(unresolvable.length, 0);

--- a/test/language/expressions/assignment/destructuring/array-rest-put-unresolvable-strict.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-put-unresolvable-strict.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    In strict mode, if the the assignment target is an unresolvable reference,
+    a ReferenceError should be thrown.
+es6id: 12.14.5.3
+flags: [onlyStrict]
+---*/
+
+assert.throws(ReferenceError, function() {
+  [ ...unresolvable ] = [];
+});

--- a/test/language/expressions/assignment/destructuring/array-rest-yield-expr.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-yield-expr.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of
+    an AssignmentRestElement and within the body of a generator function, it
+    should behave as a YieldExpression.
+es6id: 12.14.5
+features: [generators]
+---*/
+
+var value = [33, 44, 55];
+var x = {};
+var assignmentResult, iterationResult, iter;
+
+iter = (function*() {
+  assignmentResult = [...x[yield]] = value;
+}());
+
+iterationResult = iter.next();
+
+assert.sameValue(assignmentResult, undefined);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, false);
+assert.sameValue(x.prop, undefined);
+
+iterationResult = iter.next('prop');
+
+assert.sameValue(assignmentResult, value);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, true);
+assert.sameValue(x.prop.length, 3);
+assert.sameValue(x.prop[0], 33);
+assert.sameValue(x.prop[1], 44);
+assert.sameValue(x.prop[2], 55);

--- a/test/language/expressions/assignment/destructuring/array-rest-yield-ident-invalid.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-yield-ident-invalid.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of an
+    AssignmentRestElement and outside of a generator function body, it should
+    behave as an IdentifierReference.
+es6id: 12.14.5
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+var x = {};
+[...x[yield]] = [];

--- a/test/language/expressions/assignment/destructuring/array-rest-yield-ident-valid.js
+++ b/test/language/expressions/assignment/destructuring/array-rest-yield-ident-valid.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of an
+    AssignmentRestElement and outside of a generator function body, it should
+    behave as an IdentifierReference.
+es6id: 12.14.5
+flags: [noStrict]
+---*/
+
+var value = [33, 44, 55];
+var yield = 'prop';
+var x = {};
+var result;
+
+result = [...x[yield]] = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x.prop.length, 3);
+assert.sameValue(x.prop[0], 33);
+assert.sameValue(x.prop[1], 44);
+assert.sameValue(x.prop[2], 55);

--- a/test/language/expressions/assignment/destructuring/array-sparse.js
+++ b/test/language/expressions/assignment/destructuring/array-sparse.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    A sparse ArrayAssignmentPattern without an AssignmentElementList requires
+    iterable values and throws for other values.
+es6id: 12.14.5.2
+---*/
+
+var value, result;
+
+assert.throws(TypeError, function() {
+  [,] = undefined;
+});
+
+assert.throws(TypeError, function() {
+  [,] = null;
+});
+
+assert.throws(TypeError, function() {
+  [,] = true;
+});
+
+assert.throws(TypeError, function() {
+  [,] = 1;
+});
+
+result = [,] = 'string literal';
+
+assert.sameValue(result, 'string literal');
+
+assert.throws(TypeError, function() {
+  [,] = Symbol('s');
+});
+
+value = [];
+result = [,] = value;
+
+assert.sameValue(result, value);

--- a/test/language/expressions/assignment/destructuring/obj-id-identifier-resolution.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-identifier-resolution.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Evaluation of DestructuringAssignmentTarget.
+es6id: 12.14.5.4
+---*/
+
+var result, value, w, x, y;
+
+x = null;
+value = { x: 1 };
+result = { x } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 1);
+
+x = null;
+value = { x: 2 };
+result = { x, } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 2);
+
+x = null;
+value = { x: 3 };
+result = { x, y } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 3);
+
+x = null;
+value = { x: 4 };
+result = { w, x } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 4);
+
+x = null;
+value = { x: 5 };
+result = { w, x, y } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 5);

--- a/test/language/expressions/assignment/destructuring/obj-id-identifier-yield-expr.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-identifier-yield-expr.js
@@ -1,0 +1,13 @@
+/*---
+description: >
+    `yield` is not a valid IdentifierReference in an AssignmentProperty within
+    generator function bodies.
+es6id: 12.14.5
+flags: [noStrict]
+features: [generators]
+negative: SyntaxError
+---*/
+
+(function*() {
+  { yield } = {};
+});

--- a/test/language/expressions/assignment/destructuring/obj-id-identifier-yield-ident-invalid.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-identifier-yield-ident-invalid.js
@@ -1,0 +1,10 @@
+/*---
+description: >
+    `yield` is not a valid IdentifierReference in an AssignmentProperty within
+    strict mode code.
+es6id: 12.14.5
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+var { yield } = {};

--- a/test/language/expressions/assignment/destructuring/obj-id-identifier-yield-ident-valid.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-identifier-yield-ident-valid.js
@@ -1,0 +1,15 @@
+/*---
+description: >
+    `yield` is a valid IdentifierReference in an AssignmentProperty outside of
+    strict mode and generator functions.
+es6id: 12.14.5
+flags: [noStrict]
+---*/
+
+var value = { yield: 3 };
+var result, yield;
+
+result = { yield } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(yield, 3);

--- a/test/language/expressions/assignment/destructuring/obj-id-init-assignment.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-init-assignment.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    If the Initializer is present and v is undefined, the Initializer should be
+    evaluated and the result assigned to the target reference.
+es6id: 12.14.5.4
+---*/
+
+var result, value, x;
+
+value = {};
+result = { x = 1 } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 1, 'no property defined');
+
+value = { x: 2 };
+result = { x = 1 } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 2, 'own property defined (truthy value)');
+
+value = { x: null };
+result = { x = 1 } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, null, 'own property defined (`null`)');
+
+value = { x: undefined };
+result = { x = 1 } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 1, 'own property defined (`undefined`)');

--- a/test/language/expressions/assignment/destructuring/obj-id-init-evaluation.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-init-evaluation.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The Initializer should only be evaluated if v is undefined.
+es6id: 12.14.5.4
+---*/
+
+var result, value, x, flag;
+
+value = {};
+flag = false;
+result = { x = flag = true } = value;
+assert.sameValue(result, value);
+assert.sameValue(x, true);
+assert.sameValue(flag, true);
+
+value = { x: 1 };
+flag = false;
+result = { x = flag = true } = value;
+assert.sameValue(result, value);
+assert.sameValue(x, 1);
+assert.sameValue(flag, false);

--- a/test/language/expressions/assignment/destructuring/obj-id-init-in.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-init-in.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The Initializer in an AssignmentProperty may be an `in` expression.
+es6id: 12.14.5
+---*/
+
+var value = {};
+var result, prop;
+
+result = { prop = 'x' in {} } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(prop, false);

--- a/test/language/expressions/assignment/destructuring/obj-id-init-let.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-init-let.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Value retrieval of Initializer obeys `let` semantics.
+es6id: 12.14.5.4
+features: [let]
+---*/
+
+var x;
+
+assert.throws(ReferenceError, function() {
+  ({ x = y } = {});
+  let y;
+});

--- a/test/language/expressions/assignment/destructuring/obj-id-init-order.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-init-order.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Initializer values should be assigned in left-to-right order.
+es6id: 12.14.5.4
+---*/
+
+var value = {};
+var x = 0;
+var a, b, result;
+
+result = { a = x += 1, b = x *= 2 } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(a, 1);
+assert.sameValue(b, 2);
+assert.sameValue(x, 2);

--- a/test/language/expressions/assignment/destructuring/obj-id-init-simple-no-strict.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-init-simple-no-strict.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Evaluation of DestructuringAssignmentTarget.
+es6id: 12.14.5.4
+flags: [noStrict]
+---*/
+
+var value = {};
+var eval, arguments, result;
+
+result = { eval = 3, arguments = 4 } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(eval, 3);
+assert.sameValue(arguments, 4);

--- a/test/language/expressions/assignment/destructuring/obj-id-init-simple-strict.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-init-simple-strict.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    It is a Syntax Error if IsValidSimpleAssignmentTarget of
+    IdentifierReference is false.
+es6id: 12.14.5.1
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+({ eval = 0 } = {});

--- a/test/language/expressions/assignment/destructuring/obj-id-init-yield-expr.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-init-yield-expr.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of an
+    AssignmentProperty and within a generator function body, it should behave
+    as a YieldExpression.
+es6id: 12.14.5
+features: [generators]
+---*/
+
+var value = {};
+var assignmentResult, iterationResult, x, iter;
+
+iter = (function*() {
+  assignmentResult = { x = yield } = value;
+}());
+
+iterationResult = iter.next();
+
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, false);
+assert.sameValue(x, undefined);
+assert.sameValue(assignmentResult, undefined);
+
+iterationResult = iter.next(3);
+
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, true);
+assert.sameValue(x, 3);
+assert.sameValue(assignmentResult, value);

--- a/test/language/expressions/assignment/destructuring/obj-id-init-yield-ident-invalid.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-init-yield-ident-invalid.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of an
+    AssignmentProperty and outside of a generator function body, it should
+    behave as an IdentifierReference.
+es6id: 12.14.5
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+var x;
+0, { x = yield } = {};

--- a/test/language/expressions/assignment/destructuring/obj-id-init-yield-ident-valid.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-init-yield-ident-valid.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of an
+    AssignmentProperty and outside of a generator function body, it should
+    behave as an IdentifierReference.
+es6id: 12.14.5
+flags: [noStrict]
+---*/
+
+var value = {};
+var yield = 3;
+var result, x;
+
+result = { x = yield } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 3);

--- a/test/language/expressions/assignment/destructuring/obj-id-put-const.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-put-const.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The assignment target should obey `const` semantics.
+es6id: 12.14.5.4
+features: [const]
+---*/
+
+const c = null;
+
+assert.throws(TypeError, function() {
+  ({ c } = { c: 1 });
+});

--- a/test/language/expressions/assignment/destructuring/obj-id-put-let.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-put-let.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The assignment target should obey `let` semantics.
+es6id: 12.14.5.4
+features: [let]
+---*/
+
+assert.throws(ReferenceError, function() {
+  ({ x } = {});
+  let x;
+});

--- a/test/language/expressions/assignment/destructuring/obj-id-put-unresolvable-no-strict.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-put-unresolvable-no-strict.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Outside of strict mode, if the the assignment target is an unresolvable
+    reference, a new `var` binding should be created in the environment record.
+es6id: 12.14.5.4
+flags: [noStrict]
+---*/
+
+{
+  ({ unresolvable } = {});
+}
+
+assert.sameValue(unresolvable, undefined);

--- a/test/language/expressions/assignment/destructuring/obj-id-put-unresolvable-strict.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-put-unresolvable-strict.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    In strict mode, if the the assignment target is an unresolvable reference,
+    a ReferenceError should be thrown.
+es6id: 12.14.5.4
+flags: [onlyStrict]
+---*/
+
+assert.throws(ReferenceError, function() {
+  ({ unresolvable } = {});
+});

--- a/test/language/expressions/assignment/destructuring/obj-id-simple-no-strict.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-simple-no-strict.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Evaluation of DestructuringAssignmentTarget.
+es6id: 12.14.5.4
+flags: [noStrict]
+---*/
+
+var value = { eval: 1, arguments: 2 };
+var eval, arguments, result;
+
+result = { eval, arguments } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(eval, 1);
+assert.sameValue(arguments, 2);

--- a/test/language/expressions/assignment/destructuring/obj-id-simple-strict.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-simple-strict.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    It is a Syntax Error if IsValidSimpleAssignmentTarget of
+    IdentifierReference is false.
+es6id: 12.14.5.1
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+({ eval } = {});

--- a/test/language/expressions/assignment/destructuring/obj-prop-elem-init-assignment.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-elem-init-assignment.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    If the Initializer is present and v is undefined, the Initializer should be
+    evaluated and the result assigned to the target reference.
+es6id: 12.14.5.4
+---*/
+
+var result, value, x;
+
+value = {};
+result = { y: x = 1 } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 1, 'no property defined');
+
+value = { y: 2 };
+result = { y: x = 1 } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 2, 'own property defined (truthy value)');
+
+value = { y: null };
+result = { y: x = 1 } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, null, 'own property defined (`null`)');
+
+value = { y: undefined };
+result = { y: x = 1 } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 1, 'own property defined (`undefined`)');

--- a/test/language/expressions/assignment/destructuring/obj-prop-elem-init-evaluation.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-elem-init-evaluation.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The Initializer should only be evaluated if v is undefined.
+es6id: 12.14.5.4
+---*/
+
+var result, value, x, flag;
+
+value = {};
+flag = false;
+result = { x: x = flag = true } = value;
+assert.sameValue(result, value);
+assert.sameValue(x, true);
+assert.sameValue(flag, true);
+
+value = { y: 1 };
+flag = false;
+result = { y: x = flag = true } = value;
+assert.sameValue(result, value);
+assert.sameValue(x, 1);
+assert.sameValue(flag, false);

--- a/test/language/expressions/assignment/destructuring/obj-prop-elem-init-in.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-elem-init-in.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The Initializer in an AssignmentElement may be an `in` expression.
+es6id: 12.14.5
+---*/
+
+var value = {};
+var result, prop;
+
+result = { x: prop = 'x' in {} } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(prop, false);

--- a/test/language/expressions/assignment/destructuring/obj-prop-elem-init-let.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-elem-init-let.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Value retrieval of Initializer obeys `let` semantics.
+es6id: 12.14.5.4
+features: [let]
+---*/
+
+var x;
+
+assert.throws(ReferenceError, function() {
+  ({ x: x = y } = {});
+  let y;
+});

--- a/test/language/expressions/assignment/destructuring/obj-prop-elem-init-yield-expr.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-elem-init-yield-expr.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of an AssignmentElement
+    and within a generator function body, it should behave as a
+    YieldExpression.
+es6id: 12.14.5.4
+features: [generators]
+---*/
+
+var value = {};
+var assignmentResult, iterationResult, iter, x;
+
+iter = (function*() {
+  assignmentResult = { x: x = yield } = value;
+}());
+
+iterationResult = iter.next();
+
+assert.sameValue(assignmentResult, undefined);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, false);
+assert.sameValue(x, undefined);
+
+iterationResult = iter.next(86);
+
+assert.sameValue(assignmentResult, value);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, true);
+assert.sameValue(x, 86);

--- a/test/language/expressions/assignment/destructuring/obj-prop-elem-init-yield-ident-invalid.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-elem-init-yield-ident-invalid.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of an AssignmentElement
+    and outside of a generator function body, it should behave as an
+    IdentifierReference.
+es6id: 12.14.5.4
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+var x;
+0, { x: x = yield } = {};

--- a/test/language/expressions/assignment/destructuring/obj-prop-elem-init-yield-ident-valid.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-elem-init-yield-ident-valid.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of an AssignmentElement
+    and outside of a generator function body, it should behave as an
+    IdentifierReference.
+es6id: 12.14.5.4
+flags: [noStrict]
+---*/
+
+var value = {};
+var yield = 4;
+var x;
+
+assignmentResult = { x: x = yield } = value;
+
+assert.sameValue(assignmentResult, value);
+assert.sameValue(x, 4);

--- a/test/language/expressions/assignment/destructuring/obj-prop-elem-target-yield-expr.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-elem-target-yield-expr.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of an
+    AssignmentElement and within a generator function body, it should behave as
+    a YieldExpression.
+es6id: 12.14.5.4
+features: [generators]
+---*/
+
+var value = { x: 23 };
+var x = {};
+var assignmentResult, iterationResult, iter;
+
+iter = (function*() {
+  assignmentResult = { x: x[yield] } = value;
+}());
+
+iterationResult = iter.next();
+
+assert.sameValue(assignmentResult, undefined);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, false);
+assert.sameValue(x.prop, undefined);
+
+iterationResult = iter.next('prop');
+
+assert.sameValue(assignmentResult, value);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, true);
+assert.sameValue(x.prop, 23);

--- a/test/language/expressions/assignment/destructuring/obj-prop-elem-target-yield-ident-invalid.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-elem-target-yield-ident-invalid.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of an
+    AssignmentElement and outside of a generator function body, it should
+    behave as an IdentifierReference.
+es6id: 12.14.5.4
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+var x = {};
+0, { x: x[yield] } = {};

--- a/test/language/expressions/assignment/destructuring/obj-prop-elem-target-yield-ident-valid.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-elem-target-yield-ident-valid.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the DestructuringAssignmentTarget of an
+    AssignmentElement and outside of a generator function body, it should
+    behave as an IdentifierReference.
+es6id: 12.14.5.4
+flags: [noStrict]
+---*/
+
+var value = { x: 23 };
+var yield = 'prop';
+var x = {};
+var result;
+
+result = { x: x[yield] } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x.prop, 23);

--- a/test/language/expressions/assignment/destructuring/obj-prop-identifier-resolution.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-identifier-resolution.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Evaluation of DestructuringAssignmentTarget.
+es6id: 12.14.5.4
+---*/
+
+var result, value, w, x, y;
+
+x = null;
+value = { a: 1 };
+result = { a: x } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 1);
+
+x = null;
+value = { a: 2 };
+result = { a: x, } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 2);
+
+x = null;
+value = { a: 3 };
+result = { a: x, y } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 3);
+
+x = null;
+value = { a: 4 };
+result = { w, a: x } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 4);
+
+x = null;
+value = { a: 5 };
+result = { w, a: x, y } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 5);

--- a/test/language/expressions/assignment/destructuring/obj-prop-name-evaluation-error.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-name-evaluation-error.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Any error raised as a result of evaluating PropertyName should be forwarded
+    to the runtime.
+es6id: 12.14.5.2
+---*/
+
+var a, x;
+
+assert.throws(TypeError, function() {
+  ({ [a.b]: x } = {});
+});

--- a/test/language/expressions/assignment/destructuring/obj-prop-name-evaluation.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-name-evaluation.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    PropertyName of an AssignmentProperty may be a ComputedPropertyName.
+es6id: 12.14.5.2
+---*/
+
+var value = { x: 1, xy: 23, y: 2 };
+var result, x, y, xy;
+
+result = { ['x' + 'y']: x } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 23);
+assert.sameValue(y, undefined);
+assert.sameValue(xy, undefined);

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-array-invalid.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-array-invalid.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    It is a Syntax Error if LeftHandSideExpression is either an ObjectLiteral
+    or an ArrayLiteral and if the lexical token sequence matched by
+    LeftHandSideExpression cannot be parsed with no tokens left over using
+    AssignmentPattern as the goal symbol.
+es6id: 12.14.5.1
+negative: SyntaxError
+---*/
+
+var x, y;
+
+({ x: [(x, y)] } = { x: [] });

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-array-null.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-array-null.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal and the value is
+    `null`, a TypeError should be thrown.
+es6id: 12.14.5.4
+---*/
+
+var x;
+
+assert.throws(TypeError, function() {
+  ({ x: [ x ] } = { x: null });
+});

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-array-undefined-own.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-array-undefined-own.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal and the value is
+    `undefined`, a TypeError should be thrown.
+es6id: 12.14.5.4
+---*/
+
+var x;
+
+assert.throws(TypeError, function() {
+  ({ x: [ x ] } = { x: undefined });
+});

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-array-undefined.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-array-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal and the value is not
+    defined, a TypeError should be thrown.
+es6id: 12.14.5.4
+---*/
+
+var x;
+
+assert.throws(TypeError, function() {
+  ({ x: [ x ] } = {});
+});

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-array-yield-expr.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-array-yield-expr.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of a nested
+    destructuring assignment and within a generator function body, it should
+    behave as a YieldExpression.
+es6id: 12.14.5.4
+features: [generators]
+---*/
+
+var value = { x: [] };
+var assignmentResult, iterationResult, iter, x;
+
+iter = (function*() {
+  assignmentResult = { x: [x = yield] } = value;
+}());
+
+iterationResult = iter.next();
+
+assert.sameValue(assignmentResult = undefined);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, false);
+assert.sameValue(x, undefined);
+
+iterationResult = iter.next(24601);
+
+assert.sameValue(assignmentResult, value);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, true);
+assert.sameValue(x, 24601);

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-array-yield-ident-invalid.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-array-yield-ident-invalid.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of a nested
+    destructuring assignment and outside of a generator function body, it
+    should behave as an IdentifierReference.
+es6id: 12.14.5.4
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+var x;
+0, { x: [x = yield] } = { x: [] };

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-array-yield-ident-valid.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-array-yield-ident-valid.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of a nested
+    destructuring assignment and outside of a generator function body, it
+    should behave as an IdentifierReference.
+es6id: 12.14.5.4
+flags: [noStrict]
+---*/
+
+var value = { x: [] };
+var yield = 22;
+var result, x;
+
+result = { x: [x = yield] } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 22);

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-array.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-array.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an array literal, it should be parsed
+    parsed as a DestructuringAssignmentPattern and evaluated as a destructuring
+    assignment.
+es6id: 12.14.5.4
+---*/
+
+var value = { x: [321] };
+var result, y;
+
+result = { x: [y] } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(y, 321);

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-obj-invalid.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-obj-invalid.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    It is a Syntax Error if LeftHandSideExpression is either
+    an ObjectLiteral or an ArrayLiteral and if the lexical
+    token sequence matched by LeftHandSideExpression cannot be
+    parsed with no tokens left over using AssignmentPattern as
+    the goal symbol.
+es6id: 12.14.5.1
+negative: SyntaxError
+---*/
+
+({ x: { get x() {} } } = { x: {} });

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-obj-null.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-obj-null.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an object literal and the value is
+    `null`, a TypeError should be thrown.
+es6id: 12.14.5.4
+---*/
+
+var x;
+
+assert.throws(TypeError, function() {
+  ({ x: { x } } = { x: null });
+});

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-obj-undefined-own.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-obj-undefined-own.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an object literal and the value is
+    `undefined`, a TypeError should be thrown.
+es6id: 12.14.5.4
+---*/
+
+var x;
+
+assert.throws(TypeError, function() {
+  ({ x: { x } } = { x: undefined });
+});

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-obj-undefined.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-obj-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an object literal and the value is
+    not defined, a TypeError should be thrown.
+es6id: 12.14.5.4
+---*/
+
+var x;
+
+assert.throws(TypeError, function() {
+  ({ x: { x } } = {});
+});

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-obj-yield-expr.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-obj-yield-expr.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of a nested
+    destructuring assignment and within a generator function body, it should
+    behave as a YieldExpression.
+es6id: 12.14.5.4
+features: [generators]
+---*/
+
+var value = { x: {} };
+var assignmentResult, iterationResult, iter, x;
+
+iter = (function*() {
+  assignmentResult = { x: { x = yield } } = value;
+}());
+
+iterationResult = iter.next();
+
+assert.sameValue(assignmentResult, undefined);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, false);
+assert.sameValue(x, undefined);
+
+iterationResult = iter.next(4);
+
+assert.sameValue(assignmentResult, value);
+assert.sameValue(iterationResult.value, undefined);
+assert.sameValue(iterationResult.done, true);
+assert.sameValue(x, 4);

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-obj-yield-ident-invalid.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-obj-yield-ident-invalid.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of a nested
+    destructuring assignment and outside of a generator function body, it
+    should behave as an IdentifierReference.
+es6id: 12.14.5.4
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+var x;
+0, { x: { x = yield } } = { x: {} };

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-obj-yield-ident-valid.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-obj-yield-ident-valid.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When a `yield` token appears within the Initializer of a nested
+    destructuring assignment and outside of a generator function body, it
+    should behave as an IdentifierReference.
+es6id: 12.14.5.4
+flags: [noStrict]
+---*/
+
+var value = { x: {} };
+var yield = 2;
+var result, x;
+
+result = { x: { x = yield } } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 2);

--- a/test/language/expressions/assignment/destructuring/obj-prop-nested-obj.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-nested-obj.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When DestructuringAssignmentTarget is an object literal, it should be
+    parsed as a DestructuringAssignmentPattern and evaluated as a destructuring
+    assignment.
+es6id: 12.14.5.4
+---*/
+
+var value = { x: { y: 2 } };
+var result, y;
+
+result = { x: { y } } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(y, 2);

--- a/test/language/expressions/assignment/destructuring/obj-prop-put-const.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-put-const.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The assignment target should obey `const` semantics.
+es6id: 12.14.5.4
+features: [const]
+---*/
+
+const c = 1;
+
+assert.throws(TypeError, function() {
+  ({ a: c } = { a: 2 });
+});

--- a/test/language/expressions/assignment/destructuring/obj-prop-put-let.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-put-let.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The assignment target should obey `let` semantics.
+es6id: 12.14.5.4
+features: [let]
+---*/
+
+assert.throws(ReferenceError, function() {
+  ({ a: x } = {});
+  let x;
+});

--- a/test/language/expressions/assignment/destructuring/obj-prop-put-order.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-put-order.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The AssignmentElements in an AssignmentElementList are evaluated in left-
+    to-right order.
+es6id: 12.14.5.4
+---*/
+
+var value = { a: 2, z: 1 };
+var x, result;
+
+result = { z: x, a: x } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x, 2);

--- a/test/language/expressions/assignment/destructuring/obj-prop-put-prop-ref-no-get.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-put-prop-ref-no-get.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    If the DestructuringAssignmentTarget of an AssignmentElement is a
+    PropertyReference, it should not be evaluated.
+es6id: 12.14.5.4
+---*/
+
+var value = { a: 23 };
+var x, setValue, result;
+x = {
+  get y() {
+    $ERROR('The property should not be accessed.');
+  },
+  set y(val) {
+    setValue = val;
+  }
+};
+
+result = { a: x.y } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(setValue, 23);

--- a/test/language/expressions/assignment/destructuring/obj-prop-put-prop-ref-user-err.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-put-prop-ref-user-err.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Any error raised as a result of setting the value should be forwarded to
+    the runtime.
+es6id: 12.14.5.4
+---*/
+
+var value = { a: 23 };
+var x = {
+  set y(val) {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  ({ a: x.y } = value);
+});

--- a/test/language/expressions/assignment/destructuring/obj-prop-put-prop-ref.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-put-prop-ref.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The DestructuringAssignmentTarget of an AssignmentElement may be a
+    PropertyReference.
+es6id: 12.14.5.4
+---*/
+
+var value = { xy: 4 };
+var x = {};
+var result;
+
+result = { xy: x.y } = value;
+
+assert.sameValue(result, value);
+assert.sameValue(x.y, 4);

--- a/test/language/expressions/assignment/destructuring/obj-prop-put-unresolvable-no-strict.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-put-unresolvable-no-strict.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Outside of strict mode, if the the assignment target is an unresolvable
+    reference, a new `var` binding should be created in the environment record.
+es6id: 12.14.5.4
+flags: [noStrict]
+---*/
+
+{
+  ({ x: unresolvable } = {});
+}
+
+assert.sameValue(unresolvable, undefined);

--- a/test/language/expressions/assignment/destructuring/obj-prop-put-unresolvable-strict.js
+++ b/test/language/expressions/assignment/destructuring/obj-prop-put-unresolvable-strict.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    In strict mode, if the the assignment target is an unresolvable reference,
+    a ReferenceError should be thrown.
+es6id: 12.14.5.4
+flags: [onlyStrict]
+---*/
+
+assert.throws(ReferenceError, function() {
+  ({ x: unresolvable } = {});
+});

--- a/test/language/expressions/assignment/destructuring/object-empty.js
+++ b/test/language/expressions/assignment/destructuring/object-empty.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    An ObjectAssignmentPattern without an AssignmentPropertyList requires
+    object-coercible values and throws for other values.
+es6id: 12.14.5.2
+---*/
+
+var value, result;
+
+assert.throws(TypeError, function() {
+  0, {} = undefined;
+});
+
+assert.throws(TypeError, function() {
+  0, {} = null;
+});
+
+result = {} = true;
+
+assert.sameValue(result, true);
+
+result = {} = 1;
+
+assert.sameValue(result, 1);
+
+result = {} = 'string literal';
+
+assert.sameValue(result, 'string literal');
+
+value = Symbol('s');
+result = {} = value;
+
+assert.sameValue(result, value);
+
+value = {};
+result = {} = value;
+
+assert.sameValue(result, value);


### PR DESCRIPTION
@bterlson This does not include coverage for destructuring binding patterns. Those tests will have so much in common with the tests for destructuring assignment that I thought it best to get feedback on these before starting.