### PR TITLE
S15.4.4.5_A3.1_T1.js: Fix inconsistent error message

### DIFF
--- a/test/built-ins/Array/prototype/join/S15.4.4.5_A3.1_T1.js
+++ b/test/built-ins/Array/prototype/join/S15.4.4.5_A3.1_T1.js
@@ -48,5 +48,5 @@ if (x.join(undefined) !== "0,1,2,3") {
 
 //CHECK#7
 if (x.join(NaN) !== "0NaN1NaN2NaN3") {
-  $ERROR('#7: x = new Array(0,1,2,3); x.join("NaN") === "0NaN1NaN2NaN3". Actual: ' + (x.join("NaN")));
+  $ERROR('#7: x = new Array(0,1,2,3); x.join(NaN) === "0NaN1NaN2NaN3". Actual: ' + (x.join(NaN)));
 }


### PR DESCRIPTION
Test for x.join(NaN) reports an error using the content of x.join("NaN"). This is confusing.