### PR TITLE
Use a very negative number so ES5 implementations don't loop forever

### DIFF
--- a/test/built-ins/Array/prototype/concat/Array.prototype.concat_array-like-negative-length.js
+++ b/test/built-ins/Array/prototype/concat/Array.prototype.concat_array-like-negative-length.js
@@ -9,14 +9,14 @@ description: Array.prototype.concat array like negative length
 includes: [compareArray.js]
 ---*/
 var obj = {
-  "length": -6,
+  "length": -4294967294,
   "1": "A",
   "3": "B",
   "5": "C"
 };
 obj[Symbol.isConcatSpreadable] = true;
 assert(compareArray([].concat(obj), []));
-obj.length = -6.7;
+obj.length = -4294967294;
 assert(compareArray([].concat(obj), []));
-obj.length = "-6";
+obj.length = "-4294967294";
 assert(compareArray([].concat(obj), []));


### PR DESCRIPTION
Since ES5 uses ToUint32, this test will cause those implementations to loop for a very long time. This uses a much more negative number so ES5 impls will still fail but not loop forever.