### PR TITLE
Assignment with left-hand side property accessor

### DIFF
--- a/test/language/expressions/assignment/S11.13.1_A7_T1.js
+++ b/test/language/expressions/assignment/S11.13.1_A7_T1.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    null value.
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] = expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] = expr();
+});

--- a/test/language/expressions/assignment/S11.13.1_A7_T2.js
+++ b/test/language/expressions/assignment/S11.13.1_A7_T2.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    undefined value.
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] = expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] = expr();
+});

--- a/test/language/expressions/assignment/S11.13.1_A7_T3.js
+++ b/test/language/expressions/assignment/S11.13.1_A7_T3.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. Evaluating
+    ToPropertyKey(prop) throws an error.
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = {};
+  var prop = {
+    toString: function() {
+      throw new DummyError();
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] = expr();
+});

--- a/test/language/expressions/assignment/S11.13.1_A7_T4.js
+++ b/test/language/expressions/assignment/S11.13.1_A7_T4.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. ToPropertyKey(prop)
+    is only called once.
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return "";
+  }
+};
+var expr = function() {
+  return 0;
+};
+
+base[prop] = expr();

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.10_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.10_T1.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    null value.
+    Check operator is "x ^= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] ^= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] ^= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.10_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.10_T2.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    undefined value.
+    Check operator is "x ^= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] ^= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] ^= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.10_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.10_T3.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. Evaluating
+    ToPropertyKey(prop) throws an error.
+    Check operator is "x ^= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = {};
+  var prop = {
+    toString: function() {
+      throw new DummyError();
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] ^= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.10_T4.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.10_T4.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. ToPropertyKey(prop)
+    is only called once.
+    Check operator is "x ^= y".
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return "";
+  }
+};
+var expr = function() {
+  return 0;
+};
+
+base[prop] ^= expr();

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.11_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.11_T1.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    null value.
+    Check operator is "x |= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] |= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] |= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.11_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.11_T2.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    undefined value.
+    Check operator is "x |= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] |= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] |= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.11_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.11_T3.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. Evaluating
+    ToPropertyKey(prop) throws an error.
+    Check operator is "x |= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = {};
+  var prop = {
+    toString: function() {
+      throw new DummyError();
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] |= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.11_T4.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.11_T4.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. ToPropertyKey(prop)
+    is only called once.
+    Check operator is "x |= y".
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return "";
+  }
+};
+var expr = function() {
+  return 0;
+};
+
+base[prop] |= expr();

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.1_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.1_T1.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    null value.
+    Check operator is "x *= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] *= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] *= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.1_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.1_T2.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    undefined value.
+    Check operator is "x *= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] *= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] *= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.1_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.1_T3.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. Evaluating
+    ToPropertyKey(prop) throws an error.
+    Check operator is "x *= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = {};
+  var prop = {
+    toString: function() {
+      throw new DummyError();
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] *= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.1_T4.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.1_T4.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. ToPropertyKey(prop)
+    is only called once.
+    Check operator is "x *= y".
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return "";
+  }
+};
+var expr = function() {
+  return 0;
+};
+
+base[prop] *= expr();

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.2_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.2_T1.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    null value.
+    Check operator is "x /= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] /= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] /= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.2_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.2_T2.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    undefined value.
+    Check operator is "x /= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] /= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] /= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.2_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.2_T3.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. Evaluating
+    ToPropertyKey(prop) throws an error.
+    Check operator is "x /= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = {};
+  var prop = {
+    toString: function() {
+      throw new DummyError();
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] /= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.2_T4.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.2_T4.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. ToPropertyKey(prop)
+    is only called once.
+    Check operator is "x /= y".
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return "";
+  }
+};
+var expr = function() {
+  return 0;
+};
+
+base[prop] /= expr();

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.3_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.3_T1.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    null value.
+    Check operator is "x %= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] %= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] %= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.3_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.3_T2.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    undefined value.
+    Check operator is "x %= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] %= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] %= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.3_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.3_T3.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. Evaluating
+    ToPropertyKey(prop) throws an error.
+    Check operator is "x %= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = {};
+  var prop = {
+    toString: function() {
+      throw new DummyError();
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] %= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.3_T4.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.3_T4.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. ToPropertyKey(prop)
+    is only called once.
+    Check operator is "x %= y".
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return "";
+  }
+};
+var expr = function() {
+  return 0;
+};
+
+base[prop] %= expr();

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.4_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.4_T1.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    null value.
+    Check operator is "x += y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] += expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] += expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.4_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.4_T2.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    undefined value.
+    Check operator is "x += y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] += expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] += expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.4_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.4_T3.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. Evaluating
+    ToPropertyKey(prop) throws an error.
+    Check operator is "x += y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = {};
+  var prop = {
+    toString: function() {
+      throw new DummyError();
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] += expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.4_T4.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.4_T4.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. ToPropertyKey(prop)
+    is only called once.
+    Check operator is "x += y".
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return "";
+  }
+};
+var expr = function() {
+  return 0;
+};
+
+base[prop] += expr();

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.5_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.5_T1.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    null value.
+    Check operator is "x -= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] -= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] -= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.5_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.5_T2.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    undefined value.
+    Check operator is "x -= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] -= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] -= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.5_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.5_T3.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. Evaluating
+    ToPropertyKey(prop) throws an error.
+    Check operator is "x -= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = {};
+  var prop = {
+    toString: function() {
+      throw new DummyError();
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] -= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.5_T4.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.5_T4.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. ToPropertyKey(prop)
+    is only called once.
+    Check operator is "x -= y".
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return "";
+  }
+};
+var expr = function() {
+  return 0;
+};
+
+base[prop] -= expr();

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.6_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.6_T1.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    null value.
+    Check operator is "x <<= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] <<= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] <<= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.6_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.6_T2.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    undefined value.
+    Check operator is "x <<= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] <<= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] <<= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.6_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.6_T3.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. Evaluating
+    ToPropertyKey(prop) throws an error.
+    Check operator is "x <<= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = {};
+  var prop = {
+    toString: function() {
+      throw new DummyError();
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] <<= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.6_T4.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.6_T4.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. ToPropertyKey(prop)
+    is only called once.
+    Check operator is "x <<= y".
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return "";
+  }
+};
+var expr = function() {
+  return 0;
+};
+
+base[prop] <<= expr();

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.7_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.7_T1.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    null value.
+    Check operator is "x >>= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] >>= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] >>= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.7_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.7_T2.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    undefined value.
+    Check operator is "x >>= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] >>= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] >>= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.7_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.7_T3.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. Evaluating
+    ToPropertyKey(prop) throws an error.
+    Check operator is "x >>= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = {};
+  var prop = {
+    toString: function() {
+      throw new DummyError();
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] >>= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.7_T4.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.7_T4.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. ToPropertyKey(prop)
+    is only called once.
+    Check operator is "x >>= y".
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return "";
+  }
+};
+var expr = function() {
+  return 0;
+};
+
+base[prop] >>= expr();

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.8_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.8_T1.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    null value.
+    Check operator is "x >>>= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] >>>= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] >>>= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.8_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.8_T2.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    undefined value.
+    Check operator is "x >>>= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] >>>= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] >>>= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.8_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.8_T3.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. Evaluating
+    ToPropertyKey(prop) throws an error.
+    Check operator is "x >>>= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = {};
+  var prop = {
+    toString: function() {
+      throw new DummyError();
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] >>>= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.8_T4.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.8_T4.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. ToPropertyKey(prop)
+    is only called once.
+    Check operator is "x >>>= y".
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return "";
+  }
+};
+var expr = function() {
+  return 0;
+};
+
+base[prop] >>>= expr();

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.9_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.9_T1.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    null value.
+    Check operator is "x &= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] &= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] &= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.9_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.9_T2.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. base is the
+    undefined value.
+    Check operator is "x &= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop()] &= expr();
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] &= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.9_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.9_T3.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. Evaluating
+    ToPropertyKey(prop) throws an error.
+    Check operator is "x &= y".
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = {};
+  var prop = {
+    toString: function() {
+      throw new DummyError();
+    }
+  };
+  var expr = function() {
+    $ERROR("right-hand side expression evaluated");
+  };
+
+  base[prop] &= expr();
+});

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.9_T4.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.9_T4.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Compound Assignment Operator evaluates its operands from left to right.
+description: >
+    The left-hand side expression is evaluated before the right-hand side.
+    Left-hand side expression is MemberExpression: base[prop]. ToPropertyKey(prop)
+    is only called once.
+    Check operator is "x &= y".
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return "";
+  }
+};
+var expr = function() {
+  return 0;
+};
+
+base[prop] &= expr();


### PR DESCRIPTION
The assignment operator evaluates its operands from left to right. When
the left-hand side expression is a property accessor, RequireObjectCoercible
and ToPropertyKey are called on the property accessor before the right-hand
side expression is evaluated.