### PR TITLE
Increment/Decrement with property accessor expression

### DIFF
--- a/test/language/expressions/postfix-decrement/S11.3.2_A6_T1.js
+++ b/test/language/expressions/postfix-decrement/S11.3.2_A6_T1.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x-- evaluates its reference expression once.
+description: >
+    The operand expression is evaluated exactly once. Operand expression is
+    MemberExpression: base[prop]. base is the null value.
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+
+  base[prop()]--;
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+
+  base[prop]--;
+});

--- a/test/language/expressions/postfix-decrement/S11.3.2_A6_T2.js
+++ b/test/language/expressions/postfix-decrement/S11.3.2_A6_T2.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x-- evaluates its reference expression once.
+description: >
+    The operand expression is evaluated exactly once. Operand expression is
+    MemberExpression: base[prop]. base is the undefined value.
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+
+  base[prop()]--;
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+
+  base[prop]--;
+});

--- a/test/language/expressions/postfix-decrement/S11.3.2_A6_T3.js
+++ b/test/language/expressions/postfix-decrement/S11.3.2_A6_T3.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x-- evaluates its reference expression once.
+description: >
+    The operand expression is evaluated exactly once. Operand expression is
+    MemberExpression: base[prop]. ToPropertyKey(prop) is not called multiple
+    times.
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return 1;
+  }
+};
+
+base[prop]--;

--- a/test/language/expressions/postfix-increment/S11.3.1_A6_T1.js
+++ b/test/language/expressions/postfix-increment/S11.3.1_A6_T1.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x++ evaluates its reference expression once.
+description: >
+    The operand expression is evaluated exactly once. Operand expression is
+    MemberExpression: base[prop]. base is the null value.
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+
+  base[prop()]++;
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+
+  base[prop]++;
+});

--- a/test/language/expressions/postfix-increment/S11.3.1_A6_T2.js
+++ b/test/language/expressions/postfix-increment/S11.3.1_A6_T2.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x++ evaluates its reference expression once.
+description: >
+    The operand expression is evaluated exactly once. Operand expression is
+    MemberExpression: base[prop]. base is the undefined value.
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+
+  base[prop()]++;
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+
+  base[prop]++;
+});

--- a/test/language/expressions/postfix-increment/S11.3.1_A6_T3.js
+++ b/test/language/expressions/postfix-increment/S11.3.1_A6_T3.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator x++ evaluates its reference expression once.
+description: >
+    The operand expression is evaluated exactly once. Operand expression is
+    MemberExpression: base[prop]. ToPropertyKey(prop) is not called multiple
+    times.
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return 1;
+  }
+};
+
+base[prop]++;

--- a/test/language/expressions/prefix-decrement/S11.4.5_A6_T1.js
+++ b/test/language/expressions/prefix-decrement/S11.4.5_A6_T1.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator --x evaluates its reference expression once.
+description: >
+    The operand expression is evaluated exactly once. Operand expression is
+    MemberExpression: base[prop]. base is the null value.
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+
+  --base[prop()];
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+
+  --base[prop];
+});

--- a/test/language/expressions/prefix-decrement/S11.4.5_A6_T2.js
+++ b/test/language/expressions/prefix-decrement/S11.4.5_A6_T2.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator --x evaluates its reference expression once.
+description: >
+    The operand expression is evaluated exactly once. Operand expression is
+    MemberExpression: base[prop]. base is the undefined value.
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+
+  --base[prop()];
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+
+  --base[prop];
+});

--- a/test/language/expressions/prefix-decrement/S11.4.5_A6_T3.js
+++ b/test/language/expressions/prefix-decrement/S11.4.5_A6_T3.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator --x evaluates its reference expression once.
+description: >
+    The operand expression is evaluated exactly once. Operand expression is
+    MemberExpression: base[prop]. ToPropertyKey(prop) is not called multiple
+    times.
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return 1;
+  }
+};
+
+--base[prop];

--- a/test/language/expressions/prefix-increment/S11.4.4_A6_T1.js
+++ b/test/language/expressions/prefix-increment/S11.4.4_A6_T1.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator ++x evaluates its reference expression once.
+description: >
+    The operand expression is evaluated exactly once. Operand expression is
+    MemberExpression: base[prop]. base is the null value.
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = null;
+  var prop = function() {
+    throw new DummyError();
+  };
+
+  ++base[prop()];
+});
+
+assert.throws(TypeError, function() {
+  var base = null;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+
+  ++base[prop];
+});

--- a/test/language/expressions/prefix-increment/S11.4.4_A6_T2.js
+++ b/test/language/expressions/prefix-increment/S11.4.4_A6_T2.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator ++x evaluates its reference expression once.
+description: >
+    The operand expression is evaluated exactly once. Operand expression is
+    MemberExpression: base[prop]. base is the undefined value.
+---*/
+
+function DummyError() { }
+
+assert.throws(DummyError, function() {
+  var base = undefined;
+  var prop = function() {
+    throw new DummyError();
+  };
+
+  ++base[prop()];
+});
+
+assert.throws(TypeError, function() {
+  var base = undefined;
+  var prop = {
+    toString: function() {
+      $ERROR("property key evaluated");
+    }
+  };
+
+  ++base[prop];
+});

--- a/test/language/expressions/prefix-increment/S11.4.4_A6_T3.js
+++ b/test/language/expressions/prefix-increment/S11.4.4_A6_T3.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: Operator ++x evaluates its reference expression once.
+description: >
+    The operand expression is evaluated exactly once. Operand expression is
+    MemberExpression: base[prop]. ToPropertyKey(prop) is not called multiple
+    times.
+---*/
+
+var propKeyEvaluated = false;
+var base = {};
+var prop = {
+  toString: function() {
+    assert(!propKeyEvaluated);
+    propKeyEvaluated = true;
+    return 1;
+  }
+};
+
+++base[prop];


### PR DESCRIPTION
The increment/decrement operator evaluates its operand expression once. When
the operand expression is a property accessor, RequireObjectCoercible
and ToPropertyKey are called on the property accessor in the correct order.