### PR TITLE
Add tests for IdentifierReference as property

### DIFF
--- a/test/language/expressions/object/prop-def-id-eval-error-2.js
+++ b/test/language/expressions/object/prop-def-id-eval-error-2.js
@@ -1,0 +1,22 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5.9
+description: >
+    Errors thrown during IdentifierReference evaluation are forwarded to the
+    runtime.
+flags: [noStrict]
+features: [Proxy]
+---*/
+
+var p = new Proxy({}, {
+  has: function () {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  with (p) {
+    ({attr});
+  }
+});

--- a/test/language/expressions/object/prop-def-id-eval-error.js
+++ b/test/language/expressions/object/prop-def-id-eval-error.js
@@ -1,0 +1,21 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5.9
+description: >
+    Errors thrown during IdentifierReference evaluation are forwarded to the
+    runtime.
+flags: [noStrict]
+features: [Symbol, Symbol.unscopables]
+---*/
+
+var obj = {
+  attr: null,
+  get [Symbol.unscopables]() { throw new Test262Error(); }
+};
+
+assert.throws(Test262Error, function() {
+  with (obj) {
+    ({ attr });
+  }
+});

--- a/test/language/expressions/object/prop-def-id-get-error.js
+++ b/test/language/expressions/object/prop-def-id-get-error.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5.9
+description: >
+    Errors thrown during IdentifierReference value retrieval are forwarded to
+    the runtime.
+---*/
+
+assert.throws(ReferenceError, function() {
+  ({ unresolvable });
+});

--- a/test/language/expressions/object/prop-def-id-valid.js
+++ b/test/language/expressions/object/prop-def-id-valid.js
@@ -1,0 +1,21 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 12.2.5.9
+description: >
+    When a valid IdentifierReference appears in an object initializer, a new
+    data property is created. The property name is the string value of the
+    identifier, the property value is the value of the identifier, and the
+    property is enumerable, writable, and configurable.
+includes: [propertyHelper.js]
+---*/
+
+var attr = 23;
+var obj;
+
+obj = { attr };
+
+assert.sameValue(obj.attr, 23);
+verifyEnumerable(obj, 'attr');
+verifyWritable(obj, 'attr');
+verifyConfigurable(obj, 'attr');


### PR DESCRIPTION
There are three unique error cases for this production:

1. Identifier resolution
2. Value retrieval
3. Property creation

Testing (1) was difficult. Neither [ResolveBinding](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-resolvebinding) nor [GetIdentifierReference](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-getidentifierreference) throw an error, but the latter delegates to [HasBinding](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-declarative-environment-records-hasbinding-n). HasBinding never returns an abrupt completion for Declarative Environment Records, so I had to resort to using an Object Environment Record via a `with` statement. In addition to disqualifying strict mode, this approach requires a Symbol to trigger the error. I recognize that these semantics represent a heavy requirement for this test, though, and I would welcome a simpler alternative. 

Testing (2) was straightforward--[any unresolvable reference would generate an error from GetValue](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-getvalue). 

I don't think it's possible to test (3). [CreateDataPropertyOrThrow](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createdatapropertyorthrow) will only return an abrupt completion if [CreateDataProperty (O, P, V)](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-createdataproperty) returns an abrupt completion or `false`. I don't think either of these situations can occur because O in all cases will be a plain object with zero or more properties (all of which must be writable, enumerable, and configurable--I can't think of a way to initialize an object with any other kind of property). I'm likely missing something, but if my reasoning is sound, then I'll follow up with a bug against ECMAScript to simplify the spec. 