### PR TITLE
S15.4.4.4_A4.1 length enumerable should be checked on Array.prototype.concat

### DIFF
--- a/test/built-ins/Array/prototype/concat/S15.4.4.4_A4.1.js
+++ b/test/built-ins/Array/prototype/concat/S15.4.4.4_A4.1.js
@@ -14,7 +14,7 @@ if (Array.prototype.concat.propertyIsEnumerable('length') !== false) {
 
 //CHECK#2
 var result = true;
-for (var p in Array.concat){
+for (var p in Array.prototype.concat){
   if (p === "length") {
     result = false;
   }  


### PR DESCRIPTION
The test checks Array.concat which is undefined; instead it should check Array.prototype.concat.