### PR TITLE
Add tests for Proxy

### DIFF
--- a/test/built-ins/Proxy/apply/call-parameters.js
+++ b/test/built-ins/Proxy/apply/call-parameters.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.13
+description: >
+    trap is called with handler object as its context, and parameters are:
+    target, the call context and and an array list with the called arguments
+info: >
+    [[Call]] (thisArgument, argumentsList)
+
+    9. Return Call(trap, handler, «target, thisArgument, argArray»).
+---*/
+
+var _target, _args, _handler, _context;
+var target = function(a, b) { return a + b; };
+var handler = {
+    apply: function(t, c, args) {
+        _handler = this;
+        _target = t;
+        _context = c;
+        _args = args;
+    }
+};
+var p = new Proxy(target, handler);
+
+var context = {};
+
+p.call(context, 1, 2);
+
+assert.sameValue(_handler, handler, "trap context is the handler object");
+assert.sameValue(_target, target, "first parameter is the target object");
+assert.sameValue(_context, context, "second parameter is the call context");
+assert.sameValue(_args.length, 2, "arguments list contains all call arguments");
+assert.sameValue(_args[0], 1, "arguments list has first call argument");
+assert.sameValue(_args[1], 2, "arguments list has second call argument");

--- a/test/built-ins/Proxy/apply/call-result.js
+++ b/test/built-ins/Proxy/apply/call-result.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.13
+description: >
+    Return the result from the trap method.
+info: >
+    [[Call]] (thisArgument, argumentsList)
+
+    9. Return Call(trap, handler, «target, thisArgument, argArray»).
+---*/
+
+var target = function(a, b) { return a + b; };
+var result = {};
+var handler = {
+    apply: function(t, c, args) {
+        return result;
+    }
+};
+var p = new Proxy(target, handler);
+
+assert.sameValue(p.call(), result);

--- a/test/built-ins/Proxy/apply/null-handler.js
+++ b/test/built-ins/Proxy/apply/null-handler.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.13
+description: >
+    [[Call]] (thisArgument, argumentsList)
+
+    2. If handler is null, throw a TypeError exception.
+---*/
+
+
+var p = Proxy.revocable(function() {}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    p.proxy();
+});

--- a/test/built-ins/Proxy/apply/return-abrupt.js
+++ b/test/built-ins/Proxy/apply/return-abrupt.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.13
+description: >
+    Return is an abrupt completion
+includes: [Test262Error.js]
+---*/
+
+var target = function(a, b) { return a + b; };
+var p = new Proxy(target, {
+    apply: function(t, c, args) {
+        throw new Test262Error();
+    }
+});
+
+assert.throws(Test262Error, function() {
+    p.call();
+});

--- a/test/built-ins/Proxy/apply/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/apply/trap-is-not-callable.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.13
+description: >
+    Throws if trap is not callable.
+---*/
+
+var p = new Proxy(function() {}, {
+    apply: {}
+});
+
+assert.throws(TypeError, function() {
+    p();
+});

--- a/test/built-ins/Proxy/apply/trap-is-undefined-no-property.js
+++ b/test/built-ins/Proxy/apply/trap-is-undefined-no-property.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.13
+description: >
+    If trap is undefined, propagate the call to the target object.
+info: >
+    [[Call]] (thisArgument, argumentsList)
+
+    7. If trap is undefined, then Return Call(target, thisArgument,
+    argumentsList).
+---*/
+
+var target = function(a, b) {
+    return a + b;
+};
+var p = new Proxy(target, {});
+
+assert.sameValue(p(1, 2), 3);

--- a/test/built-ins/Proxy/apply/trap-is-undefined.js
+++ b/test/built-ins/Proxy/apply/trap-is-undefined.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.13
+description: >
+    If trap is undefined, propagate the call to the target object.
+info: >
+    [[Call]] (thisArgument, argumentsList)
+
+    7. If trap is undefined, then Return Call(target, thisArgument,
+    argumentsList).
+---*/
+
+var target = function(a, b) {
+    return a + b;
+};
+var p = new Proxy(target, {
+    apply: undefined
+});
+
+assert.sameValue(p(1, 2), 3);

--- a/test/built-ins/Proxy/construct/call-parameters.js
+++ b/test/built-ins/Proxy/construct/call-parameters.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.14
+description: >
+    trap is called with handler object as its context, and parameters are:
+    target, an array list with the called arguments and the new target, and the
+    constructor new.target.
+info: >
+    [[Construct]] ( argumentsList, newTarget)
+
+    9. Let newObj be Call(trap, handler, «target, argArray, newTarget »).
+---*/
+
+var _target, _handler, _args, _P;
+function Target() {}
+
+var handler = {
+    construct: function(t, args, newTarget) {
+        _handler = this;
+        _target = t;
+        _args = args;
+        _P = newTarget;
+
+        return new t(args[0], args[1]);
+    }
+};
+var P = new Proxy(Target, handler);
+
+new P(1, 2);
+
+assert.sameValue(_handler, handler, "trap context is the handler object");
+assert.sameValue(_target, Target, "first parameter is the target object");
+assert.sameValue(_args.length, 2, "arguments list contains all call arguments");
+assert.sameValue(_args[0], 1, "arguments list has first call argument");
+assert.sameValue(_args[1], 2, "arguments list has second call argument");
+assert.sameValue(_P, P, "constructor is sent as the third parameter");

--- a/test/built-ins/Proxy/construct/call-result.js
+++ b/test/built-ins/Proxy/construct/call-result.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.14
+description: >
+    Return the result from the trap method.
+info: >
+    [[Construct]] ( argumentsList, newTarget)
+
+    12. Return newObj
+---*/
+
+function Target(a, b) {
+    this.sum = a + b;
+};
+var handler = {
+    construct: function(t, c, args) {
+        return { sum: 42 };
+    }
+};
+var P = new Proxy(Target, handler);
+
+assert.sameValue((new P(1, 2)).sum, 42);

--- a/test/built-ins/Proxy/construct/null-handler.js
+++ b/test/built-ins/Proxy/construct/null-handler.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.14
+description: >
+    [[Construct]] ( argumentsList, newTarget)
+
+    2. If handler is null, throw a TypeError exception.
+---*/
+
+
+var p = Proxy.revocable(function() {}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    new p.proxy();
+});

--- a/test/built-ins/Proxy/construct/return-is-abrupt.js
+++ b/test/built-ins/Proxy/construct/return-is-abrupt.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.14
+description: >
+    Return abrupt from constructor call.
+info: >
+    [[Construct]] ( argumentsList, newTarget)
+
+    9. Let newObj be Call(trap, handler, «target, argArray, newTarget »).
+    10. ReturnIfAbrupt(newObj).
+includes: [Test262Error.js]
+---*/
+
+function Target() {}
+var P = new Proxy(Target, {
+    construct: function() {
+        throw new Test262Error();
+    }
+});
+
+assert.throws(Test262Error, function() {
+    new P();
+});

--- a/test/built-ins/Proxy/construct/return-not-object-throws-boolean.js
+++ b/test/built-ins/Proxy/construct/return-not-object-throws-boolean.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.14
+description: >
+    Throws a TypeError if trap result is not an Object: Boolean
+info: >
+    [[Construct]] ( argumentsList, newTarget)
+
+    11. If Type(newObj) is not Object, throw a TypeError exception.
+---*/
+
+function Target() {
+    this.attr = "done";
+};
+var P = new Proxy(Target, {
+    construct: function() {
+        return true;
+    }
+});
+
+assert.throws(TypeError, function() {
+    new P();
+});

--- a/test/built-ins/Proxy/construct/return-not-object-throws-number.js
+++ b/test/built-ins/Proxy/construct/return-not-object-throws-number.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.14
+description: >
+    Throws a TypeError if trap result is not an Object: Number
+info: >
+    [[Construct]] ( argumentsList, newTarget)
+
+    11. If Type(newObj) is not Object, throw a TypeError exception.
+---*/
+
+function Target() {
+    this.attr = "done";
+};
+var P = new Proxy(Target, {
+    construct: function() {
+        return 0;
+    }
+});
+
+assert.throws(TypeError, function() {
+    new P();
+});

--- a/test/built-ins/Proxy/construct/return-not-object-throws-string.js
+++ b/test/built-ins/Proxy/construct/return-not-object-throws-string.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.14
+description: >
+    Throws a TypeError if trap result is not an Object: String
+info: >
+    [[Construct]] ( argumentsList, newTarget)
+
+    11. If Type(newObj) is not Object, throw a TypeError exception.
+---*/
+
+function Target() {
+    this.attr = "done";
+};
+var P = new Proxy(Target, {
+    construct: function() {
+        return "";
+    }
+});
+
+assert.throws(TypeError, function() {
+    new P();
+});

--- a/test/built-ins/Proxy/construct/return-not-object-throws-symbol.js
+++ b/test/built-ins/Proxy/construct/return-not-object-throws-symbol.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.14
+description: >
+    Throws a TypeError if trap result is not an Object: Symbol
+info: >
+    [[Construct]] ( argumentsList, newTarget)
+
+    11. If Type(newObj) is not Object, throw a TypeError exception.
+features: [Symbol]
+---*/
+
+function Target() {
+    this.attr = "done";
+};
+var P = new Proxy(Target, {
+    construct: function() {
+        return Symbol();
+    }
+});
+
+assert.throws(TypeError, function() {
+    new P();
+});

--- a/test/built-ins/Proxy/construct/return-not-object-throws-undefined.js
+++ b/test/built-ins/Proxy/construct/return-not-object-throws-undefined.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.14
+description: >
+    Throws a TypeError if trap result is not an Object: undefined
+info: >
+    [[Construct]] ( argumentsList, newTarget)
+
+    11. If Type(newObj) is not Object, throw a TypeError exception.
+---*/
+
+function Target() {
+    this.attr = "done";
+};
+var P = new Proxy(Target, {
+    construct: function() {
+        return undefined;
+    }
+});
+
+assert.throws(TypeError, function() {
+    new P();
+});

--- a/test/built-ins/Proxy/construct/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/construct/trap-is-not-callable.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.14
+description: >
+    Throws if trap is not callable.
+---*/
+
+function Target() {}
+var p = new Proxy(Target, {
+    construct: {}
+});
+
+assert.throws(TypeError, function() {
+    new p();
+});

--- a/test/built-ins/Proxy/construct/trap-is-undefined-no-property.js
+++ b/test/built-ins/Proxy/construct/trap-is-undefined-no-property.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.14
+description: >
+    If trap is undefined, propagate the construct to the target object.
+info: >
+    [[Construct]] ( argumentsList, newTarget)
+
+    7. If trap is undefined, then
+        b. Return Construct(target, argumentsList, newTarget).
+---*/
+
+function Target(arg) {
+    this.attr = arg;
+}
+var P = new Proxy(Target, {});
+
+assert.sameValue((new P("foo")).attr, "foo");

--- a/test/built-ins/Proxy/construct/trap-is-undefined.js
+++ b/test/built-ins/Proxy/construct/trap-is-undefined.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.14
+description: >
+    If trap is undefined, propagate the construct to the target object.
+info: >
+    [[Construct]] ( argumentsList, newTarget)
+
+    7. If trap is undefined, then
+        b. Return Construct(target, argumentsList, newTarget).
+---*/
+
+function Target(arg) {
+    this.attr = arg;
+}
+var P = new Proxy(Target, {
+    construct: undefined
+});
+
+assert.sameValue((new P("foo")).attr, "foo");

--- a/test/built-ins/Proxy/constructor.js
+++ b/test/built-ins/Proxy/constructor.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.2.1
+description: >
+    The Proxy constructor is the %Proxy% intrinsic object and the
+    initial value of the Proxy property of the global object.
+---*/
+
+assert.sameValue(typeof Proxy, "function", "`typeof Proxy` is `'function'`");

--- a/test/built-ins/Proxy/create-handler-is-revoked-proxy.js
+++ b/test/built-ins/Proxy/create-handler-is-revoked-proxy.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    Proxy ( target, handler )
+    ...
+    4.  If handler is a Proxy exotic object and the value of the
+    [[ProxyHandler]] internal slot of handler is null, throw a
+    TypeError exception.
+    ...
+---*/
+
+var revocable = Proxy.revocable({}, {});
+
+revocable.revoke();
+
+assert.throws(TypeError, function() {
+    new Proxy({}, revocable.proxy);
+});

--- a/test/built-ins/Proxy/create-handler-not-object-throw-boolean.js
+++ b/test/built-ins/Proxy/create-handler-not-object-throw-boolean.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    Proxy ( target, handler )
+    ...
+    3. If Type(handler) is not Object, throw a TypeError exception.
+    ...
+---*/
+
+assert.throws(TypeError, function() {
+    new Proxy({}, false);
+});

--- a/test/built-ins/Proxy/create-handler-not-object-throw-null.js
+++ b/test/built-ins/Proxy/create-handler-not-object-throw-null.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    Proxy ( target, handler )
+    ...
+    3. If Type(handler) is not Object, throw a TypeError exception.
+    ...
+---*/
+
+assert.throws(TypeError, function() {
+    new Proxy({}, null);
+});

--- a/test/built-ins/Proxy/create-handler-not-object-throw-number.js
+++ b/test/built-ins/Proxy/create-handler-not-object-throw-number.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    Proxy ( target, handler )
+    ...
+    3. If Type(handler) is not Object, throw a TypeError exception.
+    ...
+---*/
+
+assert.throws(TypeError, function() {
+    new Proxy({}, 0);
+});

--- a/test/built-ins/Proxy/create-handler-not-object-throw-string.js
+++ b/test/built-ins/Proxy/create-handler-not-object-throw-string.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    Proxy ( target, handler )
+    ...
+    3. If Type(handler) is not Object, throw a TypeError exception.
+    ...
+---*/
+
+assert.throws(TypeError, function() {
+    new Proxy({}, "");
+});

--- a/test/built-ins/Proxy/create-handler-not-object-throw-symbol.js
+++ b/test/built-ins/Proxy/create-handler-not-object-throw-symbol.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    Proxy ( target, handler )
+    ...
+    3. If Type(handler) is not Object, throw a TypeError exception.
+    ...
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+    new Proxy({}, Symbol());
+});

--- a/test/built-ins/Proxy/create-handler-not-object-throw-undefined.js
+++ b/test/built-ins/Proxy/create-handler-not-object-throw-undefined.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    Proxy ( target, handler )
+    ...
+    3. If Type(handler) is not Object, throw a TypeError exception.
+    ...
+---*/
+
+assert.throws(TypeError, function() {
+    new Proxy({}, undefined);
+});

--- a/test/built-ins/Proxy/create-target-is-not-callable.js
+++ b/test/built-ins/Proxy/create-target-is-not-callable.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    A Proxy exotic object is only callable if the given target is callable.
+info: >
+    Proxy ( target, handler )
+
+    7. If IsCallable(target) is true, then
+        a. Set the [[Call]] internal method of P as specified in 9.5.13.
+    ...
+
+
+    12.3.4.3 Runtime Semantics: EvaluateDirectCall( func, thisValue, arguments,
+    tailPosition )
+
+    4. If IsCallable(func) is false, throw a TypeError exception.
+---*/
+
+var p = new Proxy({}, {});
+
+assert.throws(TypeError, function() {
+    p.call();
+});

--- a/test/built-ins/Proxy/create-target-is-not-constructor.js
+++ b/test/built-ins/Proxy/create-target-is-not-constructor.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    A Proxy exotic object only accepts a constructor call if target is
+    constructor.
+info: >
+    Proxy ( target, handler )
+
+    7. If IsCallable(target) is true, then
+        b. If target has a [[Construct]] internal method, then
+            i. Set the [[Construct]] internal method of P as specified in
+            9.5.14.
+    ...
+
+    12.3.3.1.1 Runtime Semantics: EvaluateNew(constructProduction, arguments)
+
+    8. If IsConstructor (constructor) is false, throw a TypeError exception.
+---*/
+
+var p = new Proxy(eval, {});
+
+p(); // the Proxy object is callable
+
+assert.throws(TypeError, function() {
+    new p();
+});

--- a/test/built-ins/Proxy/create-target-is-revoked-proxy.js
+++ b/test/built-ins/Proxy/create-target-is-revoked-proxy.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    Proxy ( target, handler )
+    ...
+    2. If target is a Proxy exotic object and the value of the
+    [[ProxyHandler]] internal slot of target is null, throw a
+    TypeError exception.
+    ...
+---*/
+
+var revocable = Proxy.revocable({}, {});
+
+revocable.revoke();
+
+assert.throws(TypeError, function() {
+    new Proxy(revocable.proxy, {});
+});

--- a/test/built-ins/Proxy/create-target-not-object-throw-boolean.js
+++ b/test/built-ins/Proxy/create-target-not-object-throw-boolean.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    Proxy ( target, handler )
+    ...
+    1. If Type(target) is not Object, throw a TypeError exception.
+    ...
+---*/
+
+assert.throws(TypeError, function() {
+    new Proxy(false, {});
+});

--- a/test/built-ins/Proxy/create-target-not-object-throw-null.js
+++ b/test/built-ins/Proxy/create-target-not-object-throw-null.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    Proxy ( target, handler )
+    ...
+    1. If Type(target) is not Object, throw a TypeError exception.
+    ...
+---*/
+
+assert.throws(TypeError, function() {
+    new Proxy(null, {});
+});

--- a/test/built-ins/Proxy/create-target-not-object-throw-number.js
+++ b/test/built-ins/Proxy/create-target-not-object-throw-number.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    Proxy ( target, handler )
+    ...
+    1. If Type(target) is not Object, throw a TypeError exception.
+    ...
+---*/
+
+assert.throws(TypeError, function() {
+    new Proxy(0, {});
+});

--- a/test/built-ins/Proxy/create-target-not-object-throw-string.js
+++ b/test/built-ins/Proxy/create-target-not-object-throw-string.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    Proxy ( target, handler )
+    ...
+    1. If Type(target) is not Object, throw a TypeError exception.
+    ...
+---*/
+
+assert.throws(TypeError, function() {
+    new Proxy("", {});
+});

--- a/test/built-ins/Proxy/create-target-not-object-throw-symbol.js
+++ b/test/built-ins/Proxy/create-target-not-object-throw-symbol.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    Proxy ( target, handler )
+    ...
+    1. If Type(target) is not Object, throw a TypeError exception.
+    ...
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+    new Proxy(Symbol(), {});
+});

--- a/test/built-ins/Proxy/create-target-not-object-throw-undefined.js
+++ b/test/built-ins/Proxy/create-target-not-object-throw-undefined.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.15
+description: >
+    Proxy ( target, handler )
+    ...
+    1. If Type(target) is not Object, throw a TypeError exception.
+    ...
+---*/
+
+assert.throws(TypeError, function() {
+    new Proxy(undefined, {});
+});

--- a/test/built-ins/Proxy/defineProperty/call-parameters.js
+++ b/test/built-ins/Proxy/defineProperty/call-parameters.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.6
+description: >
+    Trap is called with handler as context and parameters are target, P, and the
+    descriptor object.
+info: >
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    9. Let descObj be FromPropertyDescriptor(Desc).
+    10. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P,
+    descObj»)).
+    ...
+---*/
+
+var _handler, _target, _prop, _desc;
+var target = {};
+var descriptor = {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: 1
+};
+var handler = {
+    defineProperty: function(t, prop, desc) {
+        _handler = this;
+        _target = t;
+        _prop = prop;
+        _desc = desc;
+
+        return true;
+    }
+};
+var p = new Proxy(target, handler);
+
+Object.defineProperty(p, "attr", descriptor);
+
+assert.sameValue(_handler, handler);
+assert.sameValue(_target, target);
+assert.sameValue(_prop, "attr");
+
+assert.sameValue(
+    Object.keys(_desc).length, 4,
+    "descriptor arg has the same amount of keys as given descriptor"
+);
+
+assert(_desc.configurable);
+assert(_desc.writable);
+assert(_desc.enumerable);
+assert.sameValue(_desc.value, 1);

--- a/test/built-ins/Proxy/defineProperty/null-handler.js
+++ b/test/built-ins/Proxy/defineProperty/null-handler.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.6
+description: >
+    Throws a TypeError exception if handler is null.
+---*/
+
+var p = Proxy.revocable({}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    Object.defineProperty(p.proxy, "foo", {
+        configurable: true,
+        enumerable: true
+    });
+});

--- a/test/built-ins/Proxy/defineProperty/return-boolean-and-define-target.js
+++ b/test/built-ins/Proxy/defineProperty/return-boolean-and-define-target.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.6
+description: >
+    If a property has a corresponding target object property then applying the
+    Property Descriptor of the property to the target object using
+    [[DefineOwnProperty]] will not throw an exception.
+features: [Reflect]
+includes: [propertyHelper.js]
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    defineProperty: function(t, prop, desc) {
+        return Object.defineProperty(t, prop, desc);
+    }
+});
+
+var result = Reflect.defineProperty(p, "attr", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: 1
+});
+
+assert.sameValue(result, true, "result === true");
+
+verifyEqualTo(target, "attr", 1);
+verifyWritable(target, "attr");
+verifyEnumerable(target, "attr");
+verifyConfigurable(target, "attr");
+
+result = Reflect.defineProperty(p, "attr", {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: 2
+});
+
+assert.sameValue(result, true, "result === true");
+
+verifyEqualTo(target, "attr", 2);
+verifyNotWritable(target, "attr");
+verifyNotEnumerable(target, "attr");
+verifyNotConfigurable(target, "attr");

--- a/test/built-ins/Proxy/defineProperty/return-is-abrupt.js
+++ b/test/built-ins/Proxy/defineProperty/return-is-abrupt.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.6
+description: >
+    Trap return is an abrupt.
+info: >
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    10. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P,
+    descObj»)).
+    11. ReturnIfAbrupt(booleanTrapResult).
+    ...
+includes: [Test262Error.js]
+---*/
+
+var p = new Proxy({}, {
+    defineProperty: function(t, prop, desc) {
+        throw new Test262Error();
+    }
+});
+
+assert.throws(Test262Error, function() {
+    Object.defineProperty(p, "foo", {});
+});

--- a/test/built-ins/Proxy/defineProperty/targetdesc-configurable-desc-not-configurable.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-configurable-desc-not-configurable.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.6
+description: >
+    Throw a TypeError exception if Desc is not configurable and target property
+    descriptor is configurable and trap result is true.
+info: >
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    20. Else targetDesc is not undefined,
+        b. If settingConfigFalse is true and targetDesc.[[Configurable]] is
+        true, throw a TypeError exception.
+    ...
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    defineProperty: function(t, prop, desc) {
+        return true;
+    }
+});
+
+Object.defineProperty(target, "foo", {
+    value: 1,
+    configurable: true
+});
+
+assert.throws(TypeError, function() {
+    Object.defineProperty(p, "foo", {
+        value: 1,
+        configurable: false
+    });
+});

--- a/test/built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor-not-configurable-target.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor-not-configurable-target.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.6
+description: >
+    Throw a TypeError exception if Desc and target property descriptor are not
+    compatible and trap result is true.
+info: >
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    20. Else targetDesc is not undefined,
+        a. If IsCompatiblePropertyDescriptor(extensibleTarget, Desc ,
+        targetDesc) is false, throw a TypeError exception.
+    ...
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    defineProperty: function(t, prop, desc) {
+        return true;
+    }
+});
+
+Object.defineProperty(target, "foo", {
+    value: 1,
+    configurable: false
+});
+
+assert.throws(TypeError, function() {
+    Object.defineProperty(p, "foo", {
+        value: 1,
+        configurable: true
+    });
+});

--- a/test/built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.6
+description: >
+    Throw a TypeError exception if Desc and target property descriptor are not
+    compatible and trap result is true.
+info: >
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    20. Else targetDesc is not undefined,
+        a. If IsCompatiblePropertyDescriptor(extensibleTarget, Desc ,
+        targetDesc) is false, throw a TypeError exception.
+    ...
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    defineProperty: function(t, prop, desc) {
+        return true;
+    }
+});
+
+Object.defineProperty(target, "foo", {
+    value: 1
+});
+
+assert.throws(TypeError, function() {
+    Object.defineProperty(p, "foo", {
+        value: 2
+    });
+});

--- a/test/built-ins/Proxy/defineProperty/targetdesc-undefined-not-configurable-descriptor.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-undefined-not-configurable-descriptor.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.6
+description: >
+    Throw a TypeError exception if Desc is not configurable and target property
+    descriptor is undefined, and trap result is true.
+info: >
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    19. If targetDesc is undefined, then
+        ...
+        b. If settingConfigFalse is true, throw a TypeError exception.
+    ...
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    defineProperty: function(t, prop, desc) {
+        return true;
+    }
+});
+
+assert.throws(TypeError, function() {
+    Object.defineProperty(p, "foo", {
+        configurable: false
+    });
+});

--- a/test/built-ins/Proxy/defineProperty/targetdesc-undefined-target-is-not-extensible.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-undefined-target-is-not-extensible.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.6
+description: >
+    Throw a TypeError exception if Desc is not configurable and target is not
+    extensible, and trap result is true.
+info: >
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    19. If targetDesc is undefined, then
+        a. If extensibleTarget is false, throw a TypeError exception.
+    ...
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    defineProperty: function(t, prop, desc) {
+        return true;
+    }
+});
+
+Object.preventExtensions(target);
+
+assert.throws(TypeError, function() {
+    Object.defineProperty(p, "foo", {});
+});

--- a/test/built-ins/Proxy/defineProperty/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/defineProperty/trap-is-not-callable.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.6
+description: >
+    Throw a TypeError exception if trap is not callable.
+info: >
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    6. Let trap be GetMethod(handler, "defineProperty").
+    ...
+        7.3.9 GetMethod (O, P)
+        ...
+        2. Let func be GetV(O, P).
+        5. If IsCallable(func) is false, throw a TypeError exception.
+        ...
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    defineProperty: {}
+});
+
+assert.throws(TypeError, function() {
+    Object.defineProperty(p, "foo", {
+        value: 1
+    });
+});

--- a/test/built-ins/Proxy/defineProperty/trap-is-undefined.js
+++ b/test/built-ins/Proxy/defineProperty/trap-is-undefined.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.6
+description: >
+    Return target.[[DefineOwnProperty]](P, Desc) if trap is undefined.
+info: >
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    8. If trap is undefined, then
+        a. Return target.[[DefineOwnProperty]](P, Desc).
+    ...
+includes: [propertyHelper.js]
+---*/
+
+var target = {};
+var p = new Proxy(target, {});
+
+Object.defineProperty(p, "attr", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: 1
+});
+
+verifyEqualTo(target, "attr", 1);
+verifyWritable(target, "attr");
+verifyEnumerable(target, "attr");
+verifyConfigurable(target, "attr");
+
+Object.defineProperty(p, "attr", {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: 2
+});
+
+verifyEqualTo(target, "attr", 2);
+verifyNotWritable(target, "attr");
+verifyNotEnumerable(target, "attr");
+verifyNotConfigurable(target, "attr");

--- a/test/built-ins/Proxy/defineProperty/trap-return-is-false.js
+++ b/test/built-ins/Proxy/defineProperty/trap-return-is-false.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.6
+description: >
+    Trap returns a boolean. Checking on false values.
+info: >
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    12. If booleanTrapResult is false, return false.
+    ...
+features: [Reflect]
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    defineProperty: function(t, prop, desc) {
+        return 0;
+    }
+});
+
+assert.sameValue(Reflect.defineProperty(p, "attr", {}), false);
+assert.sameValue(
+    Object.getOwnPropertyDescriptor(target, "attr"),
+    undefined
+);

--- a/test/built-ins/Proxy/deleteProperty/boolean-trap-result-boolean-false.js
+++ b/test/built-ins/Proxy/deleteProperty/boolean-trap-result-boolean-false.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.10
+description: >
+    [[Delete]] (P)
+
+    The result is a Boolean value.
+features: [Reflect]
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    deleteProperty: function() {
+        return 0;
+    }
+});
+
+Object.defineProperties(target, {
+    isConfigurable: {
+        value: 1,
+        configurable: true
+    },
+    notConfigurable: {
+        value: 1,
+        configurable: false
+    }
+});
+
+assert.sameValue(Reflect.deleteProperty(p, "attr"), false);
+assert.sameValue(Reflect.deleteProperty(p, "isConfigurable"), false);
+assert.sameValue(Reflect.deleteProperty(p, "notConfigurable"), false);

--- a/test/built-ins/Proxy/deleteProperty/boolean-trap-result-boolean-true.js
+++ b/test/built-ins/Proxy/deleteProperty/boolean-trap-result-boolean-true.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.10
+description: >
+    [[Delete]] (P)
+
+    The result is a Boolean value.
+---*/
+
+var p = new Proxy({}, {
+    deleteProperty: function() {
+        return 1;
+    }
+});
+
+assert.sameValue(Reflect.deleteProperty(p, "attr"), true);

--- a/test/built-ins/Proxy/deleteProperty/call-parameters.js
+++ b/test/built-ins/Proxy/deleteProperty/call-parameters.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.10
+description: >
+    [[Delete]] (P)
+
+    9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P»)).
+info: >
+    6.1.7.2 Object Internal Methods and Internal Slots
+
+    (...) Receiver is used as the this value when evaluating the code
+---*/
+
+var _handler, _target, _prop;
+var target = {
+    attr: 1
+};
+var handler = {
+    deleteProperty: function(t, prop) {
+        _handler = this;
+        _target = t;
+        _prop = prop;
+        return delete t[prop];
+    }
+};
+var p = new Proxy(target, handler);
+
+delete p.attr;
+
+assert.sameValue(_handler, handler, "handler object as the trap context");
+assert.sameValue(_target, target, "first argument is the target object");
+assert.sameValue(_prop, "attr", "second argument is the property name");

--- a/test/built-ins/Proxy/deleteProperty/null-handler.js
+++ b/test/built-ins/Proxy/deleteProperty/null-handler.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.10
+description: >
+    [[Delete]] (P)
+
+    3. If handler is null, throw a TypeError exception.
+---*/
+
+var p = Proxy.revocable({
+    attr: 1
+}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    delete p.proxy.attr;
+});

--- a/test/built-ins/Proxy/deleteProperty/return-false-not-strict.js
+++ b/test/built-ins/Proxy/deleteProperty/return-false-not-strict.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.10
+description: >
+    [[Delete]] (P)
+
+    11. If booleanTrapResult is false, return false.
+flags: [noStrict]
+---*/
+
+var p = new Proxy({}, {
+    deleteProperty: function() {
+        return false;
+    }
+});
+
+assert.sameValue(delete p.attr, false);

--- a/test/built-ins/Proxy/deleteProperty/return-false-strict.js
+++ b/test/built-ins/Proxy/deleteProperty/return-false-strict.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.10
+description: >
+    [[Delete]] (P)
+
+    11. If booleanTrapResult is false, return false.
+flags: [onlyStrict]
+features: [Reflect]
+---*/
+
+var p = new Proxy({}, {
+    deleteProperty: function() {
+        return false;
+    }
+});
+
+assert.sameValue(Reflect.deleteProperty(p, "attr"), false);

--- a/test/built-ins/Proxy/deleteProperty/return-is-abrupt.js
+++ b/test/built-ins/Proxy/deleteProperty/return-is-abrupt.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.10
+description: >
+    Trap return is an abrupt.
+info: >
+    9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P»)).
+    10. ReturnIfAbrupt(booleanTrapResult).
+includes: [Test262Error.js]
+---*/
+
+var p = new Proxy({}, {
+    deleteProperty: function(t, prop) {
+        throw new Test262Error();
+    }
+});
+
+assert.throws(Test262Error, function() {
+    delete p.attr;
+});

--- a/test/built-ins/Proxy/deleteProperty/targetdesc-is-not-configurable.js
+++ b/test/built-ins/Proxy/deleteProperty/targetdesc-is-not-configurable.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.10
+description: >
+    [[Delete]] (P)
+
+    A property cannot be reported as deleted, if it exists as a non-configurable
+    own property of the target object.
+info: >
+    14. If targetDesc.[[Configurable]] is false, throw a TypeError exception.
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    deleteProperty: function() {
+        return true;
+    }
+});
+
+Object.defineProperty(target, "attr", {
+    configurable: false,
+    value: 1
+});
+
+assert.throws(TypeError, function() {
+    delete p.attr;
+});

--- a/test/built-ins/Proxy/deleteProperty/targetdesc-is-undefined-return-true.js
+++ b/test/built-ins/Proxy/deleteProperty/targetdesc-is-undefined-return-true.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.10
+description: >
+    [[Delete]] (P)
+
+    14. If targetDesc is undefined, return true.
+---*/
+
+var p = new Proxy({}, {
+    deleteProperty: function() {
+        return true;
+    }
+});
+
+assert.sameValue(delete p.attr, true);

--- a/test/built-ins/Proxy/deleteProperty/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/deleteProperty/trap-is-not-callable.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.10
+description: >
+    Throws when trap is not callable.
+info: >
+    9.5.10 [[Delete]] (P)
+
+    6. Let trap be GetMethod(handler, "deleteProperty").
+    ...
+
+    7.3.9 GetMethod (O, P)
+
+    5. If IsCallable(func) is false, throw a TypeError exception.
+---*/
+
+var p = new Proxy({}, {
+    deleteProperty: {}
+});
+
+assert.throws(TypeError, function() {
+    delete p.attr;
+});

--- a/test/built-ins/Proxy/deleteProperty/trap-is-undefined-not-strict.js
+++ b/test/built-ins/Proxy/deleteProperty/trap-is-undefined-not-strict.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.10
+description: >
+    [[Delete]] (P)
+
+    8. If trap is undefined, then Return target.[[Delete]](P).
+flags: [noStrict]
+---*/
+
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {});
+
+assert.sameValue(delete p.attr, true);
+assert.sameValue(delete p.notThere, true);
+assert.sameValue(
+    Object.getOwnPropertyDescriptor(target, "attr"),
+    undefined
+);
+
+Object.defineProperty(target, "attr", {
+    configurable: false,
+    enumerable: true,
+    value: 1
+});
+
+assert.sameValue(delete p.attr, false);

--- a/test/built-ins/Proxy/deleteProperty/trap-is-undefined-strict.js
+++ b/test/built-ins/Proxy/deleteProperty/trap-is-undefined-strict.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.10
+description: >
+    [[Delete]] (P)
+
+    8. If trap is undefined, then Return target.[[Delete]](P).
+flags: [onlyStrict]
+features: [Reflect]
+---*/
+
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {});
+
+assert.sameValue(delete p.attr, true);
+assert.sameValue(delete p.notThere, true);
+assert.sameValue(
+    Object.getOwnPropertyDescriptor(target, "attr"),
+    undefined
+);
+
+Object.defineProperty(target, "attr", {
+    configurable: false,
+    enumerable: true,
+    value: 1
+});
+
+assert.sameValue(Reflect.deleteProperty(p, "attr"), false);

--- a/test/built-ins/Proxy/enumerate/call-parameters.js
+++ b/test/built-ins/Proxy/enumerate/call-parameters.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.11
+description: >
+    Trap called as trap.call(handler, target)
+info: >
+    [[Enumerate]] ()
+
+    8. Let trapResult be Call(trap, handler, «target»).
+---*/
+
+var x, _target, _handler;
+var target = {
+    attr: 1
+};
+var handler = {
+    enumerate: function(t) {
+        _target = t;
+        _handler = this;
+    }
+};
+var p = new Proxy(target, handler);
+
+try {
+    for (x in p) {}
+} catch(e) {}
+
+assert.sameValue(_handler, handler);
+assert.sameValue(_target, target);

--- a/test/built-ins/Proxy/enumerate/null-handler.js
+++ b/test/built-ins/Proxy/enumerate/null-handler.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.11
+description: >
+    [[Enumerate]] ()
+
+    2. If handler is null, throw a TypeError exception.
+---*/
+
+var x;
+var p = Proxy.revocable({}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    for (x in p.proxy) {
+        x;
+    }
+});

--- a/test/built-ins/Proxy/enumerate/result-not-an-object-throws-boolean.js
+++ b/test/built-ins/Proxy/enumerate/result-not-an-object-throws-boolean.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.11
+description: >
+    [[Enumerate]] ()
+
+    The result must be an Object
+---*/
+
+var x;
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {
+    enumerate: function() {
+        return true;
+    }
+});
+
+assert.throws(TypeError, function() {
+    for (x in p) {}
+});

--- a/test/built-ins/Proxy/enumerate/result-not-an-object-throws-number.js
+++ b/test/built-ins/Proxy/enumerate/result-not-an-object-throws-number.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.11
+description: >
+    [[Enumerate]] ()
+
+    The result must be an Object
+---*/
+
+var x;
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {
+    enumerate: function() {
+        return 1;
+    }
+});
+
+assert.throws(TypeError, function() {
+    for (x in p) {}
+});

--- a/test/built-ins/Proxy/enumerate/result-not-an-object-throws-string.js
+++ b/test/built-ins/Proxy/enumerate/result-not-an-object-throws-string.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.11
+description: >
+    [[Enumerate]] ()
+
+    The result must be an Object
+---*/
+
+var x;
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {
+    enumerate: function() {
+        return "";
+    }
+});
+
+assert.throws(TypeError, function() {
+    for (x in p) {}
+});

--- a/test/built-ins/Proxy/enumerate/result-not-an-object-throws-symbol.js
+++ b/test/built-ins/Proxy/enumerate/result-not-an-object-throws-symbol.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.11
+description: >
+    [[Enumerate]] ()
+
+    The result must be an Object
+features: [Symbol]
+---*/
+
+var x;
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {
+    enumerate: function() {
+        return Symbol();
+    }
+});
+
+assert.throws(TypeError, function() {
+    for (x in p) {}
+});

--- a/test/built-ins/Proxy/enumerate/result-not-an-object-throws-undefined.js
+++ b/test/built-ins/Proxy/enumerate/result-not-an-object-throws-undefined.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.11
+description: >
+    [[Enumerate]] ()
+
+    The result must be an Object
+---*/
+
+var x;
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {
+    enumerate: function() {
+        return undefined;
+    }
+});
+
+assert.throws(TypeError, function() {
+    for (x in p) {}
+});

--- a/test/built-ins/Proxy/enumerate/return-is-abrupt.js
+++ b/test/built-ins/Proxy/enumerate/return-is-abrupt.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.11
+description: >
+    Trap returns abrupt.
+info: >
+    [[Enumerate]] ()
+
+    8. Let trapResult be Call(trap, handler, «target»).
+    9. ReturnIfAbrupt(trapResult).
+includes: [Test262Error.js]
+---*/
+
+var x;
+var p = new Proxy({}, {
+    enumerate: function(t) {
+        throw new Test262Error();
+    }
+});
+
+assert.throws(Test262Error, function() {
+    for (x in p) {}
+});

--- a/test/built-ins/Proxy/enumerate/return-trap-result-no-value.js
+++ b/test/built-ins/Proxy/enumerate/return-trap-result-no-value.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.11
+description: >
+    Trap returns an iterator whose IteratorResult does not contain a value
+    property.
+info: >
+    [[Enumerate]] ()
+
+    11. Return trapResult
+---*/
+
+var x;
+var p = new Proxy([1,2,3], {
+    enumerate: function(t) {
+        return {next: function() { return { done:true }; } };
+    }
+});
+
+for (x in p) {
+    $ERROR("returned iterable interface from trap is flagged as done.");
+}

--- a/test/built-ins/Proxy/enumerate/return-trap-result.js
+++ b/test/built-ins/Proxy/enumerate/return-trap-result.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.11
+description: >
+    Trap returns a iterable result.
+info: >
+    [[Enumerate]] ()
+
+    11. Return trapResult
+includes: [compareArray.js]
+---*/
+
+var x;
+var iter = [
+    {done: false, value: 1},
+    {done: false, value: 2},
+    {done: false, value: 3},
+    {done: true, value: 42}
+];
+var target = {
+    attr: 1
+};
+var foo = { bar: 1 };
+var p = new Proxy(target, {
+    enumerate: function() {
+        return { next: function() { return iter.shift(); } };
+    }
+});
+
+var results = [];
+for (x in p) {
+    results.push(x);
+}
+
+assert(compareArray(results, [1,2,3]));

--- a/test/built-ins/Proxy/enumerate/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/enumerate/trap-is-not-callable.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.11
+description: >
+    Trap is not callable.
+info: >
+    [[Enumerate]] ()
+
+    5. Let trap be GetMethod(handler, "enumerate").
+    ...
+
+    7.3.9 GetMethod (O, P)
+
+    5. If IsCallable(func) is false, throw a TypeError exception.
+---*/
+
+var x;
+var p = new Proxy({attr:1}, {
+    enumerate: {}
+});
+
+assert.throws(TypeError, function() {
+    for (x in p) {}
+});

--- a/test/built-ins/Proxy/enumerate/trap-is-undefined.js
+++ b/test/built-ins/Proxy/enumerate/trap-is-undefined.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.11
+description: >
+    [[Enumerate]] ()
+
+    7. If trap is undefined, then Return target.[[Enumerate]]().
+---*/
+
+var x;
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {});
+
+var count = 0;
+for (x in p) {
+    count++;
+}
+
+assert.sameValue(count, 1);

--- a/test/built-ins/Proxy/function-prototype.js
+++ b/test/built-ins/Proxy/function-prototype.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.2.2
+description: >
+    The value of the [[Prototype]] internal slot of the Proxy
+    constructor is the intrinsic object %FunctionPrototype% (19.2.3).
+---*/
+
+assert.sameValue(
+    Object.getPrototypeOf(Proxy),
+    Function.prototype,
+    "`Object.getPrototypeOf(Proxy)` returns `Function.prototype`"
+);

--- a/test/built-ins/Proxy/get/accessor-get-is-undefined-throws.js
+++ b/test/built-ins/Proxy/get/accessor-get-is-undefined-throws.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.8
+description: >
+    [[Get]] (P, Receiver)
+
+    if trap result is not undefined, then proxy must report the same value for a
+    non-configurable accessor property with an undefined get.
+info: >
+    13. If targetDesc is not undefined, then
+        b. If IsAccessorDescriptor(targetDesc) and targetDesc.[[Configurable]]
+        is false and targetDesc.[[Get]] is undefined, then
+            i. If trapResult is not undefined, throw a TypeError exception.
+
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    get: function() {
+        return 2;
+    }
+});
+
+Object.defineProperty(target, 'attr', {
+    configurable: false,
+    get: undefined
+});
+
+assert.throws(TypeError, function() {
+    p.attr;
+});
+
+assert.throws(TypeError, function() {
+    p['attr'];
+});

--- a/test/built-ins/Proxy/get/call-parameters.js
+++ b/test/built-ins/Proxy/get/call-parameters.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.8
+description: >
+    [[Get]] (P, Receiver)
+
+    9. Let trapResult be Call(trap, handler, «target, P, Receiver»).
+info: >
+    6.1.7.2 Object Internal Methods and Internal Slots
+
+    (...) Receiver is used as the this value when evaluating the code
+---*/
+
+var _target, _handler, _prop, _receiver;
+var target = {
+    attr: 1
+};
+var handler = {
+    get: function(t, prop, receiver) {
+        _handler = this;
+        _target = t;
+        _prop = prop;
+        _receiver = receiver;
+    }
+};
+var p = new Proxy(target, handler);
+
+p.attr;
+
+assert.sameValue(_handler, handler);
+assert.sameValue(_target, target);
+assert.sameValue(_prop, "attr");
+assert.sameValue(_receiver, p, "receiver is the Proxy object");
+
+_prop = null;
+p["attr"];
+assert.sameValue(
+    _prop, "attr",
+    "trap is triggered both by p.attr and p['attr']"
+);

--- a/test/built-ins/Proxy/get/not-same-value-configurable-false-writable-false-throws.js
+++ b/test/built-ins/Proxy/get/not-same-value-configurable-false-writable-false-throws.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.8
+description: >
+    Throws if proxy return has not the same value for a non-writable,
+    non-configurable property
+info: >
+    [[Get]] (P, Receiver)
+
+    13. If targetDesc is not undefined, then
+        a. If IsDataDescriptor(targetDesc) and targetDesc.[[Configurable]] is
+        false and targetDesc.[[Writable]] is false, then
+            i. If SameValue(trapResult, targetDesc.[[Value]]) is false, throw a
+            TypeError exception.
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    get: function() {
+        return 2;
+    }
+});
+
+Object.defineProperty(target, 'attr', {
+    configurable: false,
+    writable: false,
+    value: 1
+});
+
+assert.throws(TypeError, function() {
+    p.attr;
+});
+
+assert.throws(TypeError, function() {
+    p['attr'];
+});

--- a/test/built-ins/Proxy/get/null-handler.js
+++ b/test/built-ins/Proxy/get/null-handler.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.8
+description: >
+    [[Get]] (P, Receiver)
+
+    2. If handler is null, throw a TypeError exception.
+---*/
+
+var p = Proxy.revocable({}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    p.proxy.attr;
+});
+
+assert.throws(TypeError, function() {
+    p.proxy['attr'];
+});

--- a/test/built-ins/Proxy/get/return-is-abrupt.js
+++ b/test/built-ins/Proxy/get/return-is-abrupt.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.8
+description: >
+    Trap returns abrupt.
+info: >
+    [[Get]] (P, Receiver)
+
+    9. Let trapResult be Call(trap, handler, «target, P, Receiver»).
+    10. ReturnIfAbrupt(trapResult).
+includes: [Test262Error.js]
+---*/
+
+var p = new Proxy({}, {
+    get: function() {
+        throw new Test262Error();
+    }
+});
+
+assert.throws(Test262Error, function() {
+    p.attr;
+});
+
+assert.throws(Test262Error, function() {
+    p["attr"];
+});

--- a/test/built-ins/Proxy/get/return-trap-result-accessor-property.js
+++ b/test/built-ins/Proxy/get/return-trap-result-accessor-property.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.8
+description: >
+    [[Get]] (P, Receiver)
+
+    14. Return trapResult.
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    get: function() {
+        return 2;
+    }
+});
+
+Object.defineProperty(target, 'attr', {
+    get: function() {
+        return 1;
+    }
+});
+
+assert.sameValue(p.attr, 2);
+assert.sameValue(p['attr'], 2);

--- a/test/built-ins/Proxy/get/return-trap-result-configurable-false-writable-true.js
+++ b/test/built-ins/Proxy/get/return-trap-result-configurable-false-writable-true.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.8
+description: >
+    [[Get]] (P, Receiver)
+
+    14. Return trapResult.
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    get: function() {
+        return 2;
+    }
+});
+
+Object.defineProperty(target, 'attr', {
+    configurable: false,
+    writable: true,
+    value: 1
+});
+
+assert.sameValue(p.attr, 2);
+assert.sameValue(p['attr'], 2);

--- a/test/built-ins/Proxy/get/return-trap-result-configurable-true-assessor-get-undefined.js
+++ b/test/built-ins/Proxy/get/return-trap-result-configurable-true-assessor-get-undefined.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.8
+description: >
+    [[Get]] (P, Receiver)
+
+    14. Return trapResult.
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    get: function() {
+        return 2;
+    }
+});
+
+Object.defineProperty(target, 'attr', {
+    configurable: true,
+    get: undefined
+});
+
+assert.sameValue(p.attr, 2);
+assert.sameValue(p['attr'], 2);

--- a/test/built-ins/Proxy/get/return-trap-result-configurable-true-writable-false.js
+++ b/test/built-ins/Proxy/get/return-trap-result-configurable-true-writable-false.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.8
+description: >
+    [[Get]] (P, Receiver)
+
+    14. Return trapResult.
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    get: function() {
+        return 2;
+    }
+});
+
+Object.defineProperty(target, 'attr', {
+    configurable: true,
+    writable: false,
+    value: 1
+});
+
+assert.sameValue(p.attr, 2);
+assert.sameValue(p['attr'], 2);

--- a/test/built-ins/Proxy/get/return-trap-result-same-value-configurable-false-writable-false.js
+++ b/test/built-ins/Proxy/get/return-trap-result-same-value-configurable-false-writable-false.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.8
+description: >
+    Proxy must report the same value for a non-writable, non-configurable
+    property.
+info: >
+    [[Get]] (P, Receiver)
+
+    13. If targetDesc is not undefined, then
+        a. If IsDataDescriptor(targetDesc) and targetDesc.[[Configurable]] is
+        false and targetDesc.[[Writable]] is false, then
+            i. If SameValue(trapResult, targetDesc.[[Value]]) is false, throw a
+            TypeError exception.
+        ...
+    14. Return trapResult.
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    get: function() {
+        return 1;
+    }
+});
+
+Object.defineProperty(target, 'attr', {
+    configurable: false,
+    writable: false,
+    value: 1
+});
+
+assert.sameValue(p.attr, 1);
+assert.sameValue(p['attr'], 1);

--- a/test/built-ins/Proxy/get/return-trap-result.js
+++ b/test/built-ins/Proxy/get/return-trap-result.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.8
+description: >
+    [[Get]] (P, Receiver)
+
+    14. Return trapResult.
+---*/
+
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {
+    get: function() {
+        return 2;
+    }
+});
+
+assert.sameValue(p.attr, 2);
+assert.sameValue(p.foo, 2);
+
+assert.sameValue(p['attr'], 2);
+assert.sameValue(p['foo'], 2);

--- a/test/built-ins/Proxy/get/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/get/trap-is-not-callable.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.8
+description: >
+    Trap is not callable.
+info: >
+    [[Get]] (P, Receiver)
+
+    6. Let trap be GetMethod(handler, "get").
+    ...
+
+    7.3.9 GetMethod (O, P)
+
+    5. If IsCallable(func) is false, throw a TypeError exception.
+---*/
+
+var p = new Proxy({}, {
+    get: {}
+});
+
+assert.throws(TypeError, function() {
+    p.attr;
+});
+
+assert.throws(TypeError, function() {
+    p["attr"];
+});

--- a/test/built-ins/Proxy/get/trap-is-undefined-no-property.js
+++ b/test/built-ins/Proxy/get/trap-is-undefined-no-property.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.8
+description: >
+    [[Get]] (P, Receiver)
+
+    8. If trap is undefined, then return target.[[Get]](P, Receiver).
+---*/
+
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {});
+
+assert.sameValue(p.attr, 1, 'return target.attr');
+assert.sameValue(p.foo, undefined, 'return target.foo');
+assert.sameValue(p['attr'], 1, 'return target.attr');
+assert.sameValue(p['foo'], undefined, 'return target.foo');

--- a/test/built-ins/Proxy/get/trap-is-undefined.js
+++ b/test/built-ins/Proxy/get/trap-is-undefined.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.8
+description: >
+    [[Get]] (P, Receiver)
+
+    8. If trap is undefined, then return target.[[Get]](P, Receiver).
+
+---*/
+
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {
+    get: undefined
+});
+
+assert.sameValue(p.attr, 1, 'return target.attr');
+assert.sameValue(p.foo, undefined, 'return target.foo');

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/call-parameters.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/call-parameters.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Trap is called with hander context and parameters are target and P
+info: >
+    [[GetOwnProperty]] (P)
+
+    ...
+    9. Let trapResultObj be Call(trap, handler, «target, P»).
+    ...
+---*/
+
+var _target, _handler, _prop;
+var target = {attr: 1};
+var handler = {
+    getOwnPropertyDescriptor: function(t, prop) {
+        _target = t;
+        _handler = this;
+        _prop = prop;
+
+        return Object.getOwnPropertyDescriptor(t);
+    }
+};
+var p = new Proxy(target, handler);
+
+Object.getOwnPropertyDescriptor(p, "attr");
+
+assert.sameValue(_handler, handler);
+assert.sameValue(_target, target);
+assert.sameValue(_prop, "attr");

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/null-handler.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/null-handler.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Throws a TypeError exception if handler is null.
+---*/
+
+var p = Proxy.revocable({}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    Object.getOwnPropertyDescriptor(p.proxy);
+});

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/result-is-undefined-target-is-not-extensible.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/result-is-undefined-target-is-not-extensible.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Throws a TypeError exception if trap result is undefined and target is not
+    extensible
+info: >
+    [[GetOwnProperty]] (P)
+
+    ...
+    14. If trapResultObj is undefined, then
+        ...
+        e. If ToBoolean(extensibleTarget) is false, throw a TypeError exception.
+    ...
+---*/
+
+var target = {
+    foo: 1
+};
+
+var p = new Proxy(target, {
+    getOwnPropertyDescriptor: function(t, prop) {
+        return;
+    }
+});
+
+Object.preventExtensions(target);
+
+assert.throws(TypeError, function() {
+    Object.getOwnPropertyDescriptor(p, "foo");
+});

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/result-is-undefined-targetdesc-is-not-configurable.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/result-is-undefined-targetdesc-is-not-configurable.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Throws a TypeError exception if trap result is undefined and target property
+    descriptor is not configurable
+info: >
+    [[GetOwnProperty]] (P)
+
+    ...
+    14. If trapResultObj is undefined, then
+        ...
+        b. If targetDesc.[[Configurable]] is false, throw a TypeError exception.
+    ...
+---*/
+
+var target = {};
+Object.defineProperty(target, "foo", {
+    configurable: false,
+    enumerable: false,
+    value: 1
+});
+
+var p = new Proxy(target, {
+    getOwnPropertyDescriptor: function(t, prop) {
+        return;
+    }
+});
+
+assert.throws(TypeError, function() {
+    Object.getOwnPropertyDescriptor(p, "foo");
+});

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/result-is-undefined-targetdesc-is-undefined.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/result-is-undefined-targetdesc-is-undefined.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Throws a TypeError exception if trap result is undefined and target property
+    descriptor is undefined.
+info: >
+    [[GetOwnProperty]] (P)
+
+    ...
+    14. If trapResultObj is undefined, then
+        a. If targetDesc is undefined, return undefined.
+    ...
+---*/
+
+var t = {};
+var trapped;
+var p = new Proxy(t, {
+    getOwnPropertyDescriptor: function(target, prop) {
+        trapped = true;
+        return;
+    }
+});
+
+assert.sameValue(
+    Object.getOwnPropertyDescriptor(p, "attr"),
+    undefined
+);
+
+assert(trapped);

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/result-is-undefined.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/result-is-undefined.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Return undefined if trap result is undefined and target is extensible and
+    the target property descriptor is configurable.
+info: >
+    [[GetOwnProperty]] (P)
+
+    ...
+    14. If trapResultObj is undefined, then
+        ...
+        f. Return undefined.
+    ...
+---*/
+
+var target = {
+    attr: 1
+};
+
+var p = new Proxy(target, {
+    getOwnPropertyDescriptor: function(t, prop) {
+        return;
+    }
+});
+
+assert.sameValue(Object.getOwnPropertyDescriptor(p, "attr"), undefined);

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/result-type-is-not-object-nor-undefined.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/result-type-is-not-object-nor-undefined.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Throws a TypeError exception if trap result is neither Object nor Undefined
+info: >
+    [[GetOwnProperty]] (P)
+
+    ...
+    11. If Type(trapResultObj) is neither Object nor Undefined, throw a
+    TypeError exception.
+    ...
+features: [Symbol]
+---*/
+
+var target = {
+    number: 1,
+    symbol: Symbol(),
+    string: '',
+    boolean: true,
+    fn: function() {}
+};
+var p = new Proxy(target, {
+    getOwnPropertyDescriptor: function(t, prop) {
+        return t[prop];
+    }
+});
+
+assert.throws(TypeError, function() {
+    Object.getOwnPropertyDescriptor(p, "number");
+});
+
+assert.throws(TypeError, function() {
+    Object.getOwnPropertyDescriptor(p, "string");
+});
+
+assert.throws(TypeError, function() {
+    Object.getOwnPropertyDescriptor(p, "symbol");
+});
+
+assert.throws(TypeError, function() {
+    Object.getOwnPropertyDescriptor(p, "boolean");
+});
+
+assert.throws(TypeError, function() {
+    Object.getOwnPropertyDescriptor(p, "fn");
+});

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-is-invalid-descriptor.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-is-invalid-descriptor.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Throws a TypeError exception if trap result and target property descriptors
+    are not compatible.
+info: >
+    [[GetOwnProperty]] (P)
+
+    ...
+    20. Let valid be IsCompatiblePropertyDescriptor (extensibleTarget,
+    resultDesc, targetDesc).
+    21. If valid is false, throw a TypeError exception.
+---*/
+
+var target = {};
+
+var p = new Proxy(target, {
+    getOwnPropertyDescriptor: function(t, prop) {
+        var foo = { bar: 1 };
+
+        return Object.getOwnPropertyDescriptor(foo, "bar");
+    }
+});
+
+Object.preventExtensions(target);
+
+assert.throws(TypeError, function() {
+    Object.getOwnPropertyDescriptor(p, "bar");
+});

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-is-not-configurable-targetdesc-is-configurable.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-is-not-configurable-targetdesc-is-configurable.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Throws a TypeError exception if trap result is not configurable but target
+    property descriptor is configurable.
+info: >
+    [[GetOwnProperty]] (P)
+
+    ...
+    22. If resultDesc.[[Configurable]] is false, then
+        a. If targetDesc is undefined or targetDesc.[[Configurable]] is true,
+        then
+            i. Throw a TypeError exception.
+    ...
+---*/
+
+var target = {
+    bar: 1
+};
+
+var p = new Proxy(target, {
+    getOwnPropertyDescriptor: function(t, prop) {
+        var foo = {};
+
+        Object.defineProperty(foo, "bar", {
+            configurable: false,
+            enumerable: true,
+            value: 1
+        });
+
+        return Object.getOwnPropertyDescriptor(foo, prop);
+    }
+});
+
+assert.throws(TypeError, function() {
+    Object.getOwnPropertyDescriptor(p, "bar");
+});

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-is-not-configurable-targetdesc-is-undefined.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-is-not-configurable-targetdesc-is-undefined.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Throws a TypeError exception if trap result is not configurable but target
+    property descriptor is undefined.
+info: >
+    [[GetOwnProperty]] (P)
+
+    ...
+    2. Let handler be the value of the [[ProxyHandler]] internal slot of O.
+    ...
+    5. Let target be the value of the [[ProxyTarget]] internal slot of O.
+    6. Let trap be GetMethod(handler, "getOwnPropertyDescriptor").
+    ...
+    9. Let trapResultObj be Call(trap, handler, «target, P»).
+    ...
+    12. Let targetDesc be target.[[GetOwnProperty]](P).
+    ...
+    17. Let resultDesc be ToPropertyDescriptor(trapResultObj).
+    ...
+    22. If resultDesc.[[Configurable]] is false, then
+        a. If targetDesc is undefined or targetDesc.[[Configurable]] is true, then
+            i. Throw a TypeError exception.
+
+---*/
+
+var target = {};
+
+var p = new Proxy(target, {
+    getOwnPropertyDescriptor: function(t, prop) {
+        var foo = {};
+
+        Object.defineProperty(foo, "bar", {
+            configurable: false,
+            enumerable: true,
+            value: 1
+        });
+
+        return Object.getOwnPropertyDescriptor(foo, prop);
+    }
+});
+
+assert.throws(TypeError, function() {
+    Object.getOwnPropertyDescriptor(p, "bar");
+});

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-return-configurable.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-return-configurable.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Return descriptor from trap result if it has the same value as the target
+    property descriptor.
+---*/
+
+var target = {};
+var descriptor = {
+    configurable: true,
+    enumerable: true,
+    value: 1
+};
+
+Object.defineProperty(target, "bar", descriptor);
+
+var p = new Proxy(target, {
+    getOwnPropertyDescriptor: function(t, prop) {
+        return Object.getOwnPropertyDescriptor(t, prop);
+    }
+});
+
+var proxyDesc = Object.getOwnPropertyDescriptor(p, "bar");
+
+assert(proxyDesc.configurable);
+assert(proxyDesc.enumerable);
+assert.sameValue(proxyDesc.value, 1);
+assert.sameValue(proxyDesc.writable, false);

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-return-not-configurable.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-return-not-configurable.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Return descriptor from trap result if it has the same value as the target
+    property descriptor and they're not configurable.
+---*/
+
+var target = {};
+
+Object.defineProperty(target, "attr", {
+    configurable: false,
+    enumerable: true,
+    value: 1
+});
+
+var p = new Proxy(target, {
+    getOwnPropertyDescriptor: function(t, prop) {
+        return Object.getOwnPropertyDescriptor(t, prop);
+    }
+});
+
+var proxyDesc = Object.getOwnPropertyDescriptor(p, "attr");
+
+assert.sameValue(proxyDesc.configurable, false);
+assert(proxyDesc.enumerable);
+assert.sameValue(proxyDesc.value, 1);
+assert.sameValue(proxyDesc.writable, false);

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/return-is-abrupt.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/return-is-abrupt.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Trap returns abrupt.
+info: >
+    [[GetOwnProperty]] (P)
+
+    ...
+    9. Let trapResultObj be Call(trap, handler, «target, P»).
+    10. ReturnIfAbrupt(trapResultObj).
+    ...
+includes: [Test262Error.js]
+---*/
+
+var p = new Proxy({}, {
+    getOwnPropertyDescriptor: function(t, prop) {
+        throw new Test262Error();
+    }
+});
+
+assert.throws(Test262Error, function() {
+    Object.getOwnPropertyDescriptor(p, "attr");
+});

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/trap-is-not-callable.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Throws a TypeError exception if trap is not callable.
+info: >
+    [[GetOwnProperty]] (P)
+
+    ...
+    2. Let handler be the value of the [[ProxyHandler]] internal slot of O.
+    ...
+    5. Let target be the value of the [[ProxyTarget]] internal slot of O.
+    6. Let trap be GetMethod(handler, "getOwnPropertyDescriptor").
+    ...
+        7.3.9 GetMethod (O, P)
+        ...
+        2. Let func be GetV(O, P).
+        5. If IsCallable(func) is false, throw a TypeError exception.
+        ...
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    getOwnPropertyDescriptor: {}
+});
+
+assert.throws(TypeError, function() {
+    Object.getOwnPropertyDescriptor(p, "foo");
+});

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/trap-is-undefined.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/trap-is-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.5
+description: >
+    Return target.[[GetOwnProperty]](P) if trap is undefined.
+info: >
+    [[GetOwnProperty]] (P)
+
+    ...
+    8. If trap is undefined, then
+        a. Return target.[[GetOwnProperty]](P).
+    ...
+includes: [propertyHelper.js]
+---*/
+
+var target = {attr: 1};
+var p = new Proxy(target, {});
+
+var proxyDesc = Object.getOwnPropertyDescriptor(p, "attr");
+
+verifyEqualTo(p, "attr", 1);
+verifyWritable(p, "attr");
+verifyEnumerable(p, "attr");
+verifyConfigurable(p, "attr");

--- a/test/built-ins/Proxy/getPrototypeOf/call-parameters.js
+++ b/test/built-ins/Proxy/getPrototypeOf/call-parameters.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.1
+description: >
+    Trap is called with handler as context and target as the first parameter.
+info: >
+    [[GetPrototypeOf]] ( )
+
+    ...
+    8. Let handlerProto be Call(trap, handler, «target»).
+    ...
+
+---*/
+
+var _handler, _target;
+var target = {};
+var handler = {
+  getPrototypeOf: function(t) {
+    _handler = this;
+    _target = t;
+    return {};
+  }
+};
+
+var p = new Proxy(target, handler);
+
+Object.getPrototypeOf(p);
+
+assert.sameValue(_handler, handler);
+assert.sameValue(_target, target);

--- a/test/built-ins/Proxy/getPrototypeOf/extensible-target-return-handlerproto.js
+++ b/test/built-ins/Proxy/getPrototypeOf/extensible-target-return-handlerproto.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.1
+description: >
+    Return trap result if it's an Object and target is extensible.
+info: >
+    [[GetPrototypeOf]] ( )
+
+    ...
+    1. Let handler be the value of the [[ProxyHandler]] internal slot of O.
+    ...
+    4. Let target be the value of the [[ProxyTarget]] internal slot of O.
+    5. Let trap be GetMethod(handler, "getPrototypeOf").
+    ...
+    8. Let handlerProto be Call(trap, handler, «target»).
+    ...
+    11. Let extensibleTarget be IsExtensible(target).
+    12. ReturnIfAbrupt(extensibleTarget).
+    13. If extensibleTarget is true, return handlerProto.
+    ...
+
+---*/
+
+var prot = { foo: 1 };
+var p = new Proxy({}, {
+  getPrototypeOf: function() {
+    return prot;
+  }
+});
+
+assert.sameValue(Object.getPrototypeOf(p), prot);

--- a/test/built-ins/Proxy/getPrototypeOf/not-extensible-not-same-proto-throws.js
+++ b/test/built-ins/Proxy/getPrototypeOf/not-extensible-not-same-proto-throws.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.1
+description: >
+    Throws a TypeError if the target is not extensible and the trap result is
+    not the same as the target.[[GetPrototypeOf]] result.
+info: >
+    [[GetPrototypeOf]] ( )
+
+    ...
+    1. Let handler be the value of the [[ProxyHandler]] internal slot of O.
+    ...
+    4. Let target be the value of the [[ProxyTarget]] internal slot of O.
+    5. Let trap be GetMethod(handler, "getPrototypeOf").
+    ...
+    8. Let handlerProto be Call(trap, handler, «target»).
+    ...
+    11. Let extensibleTarget be IsExtensible(target).
+    ...
+    14. Let targetProto be target.[[GetPrototypeOf]]().
+    15. ReturnIfAbrupt(targetProto).
+    16. If SameValue(handlerProto, targetProto) is false, throw a TypeError
+    exception.
+    ...
+---*/
+
+var target = Object.create({ foo: 1 });
+
+var p = new Proxy(target, {
+  getPrototypeOf: function() {
+    return {};
+  }
+});
+
+Object.preventExtensions(target);
+
+assert.throws(TypeError, function() {
+    Object.getPrototypeOf(p);
+});

--- a/test/built-ins/Proxy/getPrototypeOf/not-extensible-same-proto.js
+++ b/test/built-ins/Proxy/getPrototypeOf/not-extensible-same-proto.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.1
+description: >
+    Return trap result is target is not extensible, but trap result has the same
+    value as target.[[GetPrototypeOf]] result.
+info: >
+    [[GetPrototypeOf]] ( )
+
+    ...
+    1. Let handler be the value of the [[ProxyHandler]] internal slot of O.
+    ...
+    4. Let target be the value of the [[ProxyTarget]] internal slot of O.
+    5. Let trap be GetMethod(handler, "getPrototypeOf").
+    ...
+    8. Let handlerProto be Call(trap, handler, «target»).
+    ...
+    11. Let extensibleTarget be IsExtensible(target).
+    ...
+    14. Let targetProto be target.[[GetPrototypeOf]]().
+    ...
+    17. Return handlerProto.
+
+---*/
+
+var target = Object.create(Array.prototype);
+
+var p = new Proxy(target, {
+  getPrototypeOf: function() {
+    return Array.prototype;
+  }
+});
+
+Object.preventExtensions(target);
+
+assert.sameValue(Object.getPrototypeOf(p), Array.prototype);

--- a/test/built-ins/Proxy/getPrototypeOf/null-handler.js
+++ b/test/built-ins/Proxy/getPrototypeOf/null-handler.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.1
+description: >
+    Throws a TypeError exception if handler is null.
+---*/
+
+var p = Proxy.revocable({}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    Object.getPrototypeOf(p.proxy);
+});

--- a/test/built-ins/Proxy/getPrototypeOf/return-is-abrupt.js
+++ b/test/built-ins/Proxy/getPrototypeOf/return-is-abrupt.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.1
+description: >
+    Trap returns abrupt.
+info: >
+    8. Let handlerProto be Call(trap, handler, «target»).
+    9. ReturnIfAbrupt(handlerProto).
+includes: [Test262Error.js]
+---*/
+
+var p = new Proxy({}, {
+  getPrototypeOf: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+    Object.getPrototypeOf(p);
+});

--- a/test/built-ins/Proxy/getPrototypeOf/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/getPrototypeOf/trap-is-not-callable.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.1
+description: >
+    Throws if trap is not callable.
+---*/
+
+var p = new Proxy({}, {
+    getPrototypeOf: {}
+});
+
+assert.throws(TypeError, function() {
+    Object.getPrototypeOf(p);
+});

--- a/test/built-ins/Proxy/getPrototypeOf/trap-is-undefined.js
+++ b/test/built-ins/Proxy/getPrototypeOf/trap-is-undefined.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.1
+description: >
+    Return target.[[GetPrototypeOf]]() if trap is undefined.
+---*/
+
+var target = Object.create(Array.prototype);
+var p = new Proxy(target, {});
+
+assert.sameValue(Object.getPrototypeOf(p), Array.prototype);

--- a/test/built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-boolean.js
+++ b/test/built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-boolean.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.1
+description: >
+    Throw a TypeError exception if trap result is false.
+---*/
+
+var p = new Proxy({}, {
+  getPrototypeOf: function() {
+    return false;
+  }
+});
+
+assert.throws(TypeError, function() {
+    Object.getPrototypeOf(p);
+});

--- a/test/built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-number.js
+++ b/test/built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-number.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.1
+description: >
+    Throw a TypeError exception if trap result is a Number.
+---*/
+
+var p = new Proxy({}, {
+  getPrototypeOf: function() {
+    return 0;
+  }
+});
+
+assert.throws(TypeError, function() {
+    Object.getPrototypeOf(p);
+});

--- a/test/built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-string.js
+++ b/test/built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-string.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.1
+description: >
+    throw a TypeError exception if trap result is a String.
+---*/
+
+var p = new Proxy({}, {
+  getPrototypeOf: function() {
+    return "";
+  }
+});
+
+assert.throws(TypeError, function() {
+    Object.getPrototypeOf(p);
+});

--- a/test/built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-symbol.js
+++ b/test/built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-symbol.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.1
+description: >
+    Throw a TypeError exception if trap result is a Symbol.
+features: [Symbol]
+---*/
+
+var p = new Proxy({}, {
+  getPrototypeOf: function() {
+    return Symbol();
+  }
+});
+
+assert.throws(TypeError, function() {
+    Object.getPrototypeOf(p);
+});

--- a/test/built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-undefined.js
+++ b/test/built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-undefined.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.1
+description: >
+    Throw a TypeError exception if trap result is undefined.
+---*/
+
+var p = new Proxy({}, {
+  getPrototypeOf: function() {
+    return undefined;
+  }
+});
+
+assert.throws(TypeError, function() {
+    Object.getPrototypeOf(p);
+});

--- a/test/built-ins/Proxy/has/call-in.js
+++ b/test/built-ins/Proxy/has/call-in.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    A `in` check trigger trap.call(handler, target, P);
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P»)).
+    ...
+---*/
+
+var _handler, _target, _prop;
+var target = {};
+var handler = {
+    has: function(t, prop) {
+        _handler = this;
+        _target = t;
+        _prop = prop;
+
+        return prop in t;
+    }
+};
+var p = new Proxy(target, handler);
+
+"attr" in p;
+
+assert.sameValue(_handler, handler, "handler is context");
+assert.sameValue(_target, target, "target is the first parameter");
+assert.sameValue(_prop, "attr", "given prop is the second paramter");

--- a/test/built-ins/Proxy/has/call-object-create.js
+++ b/test/built-ins/Proxy/has/call-object-create.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    `.. in Object.create(proxy)` triggers trap.call(handler, target, P);
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    2. Let handler be the value of the [[ProxyHandler]] internal slot of O.
+    ...
+    5. Let target be the value of the [[ProxyTarget]] internal slot of O.
+    6. Let trap be GetMethod(handler, "has").
+    ...
+    9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P»)).
+    ...
+---*/
+
+var _handler, _target, _prop;
+var target = {};
+var handler = {
+    has: function(t, prop) {
+        _handler = this;
+        _target = t;
+        _prop = prop;
+
+        return false;
+    }
+};
+var p = new Proxy(target, handler);
+
+"attr" in Object.create(p);
+
+assert.sameValue(_handler, handler, "handler is context");
+assert.sameValue(_target, target, "target is the first parameter");
+assert.sameValue(_prop, "attr", "given prop is the second paramter");

--- a/test/built-ins/Proxy/has/call-with.js
+++ b/test/built-ins/Proxy/has/call-with.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    A `with` variable check trigger trap.call(handler, target, P);
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P»)).
+    ...
+flags: [noStrict]
+---*/
+
+var _handler, _target, _prop;
+var target = {};
+var handler = {
+    has: function(t, prop) {
+        _handler = this;
+        _target = t;
+        _prop = prop;
+
+        return true;
+    }
+};
+var p = new Proxy(target, handler);
+
+with (p) {
+    (attr);
+}
+
+assert.sameValue(_handler, handler);
+assert.sameValue(_target, target);
+assert.sameValue(_prop, "attr");

--- a/test/built-ins/Proxy/has/null-handler-using-with.js
+++ b/test/built-ins/Proxy/has/null-handler-using-with.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    Throws a TypeError exception if handler is null.
+flags: [noStrict]
+---*/
+
+var p = Proxy.revocable({}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    with (p.proxy) {
+        (attr);
+    }
+});

--- a/test/built-ins/Proxy/has/null-handler.js
+++ b/test/built-ins/Proxy/has/null-handler.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    Throws a TypeError exception if handler is null.
+---*/
+
+var p = Proxy.revocable({}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    "attr" in p.proxy;
+});

--- a/test/built-ins/Proxy/has/return-false-target-not-extensible-using-with.js
+++ b/test/built-ins/Proxy/has/return-false-target-not-extensible-using-with.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    A property cannot be reported as non-existent, if it exists as an own
+    property of the target object and the target object is not extensible.
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    11. If booleanTrapResult is false, then
+        a. Let targetDesc be target.[[GetOwnProperty]](P).
+        b. ReturnIfAbrupt(targetDesc).
+        c. If targetDesc is not undefined, then
+            ...
+            ii. Let extensibleTarget be IsExtensible(target).
+            ...
+            iv. If extensibleTarget is false, throw a TypeError exception.
+    ...
+flags: [noStrict]
+---*/
+
+var target = {};
+var handler = {
+    has: function(t, prop) {
+        return 0;
+    }
+};
+var p = new Proxy(target, handler);
+
+Object.defineProperty(target, 'attr', {
+    configurable: true,
+    value: 1
+});
+
+Object.preventExtensions(target);
+
+assert.throws(TypeError, function() {
+    with (p) {
+        (attr);
+    }
+});

--- a/test/built-ins/Proxy/has/return-false-target-not-extensible.js
+++ b/test/built-ins/Proxy/has/return-false-target-not-extensible.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    A property cannot be reported as non-existent, if it exists as an own
+    property of the target object and the target object is not extensible.
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    11. If booleanTrapResult is false, then
+        a. Let targetDesc be target.[[GetOwnProperty]](P).
+        b. ReturnIfAbrupt(targetDesc).
+        c. If targetDesc is not undefined, then
+            ...
+            ii. Let extensibleTarget be IsExtensible(target).
+            ...
+            iv. If extensibleTarget is false, throw a TypeError exception.
+    ...
+---*/
+
+var target = {};
+var handler = {
+    has: function(t, prop) {
+        return 0;
+    }
+};
+var p = new Proxy(target, handler);
+
+Object.defineProperty(target, "attr", {
+    configurable: true,
+    value: 1
+});
+
+Object.preventExtensions(target);
+
+assert.throws(TypeError, function() {
+    "attr" in p;
+});

--- a/test/built-ins/Proxy/has/return-false-target-prop-exists-using-with.js
+++ b/test/built-ins/Proxy/has/return-false-target-prop-exists-using-with.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    The result of [[HasProperty]] is a Boolean value and will affect has
+    checkings. False returned when target property exists;
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    12. Return booleanTrapResult.
+flags: [noStrict]
+---*/
+
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {
+    has: function(t, prop) {
+        return false;
+    }
+});
+
+var attr = 0;
+with (p) {
+    assert.sameValue(attr, 0);
+}

--- a/test/built-ins/Proxy/has/return-false-target-prop-exists.js
+++ b/test/built-ins/Proxy/has/return-false-target-prop-exists.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    The result of [[HasProperty]] is a Boolean value and will affect has
+    checkings. False returned when target property exists;
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    12. Return booleanTrapResult.
+---*/
+
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {
+    has: function(t, prop) {
+        return false;
+    }
+});
+
+assert.sameValue(("attr" in p), false);

--- a/test/built-ins/Proxy/has/return-false-targetdesc-not-configurable-using-with.js
+++ b/test/built-ins/Proxy/has/return-false-targetdesc-not-configurable-using-with.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    A property cannot be reported as non-existent, if it exists as a
+    non-configurable own property of the target object.
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    11. If booleanTrapResult is false, then
+        ...
+        c. If targetDesc is not undefined, then
+            i. If targetDesc.[[Configurable]] is false, throw a TypeError
+            exception.
+    ...
+flags: [noStrict]
+---*/
+
+var target = {};
+var handler = {
+    has: function(t, prop) {
+        return 0;
+    }
+};
+var p = new Proxy(target, handler);
+
+Object.defineProperty(target, "attr", {
+    configurable: false,
+    value: 1
+});
+
+assert.throws(TypeError, function() {
+    with (p) {
+        (attr);
+    }
+});

--- a/test/built-ins/Proxy/has/return-false-targetdesc-not-configurable.js
+++ b/test/built-ins/Proxy/has/return-false-targetdesc-not-configurable.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    A property cannot be reported as non-existent, if it exists as a
+    non-configurable own property of the target object.
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    11. If booleanTrapResult is false, then
+        ...
+        c. If targetDesc is not undefined, then
+            i. If targetDesc.[[Configurable]] is false, throw a TypeError
+            exception.
+    ...
+---*/
+
+var target = {};
+var handler = {
+    has: function(t, prop) {
+        return 0;
+    }
+};
+var p = new Proxy(target, handler);
+
+Object.defineProperty(target, "attr", {
+    configurable: false,
+    value: 1
+});
+
+assert.throws(TypeError, function() {
+    "attr" in p;
+});

--- a/test/built-ins/Proxy/has/return-is-abrupt-in.js
+++ b/test/built-ins/Proxy/has/return-is-abrupt-in.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    Trap returns abrupt. Using `prop in obj`.
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P»)).
+    10. ReturnIfAbrupt(booleanTrapResult).
+    ...
+includes: [Test262Error.js]
+---*/
+
+var p = new Proxy({}, {
+    has: function() {
+        throw new Test262Error();
+    }
+});
+
+assert.throws(Test262Error, function() {
+    "attr" in p;
+});

--- a/test/built-ins/Proxy/has/return-is-abrupt-with.js
+++ b/test/built-ins/Proxy/has/return-is-abrupt-with.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    Trap returns abrupt. Using `with`.
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P»)).
+    10. ReturnIfAbrupt(booleanTrapResult).
+    ...
+flags: [noStrict]
+includes: [Test262Error.js]
+---*/
+
+var p = new Proxy({}, {
+    has: function() {
+        throw new Test262Error();
+    }
+});
+
+assert.throws(Test262Error, function() {
+    with (p) {
+        (attr);
+    }
+});

--- a/test/built-ins/Proxy/has/return-true-target-prop-exists-using-with.js
+++ b/test/built-ins/Proxy/has/return-true-target-prop-exists-using-with.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    The result of [[HasProperty]] is a Boolean value and will affect has
+    checkings. True returned when target property exists;
+flags: [noStrict]
+---*/
+
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {
+    has: function(t, prop) {
+        if (prop !== "assert") {
+            return 42;
+        }
+    }
+});
+
+var attr = 0;
+with (p) {
+    assert.sameValue(attr, 1);
+}

--- a/test/built-ins/Proxy/has/return-true-target-prop-exists.js
+++ b/test/built-ins/Proxy/has/return-true-target-prop-exists.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    The result of [[HasProperty]] is a Boolean value and will affect has
+    checkings. True returned when target property exists;
+---*/
+
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {
+    has: function(t, prop) {
+        return 1;
+    }
+});
+
+assert.sameValue(("attr" in p), true);

--- a/test/built-ins/Proxy/has/return-true-without-same-target-prop.js
+++ b/test/built-ins/Proxy/has/return-true-without-same-target-prop.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    The result of [[HasProperty]] is a Boolean value and will affect has
+    checkings. True returned when target property doesn't exists;
+---*/
+
+var p = new Proxy({}, {
+    has: function(t, prop) {
+        return true;
+    }
+});
+
+assert.sameValue(("attr" in p), true);

--- a/test/built-ins/Proxy/has/trap-is-not-callable-using-with.js
+++ b/test/built-ins/Proxy/has/trap-is-not-callable-using-with.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    Throws a TypeError exception if trap is not callable.
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    6. Let trap be GetMethod(handler, "has").
+    ...
+        7.3.9 GetMethod (O, P)
+        ...
+        2. Let func be GetV(O, P).
+        5. If IsCallable(func) is false, throw a TypeError exception.
+        ...
+flags: [noStrict]
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    has: {}
+});
+
+assert.throws(TypeError, function() {
+    with (p) {
+        (attr);
+    }
+});

--- a/test/built-ins/Proxy/has/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/has/trap-is-not-callable.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    Throws a TypeError exception if trap is not callable.
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    6. Let trap be GetMethod(handler, "has").
+    ...
+        7.3.9 GetMethod (O, P)
+        ...
+        2. Let func be GetV(O, P).
+        5. If IsCallable(func) is false, throw a TypeError exception.
+        ...
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    has: {}
+});
+
+assert.throws(TypeError, function() {
+    "attr" in p;
+});

--- a/test/built-ins/Proxy/has/trap-is-undefined-using-with.js
+++ b/test/built-ins/Proxy/has/trap-is-undefined-using-with.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    Return target.[[HasProperty]](P) if trap is undefined.
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    8. If trap is undefined, then
+        a. Return target.[[HasProperty]](P).
+    ...
+flags: [noStrict]
+---*/
+
+var target = Object.create(Array.prototype);
+var p = new Proxy(target, {});
+
+var foo = 3;
+with (target) {
+    assert.sameValue(length, 0);
+    assert.sameValue(foo, 3);
+}

--- a/test/built-ins/Proxy/has/trap-is-undefined.js
+++ b/test/built-ins/Proxy/has/trap-is-undefined.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.7
+description: >
+    Return target.[[HasProperty]](P) if trap is undefined.
+info: >
+    [[HasProperty]] (P)
+
+    ...
+    8. If trap is undefined, then
+        a. Return target.[[HasProperty]](P).
+    ...
+---*/
+
+var target = Object.create(Array.prototype);
+var p = new Proxy(target, {});
+
+assert.sameValue(("foo" in p), false);
+assert.sameValue(("length" in p), true);

--- a/test/built-ins/Proxy/isExtensible/call-parameters.js
+++ b/test/built-ins/Proxy/isExtensible/call-parameters.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.3
+description: >
+    The trap is called with handler on its context and the target object as the
+    first parabeter
+info: >
+    [[IsExtensible]] ( )
+
+    ...
+    8. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target»)).
+    ...
+
+---*/
+
+var _target, _handler;
+var target = {};
+var handler = {
+    isExtensible: function(t) {
+        _handler = this;
+        _target = t;
+        return Object.isExtensible(t);
+    }
+}
+var p = new Proxy(target, handler);
+
+Object.isExtensible(p);
+
+assert.sameValue(_handler, handler);
+assert.sameValue(_target, target);

--- a/test/built-ins/Proxy/isExtensible/null-handler.js
+++ b/test/built-ins/Proxy/isExtensible/null-handler.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.3
+description: >
+    Throws a TypeError exception if handler is null
+---*/
+
+var p = Proxy.revocable({}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    Object.isExtensible(p.proxy);
+});

--- a/test/built-ins/Proxy/isExtensible/return-is-abrupt.js
+++ b/test/built-ins/Proxy/isExtensible/return-is-abrupt.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.3
+description: >
+    Trap returns abrupt.
+info: >
+    [[IsExtensible]] ( )
+
+    ...
+    8. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target»)).
+    9. ReturnIfAbrupt(booleanTrapResult).
+    ...
+includes: [Test262Error.js]
+---*/
+
+var p = new Proxy({}, {
+    isExtensible: function(t) {
+        throw new Test262Error();
+    }
+});
+
+assert.throws(Test262Error, function() {
+    Object.isExtensible(p);
+});

--- a/test/built-ins/Proxy/isExtensible/return-is-boolean.js
+++ b/test/built-ins/Proxy/isExtensible/return-is-boolean.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.3
+description: >
+    The trap returns a boolean result.
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    isExtensible: function(t) {
+        if ( Object.isExtensible(t) ) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+});
+
+assert.sameValue(Object.isExtensible(p), true);
+
+Object.preventExtensions(target);
+
+assert.sameValue(Object.isExtensible(p), false);

--- a/test/built-ins/Proxy/isExtensible/return-is-different-from-target.js
+++ b/test/built-ins/Proxy/isExtensible/return-is-different-from-target.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.3
+description: >
+    Throws a TypeError exception if boolean trap result is not the same as
+    target.[[IsExtensible]]() result
+info: >
+    [[IsExtensible]] ( )
+
+    ...
+    12. If SameValue(booleanTrapResult, targetResult) is false, throw a
+    TypeError exception.
+    ...
+---*/
+
+var p = new Proxy({}, {
+    isExtensible: function(t) {
+        return false;
+    }
+});
+
+assert.throws(TypeError, function() {
+    Object.isExtensible(p);
+});

--- a/test/built-ins/Proxy/isExtensible/return-same-result-from-target.js
+++ b/test/built-ins/Proxy/isExtensible/return-same-result-from-target.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.3
+description: >
+    Return trap result.
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    isExtensible: function(t) {
+        return Object.isExtensible(t);
+    }
+});
+
+assert.sameValue(Object.isExtensible(p), true);
+
+Object.preventExtensions(target);
+
+assert.sameValue(Object.isExtensible(p), false);

--- a/test/built-ins/Proxy/isExtensible/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/isExtensible/trap-is-not-callable.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.3
+description: >
+    Throws a TypeError exception if trap is not callable.
+info: >
+    [[IsExtensible]] ( )
+
+    ...
+    1. Let handler be the value of the [[ProxyHandler]] internal slot of O.
+    ...
+    5. Let trap be GetMethod(handler, "isExtensible").
+    ...
+        7.3.9 GetMethod (O, P)
+        ...
+        2. Let func be GetV(O, P).
+        5. If IsCallable(func) is false, throw a TypeError exception.
+        ...
+---*/
+
+
+var target = {};
+var p = new Proxy(target, {
+    isExtensible: {}
+});
+
+assert.throws(TypeError, function() {
+    Object.isExtensible(p);
+});

--- a/test/built-ins/Proxy/isExtensible/trap-is-undefined.js
+++ b/test/built-ins/Proxy/isExtensible/trap-is-undefined.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.3
+description: >
+    Return target.[[IsExtensible]]() if trap is undefined.
+info: >
+    [[IsExtensible]] ( )
+
+    ...
+    7. If trap is undefined, then
+        a. Return target.[[IsExtensible]]().
+    ...
+---*/
+
+var target = {};
+var p = new Proxy(target, {});
+
+assert.sameValue(Object.isExtensible(p), true);
+
+Object.preventExtensions(target);
+
+assert.sameValue(Object.isExtensible(p), false);

--- a/test/built-ins/Proxy/length.js
+++ b/test/built-ins/Proxy/length.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.2.2
+description: >
+    Properties of the Proxy Constructor
+
+    Besides the length property (whose value is 2)
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Proxy.length, 2, "The value of `Proxy.length` is `2`");
+
+verifyNotEnumerable(Proxy, "length");
+verifyNotWritable(Proxy, "length");
+verifyConfigurable(Proxy, "length");

--- a/test/built-ins/Proxy/name.js
+++ b/test/built-ins/Proxy/name.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.2.1.1
+description: >
+    Proxy ( target, handler )
+
+    17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Proxy.name, "Proxy", "The value of `Proxy.name` is `'Proxy'`");
+
+verifyNotEnumerable(Proxy, "name");
+verifyNotWritable(Proxy, "name");
+verifyConfigurable(Proxy, "name");

--- a/test/built-ins/Proxy/ownKeys/call-parameters-object-getownpropertynames.js
+++ b/test/built-ins/Proxy/ownKeys/call-parameters-object-getownpropertynames.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.12
+description: >
+    [[OwnPropertyKeys]] ( )
+
+    8. Let trapResultArray be Call(trap, handler, «target»).
+---*/
+
+var _target, _handler;
+var target = {
+    foo: 1,
+    bar: 2
+};
+
+var handler = {
+    ownKeys: function(t) {
+        _handler = this;
+        _target = t;
+        return Object.getOwnPropertyNames(t);
+    }
+}
+var p = new Proxy(target, handler);
+
+var names = Object.getOwnPropertyNames(p);
+
+assert.sameValue(names[0], "foo");
+assert.sameValue(names[1], "bar");
+assert.sameValue(names.length, 2);
+assert.sameValue(_handler, handler);
+assert.sameValue(_target, target);

--- a/test/built-ins/Proxy/ownKeys/call-parameters-object-getownpropertysymbols.js
+++ b/test/built-ins/Proxy/ownKeys/call-parameters-object-getownpropertysymbols.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.12
+description: >
+    [[OwnPropertyKeys]] ( )
+
+    8. Let trapResultArray be Call(trap, handler, «target»).
+features: [Symbol]
+---*/
+
+var _target, _handler;
+var target = {};
+var a = Symbol('a');
+var b = Symbol('b');
+
+target[a] = 1;
+target[b] = 2;
+
+var handler = {
+    ownKeys: function(t) {
+        _handler = this;
+        _target = t;
+        return Object.getOwnPropertySymbols(t);
+    }
+}
+var p = new Proxy(target, handler);
+
+var symbols = Object.getOwnPropertySymbols(p);
+
+assert.sameValue(symbols[0], a);
+assert.sameValue(symbols[1], b);
+assert.sameValue(symbols.length, 2);
+assert.sameValue(_handler, handler);
+assert.sameValue(_target, target);

--- a/test/built-ins/Proxy/ownKeys/call-parameters-object-keys.js
+++ b/test/built-ins/Proxy/ownKeys/call-parameters-object-keys.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.12
+description: >
+    [[OwnPropertyKeys]] ( )
+
+    8. Let trapResultArray be Call(trap, handler, «target»).
+---*/
+
+var _target, _handler;
+var target = {
+    foo: 1,
+    bar: 2
+};
+var handler = {
+    ownKeys: function(t) {
+        _handler = this;
+        _target = t;
+        return Object.keys(t);
+    }
+};
+var p = new Proxy(target, handler);
+
+var keys = Object.keys(p);
+
+assert.sameValue(keys[0], "foo");
+assert.sameValue(keys[1], "bar");
+assert.sameValue(keys.length, 2);
+assert.sameValue(_handler, handler);
+assert.sameValue(_target, target);

--- a/test/built-ins/Proxy/ownKeys/extensible-return-trap-result-absent-not-configurable-keys.js
+++ b/test/built-ins/Proxy/ownKeys/extensible-return-trap-result-absent-not-configurable-keys.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.12
+description: >
+    If target is extensible, return the non-falsy trap result if target doesn't
+    contain any non-configurable keys.
+info: >
+    [[OwnPropertyKeys]] ( )
+
+    ...
+    19. If extensibleTarget is true and targetNonconfigurableKeys is empty, then
+        a. Return trapResult.
+---*/
+
+var p = new Proxy({attr: 42}, {
+    ownKeys: function() {
+        return ["foo", "bar"];
+    }
+});
+
+var keys = Object.getOwnPropertyNames(p);
+
+assert.sameValue(keys[0], "foo");
+assert.sameValue(keys[1], "bar");
+
+assert.sameValue(keys.length, 2);

--- a/test/built-ins/Proxy/ownKeys/extensible-return-trap-result.js
+++ b/test/built-ins/Proxy/ownKeys/extensible-return-trap-result.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.12
+description: >
+    If target is extensible, return the non-falsy trap result if it contains all
+    of target's non-configurable keys.
+info: >
+    [[OwnPropertyKeys]] ( )
+
+    ...
+    22. If extensibleTarget is true, return trapResult.
+---*/
+
+var target = {};
+
+Object.defineProperty(target, "foo", {
+    configurable: false,
+    enumerable: true,
+    value: true
+});
+
+var p = new Proxy(target, {
+    ownKeys: function() {
+        return ["foo", "bar"];
+    }
+});
+
+var keys = Object.getOwnPropertyNames(p);
+
+assert.sameValue(keys[0], "foo");
+assert.sameValue(keys[1], "bar");
+
+assert.sameValue(keys.length, 2);

--- a/test/built-ins/Proxy/ownKeys/not-extensible-missing-keys-throws.js
+++ b/test/built-ins/Proxy/ownKeys/not-extensible-missing-keys-throws.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.12
+description: >
+    If target is not extensible, the result must contain all the keys of the own
+    properties of the target object.
+info: >
+    [[OwnPropertyKeys]] ( )
+
+    ...
+    23. Repeat, for each key that is an element of targetConfigurableKeys,
+        a. If key is not an element of uncheckedResultKeys, throw a TypeError
+        exception.
+---*/
+
+var target = {
+    foo: 1,
+    bar: 2
+};
+
+var p = new Proxy(target, {
+    ownKeys: function() {
+        return ["foo"];
+    }
+});
+
+Object.preventExtensions(target);
+
+assert.throws(TypeError, function() {
+    Object.keys(p);
+});

--- a/test/built-ins/Proxy/ownKeys/not-extensible-new-keys-throws.js
+++ b/test/built-ins/Proxy/ownKeys/not-extensible-new-keys-throws.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.12
+description: >
+    If target is not extensible, the result can't contain keys names not
+    contained in the target object.
+info: >
+    [[OwnPropertyKeys]] ( )
+
+    ...
+    24. If uncheckedResultKeys is not empty, throw a TypeError exception.
+---*/
+
+var target = {
+    foo: 1
+};
+
+var p = new Proxy(target, {
+    ownKeys: function() {
+        return ["foo", "bar"];
+    }
+});
+
+Object.preventExtensions(target);
+
+assert.throws(TypeError, function() {
+    Object.keys(p);
+});

--- a/test/built-ins/Proxy/ownKeys/not-extensible-return-keys.js
+++ b/test/built-ins/Proxy/ownKeys/not-extensible-return-keys.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.12
+description: >
+    If target is not extensible, the result must contain all the keys of the own
+    properties of the target object and no other values
+info: >
+    [[OwnPropertyKeys]] ( )
+
+    ...
+    25. Return trapResult.
+---*/
+
+var target = {
+    foo: 1,
+    bar: 2
+};
+
+var p = new Proxy(target, {
+    ownKeys: function() {
+        return ["foo", "bar"];
+    }
+});
+
+Object.preventExtensions(target);
+
+var keys = Object.keys(p);
+
+assert.sameValue(keys[0], "foo");
+assert.sameValue(keys[1], "bar");
+
+assert.sameValue(keys.length, 2);

--- a/test/built-ins/Proxy/ownKeys/null-handler.js
+++ b/test/built-ins/Proxy/ownKeys/null-handler.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.12
+description: >
+    [[OwnPropertyKeys]] ( )
+
+    2. If handler is null, throw a TypeError exception.
+---*/
+
+var p = Proxy.revocable({}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    Object.keys(p.proxy);
+});

--- a/test/built-ins/Proxy/ownKeys/return-all-non-configurable-keys.js
+++ b/test/built-ins/Proxy/ownKeys/return-all-non-configurable-keys.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.12
+description: >
+    The result List must contain the keys of all non-configurable own properties
+    of the target object.
+info: >
+    [[OwnPropertyKeys]] ( )
+
+    ...
+    21. Repeat, for each key that is an element of targetNonconfigurableKeys,
+        a. If key is not an element of uncheckedResultKeys, throw a TypeError
+        exception.
+---*/
+
+var target = {
+    foo: 1
+};
+
+Object.defineProperty(target, "attr", {
+    configurable: false,
+    enumerable: true,
+    value: true
+});
+
+var p = new Proxy(target, {
+    ownKeys: function() {
+        return ["foo"];
+    }
+});
+
+assert.throws(TypeError, function() {
+    Object.keys(p);
+});

--- a/test/built-ins/Proxy/ownKeys/return-is-abrupt.js
+++ b/test/built-ins/Proxy/ownKeys/return-is-abrupt.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.12
+description: >
+    Trap returns abrupt.
+info: >
+    [[OwnPropertyKeys]] ( )
+
+    ...
+    8. Let trapResultArray be Call(trap, handler, «target»).
+    9. Let trapResult be CreateListFromArrayLike(trapResultArray, «‍String, Symbol»).
+        7.3.17 CreateListFromArrayLike (obj [, elementTypes] )
+
+        1. ReturnIfAbrupt(obj).
+    ...
+includes: [Test262Error.js]
+---*/
+
+var p = new Proxy({}, {
+    ownKeys: function() {
+        throw new Test262Error();
+    }
+});
+
+assert.throws(Test262Error, function() {
+    Object.keys(p);
+});

--- a/test/built-ins/Proxy/ownKeys/return-not-list-object-throws.js
+++ b/test/built-ins/Proxy/ownKeys/return-not-list-object-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.12
+description: >
+    If return is not a list object, throw a TypeError exception
+info: >
+    [[OwnPropertyKeys]] ( )
+
+    8. Let trapResultArray be Call(trap, handler, «target»).
+    9. Let trapResult be CreateListFromArrayLike(trapResultArray, «‍String,
+    Symbol»).
+    ...
+        7.3.17 CreateListFromArrayLike (obj [, elementTypes] )
+            3. If Type(obj) is not Object, throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    ownKeys: function() {
+        return undefined;
+    }
+});
+
+assert.throws(TypeError, function() {
+    Object.keys(p);
+});

--- a/test/built-ins/Proxy/ownKeys/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/ownKeys/trap-is-not-callable.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.12
+description: >
+    Trap is not callable.
+info: >
+    [[OwnPropertyKeys]] ( )
+
+    5. Let trap be GetMethod(handler, "ownKeys").
+    ...
+
+    7.3.9 GetMethod (O, P)
+
+    5. If IsCallable(func) is false, throw a TypeError exception.
+---*/
+
+var p = new Proxy({attr:1}, {
+    ownKeys: {}
+});
+
+assert.throws(TypeError, function() {
+    Object.keys(p);
+});

--- a/test/built-ins/Proxy/ownKeys/trap-is-undefined.js
+++ b/test/built-ins/Proxy/ownKeys/trap-is-undefined.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.12
+description: >
+    [[OwnPropertyKeys]] ( )
+
+    7. If trap is undefined, then Return target.[[OwnPropertyKeys]]()
+---*/
+
+var target = {
+    foo: 1,
+    bar: 2
+};
+var p = new Proxy(target, {});
+
+var keys = Object.keys(p);
+
+assert.sameValue(keys[0], "foo");
+assert.sameValue(keys[1], "bar");
+
+assert.sameValue(keys.length, 2);

--- a/test/built-ins/Proxy/preventExtensions/call-parameters.js
+++ b/test/built-ins/Proxy/preventExtensions/call-parameters.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.4
+description: >
+    Trap is called with handler on its context and target as the first
+    parameter.
+info: >
+    [[PreventExtensions]] ( )
+
+    ...
+    8. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target»)).
+    ...
+---*/
+
+var _target, _handler;
+var target = {};
+var handler = {
+    preventExtensions: function(t) {
+        _handler = this;
+        _target = t;
+
+        return Object.preventExtensions(target);
+    }
+};
+var p = new Proxy(target, handler);
+
+Object.preventExtensions(p);
+
+assert.sameValue(_handler, handler);
+assert.sameValue(_target, target);

--- a/test/built-ins/Proxy/preventExtensions/null-handler.js
+++ b/test/built-ins/Proxy/preventExtensions/null-handler.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.4
+description: >
+    Throws a TypeError exception if handler is null.
+---*/
+
+var p = Proxy.revocable({}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    Object.preventExtensions(p.proxy);
+});

--- a/test/built-ins/Proxy/preventExtensions/return-false.js
+++ b/test/built-ins/Proxy/preventExtensions/return-false.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.4
+description: >
+    If boolean trap result if false, return false.
+features: [Reflect]
+---*/
+
+var target = {};
+var p = new Proxy({}, {
+    preventExtensions: function(t) {
+        return 0;
+    }
+});
+
+assert.sameValue(Reflect.preventExtensions(p), false);
+
+Object.preventExtensions(target);
+
+assert.sameValue(Reflect.preventExtensions(p), false);

--- a/test/built-ins/Proxy/preventExtensions/return-is-abrupt.js
+++ b/test/built-ins/Proxy/preventExtensions/return-is-abrupt.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.4
+description: >
+    Trap returns abrupt.
+info: >
+    [[PreventExtensions]] ( )
+
+    ...
+    8. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target»)).
+    9. ReturnIfAbrupt(booleanTrapResult).
+    ...
+includes: [Test262Error.js]
+---*/
+
+var p = new Proxy({}, {
+    preventExtensions: function(t) {
+        throw new Test262Error();
+    }
+});
+
+assert.throws(Test262Error, function() {
+    Object.preventExtensions(p);
+});

--- a/test/built-ins/Proxy/preventExtensions/return-true-target-is-extensible.js
+++ b/test/built-ins/Proxy/preventExtensions/return-true-target-is-extensible.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.4
+description: >
+    Throws a TypeError exception if boolean trap result is true and target is
+    extensible.
+info: >
+    [[PreventExtensions]] ( )
+
+    ...
+    10. If booleanTrapResult is true, then
+        ...
+        c. If targetIsExtensible is true, throw a TypeError exception.
+    11. Return booleanTrapResult.
+    ...
+---*/
+
+var p = new Proxy({}, {
+    preventExtensions: function(t) {
+        return true;
+    }
+});
+
+assert.throws(TypeError, function() {
+    Object.preventExtensions(p);
+});

--- a/test/built-ins/Proxy/preventExtensions/return-true-target-is-not-extensible.js
+++ b/test/built-ins/Proxy/preventExtensions/return-true-target-is-not-extensible.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.4
+description: >
+    Return boolean trap result if its true and target is not extensible.
+features: [Reflect]
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    preventExtensions: function(t) {
+        return 1;
+    }
+});
+
+Object.preventExtensions(target);
+
+assert(Reflect.preventExtensions(p));

--- a/test/built-ins/Proxy/preventExtensions/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/preventExtensions/trap-is-not-callable.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.4
+description: >
+    Throws a TypeError exception if trap is not callable.
+info: >
+    [[PreventExtensions]] ( )
+
+    ...
+    1. Let handler be the value of the [[ProxyHandler]] internal slot of O.
+    ...
+    5. Let trap be GetMethod(handler, "preventExtensions").
+    ...
+        7.3.9 GetMethod (O, P)
+        ...
+        2. Let func be GetV(O, P).
+        5. If IsCallable(func) is false, throw a TypeError exception.
+        ...
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    preventExtensions: {}
+});
+
+assert.throws(TypeError, function() {
+    Object.preventExtensions(p);
+});

--- a/test/built-ins/Proxy/preventExtensions/trap-is-undefined.js
+++ b/test/built-ins/Proxy/preventExtensions/trap-is-undefined.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.4
+description: >
+    Return target.[[PreventExtensions]]() if target is undefined.
+features: [Reflect]
+---*/
+
+var target = {};
+var p = new Proxy(target, {});
+
+assert.sameValue(Reflect.preventExtensions(p), true);

--- a/test/built-ins/Proxy/proxy-newtarget.js
+++ b/test/built-ins/Proxy/proxy-newtarget.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.2.1.1
+description: >
+    Proxy ( target, handler )
+
+    When Proxy is called with arguments target and handler performs
+    the following steps:
+
+    ...
+    2. Return ProxyCreate(target, handler). (9.5.15)
+    ...
+        9.5.15 ProxyCreate(target, handler)
+        ...
+        5. Let P be a newly created object.
+        ...
+        10. Return P.
+
+---*/
+
+var p1 = new Proxy({}, {});
+
+assert.sameValue(
+    typeof p1,
+    'object',
+    'Return a newly created Object'
+);

--- a/test/built-ins/Proxy/proxy-no-prototype.js
+++ b/test/built-ins/Proxy/proxy-no-prototype.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.2.2
+description: >
+    The Proxy constructor does not have a prototype property because
+    proxy exotic objects do not have a [[Prototype]] internal slot
+    that requires initialization.
+---*/
+
+assert.sameValue(Object.hasOwnProperty.call(Proxy, 'prototype'), false);

--- a/test/built-ins/Proxy/proxy-undefined-newtarget.js
+++ b/test/built-ins/Proxy/proxy-undefined-newtarget.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.2.1.1
+description: >
+    Proxy ( target, handler )
+
+    When Proxy is called with arguments target and handler performs
+    the following steps:
+
+    1. If NewTarget is undefined, throw a TypeError exception.
+    ...
+
+---*/
+
+assert.throws(TypeError, function() {
+  Proxy();
+});
+
+assert.throws(TypeError, function() {
+  Proxy([]);
+});

--- a/test/built-ins/Proxy/proxy.js
+++ b/test/built-ins/Proxy/proxy.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.2.1.1
+description: >
+    Proxy ( target, handler )
+
+    17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(this, "Proxy");
+verifyWritable(this, "Proxy");
+verifyConfigurable(this, "Proxy");

--- a/test/built-ins/Proxy/revocable/proxy.js
+++ b/test/built-ins/Proxy/revocable/proxy.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.2.2.1
+description: >
+    The returned object has a proxy property which is the created Proxy object
+    built with the given target and handler given parameters.
+info: >
+    Proxy.revocable ( target, handler )
+
+    6. Perform CreateDataProperty(result, "proxy", p).
+---*/
+
+var target = {
+    attr: "foo"
+};
+var r = Proxy.revocable(target, {
+    get: function(t, prop) {
+        return t[prop] + "!";
+    }
+});
+
+assert.sameValue(r.proxy.attr, "foo!");

--- a/test/built-ins/Proxy/revocable/revoke-consecutive-call-returns-undefined.js
+++ b/test/built-ins/Proxy/revocable/revoke-consecutive-call-returns-undefined.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.2.2.1.1
+description: >
+    Calling the revoked function again will return undefined
+info: >
+    Proxy Revocation Functions
+
+    ...
+    1. Let p be the value of F’s [[RevocableProxy]] internal slot.
+    2. If p is null, return undefined.
+---*/
+
+var r = Proxy.revocable({}, {});
+
+r.revoke();
+
+assert.sameValue(r.revoke(), undefined);

--- a/test/built-ins/Proxy/revocable/revoke-returns-undefined.js
+++ b/test/built-ins/Proxy/revocable/revoke-returns-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.2.2.1.1
+description: >
+    Calling the revoked function returns undefined
+info: >
+    Proxy Revocation Functions
+
+    ...
+    7. Return undefined.
+---*/
+
+var r = Proxy.revocable({}, {});
+
+assert.sameValue(r.revoke(), undefined);

--- a/test/built-ins/Proxy/revocable/revoke.js
+++ b/test/built-ins/Proxy/revocable/revoke.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.2.2.1
+description: >
+    The returned object has a `revoked` property which is a function
+info: >
+    Proxy.revocable ( target, handler )
+
+    7. Perform CreateDataProperty(result, "revoke", revoker).
+---*/
+
+var r = Proxy.revocable({}, {});
+
+assert.sameValue(typeof r.revoke, "function");

--- a/test/built-ins/Proxy/set/boolean-trap-result-is-false-boolean-return-false.js
+++ b/test/built-ins/Proxy/set/boolean-trap-result-is-false-boolean-return-false.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    11. If booleanTrapResult is false, return false.
+features: [Reflect]
+---*/
+
+var target = {};
+var handler = {
+    set: function(t, prop, value, receiver) {
+        return false;
+    }
+};
+var p = new Proxy(target, handler);
+
+assert.sameValue(Reflect.set(p, "attr", "foo"), false);

--- a/test/built-ins/Proxy/set/boolean-trap-result-is-false-null-return-false.js
+++ b/test/built-ins/Proxy/set/boolean-trap-result-is-false-null-return-false.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    11. If booleanTrapResult is false, return false.
+features: [Reflect]
+---*/
+
+var target = {};
+var handler = {
+    set: function(t, prop, value, receiver) {
+        return null;
+    }
+};
+var p = new Proxy(target, handler);
+
+assert.sameValue(Reflect.set(p, "attr", "foo"), false);

--- a/test/built-ins/Proxy/set/boolean-trap-result-is-false-number-return-false.js
+++ b/test/built-ins/Proxy/set/boolean-trap-result-is-false-number-return-false.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    11. If booleanTrapResult is false, return false.
+features: [Reflect]
+---*/
+
+var target = {};
+var handler = {
+    set: function(t, prop, value, receiver) {
+        return 0;
+    }
+};
+var p = new Proxy(target, handler);
+
+assert.sameValue(Reflect.set(p, "attr", "foo"), false);

--- a/test/built-ins/Proxy/set/boolean-trap-result-is-false-string-return-false.js
+++ b/test/built-ins/Proxy/set/boolean-trap-result-is-false-string-return-false.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    11. If booleanTrapResult is false, return false.
+features: [Reflect]
+---*/
+
+var target = {};
+var handler = {
+    set: function(t, prop, value, receiver) {
+        return "";
+    }
+};
+var p = new Proxy(target, handler);
+
+assert.sameValue(Reflect.set(p, "attr", "foo"), false);

--- a/test/built-ins/Proxy/set/boolean-trap-result-is-false-undefined-return-false.js
+++ b/test/built-ins/Proxy/set/boolean-trap-result-is-false-undefined-return-false.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    11. If booleanTrapResult is false, return false.
+features: [Reflect]
+---*/
+
+var target = {};
+var handler = {
+    set: function(t, prop, value, receiver) {
+        return undefined;
+    }
+};
+var p = new Proxy(target, handler);
+
+assert.sameValue(Reflect.set(p, "attr", "foo"), false);

--- a/test/built-ins/Proxy/set/call-parameters.js
+++ b/test/built-ins/Proxy/set/call-parameters.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P, V,
+    Receiver»)).
+
+---*/
+
+var _target, _handler, _prop, _value, _receiver;
+var target = {};
+var handler = {
+    set: function(t, prop, value, receiver) {
+        _handler = this;
+        _target = t;
+        _prop = prop;
+        _value = value;
+        _receiver = receiver;
+        return t[prop] = value;
+    }
+};
+var p = new Proxy(target, handler);
+
+p.attr = "foo";
+
+assert.sameValue(_handler, handler, "handler object as the trap context");
+assert.sameValue(_target, target, "first argument is the target object");
+assert.sameValue(_prop, "attr", "second argument is the property name");
+assert.sameValue(_value, "foo", "third argument is the new value");
+assert.sameValue(_receiver, p, "forth argument is the proxy object");

--- a/test/built-ins/Proxy/set/null-handler.js
+++ b/test/built-ins/Proxy/set/null-handler.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    3. If handler is null, throw a TypeError exception.
+---*/
+
+var p = Proxy.revocable({}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    p.proxy.attr = 1;
+});
+
+assert.throws(TypeError, function() {
+    p.proxy['attr'] = 1;
+});

--- a/test/built-ins/Proxy/set/return-is-abrupt.js
+++ b/test/built-ins/Proxy/set/return-is-abrupt.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    Trap returns abrupt.
+info: >
+    [[Set]] ( P, V, Receiver)
+
+    ...
+    9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P, V, Receiver»)).
+    10. ReturnIfAbrupt(booleanTrapResult).
+    ...
+includes: [Test262Error.js]
+---*/
+
+var p = new Proxy({}, {
+    set: function(t, prop, value, receiver) {
+        throw new Test262Error();
+    }
+});
+
+assert.throws(Test262Error, function() {
+    p.attr = "bar";
+});
+
+assert.throws(Test262Error, function() {
+    p["attr"] = "bar";
+});

--- a/test/built-ins/Proxy/set/return-true-target-property-accessor-is-configurable-set-is-undefined.js
+++ b/test/built-ins/Proxy/set/return-true-target-property-accessor-is-configurable-set-is-undefined.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    Returns true if trap returns true and target property accessor is
+    configurable and set is undefined.
+features: [Reflect]
+---*/
+
+var target = {};
+var handler = {
+    set: function(t, prop, value, receiver) {
+        return true;
+    }
+};
+var p = new Proxy(target, handler);
+
+Object.defineProperty(target, "attr", {
+    configurable: true,
+    set: undefined
+});
+
+assert(Reflect.set(p, "attr", "bar"));

--- a/test/built-ins/Proxy/set/return-true-target-property-accessor-is-not-configurable.js
+++ b/test/built-ins/Proxy/set/return-true-target-property-accessor-is-not-configurable.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    Returns true if trap returns true and target property accessor is not
+    configurable and set is not undefined.
+features: [Reflect]
+---*/
+
+var target = {};
+var handler = {
+    set: function(t, prop, value, receiver) {
+        return true;
+    }
+};
+var p = new Proxy(target, handler);
+
+Object.defineProperty(target, 'attr', {
+    configurable: false,
+    set: function( value ) {
+        return value;
+    }
+});
+
+assert(Reflect.set(p, "attr", 1));

--- a/test/built-ins/Proxy/set/return-true-target-property-is-not-configurable.js
+++ b/test/built-ins/Proxy/set/return-true-target-property-is-not-configurable.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    Returns true if trap returns true and target property is not configurable
+    but writable.
+features: [Reflect]
+---*/
+
+var target = {};
+var handler = {
+    set: function(t, prop, value, receiver) {
+        return true;
+    }
+};
+var p = new Proxy(target, handler);
+
+Object.defineProperty(target, 'attr', {
+    configurable: false,
+    writable: true,
+    value: 'foo'
+});
+
+assert(Reflect.set(p, "attr", 1));

--- a/test/built-ins/Proxy/set/return-true-target-property-is-not-writable.js
+++ b/test/built-ins/Proxy/set/return-true-target-property-is-not-writable.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    Returns true if trap returns true and target property is configurable
+    but not writable.
+features: [Reflect]
+---*/
+
+var target = {};
+var handler = {
+    set: function(t, prop, value, receiver) {
+        return true;
+    }
+};
+var p = new Proxy(target, handler);
+
+Object.defineProperty(target, "attr", {
+    configurable: true,
+    writable: false,
+    value: "foo"
+});
+
+assert(Reflect.set(p, "attr", "foo"));

--- a/test/built-ins/Proxy/set/target-property-is-accessor-not-configurable-set-is-undefined.js
+++ b/test/built-ins/Proxy/set/target-property-is-accessor-not-configurable-set-is-undefined.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    Throws a TypeError when target property is an accessor not configurable and
+    and set is undefined.
+info: >
+    14. If targetDesc is not undefined, then
+        b. If IsAccessorDescriptor(targetDesc) and targetDesc.[[Configurable]] is false, then
+            i. If targetDesc.[[Set]] is undefined, throw a TypeError exception.
+
+---*/
+
+var target = {};
+var handler = {
+    set: function(t, prop, value, receiver) {
+        return true;
+    }
+};
+var p = new Proxy(target, handler);
+
+Object.defineProperty(target, 'attr', {
+    configurable: false,
+    set: undefined
+});
+
+assert.throws(TypeError, function() {
+    p.attr = 'bar';
+});
+
+assert.throws(TypeError, function() {
+    p['attr'] = 'bar';
+});

--- a/test/built-ins/Proxy/set/target-property-is-not-configurable-not-writable-not-equal-to-v.js
+++ b/test/built-ins/Proxy/set/target-property-is-not-configurable-not-writable-not-equal-to-v.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    Throws a TypeError when target property is not configurable neither writable
+    and its value is not strictly equal to V.
+info: >
+    14. If targetDesc is not undefined, then
+        a. If IsDataDescriptor(targetDesc) and targetDesc.[[Configurable]] is
+        false and targetDesc.[[Writable]] is false, then
+            i. If SameValue(V, targetDesc.[[Value]]) is false, throw a TypeError
+            exception.
+---*/
+
+var target = {};
+var handler = {
+    set: function(t, prop, value, receiver) {
+        return true;
+    }
+};
+var p = new Proxy(target, handler);
+
+Object.defineProperty(target, 'attr', {
+    configurable: false,
+    writable: false,
+    value: 'foo'
+});
+
+assert.throws(TypeError, function() {
+    p.attr = 'bar';
+});
+
+assert.throws(TypeError, function() {
+    p['attr'] = 'bar';
+});

--- a/test/built-ins/Proxy/set/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/set/trap-is-not-callable.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    Trap is not callable.
+info: >
+    [[Set]] ( P, V, Receiver)
+
+    6. Let trap be GetMethod(handler, "set").
+    ...
+
+    7.3.9 GetMethod (O, P)
+
+    5. If IsCallable(func) is false, throw a TypeError exception.
+---*/
+
+var p = new Proxy({}, {
+    set: {}
+});
+
+assert.throws(TypeError, function() {
+    p.attr = 1;
+});
+
+assert.throws(TypeError, function() {
+    p["attr"] = 1;
+});

--- a/test/built-ins/Proxy/set/trap-is-undefined-no-property.js
+++ b/test/built-ins/Proxy/set/trap-is-undefined-no-property.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    8. If trap is undefined, then return target.[[Set]](P, V, Receiver).
+
+---*/
+
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {});
+
+p.attr = 2;
+
+assert.sameValue(target.attr, 2);

--- a/test/built-ins/Proxy/set/trap-is-undefined.js
+++ b/test/built-ins/Proxy/set/trap-is-undefined.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.9
+description: >
+    [[Set]] ( P, V, Receiver)
+
+    8. If trap is undefined, then return target.[[Set]](P, V, Receiver).
+
+---*/
+
+var target = {
+    attr: 1
+};
+var p = new Proxy(target, {
+    get: undefined
+});
+
+p.attr = 1;
+
+assert.sameValue(target.attr, 1);

--- a/test/built-ins/Proxy/setPrototypeOf/boolean-trap-result-extensible-target.js
+++ b/test/built-ins/Proxy/setPrototypeOf/boolean-trap-result-extensible-target.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.2
+description: >
+    Return a boolean trap result if target is extensible.
+info: >
+    [[SetPrototypeOf]] (V)
+
+    ...
+    13. If extensibleTarget is true, return booleanTrapResult.
+    ...
+flags: [onlyStrict]
+features: [Reflect]
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    setPrototypeOf: function(t, v) {
+        return v.attr;
+    }
+});
+
+var result = Reflect.setPrototypeOf(p, { attr: 0 });
+assert.sameValue(result, false);
+
+result = Reflect.setPrototypeOf(p, { attr: 1 });
+assert.sameValue(result, true);

--- a/test/built-ins/Proxy/setPrototypeOf/call-parameters.js
+++ b/test/built-ins/Proxy/setPrototypeOf/call-parameters.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.2
+description: >
+    Trap is called with handler on its context, first parameter is target and
+    second parameter is the given value.
+info: >
+    [[SetPrototypeOf]] (V)
+
+    ...
+    9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, V»)).
+    ...
+---*/
+
+var _handler, _target, _value;
+var target = {};
+var val = {foo: 1};
+var handler = {
+    setPrototypeOf: function(t, v) {
+        _handler = this;
+        _target = t;
+        _value = v;
+
+        Object.setPrototypeOf(t, v);
+
+        return true;
+    }
+};
+var p = new Proxy(target, handler);
+
+Object.setPrototypeOf(p, val);
+
+assert.sameValue(_handler, handler);
+assert.sameValue(_target, target);
+assert.sameValue(_value, val);

--- a/test/built-ins/Proxy/setPrototypeOf/not-extensible-target-not-same-target-prototype.js
+++ b/test/built-ins/Proxy/setPrototypeOf/not-extensible-target-not-same-target-prototype.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.2
+description: >
+    Throws a TypeError exception if boolean trap result is true, target is
+    not extensible, and the given parameter is not the same object as the target
+    prototype.
+info: >
+    [[SetPrototypeOf]] (V)
+
+    ...
+    2. Let handler be the value of the [[ProxyHandler]] internal slot of O.
+    ...
+    5. Let target be the value of the [[ProxyTarget]] internal slot of O.
+    6. Let trap be GetMethod(handler, "setPrototypeOf").
+    ...
+    9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, V»)).
+    14. Let targetProto be target.[[GetPrototypeOf]]().
+    15. ReturnIfAbrupt(targetProto).
+    16. If booleanTrapResult is true and SameValue(V, targetProto) is false,
+    throw a TypeError exception.
+    ...
+
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    setPrototypeOf: function(t, v) {
+        return true;
+    }
+});
+
+Object.preventExtensions(target);
+
+assert.throws(TypeError, function() {
+    Object.setPrototypeOf(p, {});
+});

--- a/test/built-ins/Proxy/setPrototypeOf/not-extensible-target-same-target-prototype.js
+++ b/test/built-ins/Proxy/setPrototypeOf/not-extensible-target-same-target-prototype.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.2
+description: >
+    Return true if boolean trap result is true, target is not extensible, and
+    given parameter is the same as target prototype.
+features: [Reflect]
+---*/
+
+var target = Object.create(Array.prototype);
+var p = new Proxy(target, {
+    setPrototypeOf: function(t, v) {
+        return true;
+    }
+});
+
+Object.preventExtensions(target);
+
+assert(Reflect.setPrototypeOf(p, Array.prototype));

--- a/test/built-ins/Proxy/setPrototypeOf/not-extensible-trap-is-false-return-false.js
+++ b/test/built-ins/Proxy/setPrototypeOf/not-extensible-trap-is-false-return-false.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.2
+description: >
+    Return false if boolean trap result is false.
+features: [Reflect]
+---*/
+
+var target = [];
+var p = new Proxy(target, {
+    setPrototypeOf: function(t, v) {
+        return false;
+    }
+});
+
+Object.preventExtensions(target);
+
+assert.sameValue(Reflect.setPrototypeOf(p, {}), false);

--- a/test/built-ins/Proxy/setPrototypeOf/null-handler.js
+++ b/test/built-ins/Proxy/setPrototypeOf/null-handler.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.2
+description: >
+    Throws a TypeError exception if handler is null
+---*/
+
+var p = Proxy.revocable({},{});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+    Object.setPrototypeOf(p.proxy, {});
+});

--- a/test/built-ins/Proxy/setPrototypeOf/return-is-abrupt.js
+++ b/test/built-ins/Proxy/setPrototypeOf/return-is-abrupt.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.2
+description: >
+    Trap returns abrupt.
+info: >
+    [[SetPrototypeOf]] (V)
+
+    9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, V»)).
+    10. ReturnIfAbrupt(booleanTrapResult).
+includes: [Test262Error.js]
+---*/
+
+var p = new Proxy({}, {
+    setPrototypeOf: function() {
+        throw new Test262Error();
+    }
+});
+
+assert.throws(Test262Error, function() {
+    Object.setPrototypeOf(p, {value: 1});
+});

--- a/test/built-ins/Proxy/setPrototypeOf/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/setPrototypeOf/trap-is-not-callable.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.2
+description: >
+    Throws a TypeError exception if trap is not callable.
+info: >
+    [[SetPrototypeOf]] (V)
+
+    ...
+    2. Let handler be the value of the [[ProxyHandler]] internal slot of O.
+    ...
+    5. Let target be the value of the [[ProxyTarget]] internal slot of O.
+    6. Let trap be GetMethod(handler, "setPrototypeOf").
+    ...
+        7.3.9 GetMethod (O, P)
+        ...
+        2. Let func be GetV(O, P).
+        5. If IsCallable(func) is false, throw a TypeError exception.
+        ...
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+    setPrototypeOf: {}
+});
+
+assert.throws(TypeError, function() {
+    Object.setPrototypeOf(p, {
+        value: 1
+    });
+});

--- a/test/built-ins/Proxy/setPrototypeOf/trap-is-undefined.js
+++ b/test/built-ins/Proxy/setPrototypeOf/trap-is-undefined.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 9.5.2
+description: >
+    Return target.[[SetPrototypeOf]] (V) if trap is undefined.
+---*/
+
+var target = {};
+var p = new Proxy(target, {});
+
+Object.setPrototypeOf(p, {attr: 1});
+
+assert.sameValue(target.attr, 1);


### PR DESCRIPTION
this PR aims to bring all Proxy tests, including traps handlers and Proxy.revocable.

As it will require a few more days to get finished, I'm opening it now to allow earlier review on the already done parts and avoid concurrent work on the same tests.

As soon as I have this PR good for final reviews, the [WIP] prefix will be removed and all the commits will be squashed.