### PR TITLE
Update contribution information

### DIFF
--- a/tools/packaging/templates/runner.test262.html
+++ b/tools/packaging/templates/runner.test262.html
@@ -73,7 +73,14 @@
                     ECMAScript 5.1 was approved as an official Ecma standard by the Ecma General Assembly in June 2011.
                     The ECMAScript 5.1 standard is available in <a href='javascript:void(window.open("http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-262.pdf"));'>PDF</a> and <a href='javascript:void(window.open("http://ecma-international.org/ecma-262/5.1/"));'>HTML</a> versions from the Ecma International web site.</p>
                 <p class="headers">Who creates and maintains test262?</p>
-                <p class="content">Development of test262 is a project of Ecma TC39.  The testing framework and individual tests are created by member organizations of TC39 and contributed to Ecma for use in test262. For more information about how test262 is developed and maintained click the “Development” tab at the top of this page.</p>
+                <p class="content">
+                    Development of test262 is a project of Ecma TC39.  The
+                    testing framework and individual tests are created by
+                    developers all over the world and contributed to Ecma for
+                    use in test262. For more information about how test262 is
+                    developed and maintained, click the
+                    &#8220;Development&#8221; tab at the top of this page.
+                </p>
                 <p class="headers">What is the status of test262?</p>
                 <p class="content"><strong>test262 is not yet complete.  It is still undergoing active development.</strong> Some portions of the ES5 specification have very complete test coverage while other portions of the specification have only partial test coverage.  Some tests may be invalid or may yield false positive or false negative results. A perfect passing score on test262 does not guarantee that a JavaScript implementation perfectly supports ES5. Because tests are being actively added and modified, tests results from different days or times may not be directly comparable. Click the “Development” tab at the top of this page for instructions for reporting test262 bugs.</p>
                 <p class="headers">Where can I find out more?</p>
@@ -88,11 +95,24 @@
 
             <div class="content-dev">
                 <p class="headers">Development</p>
-                <p class="content">Test262 is being developed by the members of Ecma TC39. Ecma's intellectual property policies permit only Ecma 
-                    members to directly contribute code to the project. However, a <a href='javascript:void(window.open("http://mail.mozilla.org/pipermail/test262-discuss/"));'>public mailing list</a> is used to coordinate development of test262.  If you wish to participate in the discussion please <a href='javascript:void(window.open("http://mail.mozilla.org/listinfo/test262-discuss"));'>subscribe</a>.  Bug reports and suggestions should be sent to the mailing list.
-                </p>
                 <p class="content">
-                    Ecma members can find detailed instructions on Test262 development procedures at the <a href='javascript:void(window.open("http://wiki.ecmascript.org/doku.php?id=test262:test262"));'>Test262 Wiki</a>.
+                    Test262 is being developed as an open source project and
+                    the maintainers are accepting patches from the community.
+                    The project is maintained using <a
+                    href='javascript:void(window.open("https://git-scm.com/"));'>the
+                    git version control system</a> and is <a
+                    href='javascript:void(window.open("https://github.com/tc39/test262"));'>currently
+                    hosted on GitHub.com</a>. Bug reports and patches may be
+                    submitted to the GitHub repository.
+                </p>
+
+                <p class="content">
+                    A <a
+                    href='javascript:void(window.open("http://mail.mozilla.org/pipermail/test262-discuss/"));'>public
+                    mailing list</a> is used to coordinate development of
+                    test262. If you wish to participate in the discussion,
+                    please <a
+                    href='javascript:void(window.open("http://mail.mozilla.org/listinfo/test262-discuss"));'>subscribe</a>.
                 </p>
             </div>
 


### PR DESCRIPTION
Test262 now accepts community contributions. Update the copy on the
website to reflect this.

@bterlson I have some ideas for more extensive documentation refactoring, but I thought it would be best to keep this patch small so we can more quickly correct the text on the site in production.