### PR TITLE
Add tests for early errors in module syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,8 @@ This tag is for boolean properties associated with the test.
 
 - **`onlyStrict`** - only run the test in strict mode (*not supported by the browser runner*)
 - **`noStrict`** - only run the test in "sloppy" mode
+- **`module`** - interpret the source text as [module
+  code](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-modules)
 
 #### features
 **features**: [list]

--- a/test/language/import/dup-bound-names.js
+++ b/test/language/import/dup-bound-names.js
@@ -1,0 +1,12 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 15.2.1.1
+description: >
+    It is a Syntax Error if the BoundNames of ImportDeclaration contains any
+    duplicate entries.
+flags: [module]
+negative: SyntaxError
+---*/
+
+import { x, y as x } from 'z';

--- a/test/language/module-code/dup-export-decl.js
+++ b/test/language/module-code/dup-export-decl.js
@@ -1,0 +1,13 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 15.2.1.1
+description: >
+    It is a Syntax Error if the ExportedNames of ModuleItemList contains any
+    duplicate entries.
+flags: [module]
+negative: SyntaxError
+---*/
+
+export function f() {}
+export function *f() {}

--- a/test/language/module-code/dup-export-dflt.js
+++ b/test/language/module-code/dup-export-dflt.js
@@ -1,0 +1,13 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 15.2.1.1
+description: >
+    It is a Syntax Error if the ExportedNames of ModuleItemList contains any
+    duplicate entries.
+flags: [module]
+negative: SyntaxError
+---*/
+
+export default var x = null;
+export default var x = null;

--- a/test/language/module-code/dup-export-id-as.js
+++ b/test/language/module-code/dup-export-id-as.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 15.2.1.1
+description: >
+    It is a Syntax Error if the ExportedNames of ModuleItemList contains any
+    duplicate entries.
+flags: [module]
+negative: SyntaxError
+---*/
+
+var x, y;
+export { x as z };
+export { y as z };

--- a/test/language/module-code/dup-export-id.js
+++ b/test/language/module-code/dup-export-id.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 15.2.1.1
+description: >
+    It is a Syntax Error if the ExportedNames of ModuleItemList contains any
+    duplicate entries.
+flags: [module]
+negative: SyntaxError
+---*/
+
+var x;
+export { x };
+export { x };

--- a/test/language/module-code/dup-lables.js
+++ b/test/language/module-code/dup-lables.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 15.2.1.1
+description: >
+    It is a Syntax Error if ContainsDuplicateLabels of ModuleItemList with
+    argument « » is true.
+flags: [module]
+negative: SyntaxError
+---*/
+
+label: {
+  label: 0;
+}

--- a/test/language/module-code/dup-lex.js
+++ b/test/language/module-code/dup-lex.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 10.2.1
+description: >
+    It is a Syntax Error if the LexicallyDeclaredNames of ModuleItemList
+    contains any duplicate entries.
+flags: [module]
+features: [let, const]
+negative: SyntaxError
+---*/
+
+let x;
+const x;

--- a/test/language/module-code/export-unresolvable.js
+++ b/test/language/module-code/export-unresolvable.js
@@ -1,0 +1,13 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 15.2.1.1
+description: >
+    It is a Syntax Error if any element of the ExportedBindings of
+    ModuleItemList does not also occur in either the VarDeclaredNames of
+    ModuleItemList, or the LexicallyDeclaredNames of ModuleItemList.
+flags: [module]
+negative: SyntaxError
+---*/
+
+export { unresolvable };

--- a/test/language/module-code/import-as-stmt-list-item.js
+++ b/test/language/module-code/import-as-stmt-list-item.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 15.2
+description: >
+    An ImportDeclaration is not a valid StatementListItem and is therefore
+    restricted from appearing within statements in a ModuleBody.
+flags: [module]
+negative: SyntaxError
+---*/
+
+{
+  import { x } from 'y';
+}

--- a/test/language/module-code/lex-and-var.js
+++ b/test/language/module-code/lex-and-var.js
@@ -1,0 +1,13 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 10.2.1
+description: >
+    It is a Syntax Error if any element of the LexicallyDeclaredNames of
+    ModuleItemList also occurs in the VarDeclaredNames of ModuleItemList.
+flags: [module]
+features: [let]
+---*/
+
+let x;
+var x;

--- a/test/language/module-code/new-target.js
+++ b/test/language/module-code/new-target.js
@@ -1,0 +1,11 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 15.2.1.1
+description: >
+    It is a Syntax Error if ModuleItemList Contains NewTarget
+flags: [module]
+negative: SyntaxError
+---*/
+
+new.target;

--- a/test/language/module-code/super.js
+++ b/test/language/module-code/super.js
@@ -1,0 +1,11 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 15.2.1.1
+description: >
+    It is a Syntax Error if ModuleItemList Contains super.
+flags: [module]
+negative: SyntaxError
+---*/
+
+super;

--- a/test/language/module-code/undef-break.js
+++ b/test/language/module-code/undef-break.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 15.2.1.1
+description: >
+    It is a Syntax Error if ContainsUndefinedBreakTarget of ModuleItemList with
+    argument « » is true.
+flags: [module]
+negative: SyntaxError
+---*/
+
+while (false) {
+  break undef;
+}

--- a/test/language/module-code/undef-continue.js
+++ b/test/language/module-code/undef-continue.js
@@ -1,0 +1,14 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 15.2.1.1
+description: >
+    It is a Syntax Error if ContainsUndefinedContinueTarget of ModuleItemList
+    with arguments « » and « » is true.
+flags: [module]
+negative: SyntaxError
+---*/
+
+while (false) {
+  continue undef;
+}


### PR DESCRIPTION
@bterlson When it comes to ES6 modules, I think we're limited in what we can
practically test without a loader. Still, it seems like a good idea to get
*some* coverage into test262 because it will pave the way for more rigorous
tests in the future. For instance: harnesses will have to be made aware of
modules so they can parse the source text accordingly. I'm proposing a new
flag, `module`. I prefer this to a boolean frontmatter tag because the relation
with `onlyStrict` and `noStrict` is more clear.

Of all the tests we might write, tests for early errors seem like the most
likely to be useful to implementors today (minimal though they may be).

I've placed the test for `import`'s early error in `language/import` because it
is not technically a statement. At the same time, neither are
FunctionDeclarations, GeneratorDeclarations, ClassDeclarations, or
LexicalDeclarations, so maybe I should take this to mean a loose interpretation
of "statement". I'm happy to move that directory if so.

What do you think?