### PR TITLE
Fixed testing deletion of an environment object.

### DIFF
--- a/test/language/expressions/delete/11.4.1-4.a-5.js
+++ b/test/language/expressions/delete/11.4.1-4.a-5.js
@@ -10,14 +10,14 @@ info: >
     language provides no way to directly exercise [[Delete]], the tests are placed here.
 es5id: 11.4.1-4.a-5
 description: >
-    delete operator returns false when deleting the environment object
+    delete operator returns false when deleting the declaration of the environment object
     inside 'with'
 flags: [noStrict]
 includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  o = new Object();
+  var o = new Object();
   o.x = 1;
   var d;
   with(o)

--- a/test/language/expressions/delete/11.4.1-4.a-5.js
+++ b/test/language/expressions/delete/11.4.1-4.a-5.js
@@ -17,7 +17,7 @@ includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  var o = new Object();
+  o = new Object();
   o.x = 1;
   var d;
   with(o)


### PR DESCRIPTION
Test 11.4.1-4.a-5 states that it verifies that an environment object cannot be deleted. However, this was giving a false positive. It was actually testing where a "var" declaration on an environment object cannot be deleted (there are other tests for this). This test case fails on Chrome 43, Firefox 38 and Internet Explorer 11.

**Please review**: This test has been modified to actually test what the description states it should be testing. However, I cannot find a reference in [the specs](http://ecma-international.org/ecma-262/5.1/) that this test should actually succeed. And, none of the major browsers implement this. Thus I'm not sure whether this test should be modified or deleted. In either case, as the test is right now, it's of no use since it's not testing what it says it should be testing.

*P.S. this is the same pull request as before. I deleted the pull request by accident by force pushing my master branch.*