### PR TITLE
Generator test should specify generators feature.

### DIFF
--- a/test/language/generators/Generator_restricted-properties.js
+++ b/test/language/generators/Generator_restricted-properties.js
@@ -6,6 +6,7 @@ description: >
     Functions created using GeneratorFunction syntactic form do not
     have own properties "caller" or "arguments", but inherit them from
     %FunctionPrototype%.
+features: [generators]
 ---*/
 
 function* generator() {}


### PR DESCRIPTION
One of the generator tests did not specify a `features` or an `es6id`. Added the `features` attribute.