### PR TITLE
Remove `$FAIL` function

### DIFF
--- a/harness/$FAIL.js
+++ b/harness/$FAIL.js
@@ -1,3 +1,0 @@
-function $FAIL(message) {
-    testFailed(message);
-}

--- a/test/built-ins/Array/S15.4.3_A2.2.js
+++ b/test/built-ins/Array/S15.4.3_A2.2.js
@@ -5,12 +5,11 @@
 info: The length property of Array does not have the attribute DontDelete
 es5id: 15.4.3_A2.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (Array.hasOwnProperty('length') !== true) {
-  $FAIL('#1: Array.hasOwnProperty(\'length\') === true. Actual: ' + (Array.hasOwnProperty('length')));
+  $ERROR('#1: Array.hasOwnProperty(\'length\') === true. Actual: ' + (Array.hasOwnProperty('length')));
 }
 
 delete Array.length;

--- a/test/built-ins/Array/prototype/S15.4.3.1_A1.js
+++ b/test/built-ins/Array/prototype/S15.4.3.1_A1.js
@@ -5,10 +5,9 @@
 info: The Array has property prototype
 es5id: 15.4.3.1_A1
 description: Checking use hasOwnProperty
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (Array.hasOwnProperty('prototype') !== true) {
-	$FAIL('#1: Array.hasOwnProperty(\'prototype\') === true. Actual: ' + (Array.hasOwnProperty('prototype')));
+	$ERROR('#1: Array.hasOwnProperty(\'prototype\') === true. Actual: ' + (Array.hasOwnProperty('prototype')));
 }

--- a/test/built-ins/Array/prototype/S15.4.3.1_A3.js
+++ b/test/built-ins/Array/prototype/S15.4.3.1_A3.js
@@ -5,12 +5,12 @@
 info: The Array.prototype property has the attribute DontDelete
 es5id: 15.4.3.1_A3
 description: Checking if deleting the Array.prototype property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#1
 if (Array.hasOwnProperty('prototype') !== true) {
-	$FAIL('#1: Array.hasOwnProperty(\'prototype\') === true. Actual: ' + (Array.hasOwnProperty('prototype')));
+	$ERROR('#1: Array.hasOwnProperty(\'prototype\') === true. Actual: ' + (Array.hasOwnProperty('prototype')));
 }
 
 verifyNotConfigurable(Array, "prototype");

--- a/test/built-ins/Array/prototype/concat/S15.4.4.4_A4.2.js
+++ b/test/built-ins/Array/prototype/concat/S15.4.4.4_A4.2.js
@@ -5,12 +5,11 @@
 info: The length property of concat does not have the attribute DontDelete
 es5id: 15.4.4.4_A4.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (Array.prototype.concat.hasOwnProperty('length') !== true) {
-  $FAIL('#1: Array.prototype.concat.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.concat.hasOwnProperty('length')));
+  $ERROR('#1: Array.prototype.concat.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.concat.hasOwnProperty('length')));
 }
 
 delete Array.prototype.concat.length;

--- a/test/built-ins/Array/prototype/join/S15.4.4.5_A6.2.js
+++ b/test/built-ins/Array/prototype/join/S15.4.4.5_A6.2.js
@@ -5,12 +5,11 @@
 info: The length property of join does not have the attribute DontDelete
 es5id: 15.4.4.5_A6.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (Array.prototype.join.hasOwnProperty('length') !== true) {
-  $FAIL('#1: Array.prototype.join.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.join.hasOwnProperty('length')));
+  $ERROR('#1: Array.prototype.join.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.join.hasOwnProperty('length')));
 }
 
 delete Array.prototype.join.length;

--- a/test/built-ins/Array/prototype/pop/S15.4.4.6_A5.2.js
+++ b/test/built-ins/Array/prototype/pop/S15.4.4.6_A5.2.js
@@ -5,12 +5,11 @@
 info: The length property of pop does not have the attribute DontDelete
 es5id: 15.4.4.6_A5.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (Array.prototype.pop.hasOwnProperty('length') !== true) {
-  $FAIL('#1: Array.prototype.pop.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.pop.hasOwnProperty('length')));
+  $ERROR('#1: Array.prototype.pop.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.pop.hasOwnProperty('length')));
 }
 
 delete Array.prototype.pop.length;

--- a/test/built-ins/Array/prototype/push/S15.4.4.7_A6.2.js
+++ b/test/built-ins/Array/prototype/push/S15.4.4.7_A6.2.js
@@ -5,12 +5,11 @@
 info: The length property of push does not have the attribute DontDelete
 es5id: 15.4.4.7_A6.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (Array.prototype.push.hasOwnProperty('length') !== true) {
-  $FAIL('#1: Array.prototype.push.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.push.hasOwnProperty('length')));
+  $ERROR('#1: Array.prototype.push.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.push.hasOwnProperty('length')));
 }
 
 delete Array.prototype.push.length;

--- a/test/built-ins/Array/prototype/reverse/S15.4.4.8_A5.2.js
+++ b/test/built-ins/Array/prototype/reverse/S15.4.4.8_A5.2.js
@@ -5,12 +5,11 @@
 info: The length property of reverse does not have the attribute DontDelete
 es5id: 15.4.4.8_A5.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (Array.prototype.reverse.hasOwnProperty('length') !== true) {
-  $FAIL('#1: Array.prototype.reverse.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.reverse.hasOwnProperty('length')));
+  $ERROR('#1: Array.prototype.reverse.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.reverse.hasOwnProperty('length')));
 }
 
 delete Array.prototype.reverse.length;

--- a/test/built-ins/Array/prototype/shift/S15.4.4.9_A5.2.js
+++ b/test/built-ins/Array/prototype/shift/S15.4.4.9_A5.2.js
@@ -5,12 +5,11 @@
 info: The length property of shift does not have the attribute DontDelete
 es5id: 15.4.4.9_A5.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (Array.prototype.shift.hasOwnProperty('length') !== true) {
-  $FAIL('#1: Array.prototype.shift.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.shift.hasOwnProperty('length')));
+  $ERROR('#1: Array.prototype.shift.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.shift.hasOwnProperty('length')));
 }
 
 delete Array.prototype.shift.length;

--- a/test/built-ins/Array/prototype/slice/S15.4.4.10_A3_T1.js
+++ b/test/built-ins/Array/prototype/slice/S15.4.4.10_A3_T1.js
@@ -5,7 +5,6 @@
 info: Check ToLength(length) for non Array objects
 es5id: 15.4.4.10_A3_T1
 description: length = 4294967296
-includes: [$FAIL.js]
 ---*/
 
 var obj = {};
@@ -16,7 +15,7 @@ obj.length = 4294967296;
 
 try {
   var arr = obj.slice(0,4294967296);
-  $FAIL('#1: var obj = {}; obj.slice = Array.prototype.slice; obj[0] = "x"; obj[4294967295] = "y"; obj.length = 4294967296; var arr = obj.slice(0,4294967296); lead to throwing exception. Actual: '+arr);
+  $ERROR('#1: var obj = {}; obj.slice = Array.prototype.slice; obj[0] = "x"; obj[4294967295] = "y"; obj.length = 4294967296; var arr = obj.slice(0,4294967296); lead to throwing exception. Actual: '+arr);
 } catch (e) {
   if (!(e instanceof RangeError)) {
     $ERROR('#1.1: var obj = {}; obj.slice = Array.prototype.slice; obj[0] = "x"; obj[4294967295] = "y"; obj.length = 4294967296; var arr = obj.slice(0,4294967296); lead to throwing exception. Exception is instance of RangeError. Actual: exception is '+e);

--- a/test/built-ins/Array/prototype/slice/S15.4.4.10_A3_T2.js
+++ b/test/built-ins/Array/prototype/slice/S15.4.4.10_A3_T2.js
@@ -5,7 +5,6 @@
 info: Check ToLength(length) for non Array objects
 es5id: 15.4.4.10_A3_T2
 description: length = 4294967297
-includes: [$FAIL.js]
 ---*/
 
 var obj = {};
@@ -16,7 +15,7 @@ obj.length = 4294967297;
 
 try {
   var arr = obj.slice(0,4294967297);
-  $FAIL('#1: var obj = {}; obj.slice = Array.prototype.slice; obj[0] = "x"; obj[4294967296] = "y"; obj.length = 4294967297; var arr = obj.slice(0,4294967297); lead to throwing exception. Actual: '+arr);
+  $ERROR('#1: var obj = {}; obj.slice = Array.prototype.slice; obj[0] = "x"; obj[4294967296] = "y"; obj.length = 4294967297; var arr = obj.slice(0,4294967297); lead to throwing exception. Actual: '+arr);
 } catch (e) {
   if (!(e instanceof RangeError)) {
     $ERROR('#1.1: var obj = {}; obj.slice = Array.prototype.slice; obj[0] = "x"; obj[4294967296] = "y"; obj.length = 4294967297; var arr = obj.slice(0,4294967297); lead to throwing exception. Exception is instance of RangeError. Actual: exception is '+e);

--- a/test/built-ins/Array/prototype/slice/S15.4.4.10_A5.2.js
+++ b/test/built-ins/Array/prototype/slice/S15.4.4.10_A5.2.js
@@ -5,12 +5,11 @@
 info: The length property of slice does not have the attribute DontDelete
 es5id: 15.4.4.10_A5.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (Array.prototype.slice.hasOwnProperty('length') !== true) {
-  $FAIL('#1: Array.prototype.slice.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.slice.hasOwnProperty('length')));
+  $ERROR('#1: Array.prototype.slice.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.slice.hasOwnProperty('length')));
 }
 
 delete Array.prototype.slice.length;

--- a/test/built-ins/Array/prototype/sort/S15.4.4.11_A7.2.js
+++ b/test/built-ins/Array/prototype/sort/S15.4.4.11_A7.2.js
@@ -5,12 +5,11 @@
 info: The length property of sort does not have the attribute DontDelete
 es5id: 15.4.4.11_A7.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (Array.prototype.sort.hasOwnProperty('length') !== true) {
-  $FAIL('#1: Array.sort.prototype.hasOwnProperty(\'length\') === true. Actual: ' + (Array.sort.prototype.hasOwnProperty('length')));
+  $ERROR('#1: Array.sort.prototype.hasOwnProperty(\'length\') === true. Actual: ' + (Array.sort.prototype.hasOwnProperty('length')));
 }
 
 delete Array.prototype.sort.length;

--- a/test/built-ins/Array/prototype/sort/S15.4.4.11_A8.js
+++ b/test/built-ins/Array/prototype/sort/S15.4.4.11_A8.js
@@ -6,7 +6,6 @@ info: Call the comparefn passing undefined as the this value (step 13b)
 es5id: 15.4.4.11_A8
 description: comparefn tests that its this value is undefined
 flags: [onlyStrict]
-includes: [$FAIL.js]
 ---*/
 
 var global = this;
@@ -14,10 +13,10 @@ var global = this;
   "use strict";
 
   if (this === global) {
-    $FAIL('#1: Sort leaks global');
+    $ERROR('#1: Sort leaks global');
   }
   if (this !== undefined) {
-    $FAIL('#2: Sort comparefn should be called with this===undefined. ' +
+    $ERROR('#2: Sort comparefn should be called with this===undefined. ' +
           'Actual: ' + this);
   }
   return x - y;

--- a/test/built-ins/Array/prototype/splice/S15.4.4.12_A5.2.js
+++ b/test/built-ins/Array/prototype/splice/S15.4.4.12_A5.2.js
@@ -5,12 +5,11 @@
 info: The length property of splice does not have the attribute DontDelete
 es5id: 15.4.4.12_A5.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (Array.prototype.splice.hasOwnProperty('length') !== true) {
-  $FAIL('#1: Array.prototype.splice.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.splice.hasOwnProperty('length')));
+  $ERROR('#1: Array.prototype.splice.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.splice.hasOwnProperty('length')));
 }
 
 delete Array.prototype.splice.length;

--- a/test/built-ins/Array/prototype/toLocaleString/S15.4.4.3_A4.2.js
+++ b/test/built-ins/Array/prototype/toLocaleString/S15.4.4.3_A4.2.js
@@ -7,12 +7,11 @@ info: >
     DontDelete
 es5id: 15.4.4.3_A4.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (Array.prototype.toLocaleString.hasOwnProperty('length') !== true) {
-  $FAIL('#1: Array.prototype.toLocaleString.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.toLocaleString.hasOwnProperty('length')));
+  $ERROR('#1: Array.prototype.toLocaleString.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.toLocaleString.hasOwnProperty('length')));
 }
 
 delete Array.prototype.toLocaleString.length;

--- a/test/built-ins/Array/prototype/toString/S15.4.4.2_A4.2.js
+++ b/test/built-ins/Array/prototype/toString/S15.4.4.2_A4.2.js
@@ -5,12 +5,11 @@
 info: The length property of toString does not have the attribute DontDelete
 es5id: 15.4.4.2_A4.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (Array.prototype.toString.hasOwnProperty('length') !== true) {
-  $FAIL('#1: Array.prototype.toString.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.toString.hasOwnProperty('length')));
+  $ERROR('#1: Array.prototype.toString.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.toString.hasOwnProperty('length')));
 }
 
 delete Array.prototype.toString.length;

--- a/test/built-ins/Array/prototype/unshift/S15.4.4.13_A5.2.js
+++ b/test/built-ins/Array/prototype/unshift/S15.4.4.13_A5.2.js
@@ -5,12 +5,11 @@
 info: The length property of unshift does not have the attribute DontDelete
 es5id: 15.4.4.13_A5.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (Array.prototype.unshift.hasOwnProperty('length') !== true) {
-  $FAIL('#1: Array.prototype.unshift.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.unshift.hasOwnProperty('length')));
+  $ERROR('#1: Array.prototype.unshift.hasOwnProperty(\'length\') === true. Actual: ' + (Array.prototype.unshift.hasOwnProperty('length')));
 }
 
 delete Array.prototype.unshift.length;

--- a/test/built-ins/Boolean/prototype/S15.6.3.1_A1.js
+++ b/test/built-ins/Boolean/prototype/S15.6.3.1_A1.js
@@ -7,7 +7,6 @@ info: >
     prototype object
 es5id: 15.6.3.1_A1
 description: Checking Boolean.prototype property
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
@@ -18,7 +17,7 @@ if (typeof Boolean.prototype !== "object") {
 //CHECK#2
 try {
   (Boolean.prototype != false);
-  $FAIL('#2: "(Boolean.prototype != false);" lead to throwing exception. Actual: '+(Boolean.prototype != false));
+  $ERROR('#2: "(Boolean.prototype != false);" lead to throwing exception. Actual: '+(Boolean.prototype != false));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#2.1: "(Boolean.prototype != false)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Boolean/prototype/S15.6.4_A1.js
+++ b/test/built-ins/Boolean/prototype/S15.6.4_A1.js
@@ -7,7 +7,6 @@ info: >
     (its [[Class]] is "Object")
 es5id: 15.6.4_A1
 description: Checking type and value of Boolean.prototype
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
@@ -18,7 +17,7 @@ if (typeof Boolean.prototype !== "object") {
 //CHECK#2
 try {
   (Boolean.prototype != false);
-  $FAIL('#2: "(Boolean.prototype != false);" lead to throwing exception. Actual: '+(Boolean.prototype != false));
+  $ERROR('#2: "(Boolean.prototype != false);" lead to throwing exception. Actual: '+(Boolean.prototype != false));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#2.1: "(Boolean.prototype != false)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A1_T1.js
+++ b/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A1_T1.js
@@ -8,13 +8,12 @@ info: >
     "false" is returned
 es5id: 15.6.4.2_A1_T1
 description: no arguments
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   (Boolean.prototype.toString() !== "false");
-  $FAIL('#1: "(Boolean.prototype.toString() !== "false");" lead to throwing exception. Actual: '+(Boolean.prototype.toString() !== "false"));
+  $ERROR('#1: "(Boolean.prototype.toString() !== "false");" lead to throwing exception. Actual: '+(Boolean.prototype.toString() !== "false"));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "(Boolean.prototype.toString() !== "false")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A1_T2.js
+++ b/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A1_T2.js
@@ -8,13 +8,12 @@ info: >
     "false" is returned
 es5id: 15.6.4.2_A1_T2
 description: with some argument
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   (Boolean.prototype.toString(true) !== "false");
-  $FAIL('#1: "(Boolean.prototype.toString(true) !== "false");" lead to throwing exception. Actual: '+(Boolean.prototype.toString(true) !== "false"));
+  $ERROR('#1: "(Boolean.prototype.toString(true) !== "false");" lead to throwing exception. Actual: '+(Boolean.prototype.toString(true) !== "false"));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "(Boolean.prototype.toString(true) !== "false")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A1_T1.js
+++ b/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A1_T1.js
@@ -5,13 +5,12 @@
 info: Boolean.prototype.valueOf() returns this boolean value
 es5id: 15.6.4.3_A1_T1
 description: no arguments
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   (Boolean.prototype.valueOf() !== false);
-  $FAIL('#1: "(Boolean.prototype.valueOf() !== false);" lead to throwing exception. Actual: '+(Boolean.prototype.valueOf() !== false));
+  $ERROR('#1: "(Boolean.prototype.valueOf() !== false);" lead to throwing exception. Actual: '+(Boolean.prototype.valueOf() !== false));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "(Boolean.prototype.valueOf() !== false)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A1_T2.js
+++ b/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A1_T2.js
@@ -5,13 +5,12 @@
 info: Boolean.prototype.valueOf() returns this boolean value
 es5id: 15.6.4.3_A1_T2
 description: calling with argument
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   (Boolean.prototype.valueOf(true) !== false);
-  $FAIL('#1: "(Boolean.prototype.valueOf(true) !== false);" lead to throwing exception. Actual: '+(Boolean.prototype.valueOf(true) !== false));
+  $ERROR('#1: "(Boolean.prototype.valueOf(true) !== false);" lead to throwing exception. Actual: '+(Boolean.prototype.valueOf(true) !== false));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "(Boolean.prototype.valueOf(true) !== false)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Date/S15.9.3.1_A1_T1.js
+++ b/test/built-ins/Date/S15.9.3.1_A1_T1.js
@@ -7,221 +7,220 @@ info: >
     a constructor: it initializes the newly created object
 es5id: 15.9.3.1_A1_T1
 description: 2 arguments, (year, month)
-includes: [$FAIL.js]
 ---*/
 
 if (typeof new Date(1899, 11) !== "object") {
-  $FAIL("#1.1: typeof new Date(1899, 11) should be 'object'");
+  $ERROR("#1.1: typeof new Date(1899, 11) should be 'object'");
 }
 
 if (new Date(1899, 11) === undefined) {
-  $FAIL("#1.2: new Date(1899, 11) should not be undefined");
+  $ERROR("#1.2: new Date(1899, 11) should not be undefined");
 }
 
 var x13 = new Date(1899, 11);
 if(typeof x13 !== "object"){
-  $FAIL("#1.3: typeof new Date(1899, 11) should be 'object'");
+  $ERROR("#1.3: typeof new Date(1899, 11) should be 'object'");
 }
 
 var x14 = new Date(1899, 11);
 if(x14 === undefined){
-  $FAIL("#1.4: new Date(1899, 11) should not be undefined");
+  $ERROR("#1.4: new Date(1899, 11) should not be undefined");
 }
 
 if (typeof new Date(1899, 12) !== "object") {
-  $FAIL("#2.1: typeof new Date(1899, 12) should be 'object'");
+  $ERROR("#2.1: typeof new Date(1899, 12) should be 'object'");
 }
 
 if (new Date(1899, 12) === undefined) {
-  $FAIL("#2.2: new Date(1899, 12) should not be undefined");
+  $ERROR("#2.2: new Date(1899, 12) should not be undefined");
 }
 
 var x23 = new Date(1899, 12);
 if(typeof x23 !== "object"){
-  $FAIL("#2.3: typeof new Date(1899, 12) should be 'object'");
+  $ERROR("#2.3: typeof new Date(1899, 12) should be 'object'");
 }
 
 var x24 = new Date(1899, 12);
 if(x24 === undefined){
-  $FAIL("#2.4: new Date(1899, 12) should not be undefined");
+  $ERROR("#2.4: new Date(1899, 12) should not be undefined");
 }
 
 if (typeof new Date(1900, 0) !== "object") {
-  $FAIL("#3.1: typeof new Date(1900, 0) should be 'object'");
+  $ERROR("#3.1: typeof new Date(1900, 0) should be 'object'");
 }
 
 if (new Date(1900, 0) === undefined) {
-  $FAIL("#3.2: new Date(1900, 0) should not be undefined");
+  $ERROR("#3.2: new Date(1900, 0) should not be undefined");
 }
 
 var x33 = new Date(1900, 0);
 if(typeof x33 !== "object"){
-  $FAIL("#3.3: typeof new Date(1900, 0) should be 'object'");
+  $ERROR("#3.3: typeof new Date(1900, 0) should be 'object'");
 }
 
 var x34 = new Date(1900, 0);
 if(x34 === undefined){
-  $FAIL("#3.4: new Date(1900, 0) should not be undefined");
+  $ERROR("#3.4: new Date(1900, 0) should not be undefined");
 }
 
 if (typeof new Date(1969, 11) !== "object") {
-  $FAIL("#4.1: typeof new Date(1969, 11) should be 'object'");
+  $ERROR("#4.1: typeof new Date(1969, 11) should be 'object'");
 }
 
 if (new Date(1969, 11) === undefined) {
-  $FAIL("#4.2: new Date(1969, 11) should not be undefined");
+  $ERROR("#4.2: new Date(1969, 11) should not be undefined");
 }
 
 var x43 = new Date(1969, 11);
 if(typeof x43 !== "object"){
-  $FAIL("#4.3: typeof new Date(1969, 11) should be 'object'");
+  $ERROR("#4.3: typeof new Date(1969, 11) should be 'object'");
 }
 
 var x44 = new Date(1969, 11);
 if(x44 === undefined){
-  $FAIL("#4.4: new Date(1969, 11) should not be undefined");
+  $ERROR("#4.4: new Date(1969, 11) should not be undefined");
 }
 
 if (typeof new Date(1969, 12) !== "object") {
-  $FAIL("#5.1: typeof new Date(1969, 12) should be 'object'");
+  $ERROR("#5.1: typeof new Date(1969, 12) should be 'object'");
 }
 
 if (new Date(1969, 12) === undefined) {
-  $FAIL("#5.2: new Date(1969, 12) should not be undefined");
+  $ERROR("#5.2: new Date(1969, 12) should not be undefined");
 }
 
 var x53 = new Date(1969, 12);
 if(typeof x53 !== "object"){
-  $FAIL("#5.3: typeof new Date(1969, 12) should be 'object'");
+  $ERROR("#5.3: typeof new Date(1969, 12) should be 'object'");
 }
 
 var x54 = new Date(1969, 12);
 if(x54 === undefined){
-  $FAIL("#5.4: new Date(1969, 12) should not be undefined");
+  $ERROR("#5.4: new Date(1969, 12) should not be undefined");
 }
 
 if (typeof new Date(1970, 0) !== "object") {
-  $FAIL("#6.1: typeof new Date(1970, 0) should be 'object'");
+  $ERROR("#6.1: typeof new Date(1970, 0) should be 'object'");
 }
 
 if (new Date(1970, 0) === undefined) {
-  $FAIL("#6.2: new Date(1970, 0) should not be undefined");
+  $ERROR("#6.2: new Date(1970, 0) should not be undefined");
 }
 
 var x63 = new Date(1970, 0);
 if(typeof x63 !== "object"){
-  $FAIL("#6.3: typeof new Date(1970, 0) should be 'object'");
+  $ERROR("#6.3: typeof new Date(1970, 0) should be 'object'");
 }
 
 var x64 = new Date(1970, 0);
 if(x64 === undefined){
-  $FAIL("#6.4: new Date(1970, 0) should not be undefined");
+  $ERROR("#6.4: new Date(1970, 0) should not be undefined");
 }
 
 if (typeof new Date(1999, 11) !== "object") {
-  $FAIL("#7.1: typeof new Date(1999, 11) should be 'object'");
+  $ERROR("#7.1: typeof new Date(1999, 11) should be 'object'");
 }
 
 if (new Date(1999, 11) === undefined) {
-  $FAIL("#7.2: new Date(1999, 11) should not be undefined");
+  $ERROR("#7.2: new Date(1999, 11) should not be undefined");
 }
 
 var x73 = new Date(1999, 11);
 if(typeof x73 !== "object"){
-  $FAIL("#7.3: typeof new Date(1999, 11) should be 'object'");
+  $ERROR("#7.3: typeof new Date(1999, 11) should be 'object'");
 }
 
 var x74 = new Date(1999, 11);
 if(x74 === undefined){
-  $FAIL("#7.4: new Date(1999, 11) should not be undefined");
+  $ERROR("#7.4: new Date(1999, 11) should not be undefined");
 }
 
 if (typeof new Date(1999, 12) !== "object") {
-  $FAIL("#8.1: typeof new Date(1999, 12) should be 'object'");
+  $ERROR("#8.1: typeof new Date(1999, 12) should be 'object'");
 }
 
 if (new Date(1999, 12) === undefined) {
-  $FAIL("#8.2: new Date(1999, 12) should not be undefined");
+  $ERROR("#8.2: new Date(1999, 12) should not be undefined");
 }
 
 var x83 = new Date(1999, 12);
 if(typeof x83 !== "object"){
-  $FAIL("#8.3: typeof new Date(1999, 12) should be 'object'");
+  $ERROR("#8.3: typeof new Date(1999, 12) should be 'object'");
 }
 
 var x84 = new Date(1999, 12);
 if(x84 === undefined){
-  $FAIL("#8.4: new Date(1999, 12) should not be undefined");
+  $ERROR("#8.4: new Date(1999, 12) should not be undefined");
 }
 
 if (typeof new Date(2000, 0) !== "object") {
-  $FAIL("#9.1: typeof new Date(2000, 0) should be 'object'");
+  $ERROR("#9.1: typeof new Date(2000, 0) should be 'object'");
 }
 
 if (new Date(2000, 0) === undefined) {
-  $FAIL("#9.2: new Date(2000, 0) should not be undefined");
+  $ERROR("#9.2: new Date(2000, 0) should not be undefined");
 }
 
 var x93 = new Date(2000, 0);
 if(typeof x93 !== "object"){
-  $FAIL("#9.3: typeof new Date(2000, 0) should be 'object'");
+  $ERROR("#9.3: typeof new Date(2000, 0) should be 'object'");
 }
 
 var x94 = new Date(2000, 0);
 if(x94 === undefined){
-  $FAIL("#9.4: new Date(2000, 0) should not be undefined");
+  $ERROR("#9.4: new Date(2000, 0) should not be undefined");
 }
 
 if (typeof new Date(2099, 11) !== "object") {
-  $FAIL("#10.1: typeof new Date(2099, 11) should be 'object'");
+  $ERROR("#10.1: typeof new Date(2099, 11) should be 'object'");
 }
 
 if (new Date(2099, 11) === undefined) {
-  $FAIL("#10.2: new Date(2099, 11) should not be undefined");
+  $ERROR("#10.2: new Date(2099, 11) should not be undefined");
 }
 
 var x103 = new Date(2099, 11);
 if(typeof x103 !== "object"){
-  $FAIL("#10.3: typeof new Date(2099, 11) should be 'object'");
+  $ERROR("#10.3: typeof new Date(2099, 11) should be 'object'");
 }
 
 var x104 = new Date(2099, 11);
 if(x104 === undefined){
-  $FAIL("#10.4: new Date(2099, 11) should not be undefined");
+  $ERROR("#10.4: new Date(2099, 11) should not be undefined");
 }
 
 if (typeof new Date(2099, 12) !== "object") {
-  $FAIL("#11.1: typeof new Date(2099, 12) should be 'object'");
+  $ERROR("#11.1: typeof new Date(2099, 12) should be 'object'");
 }
 
 if (new Date(2099, 12) === undefined) {
-  $FAIL("#11.2: new Date(2099, 12) should not be undefined");
+  $ERROR("#11.2: new Date(2099, 12) should not be undefined");
 }
 
 var x113 = new Date(2099, 12);
 if(typeof x113 !== "object"){
-  $FAIL("#11.3: typeof new Date(2099, 12) should be 'object'");
+  $ERROR("#11.3: typeof new Date(2099, 12) should be 'object'");
 }
 
 var x114 = new Date(2099, 12);
 if(x114 === undefined){
-  $FAIL("#11.4: new Date(2099, 12) should not be undefined");
+  $ERROR("#11.4: new Date(2099, 12) should not be undefined");
 }
 
 if (typeof new Date(2100, 0) !== "object") {
-  $FAIL("#12.1: typeof new Date(2100, 0) should be 'object'");
+  $ERROR("#12.1: typeof new Date(2100, 0) should be 'object'");
 }
 
 if (new Date(2100, 0) === undefined) {
-  $FAIL("#12.2: new Date(2100, 0) should not be undefined");
+  $ERROR("#12.2: new Date(2100, 0) should not be undefined");
 }
 
 var x123 = new Date(2100, 0);
 if(typeof x123 !== "object"){
-  $FAIL("#12.3: typeof new Date(2100, 0) should be 'object'");
+  $ERROR("#12.3: typeof new Date(2100, 0) should be 'object'");
 }
 
 var x124 = new Date(2100, 0);
 if(x124 === undefined){
-  $FAIL("#12.4: new Date(2100, 0) should not be undefined");
+  $ERROR("#12.4: new Date(2100, 0) should not be undefined");
 }

--- a/test/built-ins/Date/S15.9.3.1_A1_T2.js
+++ b/test/built-ins/Date/S15.9.3.1_A1_T2.js
@@ -7,221 +7,220 @@ info: >
     a constructor: it initializes the newly created object
 es5id: 15.9.3.1_A1_T2
 description: 3 arguments, (year, month, date)
-includes: [$FAIL.js]
 ---*/
 
 if (typeof new Date(1899, 11, 31) !== "object") {
-  $FAIL("#1.1: typeof new Date(1899, 11, 31) should be 'object'");
+  $ERROR("#1.1: typeof new Date(1899, 11, 31) should be 'object'");
 }
 
 if (new Date(1899, 11, 31) === undefined) {
-  $FAIL("#1.2: new Date(1899, 11, 31) should not be undefined");
+  $ERROR("#1.2: new Date(1899, 11, 31) should not be undefined");
 }
 
 var x13 = new Date(1899, 11, 31);
 if(typeof x13 !== "object"){
-  $FAIL("#1.3: typeof new Date(1899, 11, 31) should be 'object'");
+  $ERROR("#1.3: typeof new Date(1899, 11, 31) should be 'object'");
 }
 
 var x14 = new Date(1899, 11, 31);
 if(x14 === undefined){
-  $FAIL("#1.4: new Date(1899, 11, 31) should not be undefined");
+  $ERROR("#1.4: new Date(1899, 11, 31) should not be undefined");
 }
 
 if (typeof new Date(1899, 12, 1) !== "object") {
-  $FAIL("#2.1: typeof new Date(1899, 12, 1) should be 'object'");
+  $ERROR("#2.1: typeof new Date(1899, 12, 1) should be 'object'");
 }
 
 if (new Date(1899, 12, 1) === undefined) {
-  $FAIL("#2.2: new Date(1899, 12, 1) should not be undefined");
+  $ERROR("#2.2: new Date(1899, 12, 1) should not be undefined");
 }
 
 var x23 = new Date(1899, 12, 1);
 if(typeof x23 !== "object"){
-  $FAIL("#2.3: typeof new Date(1899, 12, 1) should be 'object'");
+  $ERROR("#2.3: typeof new Date(1899, 12, 1) should be 'object'");
 }
 
 var x24 = new Date(1899, 12, 1);
 if(x24 === undefined){
-  $FAIL("#2.4: new Date(1899, 12, 1) should not be undefined");
+  $ERROR("#2.4: new Date(1899, 12, 1) should not be undefined");
 }
 
 if (typeof new Date(1900, 0, 1) !== "object") {
-  $FAIL("#3.1: typeof new Date(1900, 0, 1) should be 'object'");
+  $ERROR("#3.1: typeof new Date(1900, 0, 1) should be 'object'");
 }
 
 if (new Date(1900, 0, 1) === undefined) {
-  $FAIL("#3.2: new Date(1900, 0, 1) should not be undefined");
+  $ERROR("#3.2: new Date(1900, 0, 1) should not be undefined");
 }
 
 var x33 = new Date(1900, 0, 1);
 if(typeof x33 !== "object"){
-  $FAIL("#3.3: typeof new Date(1900, 0, 1) should be 'object'");
+  $ERROR("#3.3: typeof new Date(1900, 0, 1) should be 'object'");
 }
 
 var x34 = new Date(1900, 0, 1);
 if(x34 === undefined){
-  $FAIL("#3.4: new Date(1900, 0, 1) should not be undefined");
+  $ERROR("#3.4: new Date(1900, 0, 1) should not be undefined");
 }
 
 if (typeof new Date(1969, 11, 31) !== "object") {
-  $FAIL("#4.1: typeof new Date(1969, 11, 31) should be 'object'");
+  $ERROR("#4.1: typeof new Date(1969, 11, 31) should be 'object'");
 }
 
 if (new Date(1969, 11, 31) === undefined) {
-  $FAIL("#4.2: new Date(1969, 11, 31) should not be undefined");
+  $ERROR("#4.2: new Date(1969, 11, 31) should not be undefined");
 }
 
 var x43 = new Date(1969, 11, 31);
 if(typeof x43 !== "object"){
-  $FAIL("#4.3: typeof new Date(1969, 11, 31) should be 'object'");
+  $ERROR("#4.3: typeof new Date(1969, 11, 31) should be 'object'");
 }
 
 var x44 = new Date(1969, 11, 31);
 if(x44 === undefined){
-  $FAIL("#4.4: new Date(1969, 11, 31) should not be undefined");
+  $ERROR("#4.4: new Date(1969, 11, 31) should not be undefined");
 }
 
 if (typeof new Date(1969, 12, 1) !== "object") {
-  $FAIL("#5.1: typeof new Date(1969, 12, 1) should be 'object'");
+  $ERROR("#5.1: typeof new Date(1969, 12, 1) should be 'object'");
 }
 
 if (new Date(1969, 12, 1) === undefined) {
-  $FAIL("#5.2: new Date(1969, 12, 1) should not be undefined");
+  $ERROR("#5.2: new Date(1969, 12, 1) should not be undefined");
 }
 
 var x53 = new Date(1969, 12, 1);
 if(typeof x53 !== "object"){
-  $FAIL("#5.3: typeof new Date(1969, 12, 1) should be 'object'");
+  $ERROR("#5.3: typeof new Date(1969, 12, 1) should be 'object'");
 }
 
 var x54 = new Date(1969, 12, 1);
 if(x54 === undefined){
-  $FAIL("#5.4: new Date(1969, 12, 1) should not be undefined");
+  $ERROR("#5.4: new Date(1969, 12, 1) should not be undefined");
 }
 
 if (typeof new Date(1970, 0, 1) !== "object") {
-  $FAIL("#6.1: typeof new Date(1970, 0, 1) should be 'object'");
+  $ERROR("#6.1: typeof new Date(1970, 0, 1) should be 'object'");
 }
 
 if (new Date(1970, 0, 1) === undefined) {
-  $FAIL("#6.2: new Date(1970, 0, 1) should not be undefined");
+  $ERROR("#6.2: new Date(1970, 0, 1) should not be undefined");
 }
 
 var x63 = new Date(1970, 0, 1);
 if(typeof x63 !== "object"){
-  $FAIL("#6.3: typeof new Date(1970, 0, 1) should be 'object'");
+  $ERROR("#6.3: typeof new Date(1970, 0, 1) should be 'object'");
 }
 
 var x64 = new Date(1970, 0, 1);
 if(x64 === undefined){
-  $FAIL("#6.4: new Date(1970, 0, 1) should not be undefined");
+  $ERROR("#6.4: new Date(1970, 0, 1) should not be undefined");
 }
 
 if (typeof new Date(1999, 11, 31) !== "object") {
-  $FAIL("#7.1: typeof new Date(1999, 11, 31) should be 'object'");
+  $ERROR("#7.1: typeof new Date(1999, 11, 31) should be 'object'");
 }
 
 if (new Date(1999, 11, 31) === undefined) {
-  $FAIL("#7.2: new Date(1999, 11, 31) should not be undefined");
+  $ERROR("#7.2: new Date(1999, 11, 31) should not be undefined");
 }
 
 var x73 = new Date(1999, 11, 31);
 if(typeof x73 !== "object"){
-  $FAIL("#7.3: typeof new Date(1999, 11, 31) should be 'object'");
+  $ERROR("#7.3: typeof new Date(1999, 11, 31) should be 'object'");
 }
 
 var x74 = new Date(1999, 11, 31);
 if(x74 === undefined){
-  $FAIL("#7.4: new Date(1999, 11, 31) should not be undefined");
+  $ERROR("#7.4: new Date(1999, 11, 31) should not be undefined");
 }
 
 if (typeof new Date(1999, 12, 1) !== "object") {
-  $FAIL("#8.1: typeof new Date(1999, 12, 1) should be 'object'");
+  $ERROR("#8.1: typeof new Date(1999, 12, 1) should be 'object'");
 }
 
 if (new Date(1999, 12, 1) === undefined) {
-  $FAIL("#8.2: new Date(1999, 12, 1) should not be undefined");
+  $ERROR("#8.2: new Date(1999, 12, 1) should not be undefined");
 }
 
 var x83 = new Date(1999, 12, 1);
 if(typeof x83 !== "object"){
-  $FAIL("#8.3: typeof new Date(1999, 12, 1) should be 'object'");
+  $ERROR("#8.3: typeof new Date(1999, 12, 1) should be 'object'");
 }
 
 var x84 = new Date(1999, 12, 1);
 if(x84 === undefined){
-  $FAIL("#8.4: new Date(1999, 12, 1) should not be undefined");
+  $ERROR("#8.4: new Date(1999, 12, 1) should not be undefined");
 }
 
 if (typeof new Date(2000, 0, 1) !== "object") {
-  $FAIL("#9.1: typeof new Date(2000, 0, 1) should be 'object'");
+  $ERROR("#9.1: typeof new Date(2000, 0, 1) should be 'object'");
 }
 
 if (new Date(2000, 0, 1) === undefined) {
-  $FAIL("#9.2: new Date(2000, 0, 1) should not be undefined");
+  $ERROR("#9.2: new Date(2000, 0, 1) should not be undefined");
 }
 
 var x93 = new Date(2000, 0, 1);
 if(typeof x93 !== "object"){
-  $FAIL("#9.3: typeof new Date(2000, 0, 1) should be 'object'");
+  $ERROR("#9.3: typeof new Date(2000, 0, 1) should be 'object'");
 }
 
 var x94 = new Date(2000, 0, 1);
 if(x94 === undefined){
-  $FAIL("#9.4: new Date(2000, 0, 1) should not be undefined");
+  $ERROR("#9.4: new Date(2000, 0, 1) should not be undefined");
 }
 
 if (typeof new Date(2099, 11, 31) !== "object") {
-  $FAIL("#10.1: typeof new Date(2099, 11, 31) should be 'object'");
+  $ERROR("#10.1: typeof new Date(2099, 11, 31) should be 'object'");
 }
 
 if (new Date(2099, 11, 31) === undefined) {
-  $FAIL("#10.2: new Date(2099, 11, 31) should not be undefined");
+  $ERROR("#10.2: new Date(2099, 11, 31) should not be undefined");
 }
 
 var x103 = new Date(2099, 11, 31);
 if(typeof x103 !== "object"){
-  $FAIL("#10.3: typeof new Date(2099, 11, 31) should be 'object'");
+  $ERROR("#10.3: typeof new Date(2099, 11, 31) should be 'object'");
 }
 
 var x104 = new Date(2099, 11, 31);
 if(x104 === undefined){
-  $FAIL("#10.4: new Date(2099, 11, 31) should not be undefined");
+  $ERROR("#10.4: new Date(2099, 11, 31) should not be undefined");
 }
 
 if (typeof new Date(2099, 12, 1) !== "object") {
-  $FAIL("#11.1: typeof new Date(2099, 12, 1) should be 'object'");
+  $ERROR("#11.1: typeof new Date(2099, 12, 1) should be 'object'");
 }
 
 if (new Date(2099, 12, 1) === undefined) {
-  $FAIL("#11.2: new Date(2099, 12, 1) should not be undefined");
+  $ERROR("#11.2: new Date(2099, 12, 1) should not be undefined");
 }
 
 var x113 = new Date(2099, 12, 1);
 if(typeof x113 !== "object"){
-  $FAIL("#11.3: typeof new Date(2099, 12, 1) should be 'object'");
+  $ERROR("#11.3: typeof new Date(2099, 12, 1) should be 'object'");
 }
 
 var x114 = new Date(2099, 12, 1);
 if(x114 === undefined){
-  $FAIL("#11.4: new Date(2099, 12, 1) should not be undefined");
+  $ERROR("#11.4: new Date(2099, 12, 1) should not be undefined");
 }
 
 if (typeof new Date(2100, 0, 1) !== "object") {
-  $FAIL("#12.1: typeof new Date(2100, 0, 1) should be 'object'");
+  $ERROR("#12.1: typeof new Date(2100, 0, 1) should be 'object'");
 }
 
 if (new Date(2100, 0, 1) === undefined) {
-  $FAIL("#12.2: new Date(2100, 0, 1) should not be undefined");
+  $ERROR("#12.2: new Date(2100, 0, 1) should not be undefined");
 }
 
 var x123 = new Date(2100, 0, 1);
 if(typeof x123 !== "object"){
-  $FAIL("#12.3: typeof new Date(2100, 0, 1) should be 'object'");
+  $ERROR("#12.3: typeof new Date(2100, 0, 1) should be 'object'");
 }
 
 var x124 = new Date(2100, 0, 1);
 if(x124 === undefined){
-  $FAIL("#12.4: new Date(2100, 0, 1) should not be undefined");
+  $ERROR("#12.4: new Date(2100, 0, 1) should not be undefined");
 }

--- a/test/built-ins/Date/S15.9.3.1_A1_T3.js
+++ b/test/built-ins/Date/S15.9.3.1_A1_T3.js
@@ -7,221 +7,220 @@ info: >
     a constructor: it initializes the newly created object
 es5id: 15.9.3.1_A1_T3
 description: 4 arguments, (year, month, date, hours)
-includes: [$FAIL.js]
 ---*/
 
 if (typeof new Date(1899, 11, 31, 23) !== "object") {
-  $FAIL("#1.1: typeof new Date(1899, 11, 31, 23) should be 'object'");
+  $ERROR("#1.1: typeof new Date(1899, 11, 31, 23) should be 'object'");
 }
 
 if (new Date(1899, 11, 31, 23) === undefined) {
-  $FAIL("#1.2: new Date(1899, 11, 31, 23) should not be undefined");
+  $ERROR("#1.2: new Date(1899, 11, 31, 23) should not be undefined");
 }
 
 var x13 = new Date(1899, 11, 31, 23);
 if(typeof x13 !== "object"){
-  $FAIL("#1.3: typeof new Date(1899, 11, 31, 23) should be 'object'");
+  $ERROR("#1.3: typeof new Date(1899, 11, 31, 23) should be 'object'");
 }
 
 var x14 = new Date(1899, 11, 31, 23);
 if(x14 === undefined){
-  $FAIL("#1.4: new Date(1899, 11, 31, 23) should not be undefined");
+  $ERROR("#1.4: new Date(1899, 11, 31, 23) should not be undefined");
 }
 
 if (typeof new Date(1899, 12, 1, 0) !== "object") {
-  $FAIL("#2.1: typeof new Date(1899, 12, 1, 0) should be 'object'");
+  $ERROR("#2.1: typeof new Date(1899, 12, 1, 0) should be 'object'");
 }
 
 if (new Date(1899, 12, 1, 0) === undefined) {
-  $FAIL("#2.2: new Date(1899, 12, 1, 0) should not be undefined");
+  $ERROR("#2.2: new Date(1899, 12, 1, 0) should not be undefined");
 }
 
 var x23 = new Date(1899, 12, 1, 0);
 if(typeof x23 !== "object"){
-  $FAIL("#2.3: typeof new Date(1899, 12, 1, 0) should be 'object'");
+  $ERROR("#2.3: typeof new Date(1899, 12, 1, 0) should be 'object'");
 }
 
 var x24 = new Date(1899, 12, 1, 0);
 if(x24 === undefined){
-  $FAIL("#2.4: new Date(1899, 12, 1, 0) should not be undefined");
+  $ERROR("#2.4: new Date(1899, 12, 1, 0) should not be undefined");
 }
 
 if (typeof new Date(1900, 0, 1, 0) !== "object") {
-  $FAIL("#3.1: typeof new Date(1900, 0, 1, 0) should be 'object'");
+  $ERROR("#3.1: typeof new Date(1900, 0, 1, 0) should be 'object'");
 }
 
 if (new Date(1900, 0, 1, 0) === undefined) {
-  $FAIL("#3.2: new Date(1900, 0, 1, 0) should not be undefined");
+  $ERROR("#3.2: new Date(1900, 0, 1, 0) should not be undefined");
 }
 
 var x33 = new Date(1900, 0, 1, 0);
 if(typeof x33 !== "object"){
-  $FAIL("#3.3: typeof new Date(1900, 0, 1, 0) should be 'object'");
+  $ERROR("#3.3: typeof new Date(1900, 0, 1, 0) should be 'object'");
 }
 
 var x34 = new Date(1900, 0, 1, 0);
 if(x34 === undefined){
-  $FAIL("#3.4: new Date(1900, 0, 1, 0) should not be undefined");
+  $ERROR("#3.4: new Date(1900, 0, 1, 0) should not be undefined");
 }
 
 if (typeof new Date(1969, 11, 31, 23) !== "object") {
-  $FAIL("#4.1: typeof new Date(1969, 11, 31, 23) should be 'object'");
+  $ERROR("#4.1: typeof new Date(1969, 11, 31, 23) should be 'object'");
 }
 
 if (new Date(1969, 11, 31, 23) === undefined) {
-  $FAIL("#4.2: new Date(1969, 11, 31, 23) should not be undefined");
+  $ERROR("#4.2: new Date(1969, 11, 31, 23) should not be undefined");
 }
 
 var x43 = new Date(1969, 11, 31, 23);
 if(typeof x43 !== "object"){
-  $FAIL("#4.3: typeof new Date(1969, 11, 31, 23) should be 'object'");
+  $ERROR("#4.3: typeof new Date(1969, 11, 31, 23) should be 'object'");
 }
 
 var x44 = new Date(1969, 11, 31, 23);
 if(x44 === undefined){
-  $FAIL("#4.4: new Date(1969, 11, 31, 23) should not be undefined");
+  $ERROR("#4.4: new Date(1969, 11, 31, 23) should not be undefined");
 }
 
 if (typeof new Date(1969, 12, 1, 0) !== "object") {
-  $FAIL("#5.1: typeof new Date(1969, 12, 1, 0) should be 'object'");
+  $ERROR("#5.1: typeof new Date(1969, 12, 1, 0) should be 'object'");
 }
 
 if (new Date(1969, 12, 1, 0) === undefined) {
-  $FAIL("#5.2: new Date(1969, 12, 1, 0) should not be undefined");
+  $ERROR("#5.2: new Date(1969, 12, 1, 0) should not be undefined");
 }
 
 var x53 = new Date(1969, 12, 1, 0);
 if(typeof x53 !== "object"){
-  $FAIL("#5.3: typeof new Date(1969, 12, 1, 0) should be 'object'");
+  $ERROR("#5.3: typeof new Date(1969, 12, 1, 0) should be 'object'");
 }
 
 var x54 = new Date(1969, 12, 1, 0);
 if(x54 === undefined){
-  $FAIL("#5.4: new Date(1969, 12, 1, 0) should not be undefined");
+  $ERROR("#5.4: new Date(1969, 12, 1, 0) should not be undefined");
 }
 
 if (typeof new Date(1970, 0, 1, 0) !== "object") {
-  $FAIL("#6.1: typeof new Date(1970, 0, 1, 0) should be 'object'");
+  $ERROR("#6.1: typeof new Date(1970, 0, 1, 0) should be 'object'");
 }
 
 if (new Date(1970, 0, 1, 0) === undefined) {
-  $FAIL("#6.2: new Date(1970, 0, 1, 0) should not be undefined");
+  $ERROR("#6.2: new Date(1970, 0, 1, 0) should not be undefined");
 }
 
 var x63 = new Date(1970, 0, 1, 0);
 if(typeof x63 !== "object"){
-  $FAIL("#6.3: typeof new Date(1970, 0, 1, 0) should be 'object'");
+  $ERROR("#6.3: typeof new Date(1970, 0, 1, 0) should be 'object'");
 }
 
 var x64 = new Date(1970, 0, 1, 0);
 if(x64 === undefined){
-  $FAIL("#6.4: new Date(1970, 0, 1, 0) should not be undefined");
+  $ERROR("#6.4: new Date(1970, 0, 1, 0) should not be undefined");
 }
 
 if (typeof new Date(1999, 11, 31, 23) !== "object") {
-  $FAIL("#7.1: typeof new Date(1999, 11, 31, 23) should be 'object'");
+  $ERROR("#7.1: typeof new Date(1999, 11, 31, 23) should be 'object'");
 }
 
 if (new Date(1999, 11, 31, 23) === undefined) {
-  $FAIL("#7.2: new Date(1999, 11, 31, 23) should not be undefined");
+  $ERROR("#7.2: new Date(1999, 11, 31, 23) should not be undefined");
 }
 
 var x73 = new Date(1999, 11, 31, 23);
 if(typeof x73 !== "object"){
-  $FAIL("#7.3: typeof new Date(1999, 11, 31, 23) should be 'object'");
+  $ERROR("#7.3: typeof new Date(1999, 11, 31, 23) should be 'object'");
 }
 
 var x74 = new Date(1999, 11, 31, 23);
 if(x74 === undefined){
-  $FAIL("#7.4: new Date(1999, 11, 31, 23) should not be undefined");
+  $ERROR("#7.4: new Date(1999, 11, 31, 23) should not be undefined");
 }
 
 if (typeof new Date(1999, 12, 1, 0) !== "object") {
-  $FAIL("#8.1: typeof new Date(1999, 12, 1, 0) should be 'object'");
+  $ERROR("#8.1: typeof new Date(1999, 12, 1, 0) should be 'object'");
 }
 
 if (new Date(1999, 12, 1, 0) === undefined) {
-  $FAIL("#8.2: new Date(1999, 12, 1, 0) should not be undefined");
+  $ERROR("#8.2: new Date(1999, 12, 1, 0) should not be undefined");
 }
 
 var x83 = new Date(1999, 12, 1, 0);
 if(typeof x83 !== "object"){
-  $FAIL("#8.3: typeof new Date(1999, 12, 1, 0) should be 'object'");
+  $ERROR("#8.3: typeof new Date(1999, 12, 1, 0) should be 'object'");
 }
 
 var x84 = new Date(1999, 12, 1, 0);
 if(x84 === undefined){
-  $FAIL("#8.4: new Date(1999, 12, 1, 0) should not be undefined");
+  $ERROR("#8.4: new Date(1999, 12, 1, 0) should not be undefined");
 }
 
 if (typeof new Date(2000, 0, 1, 0) !== "object") {
-  $FAIL("#9.1: typeof new Date(2000, 0, 1, 0) should be 'object'");
+  $ERROR("#9.1: typeof new Date(2000, 0, 1, 0) should be 'object'");
 }
 
 if (new Date(2000, 0, 1, 0) === undefined) {
-  $FAIL("#9.2: new Date(2000, 0, 1, 0) should not be undefined");
+  $ERROR("#9.2: new Date(2000, 0, 1, 0) should not be undefined");
 }
 
 var x93 = new Date(2000, 0, 1, 0);
 if(typeof x93 !== "object"){
-  $FAIL("#9.3: typeof new Date(2000, 0, 1, 0) should be 'object'");
+  $ERROR("#9.3: typeof new Date(2000, 0, 1, 0) should be 'object'");
 }
 
 var x94 = new Date(2000, 0, 1, 0);
 if(x94 === undefined){
-  $FAIL("#9.4: new Date(2000, 0, 1, 0) should not be undefined");
+  $ERROR("#9.4: new Date(2000, 0, 1, 0) should not be undefined");
 }
 
 if (typeof new Date(2099, 11, 31, 23) !== "object") {
-  $FAIL("#10.1: typeof new Date(2099, 11, 31, 23) should be 'object'");
+  $ERROR("#10.1: typeof new Date(2099, 11, 31, 23) should be 'object'");
 }
 
 if (new Date(2099, 11, 31, 23) === undefined) {
-  $FAIL("#10.2: new Date(2099, 11, 31, 23) should not be undefined");
+  $ERROR("#10.2: new Date(2099, 11, 31, 23) should not be undefined");
 }
 
 var x103 = new Date(2099, 11, 31, 23);
 if(typeof x103 !== "object"){
-  $FAIL("#10.3: typeof new Date(2099, 11, 31, 23) should be 'object'");
+  $ERROR("#10.3: typeof new Date(2099, 11, 31, 23) should be 'object'");
 }
 
 var x104 = new Date(2099, 11, 31, 23);
 if(x104 === undefined){
-  $FAIL("#10.4: new Date(2099, 11, 31, 23) should not be undefined");
+  $ERROR("#10.4: new Date(2099, 11, 31, 23) should not be undefined");
 }
 
 if (typeof new Date(2099, 12, 1, 0) !== "object") {
-  $FAIL("#11.1: typeof new Date(2099, 12, 1, 0) should be 'object'");
+  $ERROR("#11.1: typeof new Date(2099, 12, 1, 0) should be 'object'");
 }
 
 if (new Date(2099, 12, 1, 0) === undefined) {
-  $FAIL("#11.2: new Date(2099, 12, 1, 0) should not be undefined");
+  $ERROR("#11.2: new Date(2099, 12, 1, 0) should not be undefined");
 }
 
 var x113 = new Date(2099, 12, 1, 0);
 if(typeof x113 !== "object"){
-  $FAIL("#11.3: typeof new Date(2099, 12, 1, 0) should be 'object'");
+  $ERROR("#11.3: typeof new Date(2099, 12, 1, 0) should be 'object'");
 }
 
 var x114 = new Date(2099, 12, 1, 0);
 if(x114 === undefined){
-  $FAIL("#11.4: new Date(2099, 12, 1, 0) should not be undefined");
+  $ERROR("#11.4: new Date(2099, 12, 1, 0) should not be undefined");
 }
 
 if (typeof new Date(2100, 0, 1, 0) !== "object") {
-  $FAIL("#12.1: typeof new Date(2100, 0, 1, 0) should be 'object'");
+  $ERROR("#12.1: typeof new Date(2100, 0, 1, 0) should be 'object'");
 }
 
 if (new Date(2100, 0, 1, 0) === undefined) {
-  $FAIL("#12.2: new Date(2100, 0, 1, 0) should not be undefined");
+  $ERROR("#12.2: new Date(2100, 0, 1, 0) should not be undefined");
 }
 
 var x123 = new Date(2100, 0, 1, 0);
 if(typeof x123 !== "object"){
-  $FAIL("#12.3: typeof new Date(2100, 0, 1, 0) should be 'object'");
+  $ERROR("#12.3: typeof new Date(2100, 0, 1, 0) should be 'object'");
 }
 
 var x124 = new Date(2100, 0, 1, 0);
 if(x124 === undefined){
-  $FAIL("#12.4: new Date(2100, 0, 1, 0) should not be undefined");
+  $ERROR("#12.4: new Date(2100, 0, 1, 0) should not be undefined");
 }

--- a/test/built-ins/Date/S15.9.3.1_A1_T4.js
+++ b/test/built-ins/Date/S15.9.3.1_A1_T4.js
@@ -7,221 +7,220 @@ info: >
     a constructor: it initializes the newly created object
 es5id: 15.9.3.1_A1_T4
 description: 5 arguments, (year, month, date, hours, minutes)
-includes: [$FAIL.js]
 ---*/
 
 if (typeof new Date(1899, 11, 31, 23, 59) !== "object") {
-  $FAIL("#1.1: typeof new Date(1899, 11, 31, 23, 59) should be 'object'");
+  $ERROR("#1.1: typeof new Date(1899, 11, 31, 23, 59) should be 'object'");
 }
 
 if (new Date(1899, 11, 31, 23, 59) === undefined) {
-  $FAIL("#1.2: new Date(1899, 11, 31, 23, 59) should not be undefined");
+  $ERROR("#1.2: new Date(1899, 11, 31, 23, 59) should not be undefined");
 }
 
 var x13 = new Date(1899, 11, 31, 23, 59);
 if(typeof x13 !== "object"){
-  $FAIL("#1.3: typeof new Date(1899, 11, 31, 23, 59) should be 'object'");
+  $ERROR("#1.3: typeof new Date(1899, 11, 31, 23, 59) should be 'object'");
 }
 
 var x14 = new Date(1899, 11, 31, 23, 59);
 if(x14 === undefined){
-  $FAIL("#1.4: new Date(1899, 11, 31, 23, 59) should not be undefined");
+  $ERROR("#1.4: new Date(1899, 11, 31, 23, 59) should not be undefined");
 }
 
 if (typeof new Date(1899, 12, 1, 0, 0) !== "object") {
-  $FAIL("#2.1: typeof new Date(1899, 12, 1, 0, 0) should be 'object'");
+  $ERROR("#2.1: typeof new Date(1899, 12, 1, 0, 0) should be 'object'");
 }
 
 if (new Date(1899, 12, 1, 0, 0) === undefined) {
-  $FAIL("#2.2: new Date(1899, 12, 1, 0, 0) should not be undefined");
+  $ERROR("#2.2: new Date(1899, 12, 1, 0, 0) should not be undefined");
 }
 
 var x23 = new Date(1899, 12, 1, 0, 0);
 if(typeof x23 !== "object"){
-  $FAIL("#2.3: typeof new Date(1899, 12, 1, 0, 0) should be 'object'");
+  $ERROR("#2.3: typeof new Date(1899, 12, 1, 0, 0) should be 'object'");
 }
 
 var x24 = new Date(1899, 12, 1, 0, 0);
 if(x24 === undefined){
-  $FAIL("#2.4: new Date(1899, 12, 1, 0, 0) should not be undefined");
+  $ERROR("#2.4: new Date(1899, 12, 1, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(1900, 0, 1, 0, 0) !== "object") {
-  $FAIL("#3.1: typeof new Date(1900, 0, 1, 0, 0) should be 'object'");
+  $ERROR("#3.1: typeof new Date(1900, 0, 1, 0, 0) should be 'object'");
 }
 
 if (new Date(1900, 0, 1, 0, 0) === undefined) {
-  $FAIL("#3.2: new Date(1900, 0, 1, 0, 0) should not be undefined");
+  $ERROR("#3.2: new Date(1900, 0, 1, 0, 0) should not be undefined");
 }
 
 var x33 = new Date(1900, 0, 1, 0, 0);
 if(typeof x33 !== "object"){
-  $FAIL("#3.3: typeof new Date(1900, 0, 1, 0, 0) should be 'object'");
+  $ERROR("#3.3: typeof new Date(1900, 0, 1, 0, 0) should be 'object'");
 }
 
 var x34 = new Date(1900, 0, 1, 0, 0);
 if(x34 === undefined){
-  $FAIL("#3.4: new Date(1900, 0, 1, 0, 0) should not be undefined");
+  $ERROR("#3.4: new Date(1900, 0, 1, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(1969, 11, 31, 23, 59) !== "object") {
-  $FAIL("#4.1: typeof new Date(1969, 11, 31, 23, 59) should be 'object'");
+  $ERROR("#4.1: typeof new Date(1969, 11, 31, 23, 59) should be 'object'");
 }
 
 if (new Date(1969, 11, 31, 23, 59) === undefined) {
-  $FAIL("#4.2: new Date(1969, 11, 31, 23, 59) should not be undefined");
+  $ERROR("#4.2: new Date(1969, 11, 31, 23, 59) should not be undefined");
 }
 
 var x43 = new Date(1969, 11, 31, 23, 59);
 if(typeof x43 !== "object"){
-  $FAIL("#4.3: typeof new Date(1969, 11, 31, 23, 59) should be 'object'");
+  $ERROR("#4.3: typeof new Date(1969, 11, 31, 23, 59) should be 'object'");
 }
 
 var x44 = new Date(1969, 11, 31, 23, 59);
 if(x44 === undefined){
-  $FAIL("#4.4: new Date(1969, 11, 31, 23, 59) should not be undefined");
+  $ERROR("#4.4: new Date(1969, 11, 31, 23, 59) should not be undefined");
 }
 
 if (typeof new Date(1969, 12, 1, 0, 0) !== "object") {
-  $FAIL("#5.1: typeof new Date(1969, 12, 1, 0, 0) should be 'object'");
+  $ERROR("#5.1: typeof new Date(1969, 12, 1, 0, 0) should be 'object'");
 }
 
 if (new Date(1969, 12, 1, 0, 0) === undefined) {
-  $FAIL("#5.2: new Date(1969, 12, 1, 0, 0) should not be undefined");
+  $ERROR("#5.2: new Date(1969, 12, 1, 0, 0) should not be undefined");
 }
 
 var x53 = new Date(1969, 12, 1, 0, 0);
 if(typeof x53 !== "object"){
-  $FAIL("#5.3: typeof new Date(1969, 12, 1, 0, 0) should be 'object'");
+  $ERROR("#5.3: typeof new Date(1969, 12, 1, 0, 0) should be 'object'");
 }
 
 var x54 = new Date(1969, 12, 1, 0, 0);
 if(x54 === undefined){
-  $FAIL("#5.4: new Date(1969, 12, 1, 0, 0) should not be undefined");
+  $ERROR("#5.4: new Date(1969, 12, 1, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(1970, 0, 1, 0, 0) !== "object") {
-  $FAIL("#6.1: typeof new Date(1970, 0, 1, 0, 0) should be 'object'");
+  $ERROR("#6.1: typeof new Date(1970, 0, 1, 0, 0) should be 'object'");
 }
 
 if (new Date(1970, 0, 1, 0, 0) === undefined) {
-  $FAIL("#6.2: new Date(1970, 0, 1, 0, 0) should not be undefined");
+  $ERROR("#6.2: new Date(1970, 0, 1, 0, 0) should not be undefined");
 }
 
 var x63 = new Date(1970, 0, 1, 0, 0);
 if(typeof x63 !== "object"){
-  $FAIL("#6.3: typeof new Date(1970, 0, 1, 0, 0) should be 'object'");
+  $ERROR("#6.3: typeof new Date(1970, 0, 1, 0, 0) should be 'object'");
 }
 
 var x64 = new Date(1970, 0, 1, 0, 0);
 if(x64 === undefined){
-  $FAIL("#6.4: new Date(1970, 0, 1, 0, 0) should not be undefined");
+  $ERROR("#6.4: new Date(1970, 0, 1, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(1999, 11, 31, 23, 59) !== "object") {
-  $FAIL("#7.1: typeof new Date(1999, 11, 31, 23, 59) should be 'object'");
+  $ERROR("#7.1: typeof new Date(1999, 11, 31, 23, 59) should be 'object'");
 }
 
 if (new Date(1999, 11, 31, 23, 59) === undefined) {
-  $FAIL("#7.2: new Date(1999, 11, 31, 23, 59) should not be undefined");
+  $ERROR("#7.2: new Date(1999, 11, 31, 23, 59) should not be undefined");
 }
 
 var x73 = new Date(1999, 11, 31, 23, 59);
 if(typeof x73 !== "object"){
-  $FAIL("#7.3: typeof new Date(1999, 11, 31, 23, 59) should be 'object'");
+  $ERROR("#7.3: typeof new Date(1999, 11, 31, 23, 59) should be 'object'");
 }
 
 var x74 = new Date(1999, 11, 31, 23, 59);
 if(x74 === undefined){
-  $FAIL("#7.4: new Date(1999, 11, 31, 23, 59) should not be undefined");
+  $ERROR("#7.4: new Date(1999, 11, 31, 23, 59) should not be undefined");
 }
 
 if (typeof new Date(1999, 12, 1, 0, 0) !== "object") {
-  $FAIL("#8.1: typeof new Date(1999, 12, 1, 0, 0) should be 'object'");
+  $ERROR("#8.1: typeof new Date(1999, 12, 1, 0, 0) should be 'object'");
 }
 
 if (new Date(1999, 12, 1, 0, 0) === undefined) {
-  $FAIL("#8.2: new Date(1999, 12, 1, 0, 0) should not be undefined");
+  $ERROR("#8.2: new Date(1999, 12, 1, 0, 0) should not be undefined");
 }
 
 var x83 = new Date(1999, 12, 1, 0, 0);
 if(typeof x83 !== "object"){
-  $FAIL("#8.3: typeof new Date(1999, 12, 1, 0, 0) should be 'object'");
+  $ERROR("#8.3: typeof new Date(1999, 12, 1, 0, 0) should be 'object'");
 }
 
 var x84 = new Date(1999, 12, 1, 0, 0);
 if(x84 === undefined){
-  $FAIL("#8.4: new Date(1999, 12, 1, 0, 0) should not be undefined");
+  $ERROR("#8.4: new Date(1999, 12, 1, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(2000, 0, 1, 0, 0) !== "object") {
-  $FAIL("#9.1: typeof new Date(2000, 0, 1, 0, 0) should be 'object'");
+  $ERROR("#9.1: typeof new Date(2000, 0, 1, 0, 0) should be 'object'");
 }
 
 if (new Date(2000, 0, 1, 0, 0) === undefined) {
-  $FAIL("#9.2: new Date(2000, 0, 1, 0, 0) should not be undefined");
+  $ERROR("#9.2: new Date(2000, 0, 1, 0, 0) should not be undefined");
 }
 
 var x93 = new Date(2000, 0, 1, 0, 0);
 if(typeof x93 !== "object"){
-  $FAIL("#9.3: typeof new Date(2000, 0, 1, 0, 0) should be 'object'");
+  $ERROR("#9.3: typeof new Date(2000, 0, 1, 0, 0) should be 'object'");
 }
 
 var x94 = new Date(2000, 0, 1, 0, 0);
 if(x94 === undefined){
-  $FAIL("#9.4: new Date(2000, 0, 1, 0, 0) should not be undefined");
+  $ERROR("#9.4: new Date(2000, 0, 1, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(2099, 11, 31, 23, 59) !== "object") {
-  $FAIL("#10.1: typeof new Date(2099, 11, 31, 23, 59) should be 'object'");
+  $ERROR("#10.1: typeof new Date(2099, 11, 31, 23, 59) should be 'object'");
 }
 
 if (new Date(2099, 11, 31, 23, 59) === undefined) {
-  $FAIL("#10.2: new Date(2099, 11, 31, 23, 59) should not be undefined");
+  $ERROR("#10.2: new Date(2099, 11, 31, 23, 59) should not be undefined");
 }
 
 var x103 = new Date(2099, 11, 31, 23, 59);
 if(typeof x103 !== "object"){
-  $FAIL("#10.3: typeof new Date(2099, 11, 31, 23, 59) should be 'object'");
+  $ERROR("#10.3: typeof new Date(2099, 11, 31, 23, 59) should be 'object'");
 }
 
 var x104 = new Date(2099, 11, 31, 23, 59);
 if(x104 === undefined){
-  $FAIL("#10.4: new Date(2099, 11, 31, 23, 59) should not be undefined");
+  $ERROR("#10.4: new Date(2099, 11, 31, 23, 59) should not be undefined");
 }
 
 if (typeof new Date(2099, 12, 1, 0, 0) !== "object") {
-  $FAIL("#11.1: typeof new Date(2099, 12, 1, 0, 0) should be 'object'");
+  $ERROR("#11.1: typeof new Date(2099, 12, 1, 0, 0) should be 'object'");
 }
 
 if (new Date(2099, 12, 1, 0, 0) === undefined) {
-  $FAIL("#11.2: new Date(2099, 12, 1, 0, 0) should not be undefined");
+  $ERROR("#11.2: new Date(2099, 12, 1, 0, 0) should not be undefined");
 }
 
 var x113 = new Date(2099, 12, 1, 0, 0);
 if(typeof x113 !== "object"){
-  $FAIL("#11.3: typeof new Date(2099, 12, 1, 0, 0) should be 'object'");
+  $ERROR("#11.3: typeof new Date(2099, 12, 1, 0, 0) should be 'object'");
 }
 
 var x114 = new Date(2099, 12, 1, 0, 0);
 if(x114 === undefined){
-  $FAIL("#11.4: new Date(2099, 12, 1, 0, 0) should not be undefined");
+  $ERROR("#11.4: new Date(2099, 12, 1, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(2100, 0, 1, 0, 0) !== "object") {
-  $FAIL("#12.1: typeof new Date(2100, 0, 1, 0, 0) should be 'object'");
+  $ERROR("#12.1: typeof new Date(2100, 0, 1, 0, 0) should be 'object'");
 }
 
 if (new Date(2100, 0, 1, 0, 0) === undefined) {
-  $FAIL("#12.2: new Date(2100, 0, 1, 0, 0) should not be undefined");
+  $ERROR("#12.2: new Date(2100, 0, 1, 0, 0) should not be undefined");
 }
 
 var x123 = new Date(2100, 0, 1, 0, 0);
 if(typeof x123 !== "object"){
-  $FAIL("#12.3: typeof new Date(2100, 0, 1, 0, 0) should be 'object'");
+  $ERROR("#12.3: typeof new Date(2100, 0, 1, 0, 0) should be 'object'");
 }
 
 var x124 = new Date(2100, 0, 1, 0, 0);
 if(x124 === undefined){
-  $FAIL("#12.4: new Date(2100, 0, 1, 0, 0) should not be undefined");
+  $ERROR("#12.4: new Date(2100, 0, 1, 0, 0) should not be undefined");
 }

--- a/test/built-ins/Date/S15.9.3.1_A1_T5.js
+++ b/test/built-ins/Date/S15.9.3.1_A1_T5.js
@@ -7,221 +7,220 @@ info: >
     a constructor: it initializes the newly created object
 es5id: 15.9.3.1_A1_T5
 description: 6 arguments, (year, month, date, hours, minutes, seconds)
-includes: [$FAIL.js]
 ---*/
 
 if (typeof new Date(1899, 11, 31, 23, 59, 59) !== "object") {
-  $FAIL("#1.1: typeof new Date(1899, 11, 31, 23, 59, 59) should be 'object'");
+  $ERROR("#1.1: typeof new Date(1899, 11, 31, 23, 59, 59) should be 'object'");
 }
 
 if (new Date(1899, 11, 31, 23, 59, 59) === undefined) {
-  $FAIL("#1.2: new Date(1899, 11, 31, 23, 59, 59) should not be undefined");
+  $ERROR("#1.2: new Date(1899, 11, 31, 23, 59, 59) should not be undefined");
 }
 
 var x13 = new Date(1899, 11, 31, 23, 59, 59);
 if(typeof x13 !== "object"){
-  $FAIL("#1.3: typeof new Date(1899, 11, 31, 23, 59, 59) should be 'object'");
+  $ERROR("#1.3: typeof new Date(1899, 11, 31, 23, 59, 59) should be 'object'");
 }
 
 var x14 = new Date(1899, 11, 31, 23, 59, 59);
 if(x14 === undefined){
-  $FAIL("#1.4: new Date(1899, 11, 31, 23, 59, 59) should not be undefined");
+  $ERROR("#1.4: new Date(1899, 11, 31, 23, 59, 59) should not be undefined");
 }
 
 if (typeof new Date(1899, 12, 1, 0, 0, 0) !== "object") {
-  $FAIL("#2.1: typeof new Date(1899, 12, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#2.1: typeof new Date(1899, 12, 1, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(1899, 12, 1, 0, 0, 0) === undefined) {
-  $FAIL("#2.2: new Date(1899, 12, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#2.2: new Date(1899, 12, 1, 0, 0, 0) should not be undefined");
 }
 
 var x23 = new Date(1899, 12, 1, 0, 0, 0);
 if(typeof x23 !== "object"){
-  $FAIL("#2.3: typeof new Date(1899, 12, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#2.3: typeof new Date(1899, 12, 1, 0, 0, 0) should be 'object'");
 }
 
 var x24 = new Date(1899, 12, 1, 0, 0, 0);
 if(x24 === undefined){
-  $FAIL("#2.4: new Date(1899, 12, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#2.4: new Date(1899, 12, 1, 0, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(1900, 0, 1, 0, 0, 0) !== "object") {
-  $FAIL("#3.1: typeof new Date(1900, 0, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#3.1: typeof new Date(1900, 0, 1, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(1900, 0, 1, 0, 0, 0) === undefined) {
-  $FAIL("#3.2: new Date(1900, 0, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#3.2: new Date(1900, 0, 1, 0, 0, 0) should not be undefined");
 }
 
 var x33 = new Date(1900, 0, 1, 0, 0, 0);
 if(typeof x33 !== "object"){
-  $FAIL("#3.3: typeof new Date(1900, 0, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#3.3: typeof new Date(1900, 0, 1, 0, 0, 0) should be 'object'");
 }
 
 var x34 = new Date(1900, 0, 1, 0, 0, 0);
 if(x34 === undefined){
-  $FAIL("#3.4: new Date(1900, 0, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#3.4: new Date(1900, 0, 1, 0, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(1969, 11, 31, 23, 59, 59) !== "object") {
-  $FAIL("#4.1: typeof new Date(1969, 11, 31, 23, 59, 59) should be 'object'");
+  $ERROR("#4.1: typeof new Date(1969, 11, 31, 23, 59, 59) should be 'object'");
 }
 
 if (new Date(1969, 11, 31, 23, 59, 59) === undefined) {
-  $FAIL("#4.2: new Date(1969, 11, 31, 23, 59, 59) should not be undefined");
+  $ERROR("#4.2: new Date(1969, 11, 31, 23, 59, 59) should not be undefined");
 }
 
 var x43 = new Date(1969, 11, 31, 23, 59, 59);
 if(typeof x43 !== "object"){
-  $FAIL("#4.3: typeof new Date(1969, 11, 31, 23, 59, 59) should be 'object'");
+  $ERROR("#4.3: typeof new Date(1969, 11, 31, 23, 59, 59) should be 'object'");
 }
 
 var x44 = new Date(1969, 11, 31, 23, 59, 59);
 if(x44 === undefined){
-  $FAIL("#4.4: new Date(1969, 11, 31, 23, 59, 59) should not be undefined");
+  $ERROR("#4.4: new Date(1969, 11, 31, 23, 59, 59) should not be undefined");
 }
 
 if (typeof new Date(1969, 12, 1, 0, 0, 0) !== "object") {
-  $FAIL("#5.1: typeof new Date(1969, 12, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#5.1: typeof new Date(1969, 12, 1, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(1969, 12, 1, 0, 0, 0) === undefined) {
-  $FAIL("#5.2: new Date(1969, 12, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#5.2: new Date(1969, 12, 1, 0, 0, 0) should not be undefined");
 }
 
 var x53 = new Date(1969, 12, 1, 0, 0, 0);
 if(typeof x53 !== "object"){
-  $FAIL("#5.3: typeof new Date(1969, 12, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#5.3: typeof new Date(1969, 12, 1, 0, 0, 0) should be 'object'");
 }
 
 var x54 = new Date(1969, 12, 1, 0, 0, 0);
 if(x54 === undefined){
-  $FAIL("#5.4: new Date(1969, 12, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#5.4: new Date(1969, 12, 1, 0, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(1970, 0, 1, 0, 0, 0) !== "object") {
-  $FAIL("#6.1: typeof new Date(1970, 0, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#6.1: typeof new Date(1970, 0, 1, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(1970, 0, 1, 0, 0, 0) === undefined) {
-  $FAIL("#6.2: new Date(1970, 0, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#6.2: new Date(1970, 0, 1, 0, 0, 0) should not be undefined");
 }
 
 var x63 = new Date(1970, 0, 1, 0, 0, 0);
 if(typeof x63 !== "object"){
-  $FAIL("#6.3: typeof new Date(1970, 0, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#6.3: typeof new Date(1970, 0, 1, 0, 0, 0) should be 'object'");
 }
 
 var x64 = new Date(1970, 0, 1, 0, 0, 0);
 if(x64 === undefined){
-  $FAIL("#6.4: new Date(1970, 0, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#6.4: new Date(1970, 0, 1, 0, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(1999, 11, 31, 23, 59, 59) !== "object") {
-  $FAIL("#7.1: typeof new Date(1999, 11, 31, 23, 59, 59) should be 'object'");
+  $ERROR("#7.1: typeof new Date(1999, 11, 31, 23, 59, 59) should be 'object'");
 }
 
 if (new Date(1999, 11, 31, 23, 59, 59) === undefined) {
-  $FAIL("#7.2: new Date(1999, 11, 31, 23, 59, 59) should not be undefined");
+  $ERROR("#7.2: new Date(1999, 11, 31, 23, 59, 59) should not be undefined");
 }
 
 var x73 = new Date(1999, 11, 31, 23, 59, 59);
 if(typeof x73 !== "object"){
-  $FAIL("#7.3: typeof new Date(1999, 11, 31, 23, 59, 59) should be 'object'");
+  $ERROR("#7.3: typeof new Date(1999, 11, 31, 23, 59, 59) should be 'object'");
 }
 
 var x74 = new Date(1999, 11, 31, 23, 59, 59);
 if(x74 === undefined){
-  $FAIL("#7.4: new Date(1999, 11, 31, 23, 59, 59) should not be undefined");
+  $ERROR("#7.4: new Date(1999, 11, 31, 23, 59, 59) should not be undefined");
 }
 
 if (typeof new Date(1999, 12, 1, 0, 0, 0) !== "object") {
-  $FAIL("#8.1: typeof new Date(1999, 12, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#8.1: typeof new Date(1999, 12, 1, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(1999, 12, 1, 0, 0, 0) === undefined) {
-  $FAIL("#8.2: new Date(1999, 12, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#8.2: new Date(1999, 12, 1, 0, 0, 0) should not be undefined");
 }
 
 var x83 = new Date(1999, 12, 1, 0, 0, 0);
 if(typeof x83 !== "object"){
-  $FAIL("#8.3: typeof new Date(1999, 12, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#8.3: typeof new Date(1999, 12, 1, 0, 0, 0) should be 'object'");
 }
 
 var x84 = new Date(1999, 12, 1, 0, 0, 0);
 if(x84 === undefined){
-  $FAIL("#8.4: new Date(1999, 12, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#8.4: new Date(1999, 12, 1, 0, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(2000, 0, 1, 0, 0, 0) !== "object") {
-  $FAIL("#9.1: typeof new Date(2000, 0, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#9.1: typeof new Date(2000, 0, 1, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(2000, 0, 1, 0, 0, 0) === undefined) {
-  $FAIL("#9.2: new Date(2000, 0, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#9.2: new Date(2000, 0, 1, 0, 0, 0) should not be undefined");
 }
 
 var x93 = new Date(2000, 0, 1, 0, 0, 0);
 if(typeof x93 !== "object"){
-  $FAIL("#9.3: typeof new Date(2000, 0, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#9.3: typeof new Date(2000, 0, 1, 0, 0, 0) should be 'object'");
 }
 
 var x94 = new Date(2000, 0, 1, 0, 0, 0);
 if(x94 === undefined){
-  $FAIL("#9.4: new Date(2000, 0, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#9.4: new Date(2000, 0, 1, 0, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(2099, 11, 31, 23, 59, 59) !== "object") {
-  $FAIL("#10.1: typeof new Date(2099, 11, 31, 23, 59, 59) should be 'object'");
+  $ERROR("#10.1: typeof new Date(2099, 11, 31, 23, 59, 59) should be 'object'");
 }
 
 if (new Date(2099, 11, 31, 23, 59, 59) === undefined) {
-  $FAIL("#10.2: new Date(2099, 11, 31, 23, 59, 59) should not be undefined");
+  $ERROR("#10.2: new Date(2099, 11, 31, 23, 59, 59) should not be undefined");
 }
 
 var x103 = new Date(2099, 11, 31, 23, 59, 59);
 if(typeof x103 !== "object"){
-  $FAIL("#10.3: typeof new Date(2099, 11, 31, 23, 59, 59) should be 'object'");
+  $ERROR("#10.3: typeof new Date(2099, 11, 31, 23, 59, 59) should be 'object'");
 }
 
 var x104 = new Date(2099, 11, 31, 23, 59, 59);
 if(x104 === undefined){
-  $FAIL("#10.4: new Date(2099, 11, 31, 23, 59, 59) should not be undefined");
+  $ERROR("#10.4: new Date(2099, 11, 31, 23, 59, 59) should not be undefined");
 }
 
 if (typeof new Date(2099, 12, 1, 0, 0, 0) !== "object") {
-  $FAIL("#11.1: typeof new Date(2099, 12, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#11.1: typeof new Date(2099, 12, 1, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(2099, 12, 1, 0, 0, 0) === undefined) {
-  $FAIL("#11.2: new Date(2099, 12, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#11.2: new Date(2099, 12, 1, 0, 0, 0) should not be undefined");
 }
 
 var x113 = new Date(2099, 12, 1, 0, 0, 0);
 if(typeof x113 !== "object"){
-  $FAIL("#11.3: typeof new Date(2099, 12, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#11.3: typeof new Date(2099, 12, 1, 0, 0, 0) should be 'object'");
 }
 
 var x114 = new Date(2099, 12, 1, 0, 0, 0);
 if(x114 === undefined){
-  $FAIL("#11.4: new Date(2099, 12, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#11.4: new Date(2099, 12, 1, 0, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(2100, 0, 1, 0, 0, 0) !== "object") {
-  $FAIL("#12.1: typeof new Date(2100, 0, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#12.1: typeof new Date(2100, 0, 1, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(2100, 0, 1, 0, 0, 0) === undefined) {
-  $FAIL("#12.2: new Date(2100, 0, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#12.2: new Date(2100, 0, 1, 0, 0, 0) should not be undefined");
 }
 
 var x123 = new Date(2100, 0, 1, 0, 0, 0);
 if(typeof x123 !== "object"){
-  $FAIL("#12.3: typeof new Date(2100, 0, 1, 0, 0, 0) should be 'object'");
+  $ERROR("#12.3: typeof new Date(2100, 0, 1, 0, 0, 0) should be 'object'");
 }
 
 var x124 = new Date(2100, 0, 1, 0, 0, 0);
 if(x124 === undefined){
-  $FAIL("#12.4: new Date(2100, 0, 1, 0, 0, 0) should not be undefined");
+  $ERROR("#12.4: new Date(2100, 0, 1, 0, 0, 0) should not be undefined");
 }

--- a/test/built-ins/Date/S15.9.3.1_A1_T6.js
+++ b/test/built-ins/Date/S15.9.3.1_A1_T6.js
@@ -7,221 +7,220 @@ info: >
     a constructor: it initializes the newly created object
 es5id: 15.9.3.1_A1_T6
 description: 7 arguments, (year, month, date, hours, minutes, seconds, ms)
-includes: [$FAIL.js]
 ---*/
 
 if (typeof new Date(1899, 11, 31, 23, 59, 59, 999) !== "object") {
-  $FAIL("#1.1: typeof new Date(1899, 11, 31, 23, 59, 59, 999) should be 'object'");
+  $ERROR("#1.1: typeof new Date(1899, 11, 31, 23, 59, 59, 999) should be 'object'");
 }
 
 if (new Date(1899, 11, 31, 23, 59, 59, 999) === undefined) {
-  $FAIL("#1.2: new Date(1899, 11, 31, 23, 59, 59, 999) should not be undefined");
+  $ERROR("#1.2: new Date(1899, 11, 31, 23, 59, 59, 999) should not be undefined");
 }
 
 var x13 = new Date(1899, 11, 31, 23, 59, 59, 999);
 if(typeof x13 !== "object"){
-  $FAIL("#1.3: typeof new Date(1899, 11, 31, 23, 59, 59, 999) should be 'object'");
+  $ERROR("#1.3: typeof new Date(1899, 11, 31, 23, 59, 59, 999) should be 'object'");
 }
 
 var x14 = new Date(1899, 11, 31, 23, 59, 59, 999);
 if(x14 === undefined){
-  $FAIL("#1.4: new Date(1899, 11, 31, 23, 59, 59, 999) should not be undefined");
+  $ERROR("#1.4: new Date(1899, 11, 31, 23, 59, 59, 999) should not be undefined");
 }
 
 if (typeof new Date(1899, 12, 1, 0, 0, 0, 0) !== "object") {
-  $FAIL("#2.1: typeof new Date(1899, 12, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#2.1: typeof new Date(1899, 12, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(1899, 12, 1, 0, 0, 0, 0) === undefined) {
-  $FAIL("#2.2: new Date(1899, 12, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#2.2: new Date(1899, 12, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 var x23 = new Date(1899, 12, 1, 0, 0, 0, 0);
 if(typeof x23 !== "object"){
-  $FAIL("#2.3: typeof new Date(1899, 12, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#2.3: typeof new Date(1899, 12, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 var x24 = new Date(1899, 12, 1, 0, 0, 0, 0);
 if(x24 === undefined){
-  $FAIL("#2.4: new Date(1899, 12, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#2.4: new Date(1899, 12, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(1900, 0, 1, 0, 0, 0, 0) !== "object") {
-  $FAIL("#3.1: typeof new Date(1900, 0, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#3.1: typeof new Date(1900, 0, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(1900, 0, 1, 0, 0, 0, 0) === undefined) {
-  $FAIL("#3.2: new Date(1900, 0, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#3.2: new Date(1900, 0, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 var x33 = new Date(1900, 0, 1, 0, 0, 0, 0);
 if(typeof x33 !== "object"){
-  $FAIL("#3.3: typeof new Date(1900, 0, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#3.3: typeof new Date(1900, 0, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 var x34 = new Date(1900, 0, 1, 0, 0, 0, 0);
 if(x34 === undefined){
-  $FAIL("#3.4: new Date(1900, 0, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#3.4: new Date(1900, 0, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(1969, 11, 31, 23, 59, 59, 999) !== "object") {
-  $FAIL("#4.1: typeof new Date(1969, 11, 31, 23, 59, 59, 999) should be 'object'");
+  $ERROR("#4.1: typeof new Date(1969, 11, 31, 23, 59, 59, 999) should be 'object'");
 }
 
 if (new Date(1969, 11, 31, 23, 59, 59, 999) === undefined) {
-  $FAIL("#4.2: new Date(1969, 11, 31, 23, 59, 59, 999) should not be undefined");
+  $ERROR("#4.2: new Date(1969, 11, 31, 23, 59, 59, 999) should not be undefined");
 }
 
 var x43 = new Date(1969, 11, 31, 23, 59, 59, 999);
 if(typeof x43 !== "object"){
-  $FAIL("#4.3: typeof new Date(1969, 11, 31, 23, 59, 59, 999) should be 'object'");
+  $ERROR("#4.3: typeof new Date(1969, 11, 31, 23, 59, 59, 999) should be 'object'");
 }
 
 var x44 = new Date(1969, 11, 31, 23, 59, 59, 999);
 if(x44 === undefined){
-  $FAIL("#4.4: new Date(1969, 11, 31, 23, 59, 59, 999) should not be undefined");
+  $ERROR("#4.4: new Date(1969, 11, 31, 23, 59, 59, 999) should not be undefined");
 }
 
 if (typeof new Date(1969, 12, 1, 0, 0, 0, 0) !== "object") {
-  $FAIL("#5.1: typeof new Date(1969, 12, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#5.1: typeof new Date(1969, 12, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(1969, 12, 1, 0, 0, 0, 0) === undefined) {
-  $FAIL("#5.2: new Date(1969, 12, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#5.2: new Date(1969, 12, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 var x53 = new Date(1969, 12, 1, 0, 0, 0, 0);
 if(typeof x53 !== "object"){
-  $FAIL("#5.3: typeof new Date(1969, 12, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#5.3: typeof new Date(1969, 12, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 var x54 = new Date(1969, 12, 1, 0, 0, 0, 0);
 if(x54 === undefined){
-  $FAIL("#5.4: new Date(1969, 12, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#5.4: new Date(1969, 12, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(1970, 0, 1, 0, 0, 0, 0) !== "object") {
-  $FAIL("#6.1: typeof new Date(1970, 0, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#6.1: typeof new Date(1970, 0, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(1970, 0, 1, 0, 0, 0, 0) === undefined) {
-  $FAIL("#6.2: new Date(1970, 0, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#6.2: new Date(1970, 0, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 var x63 = new Date(1970, 0, 1, 0, 0, 0, 0);
 if(typeof x63 !== "object"){
-  $FAIL("#6.3: typeof new Date(1970, 0, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#6.3: typeof new Date(1970, 0, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 var x64 = new Date(1970, 0, 1, 0, 0, 0, 0);
 if(x64 === undefined){
-  $FAIL("#6.4: new Date(1970, 0, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#6.4: new Date(1970, 0, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(1999, 11, 31, 23, 59, 59, 999) !== "object") {
-  $FAIL("#7.1: typeof new Date(1999, 11, 31, 23, 59, 59, 999) should be 'object'");
+  $ERROR("#7.1: typeof new Date(1999, 11, 31, 23, 59, 59, 999) should be 'object'");
 }
 
 if (new Date(1999, 11, 31, 23, 59, 59, 999) === undefined) {
-  $FAIL("#7.2: new Date(1999, 11, 31, 23, 59, 59, 999) should not be undefined");
+  $ERROR("#7.2: new Date(1999, 11, 31, 23, 59, 59, 999) should not be undefined");
 }
 
 var x73 = new Date(1999, 11, 31, 23, 59, 59, 999);
 if(typeof x73 !== "object"){
-  $FAIL("#7.3: typeof new Date(1999, 11, 31, 23, 59, 59, 999) should be 'object'");
+  $ERROR("#7.3: typeof new Date(1999, 11, 31, 23, 59, 59, 999) should be 'object'");
 }
 
 var x74 = new Date(1999, 11, 31, 23, 59, 59, 999);
 if(x74 === undefined){
-  $FAIL("#7.4: new Date(1999, 11, 31, 23, 59, 59, 999) should not be undefined");
+  $ERROR("#7.4: new Date(1999, 11, 31, 23, 59, 59, 999) should not be undefined");
 }
 
 if (typeof new Date(1999, 12, 1, 0, 0, 0, 0) !== "object") {
-  $FAIL("#8.1: typeof new Date(1999, 12, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#8.1: typeof new Date(1999, 12, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(1999, 12, 1, 0, 0, 0, 0) === undefined) {
-  $FAIL("#8.2: new Date(1999, 12, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#8.2: new Date(1999, 12, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 var x83 = new Date(1999, 12, 1, 0, 0, 0, 0);
 if(typeof x83 !== "object"){
-  $FAIL("#8.3: typeof new Date(1999, 12, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#8.3: typeof new Date(1999, 12, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 var x84 = new Date(1999, 12, 1, 0, 0, 0, 0);
 if(x84 === undefined){
-  $FAIL("#8.4: new Date(1999, 12, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#8.4: new Date(1999, 12, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(2000, 0, 1, 0, 0, 0, 0) !== "object") {
-  $FAIL("#9.1: typeof new Date(2000, 0, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#9.1: typeof new Date(2000, 0, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(2000, 0, 1, 0, 0, 0, 0) === undefined) {
-  $FAIL("#9.2: new Date(2000, 0, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#9.2: new Date(2000, 0, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 var x93 = new Date(2000, 0, 1, 0, 0, 0, 0);
 if(typeof x93 !== "object"){
-  $FAIL("#9.3: typeof new Date(2000, 0, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#9.3: typeof new Date(2000, 0, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 var x94 = new Date(2000, 0, 1, 0, 0, 0, 0);
 if(x94 === undefined){
-  $FAIL("#9.4: new Date(2000, 0, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#9.4: new Date(2000, 0, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(2099, 11, 31, 23, 59, 59, 999) !== "object") {
-  $FAIL("#10.1: typeof new Date(2099, 11, 31, 23, 59, 59, 999) should be 'object'");
+  $ERROR("#10.1: typeof new Date(2099, 11, 31, 23, 59, 59, 999) should be 'object'");
 }
 
 if (new Date(2099, 11, 31, 23, 59, 59, 999) === undefined) {
-  $FAIL("#10.2: new Date(2099, 11, 31, 23, 59, 59, 999) should not be undefined");
+  $ERROR("#10.2: new Date(2099, 11, 31, 23, 59, 59, 999) should not be undefined");
 }
 
 var x103 = new Date(2099, 11, 31, 23, 59, 59, 999);
 if(typeof x103 !== "object"){
-  $FAIL("#10.3: typeof new Date(2099, 11, 31, 23, 59, 59, 999) should be 'object'");
+  $ERROR("#10.3: typeof new Date(2099, 11, 31, 23, 59, 59, 999) should be 'object'");
 }
 
 var x104 = new Date(2099, 11, 31, 23, 59, 59, 999);
 if(x104 === undefined){
-  $FAIL("#10.4: new Date(2099, 11, 31, 23, 59, 59, 999) should not be undefined");
+  $ERROR("#10.4: new Date(2099, 11, 31, 23, 59, 59, 999) should not be undefined");
 }
 
 if (typeof new Date(2099, 12, 1, 0, 0, 0, 0) !== "object") {
-  $FAIL("#11.1: typeof new Date(2099, 12, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#11.1: typeof new Date(2099, 12, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(2099, 12, 1, 0, 0, 0, 0) === undefined) {
-  $FAIL("#11.2: new Date(2099, 12, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#11.2: new Date(2099, 12, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 var x113 = new Date(2099, 12, 1, 0, 0, 0, 0);
 if(typeof x113 !== "object"){
-  $FAIL("#11.3: typeof new Date(2099, 12, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#11.3: typeof new Date(2099, 12, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 var x114 = new Date(2099, 12, 1, 0, 0, 0, 0);
 if(x114 === undefined){
-  $FAIL("#11.4: new Date(2099, 12, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#11.4: new Date(2099, 12, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 if (typeof new Date(2100, 0, 1, 0, 0, 0, 0) !== "object") {
-  $FAIL("#12.1: typeof new Date(2100, 0, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#12.1: typeof new Date(2100, 0, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 if (new Date(2100, 0, 1, 0, 0, 0, 0) === undefined) {
-  $FAIL("#12.2: new Date(2100, 0, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#12.2: new Date(2100, 0, 1, 0, 0, 0, 0) should not be undefined");
 }
 
 var x123 = new Date(2100, 0, 1, 0, 0, 0, 0);
 if(typeof x123 !== "object"){
-  $FAIL("#12.3: typeof new Date(2100, 0, 1, 0, 0, 0, 0) should be 'object'");
+  $ERROR("#12.3: typeof new Date(2100, 0, 1, 0, 0, 0, 0) should be 'object'");
 }
 
 var x124 = new Date(2100, 0, 1, 0, 0, 0, 0);
 if(x124 === undefined){
-  $FAIL("#12.4: new Date(2100, 0, 1, 0, 0, 0, 0) should not be undefined");
+  $ERROR("#12.4: new Date(2100, 0, 1, 0, 0, 0, 0) should not be undefined");
 }

--- a/test/built-ins/Date/S15.9.3.1_A2_T1.js
+++ b/test/built-ins/Date/S15.9.3.1_A2_T1.js
@@ -8,12 +8,11 @@ info: >
     initial value of Date.prototype
 es5id: 15.9.3.1_A2_T1
 description: 2 arguments, (year, month)
-includes: [$FAIL.js]
 ---*/
 
 var x11 = new Date(1899, 11);
 if (typeof x11.constructor.prototype !== "object") {
-  $FAIL("#1.1: typeof x11.constructor.prototype === 'object'");
+  $ERROR("#1.1: typeof x11.constructor.prototype === 'object'");
 }
 
 var x12 = new Date(1899, 11);
@@ -23,12 +22,12 @@ if (!Date.prototype.isPrototypeOf(x12)) {
 
 var x13 = new Date(1899, 11);
 if(Date.prototype !== x13.constructor.prototype){
-  $FAIL("#1.3: Date.prototype === x13.constructor.prototype");
+  $ERROR("#1.3: Date.prototype === x13.constructor.prototype");
 }
 
 var x21 = new Date(1899, 12);
 if (typeof x21.constructor.prototype !== "object") {
-  $FAIL("#2.1: typeof x11.constructor.prototype === 'object'");
+  $ERROR("#2.1: typeof x11.constructor.prototype === 'object'");
 }
 
 var x22 = new Date(1899, 12);
@@ -38,12 +37,12 @@ if (!Date.prototype.isPrototypeOf(x22)) {
 
 var x23 = new Date(1899, 12);
 if(Date.prototype !== x23.constructor.prototype){
-  $FAIL("#2.3: Date.prototype === x23.constructor.prototype");
+  $ERROR("#2.3: Date.prototype === x23.constructor.prototype");
 }
 
 var x31 = new Date(1900, 0);
 if (typeof x31.constructor.prototype !== "object") {
-  $FAIL("#3.1: typeof x31.constructor.prototype === 'object'");
+  $ERROR("#3.1: typeof x31.constructor.prototype === 'object'");
 }
 
 var x32 = new Date(1900, 0);
@@ -53,12 +52,12 @@ if (!Date.prototype.isPrototypeOf(x32)) {
 
 var x33 = new Date(1900, 0);
 if(Date.prototype !== x33.constructor.prototype){
-  $FAIL("#3.3: Date.prototype === x33.constructor.prototype");
+  $ERROR("#3.3: Date.prototype === x33.constructor.prototype");
 }
 
 var x41 = new Date(1969, 11);
 if (typeof x41.constructor.prototype !== "object") {
-  $FAIL("#4.1: typeof x41.constructor.prototype === 'object'");
+  $ERROR("#4.1: typeof x41.constructor.prototype === 'object'");
 }
 
 var x42 = new Date(1969, 11);
@@ -68,12 +67,12 @@ if (!Date.prototype.isPrototypeOf(x42)) {
 
 var x43 = new Date(1969, 11);
 if(Date.prototype !== x43.constructor.prototype){
-  $FAIL("#4.3: Date.prototype === x43.constructor.prototype");
+  $ERROR("#4.3: Date.prototype === x43.constructor.prototype");
 }
 
 var x51 = new Date(1969, 12);
 if (typeof x51.constructor.prototype !== "object") {
-  $FAIL("#5.1: typeof x51.constructor.prototype === 'object'");
+  $ERROR("#5.1: typeof x51.constructor.prototype === 'object'");
 }
 
 var x52 = new Date(1969, 12);
@@ -83,12 +82,12 @@ if (!Date.prototype.isPrototypeOf(x52)) {
 
 var x53 = new Date(1969, 12);
 if(Date.prototype !== x53.constructor.prototype){
-  $FAIL("#5.3: Date.prototype === x53.constructor.prototype");
+  $ERROR("#5.3: Date.prototype === x53.constructor.prototype");
 }
 
 var x61 = new Date(1970, 0);
 if (typeof x61.constructor.prototype !== "object") {
-  $FAIL("#6.1: typeof x61.constructor.prototype === 'object'");
+  $ERROR("#6.1: typeof x61.constructor.prototype === 'object'");
 }
 
 var x62 = new Date(1970, 0);
@@ -98,12 +97,12 @@ if (!Date.prototype.isPrototypeOf(x62)) {
 
 var x63 = new Date(1970, 0);
 if(Date.prototype !== x63.constructor.prototype){
-  $FAIL("#6.3: Date.prototype === x63.constructor.prototype");
+  $ERROR("#6.3: Date.prototype === x63.constructor.prototype");
 }
 
 var x71 = new Date(1999, 11);
 if (typeof x71.constructor.prototype !== "object") {
-  $FAIL("#7.1: typeof x71.constructor.prototype === 'object'");
+  $ERROR("#7.1: typeof x71.constructor.prototype === 'object'");
 }
 
 var x72 = new Date(1999, 11);
@@ -113,12 +112,12 @@ if (!Date.prototype.isPrototypeOf(x72)) {
 
 var x73 = new Date(1999, 11);
 if(Date.prototype !== x73.constructor.prototype){
-  $FAIL("#7.3: Date.prototype === x73.constructor.prototype");
+  $ERROR("#7.3: Date.prototype === x73.constructor.prototype");
 }
 
 var x81 = new Date(1999, 12);
 if (typeof x81.constructor.prototype !== "object") {
-  $FAIL("#8.1: typeof x81.constructor.prototype === 'object'");
+  $ERROR("#8.1: typeof x81.constructor.prototype === 'object'");
 }
 
 var x82 = new Date(1999, 12);
@@ -128,12 +127,12 @@ if (!Date.prototype.isPrototypeOf(x82)) {
 
 var x83 = new Date(1999, 12);
 if(Date.prototype !== x83.constructor.prototype){
-  $FAIL("#8.3: Date.prototype === x83.constructor.prototype");
+  $ERROR("#8.3: Date.prototype === x83.constructor.prototype");
 }
 
 var x91 = new Date(2000, 0);
 if (typeof x91.constructor.prototype !== "object") {
-  $FAIL("#9.1: typeof x91.constructor.prototype === 'object'");
+  $ERROR("#9.1: typeof x91.constructor.prototype === 'object'");
 }
 
 var x92 = new Date(2000, 0);
@@ -143,12 +142,12 @@ if (!Date.prototype.isPrototypeOf(x92)) {
 
 var x93 = new Date(2000, 0);
 if(Date.prototype !== x93.constructor.prototype){
-  $FAIL("#9.3: Date.prototype === x93.constructor.prototype");
+  $ERROR("#9.3: Date.prototype === x93.constructor.prototype");
 }
 
 var x101 = new Date(2099, 11);
 if (typeof x101.constructor.prototype !== "object") {
-  $FAIL("#10.1: typeof x101.constructor.prototype === 'object'");
+  $ERROR("#10.1: typeof x101.constructor.prototype === 'object'");
 }
 
 var x102 = new Date(2099, 11);
@@ -158,12 +157,12 @@ if (!Date.prototype.isPrototypeOf(x102)) {
 
 var x103 = new Date(2099, 11);
 if(Date.prototype !== x103.constructor.prototype){
-  $FAIL("#10.3: Date.prototype === x103.constructor.prototype");
+  $ERROR("#10.3: Date.prototype === x103.constructor.prototype");
 }
 
 var x111 = new Date(2099, 12);
 if (typeof x111.constructor.prototype !== "object") {
-  $FAIL("#11.1: typeof x111.constructor.prototype === 'object'");
+  $ERROR("#11.1: typeof x111.constructor.prototype === 'object'");
 }
 
 var x112 = new Date(2099, 12);
@@ -173,12 +172,12 @@ if (!Date.prototype.isPrototypeOf(x112)) {
 
 var x113 = new Date(2099, 12);
 if(Date.prototype !== x113.constructor.prototype){
-  $FAIL("#11.3: Date.prototype === x113.constructor.prototype");
+  $ERROR("#11.3: Date.prototype === x113.constructor.prototype");
 }
 
 var x121 = new Date(2100, 0);
 if (typeof x121.constructor.prototype !== "object") {
-  $FAIL("#12.1: typeof x121.constructor.prototype === 'object'");
+  $ERROR("#12.1: typeof x121.constructor.prototype === 'object'");
 }
 
 var x122 = new Date(2100, 0);
@@ -188,5 +187,5 @@ if (!Date.prototype.isPrototypeOf(x122)) {
 
 var x123 = new Date(2100, 0);
 if(Date.prototype !== x123.constructor.prototype){
-  $FAIL("#12.3: Date.prototype === x123.constructor.prototype");
+  $ERROR("#12.3: Date.prototype === x123.constructor.prototype");
 }

--- a/test/built-ins/Date/S15.9.3.1_A2_T2.js
+++ b/test/built-ins/Date/S15.9.3.1_A2_T2.js
@@ -8,12 +8,11 @@ info: >
     initial value of Date.prototype
 es5id: 15.9.3.1_A2_T2
 description: 3 arguments, (year, month, date)
-includes: [$FAIL.js]
 ---*/
 
 var x11 = new Date(1899, 11, 31);
 if (typeof x11.constructor.prototype !== "object") {
-  $FAIL("#1.1: typeof x11.constructor.prototype === 'object'");
+  $ERROR("#1.1: typeof x11.constructor.prototype === 'object'");
 }
 
 var x12 = new Date(1899, 11, 31);
@@ -23,12 +22,12 @@ if (!Date.prototype.isPrototypeOf(x12)) {
 
 var x13 = new Date(1899, 11, 31);
 if(Date.prototype !== x13.constructor.prototype){
-  $FAIL("#1.3: Date.prototype === x13.constructor.prototype");
+  $ERROR("#1.3: Date.prototype === x13.constructor.prototype");
 }
 
 var x21 = new Date(1899, 12, 1);
 if (typeof x21.constructor.prototype !== "object") {
-  $FAIL("#2.1: typeof x21.constructor.prototype === 'object'");
+  $ERROR("#2.1: typeof x21.constructor.prototype === 'object'");
 }
 
 var x22 = new Date(1899, 12, 1);
@@ -38,12 +37,12 @@ if (!Date.prototype.isPrototypeOf(x22)) {
 
 var x23 = new Date(1899, 12, 1);
 if(Date.prototype !== x23.constructor.prototype){
-  $FAIL("#2.3: Date.prototype === x23.constructor.prototype");
+  $ERROR("#2.3: Date.prototype === x23.constructor.prototype");
 }
 
 var x31 = new Date(1900, 0, 1);
 if (typeof x31.constructor.prototype !== "object") {
-  $FAIL("#3.1: typeof x31.constructor.prototype === 'object'");
+  $ERROR("#3.1: typeof x31.constructor.prototype === 'object'");
 }
 
 var x32 = new Date(1900, 0, 1);
@@ -53,12 +52,12 @@ if (!Date.prototype.isPrototypeOf(x32)) {
 
 var x33 = new Date(1900, 0, 1);
 if(Date.prototype !== x33.constructor.prototype){
-  $FAIL("#3.3: Date.prototype === x33.constructor.prototype");
+  $ERROR("#3.3: Date.prototype === x33.constructor.prototype");
 }
 
 var x41 = new Date(1969, 11, 31);
 if (typeof x41.constructor.prototype !== "object") {
-  $FAIL("#4.1: typeof x41.constructor.prototype === 'object'");
+  $ERROR("#4.1: typeof x41.constructor.prototype === 'object'");
 }
 
 var x42 = new Date(1969, 11, 31);
@@ -68,12 +67,12 @@ if (!Date.prototype.isPrototypeOf(x42)) {
 
 var x43 = new Date(1969, 11, 31);
 if(Date.prototype !== x43.constructor.prototype){
-  $FAIL("#4.3: Date.prototype === x43.constructor.prototype");
+  $ERROR("#4.3: Date.prototype === x43.constructor.prototype");
 }
 
 var x51 = new Date(1969, 12, 1);
 if (typeof x51.constructor.prototype !== "object") {
-  $FAIL("#5.1: typeof x51.constructor.prototype === 'object'");
+  $ERROR("#5.1: typeof x51.constructor.prototype === 'object'");
 }
 
 var x52 = new Date(1969, 12, 1);
@@ -83,12 +82,12 @@ if (!Date.prototype.isPrototypeOf(x52)) {
 
 var x53 = new Date(1969, 12, 1);
 if(Date.prototype !== x53.constructor.prototype){
-  $FAIL("#5.3: Date.prototype === x53.constructor.prototype");
+  $ERROR("#5.3: Date.prototype === x53.constructor.prototype");
 }
 
 var x61 = new Date(1970, 0, 1);
 if (typeof x61.constructor.prototype !== "object") {
-  $FAIL("#6.1: typeof x61.constructor.prototype === 'object'");
+  $ERROR("#6.1: typeof x61.constructor.prototype === 'object'");
 }
 
 var x62 = new Date(1970, 0, 1);
@@ -98,12 +97,12 @@ if (!Date.prototype.isPrototypeOf(x62)) {
 
 var x63 = new Date(1970, 0, 1);
 if(Date.prototype !== x63.constructor.prototype){
-  $FAIL("#6.3: Date.prototype === x63.constructor.prototype");
+  $ERROR("#6.3: Date.prototype === x63.constructor.prototype");
 }
 
 var x71 = new Date(1999, 11, 31);
 if (typeof x71.constructor.prototype !== "object") {
-  $FAIL("#7.1: typeof x71.constructor.prototype === 'object'");
+  $ERROR("#7.1: typeof x71.constructor.prototype === 'object'");
 }
 
 var x72 = new Date(1999, 11, 31);
@@ -113,12 +112,12 @@ if (!Date.prototype.isPrototypeOf(x72)) {
 
 var x73 = new Date(1999, 11, 31);
 if(Date.prototype !== x73.constructor.prototype){
-  $FAIL("#7.3: Date.prototype === x73.constructor.prototype");
+  $ERROR("#7.3: Date.prototype === x73.constructor.prototype");
 }
 
 var x81 = new Date(1999, 12, 1);
 if (typeof x81.constructor.prototype !== "object") {
-  $FAIL("#8.1: typeof x81.constructor.prototype === 'object'");
+  $ERROR("#8.1: typeof x81.constructor.prototype === 'object'");
 }
 
 var x82 = new Date(1999, 12, 1);
@@ -128,12 +127,12 @@ if (!Date.prototype.isPrototypeOf(x82)) {
 
 var x83 = new Date(1999, 12, 1);
 if(Date.prototype !== x83.constructor.prototype){
-  $FAIL("#8.3: Date.prototype === x83.constructor.prototype");
+  $ERROR("#8.3: Date.prototype === x83.constructor.prototype");
 }
 
 var x91 = new Date(2000, 0, 1);
 if (typeof x91.constructor.prototype !== "object") {
-  $FAIL("#9.1: typeof x91.constructor.prototype === 'object'");
+  $ERROR("#9.1: typeof x91.constructor.prototype === 'object'");
 }
 
 var x92 = new Date(2000, 0, 1);
@@ -143,12 +142,12 @@ if (!Date.prototype.isPrototypeOf(x92)) {
 
 var x93 = new Date(2000, 0, 1);
 if(Date.prototype !== x93.constructor.prototype){
-  $FAIL("#9.3: Date.prototype === x93.constructor.prototype");
+  $ERROR("#9.3: Date.prototype === x93.constructor.prototype");
 }
 
 var x101 = new Date(2099, 11, 31);
 if (typeof x101.constructor.prototype !== "object") {
-  $FAIL("#10.1: typeof x101.constructor.prototype === 'object'");
+  $ERROR("#10.1: typeof x101.constructor.prototype === 'object'");
 }
 
 var x102 = new Date(2099, 11, 31);
@@ -158,12 +157,12 @@ if (!Date.prototype.isPrototypeOf(x102)) {
 
 var x103 = new Date(2099, 11, 31);
 if(Date.prototype !== x103.constructor.prototype){
-  $FAIL("#10.3: Date.prototype === x103.constructor.prototype");
+  $ERROR("#10.3: Date.prototype === x103.constructor.prototype");
 }
 
 var x111 = new Date(2099, 12, 1);
 if (typeof x111.constructor.prototype !== "object") {
-  $FAIL("#11.1: typeof x111.constructor.prototype === 'object'");
+  $ERROR("#11.1: typeof x111.constructor.prototype === 'object'");
 }
 
 var x112 = new Date(2099, 12, 1);
@@ -173,12 +172,12 @@ if (!Date.prototype.isPrototypeOf(x112)) {
 
 var x113 = new Date(2099, 12, 1);
 if(Date.prototype !== x113.constructor.prototype){
-  $FAIL("#11.3: Date.prototype === x113.constructor.prototype");
+  $ERROR("#11.3: Date.prototype === x113.constructor.prototype");
 }
 
 var x121 = new Date(2100, 0, 1);
 if (typeof x121.constructor.prototype !== "object") {
-  $FAIL("#12.1: typeof x121.constructor.prototype === 'object'");
+  $ERROR("#12.1: typeof x121.constructor.prototype === 'object'");
 }
 
 var x122 = new Date(2100, 0, 1);
@@ -188,5 +187,5 @@ if (!Date.prototype.isPrototypeOf(x122)) {
 
 var x123 = new Date(2100, 0, 1);
 if(Date.prototype !== x123.constructor.prototype){
-  $FAIL("#12.3: Date.prototype === x123.constructor.prototype");
+  $ERROR("#12.3: Date.prototype === x123.constructor.prototype");
 }

--- a/test/built-ins/Date/S15.9.3.1_A2_T3.js
+++ b/test/built-ins/Date/S15.9.3.1_A2_T3.js
@@ -8,12 +8,11 @@ info: >
     initial value of Date.prototype
 es5id: 15.9.3.1_A2_T3
 description: 4 arguments, (year, month, date, hours)
-includes: [$FAIL.js]
 ---*/
 
 var x11 = new Date(1899, 11, 31, 23);
 if (typeof x11.constructor.prototype !== "object") {
-  $FAIL("#1.1: typeof x11.constructor.prototype === 'object'");
+  $ERROR("#1.1: typeof x11.constructor.prototype === 'object'");
 }
 
 var x12 = new Date(1899, 11, 31, 23);
@@ -23,12 +22,12 @@ if (!Date.prototype.isPrototypeOf(x12)) {
 
 var x13 = new Date(1899, 11, 31, 23);
 if(Date.prototype !== x13.constructor.prototype){
-  $FAIL("#1.3: Date.prototype === x13.constructor.prototype");
+  $ERROR("#1.3: Date.prototype === x13.constructor.prototype");
 }
 
 var x21 = new Date(1899, 12, 1, 0);
 if (typeof x21.constructor.prototype !== "object") {
-  $FAIL("#2.1: typeof x21.constructor.prototype === 'object'");
+  $ERROR("#2.1: typeof x21.constructor.prototype === 'object'");
 }
 
 var x22 = new Date(1899, 12, 1, 0);
@@ -38,12 +37,12 @@ if (!Date.prototype.isPrototypeOf(x22)) {
 
 var x23 = new Date(1899, 12, 1, 0);
 if(Date.prototype !== x23.constructor.prototype){
-  $FAIL("#2.3: Date.prototype === x23.constructor.prototype");
+  $ERROR("#2.3: Date.prototype === x23.constructor.prototype");
 }
 
 var x31 = new Date(1900, 0, 1, 0);
 if (typeof x31.constructor.prototype !== "object") {
-  $FAIL("#3.1: typeof x31.constructor.prototype === 'object'");
+  $ERROR("#3.1: typeof x31.constructor.prototype === 'object'");
 }
 
 var x32 = new Date(1900, 0, 1, 0);
@@ -53,12 +52,12 @@ if (!Date.prototype.isPrototypeOf(x32)) {
 
 var x33 = new Date(1900, 0, 1, 0);
 if(Date.prototype !== x33.constructor.prototype){
-  $FAIL("#3.3: Date.prototype === x33.constructor.prototype");
+  $ERROR("#3.3: Date.prototype === x33.constructor.prototype");
 }
 
 var x41 = new Date(1969, 11, 31, 23);
 if (typeof x41.constructor.prototype !== "object") {
-  $FAIL("#4.1: typeof x41.constructor.prototype === 'object'");
+  $ERROR("#4.1: typeof x41.constructor.prototype === 'object'");
 }
 
 var x42 = new Date(1969, 11, 31, 23);
@@ -68,12 +67,12 @@ if (!Date.prototype.isPrototypeOf(x42)) {
 
 var x43 = new Date(1969, 11, 31, 23);
 if(Date.prototype !== x43.constructor.prototype){
-  $FAIL("#4.3: Date.prototype === x43.constructor.prototype");
+  $ERROR("#4.3: Date.prototype === x43.constructor.prototype");
 }
 
 var x51 = new Date(1969, 12, 1, 0);
 if (typeof x51.constructor.prototype !== "object") {
-  $FAIL("#5.1: typeof x51.constructor.prototype === 'object'");
+  $ERROR("#5.1: typeof x51.constructor.prototype === 'object'");
 }
 
 var x52 = new Date(1969, 12, 1, 0);
@@ -83,12 +82,12 @@ if (!Date.prototype.isPrototypeOf(x52)) {
 
 var x53 = new Date(1969, 12, 1, 0);
 if(Date.prototype !== x53.constructor.prototype){
-  $FAIL("#5.3: Date.prototype === x53.constructor.prototype");
+  $ERROR("#5.3: Date.prototype === x53.constructor.prototype");
 }
 
 var x61 = new Date(1970, 0, 1, 0);
 if (typeof x61.constructor.prototype !== "object") {
-  $FAIL("#6.1: typeof x61.constructor.prototype === 'object'");
+  $ERROR("#6.1: typeof x61.constructor.prototype === 'object'");
 }
 
 var x62 = new Date(1970, 0, 1, 0);
@@ -98,12 +97,12 @@ if (!Date.prototype.isPrototypeOf(x62)) {
 
 var x63 = new Date(1970, 0, 1, 0);
 if(Date.prototype !== x63.constructor.prototype){
-  $FAIL("#6.3: Date.prototype === x63.constructor.prototype");
+  $ERROR("#6.3: Date.prototype === x63.constructor.prototype");
 }
 
 var x71 = new Date(1999, 11, 31, 23);
 if (typeof x71.constructor.prototype !== "object") {
-  $FAIL("#7.1: typeof x71.constructor.prototype === 'object'");
+  $ERROR("#7.1: typeof x71.constructor.prototype === 'object'");
 }
 
 var x72 = new Date(1999, 11, 31, 23);
@@ -113,12 +112,12 @@ if (!Date.prototype.isPrototypeOf(x72)) {
 
 var x73 = new Date(1999, 11, 31, 23);
 if(Date.prototype !== x73.constructor.prototype){
-  $FAIL("#7.3: Date.prototype === x73.constructor.prototype");
+  $ERROR("#7.3: Date.prototype === x73.constructor.prototype");
 }
 
 var x81 = new Date(1999, 12, 1, 0);
 if (typeof x81.constructor.prototype !== "object") {
-  $FAIL("#8.1: typeof x81.constructor.prototype === 'object'");
+  $ERROR("#8.1: typeof x81.constructor.prototype === 'object'");
 }
 
 var x82 = new Date(1999, 12, 1, 0);
@@ -128,12 +127,12 @@ if (!Date.prototype.isPrototypeOf(x82)) {
 
 var x83 = new Date(1999, 12, 1, 0);
 if(Date.prototype !== x83.constructor.prototype){
-  $FAIL("#8.3: Date.prototype === x83.constructor.prototype");
+  $ERROR("#8.3: Date.prototype === x83.constructor.prototype");
 }
 
 var x91 = new Date(2000, 0, 1, 0);
 if (typeof x91.constructor.prototype !== "object") {
-  $FAIL("#9.1: typeof x91.constructor.prototype === 'object'");
+  $ERROR("#9.1: typeof x91.constructor.prototype === 'object'");
 }
 
 var x92 = new Date(2000, 0, 1, 0);
@@ -143,12 +142,12 @@ if (!Date.prototype.isPrototypeOf(x92)) {
 
 var x93 = new Date(2000, 0, 1, 0);
 if(Date.prototype !== x93.constructor.prototype){
-  $FAIL("#9.3: Date.prototype === x93.constructor.prototype");
+  $ERROR("#9.3: Date.prototype === x93.constructor.prototype");
 }
 
 var x101 = new Date(2099, 11, 31, 23);
 if (typeof x101.constructor.prototype !== "object") {
-  $FAIL("#10.1: typeof x101.constructor.prototype === 'object'");
+  $ERROR("#10.1: typeof x101.constructor.prototype === 'object'");
 }
 
 var x102 = new Date(2099, 11, 31, 23);
@@ -158,12 +157,12 @@ if (!Date.prototype.isPrototypeOf(x102)) {
 
 var x103 = new Date(2099, 11, 31, 23);
 if(Date.prototype !== x103.constructor.prototype){
-  $FAIL("#10.3: Date.prototype === x103.constructor.prototype");
+  $ERROR("#10.3: Date.prototype === x103.constructor.prototype");
 }
 
 var x111 = new Date(2099, 12, 1, 0);
 if (typeof x111.constructor.prototype !== "object") {
-  $FAIL("#11.1: typeof x111.constructor.prototype === 'object'");
+  $ERROR("#11.1: typeof x111.constructor.prototype === 'object'");
 }
 
 var x112 = new Date(2099, 12, 1, 0);
@@ -173,12 +172,12 @@ if (!Date.prototype.isPrototypeOf(x112)) {
 
 var x113 = new Date(2099, 12, 1, 0);
 if(Date.prototype !== x113.constructor.prototype){
-  $FAIL("#11.3: Date.prototype === x113.constructor.prototype");
+  $ERROR("#11.3: Date.prototype === x113.constructor.prototype");
 }
 
 var x121 = new Date(2100, 0, 1, 0);
 if (typeof x121.constructor.prototype !== "object") {
-  $FAIL("#12.1: typeof x121.constructor.prototype === 'object'");
+  $ERROR("#12.1: typeof x121.constructor.prototype === 'object'");
 }
 
 var x122 = new Date(2100, 0, 1, 0);
@@ -188,5 +187,5 @@ if (!Date.prototype.isPrototypeOf(x122)) {
 
 var x123 = new Date(2100, 0, 1, 0);
 if(Date.prototype !== x123.constructor.prototype){
-  $FAIL("#12.3: Date.prototype === x123.constructor.prototype");
+  $ERROR("#12.3: Date.prototype === x123.constructor.prototype");
 }

--- a/test/built-ins/Date/S15.9.3.1_A2_T4.js
+++ b/test/built-ins/Date/S15.9.3.1_A2_T4.js
@@ -8,12 +8,11 @@ info: >
     initial value of Date.prototype
 es5id: 15.9.3.1_A2_T4
 description: 5 arguments, (year, month, date, hours, minutes)
-includes: [$FAIL.js]
 ---*/
 
 var x11 = new Date(1899, 11, 31, 23, 59);
 if (typeof x11.constructor.prototype !== "object") {
-  $FAIL("#1.1: typeof x11.constructor.prototype === 'object'");
+  $ERROR("#1.1: typeof x11.constructor.prototype === 'object'");
 }
 
 var x12 = new Date(1899, 11, 31, 23, 59);
@@ -23,12 +22,12 @@ if (!Date.prototype.isPrototypeOf(x12)) {
 
 var x13 = new Date(1899, 11, 31, 23, 59);
 if(Date.prototype !== x13.constructor.prototype){
-  $FAIL("#1.3: Date.prototype === x13.constructor.prototype");
+  $ERROR("#1.3: Date.prototype === x13.constructor.prototype");
 }
 
 var x21 = new Date(1899, 12, 1, 0, 0);
 if (typeof x21.constructor.prototype !== "object") {
-  $FAIL("#2.1: typeof x21.constructor.prototype === 'object'");
+  $ERROR("#2.1: typeof x21.constructor.prototype === 'object'");
 }
 
 var x22 = new Date(1899, 12, 1, 0, 0);
@@ -38,12 +37,12 @@ if (!Date.prototype.isPrototypeOf(x22)) {
 
 var x23 = new Date(1899, 12, 1, 0, 0);
 if(Date.prototype !== x23.constructor.prototype){
-  $FAIL("#2.3: Date.prototype === x23.constructor.prototype");
+  $ERROR("#2.3: Date.prototype === x23.constructor.prototype");
 }
 
 var x31 = new Date(1900, 0, 1, 0, 0);
 if (typeof x31.constructor.prototype !== "object") {
-  $FAIL("#3.1: typeof x31.constructor.prototype === 'object'");
+  $ERROR("#3.1: typeof x31.constructor.prototype === 'object'");
 }
 
 var x32 = new Date(1900, 0, 1, 0, 0);
@@ -53,12 +52,12 @@ if (!Date.prototype.isPrototypeOf(x32)) {
 
 var x33 = new Date(1900, 0, 1, 0, 0);
 if(Date.prototype !== x33.constructor.prototype){
-  $FAIL("#3.3: Date.prototype === x33.constructor.prototype");
+  $ERROR("#3.3: Date.prototype === x33.constructor.prototype");
 }
 
 var x41 = new Date(1969, 11, 31, 23, 59);
 if (typeof x41.constructor.prototype !== "object") {
-  $FAIL("#4.1: typeof x41.constructor.prototype === 'object'");
+  $ERROR("#4.1: typeof x41.constructor.prototype === 'object'");
 }
 
 var x42 = new Date(1969, 11, 31, 23, 59);
@@ -68,12 +67,12 @@ if (!Date.prototype.isPrototypeOf(x42)) {
 
 var x43 = new Date(1969, 11, 31, 23, 59);
 if(Date.prototype !== x43.constructor.prototype){
-  $FAIL("#4.3: Date.prototype === x43.constructor.prototype");
+  $ERROR("#4.3: Date.prototype === x43.constructor.prototype");
 }
 
 var x51 = new Date(1969, 12, 1, 0, 0);
 if (typeof x51.constructor.prototype !== "object") {
-  $FAIL("#5.1: typeof x51.constructor.prototype === 'object'");
+  $ERROR("#5.1: typeof x51.constructor.prototype === 'object'");
 }
 
 var x52 = new Date(1969, 12, 1, 0, 0);
@@ -83,12 +82,12 @@ if (!Date.prototype.isPrototypeOf(x52)) {
 
 var x53 = new Date(1969, 12, 1, 0, 0);
 if(Date.prototype !== x53.constructor.prototype){
-  $FAIL("#5.3: Date.prototype === x53.constructor.prototype");
+  $ERROR("#5.3: Date.prototype === x53.constructor.prototype");
 }
 
 var x61 = new Date(1970, 0, 1, 0, 0);
 if (typeof x61.constructor.prototype !== "object") {
-  $FAIL("#6.1: typeof x61.constructor.prototype === 'object'");
+  $ERROR("#6.1: typeof x61.constructor.prototype === 'object'");
 }
 
 var x62 = new Date(1970, 0, 1, 0, 0);
@@ -98,12 +97,12 @@ if (!Date.prototype.isPrototypeOf(x62)) {
 
 var x63 = new Date(1970, 0, 1, 0, 0);
 if(Date.prototype !== x63.constructor.prototype){
-  $FAIL("#6.3: Date.prototype === x63.constructor.prototype");
+  $ERROR("#6.3: Date.prototype === x63.constructor.prototype");
 }
 
 var x71 = new Date(1999, 11, 31, 23, 59);
 if (typeof x71.constructor.prototype !== "object") {
-  $FAIL("#7.1: typeof x71.constructor.prototype === 'object'");
+  $ERROR("#7.1: typeof x71.constructor.prototype === 'object'");
 }
 
 var x72 = new Date(1999, 11, 31, 23, 59);
@@ -113,12 +112,12 @@ if (!Date.prototype.isPrototypeOf(x72)) {
 
 var x73 = new Date(1999, 11, 31, 23, 59);
 if(Date.prototype !== x73.constructor.prototype){
-  $FAIL("#7.3: Date.prototype === x73.constructor.prototype");
+  $ERROR("#7.3: Date.prototype === x73.constructor.prototype");
 }
 
 var x81 = new Date(1999, 12, 1, 0, 0);
 if (typeof x81.constructor.prototype !== "object") {
-  $FAIL("#8.1: typeof x81.constructor.prototype === 'object'");
+  $ERROR("#8.1: typeof x81.constructor.prototype === 'object'");
 }
 
 var x82 = new Date(1999, 12, 1, 0, 0);
@@ -128,12 +127,12 @@ if (!Date.prototype.isPrototypeOf(x82)) {
 
 var x83 = new Date(1999, 12, 1, 0, 0);
 if(Date.prototype !== x83.constructor.prototype){
-  $FAIL("#8.3: Date.prototype === x83.constructor.prototype");
+  $ERROR("#8.3: Date.prototype === x83.constructor.prototype");
 }
 
 var x91 = new Date(2000, 0, 1, 0, 0);
 if (typeof x91.constructor.prototype !== "object") {
-  $FAIL("#9.1: typeof x91.constructor.prototype === 'object'");
+  $ERROR("#9.1: typeof x91.constructor.prototype === 'object'");
 }
 
 var x92 = new Date(2000, 0, 1, 0, 0);
@@ -143,12 +142,12 @@ if (!Date.prototype.isPrototypeOf(x92)) {
 
 var x93 = new Date(2000, 0, 1, 0, 0);
 if(Date.prototype !== x93.constructor.prototype){
-  $FAIL("#9.3: Date.prototype === x93.constructor.prototype");
+  $ERROR("#9.3: Date.prototype === x93.constructor.prototype");
 }
 
 var x101 = new Date(2099, 11, 31, 23, 59);
 if (typeof x101.constructor.prototype !== "object") {
-  $FAIL("#10.1: typeof x101.constructor.prototype === 'object'");
+  $ERROR("#10.1: typeof x101.constructor.prototype === 'object'");
 }
 
 var x102 = new Date(2099, 11, 31, 23, 59);
@@ -158,12 +157,12 @@ if (!Date.prototype.isPrototypeOf(x102)) {
 
 var x103 = new Date(2099, 11, 31, 23, 59);
 if(Date.prototype !== x103.constructor.prototype){
-  $FAIL("#10.3: Date.prototype === x103.constructor.prototype");
+  $ERROR("#10.3: Date.prototype === x103.constructor.prototype");
 }
 
 var x111 = new Date(2099, 12, 1, 0, 0);
 if (typeof x111.constructor.prototype !== "object") {
-  $FAIL("#11.1: typeof x111.constructor.prototype === 'object'");
+  $ERROR("#11.1: typeof x111.constructor.prototype === 'object'");
 }
 
 var x112 = new Date(2099, 12, 1, 0, 0);
@@ -173,12 +172,12 @@ if (!Date.prototype.isPrototypeOf(x112)) {
 
 var x113 = new Date(2099, 12, 1, 0, 0);
 if(Date.prototype !== x113.constructor.prototype){
-  $FAIL("#11.3: Date.prototype === x113.constructor.prototype");
+  $ERROR("#11.3: Date.prototype === x113.constructor.prototype");
 }
 
 var x121 = new Date(2100, 0, 1, 0, 0);
 if (typeof x121.constructor.prototype !== "object") {
-  $FAIL("#12.1: typeof x121.constructor.prototype === 'object'");
+  $ERROR("#12.1: typeof x121.constructor.prototype === 'object'");
 }
 
 var x122 = new Date(2100, 0, 1, 0, 0);
@@ -188,5 +187,5 @@ if (!Date.prototype.isPrototypeOf(x122)) {
 
 var x123 = new Date(2100, 0, 1, 0, 0);
 if(Date.prototype !== x123.constructor.prototype){
-  $FAIL("#12.3: Date.prototype === x123.constructor.prototype");
+  $ERROR("#12.3: Date.prototype === x123.constructor.prototype");
 }

--- a/test/built-ins/Date/S15.9.3.1_A2_T5.js
+++ b/test/built-ins/Date/S15.9.3.1_A2_T5.js
@@ -8,12 +8,11 @@ info: >
     initial value of Date.prototype
 es5id: 15.9.3.1_A2_T5
 description: 6 arguments, (year, month, date, hours, minutes, seconds)
-includes: [$FAIL.js]
 ---*/
 
 var x11 = new Date(1899, 11, 31, 23, 59, 59);
 if (typeof x11.constructor.prototype !== "object") {
-  $FAIL("#1.1: typeof x11.constructor.prototype === 'object'");
+  $ERROR("#1.1: typeof x11.constructor.prototype === 'object'");
 }
 
 var x12 = new Date(1899, 11, 31, 23, 59, 59);
@@ -23,12 +22,12 @@ if (!Date.prototype.isPrototypeOf(x12)) {
 
 var x13 = new Date(1899, 11, 31, 23, 59, 59);
 if(Date.prototype !== x13.constructor.prototype){
-  $FAIL("#1.3: Date.prototype === x13.constructor.prototype");
+  $ERROR("#1.3: Date.prototype === x13.constructor.prototype");
 }
 
 var x21 = new Date(1899, 12, 1, 0, 0, 0);
 if (typeof x21.constructor.prototype !== "object") {
-  $FAIL("#2.1: typeof x21.constructor.prototype === 'object'");
+  $ERROR("#2.1: typeof x21.constructor.prototype === 'object'");
 }
 
 var x22 = new Date(1899, 12, 1, 0, 0, 0);
@@ -38,12 +37,12 @@ if (!Date.prototype.isPrototypeOf(x22)) {
 
 var x23 = new Date(1899, 12, 1, 0, 0, 0);
 if(Date.prototype !== x23.constructor.prototype){
-  $FAIL("#2.3: Date.prototype === x23.constructor.prototype");
+  $ERROR("#2.3: Date.prototype === x23.constructor.prototype");
 }
 
 var x31 = new Date(1900, 0, 1, 0, 0, 0);
 if (typeof x31.constructor.prototype !== "object") {
-  $FAIL("#3.1: typeof x31.constructor.prototype === 'object'");
+  $ERROR("#3.1: typeof x31.constructor.prototype === 'object'");
 }
 
 var x32 = new Date(1900, 0, 1, 0, 0, 0);
@@ -53,12 +52,12 @@ if (!Date.prototype.isPrototypeOf(x32)) {
 
 var x33 = new Date(1900, 0, 1, 0, 0, 0);
 if(Date.prototype !== x33.constructor.prototype){
-  $FAIL("#3.3: Date.prototype === x33.constructor.prototype");
+  $ERROR("#3.3: Date.prototype === x33.constructor.prototype");
 }
 
 var x41 = new Date(1969, 11, 31, 23, 59, 59);
 if (typeof x41.constructor.prototype !== "object") {
-  $FAIL("#4.1: typeof x41.constructor.prototype === 'object'");
+  $ERROR("#4.1: typeof x41.constructor.prototype === 'object'");
 }
 
 var x42 = new Date(1969, 11, 31, 23, 59, 59);
@@ -68,12 +67,12 @@ if (!Date.prototype.isPrototypeOf(x42)) {
 
 var x43 = new Date(1969, 11, 31, 23, 59, 59);
 if(Date.prototype !== x43.constructor.prototype){
-  $FAIL("#4.3: Date.prototype === x43.constructor.prototype");
+  $ERROR("#4.3: Date.prototype === x43.constructor.prototype");
 }
 
 var x51 = new Date(1969, 12, 1, 0, 0, 0);
 if (typeof x51.constructor.prototype !== "object") {
-  $FAIL("#5.1: typeof x51.constructor.prototype === 'object'");
+  $ERROR("#5.1: typeof x51.constructor.prototype === 'object'");
 }
 
 var x52 = new Date(1969, 12, 1, 0, 0, 0);
@@ -83,12 +82,12 @@ if (!Date.prototype.isPrototypeOf(x52)) {
 
 var x53 = new Date(1969, 12, 1, 0, 0, 0);
 if(Date.prototype !== x53.constructor.prototype){
-  $FAIL("#5.3: Date.prototype === x53.constructor.prototype");
+  $ERROR("#5.3: Date.prototype === x53.constructor.prototype");
 }
 
 var x61 = new Date(1970, 0, 1, 0, 0, 0);
 if (typeof x61.constructor.prototype !== "object") {
-  $FAIL("#6.1: typeof x61.constructor.prototype === 'object'");
+  $ERROR("#6.1: typeof x61.constructor.prototype === 'object'");
 }
 
 var x62 = new Date(1970, 0, 1, 0, 0, 0);
@@ -98,12 +97,12 @@ if (!Date.prototype.isPrototypeOf(x62)) {
 
 var x63 = new Date(1970, 0, 1, 0, 0, 0);
 if(Date.prototype !== x63.constructor.prototype){
-  $FAIL("#6.3: Date.prototype === x63.constructor.prototype");
+  $ERROR("#6.3: Date.prototype === x63.constructor.prototype");
 }
 
 var x71 = new Date(1999, 11, 31, 23, 59, 59);
 if (typeof x71.constructor.prototype !== "object") {
-  $FAIL("#7.1: typeof x71.constructor.prototype === 'object'");
+  $ERROR("#7.1: typeof x71.constructor.prototype === 'object'");
 }
 
 var x72 = new Date(1999, 11, 31, 23, 59, 59);
@@ -113,12 +112,12 @@ if (!Date.prototype.isPrototypeOf(x72)) {
 
 var x73 = new Date(1999, 11, 31, 23, 59, 59);
 if(Date.prototype !== x73.constructor.prototype){
-  $FAIL("#7.3: Date.prototype === x73.constructor.prototype");
+  $ERROR("#7.3: Date.prototype === x73.constructor.prototype");
 }
 
 var x81 = new Date(1999, 12, 1, 0, 0, 0);
 if (typeof x81.constructor.prototype !== "object") {
-  $FAIL("#8.1: typeof x81.constructor.prototype === 'object'");
+  $ERROR("#8.1: typeof x81.constructor.prototype === 'object'");
 }
 
 var x82 = new Date(1999, 12, 1, 0, 0, 0);
@@ -128,12 +127,12 @@ if (!Date.prototype.isPrototypeOf(x82)) {
 
 var x83 = new Date(1999, 12, 1, 0, 0, 0);
 if(Date.prototype !== x83.constructor.prototype){
-  $FAIL("#8.3: Date.prototype === x83.constructor.prototype");
+  $ERROR("#8.3: Date.prototype === x83.constructor.prototype");
 }
 
 var x91 = new Date(2000, 0, 1, 0, 0, 0);
 if (typeof x91.constructor.prototype !== "object") {
-  $FAIL("#9.1: typeof x91.constructor.prototype === 'object'");
+  $ERROR("#9.1: typeof x91.constructor.prototype === 'object'");
 }
 
 var x92 = new Date(2000, 0, 1, 0, 0, 0);
@@ -143,12 +142,12 @@ if (!Date.prototype.isPrototypeOf(x92)) {
 
 var x93 = new Date(2000, 0, 1, 0, 0, 0);
 if(Date.prototype !== x93.constructor.prototype){
-  $FAIL("#9.3: Date.prototype === x93.constructor.prototype");
+  $ERROR("#9.3: Date.prototype === x93.constructor.prototype");
 }
 
 var x101 = new Date(2099, 11, 31, 23, 59, 59);
 if (typeof x101.constructor.prototype !== "object") {
-  $FAIL("#10.1: typeof x101.constructor.prototype === 'object'");
+  $ERROR("#10.1: typeof x101.constructor.prototype === 'object'");
 }
 
 var x102 = new Date(2099, 11, 31, 23, 59, 59);
@@ -158,12 +157,12 @@ if (!Date.prototype.isPrototypeOf(x102)) {
 
 var x103 = new Date(2099, 11, 31, 23, 59, 59);
 if(Date.prototype !== x103.constructor.prototype){
-  $FAIL("#10.3: Date.prototype === x103.constructor.prototype");
+  $ERROR("#10.3: Date.prototype === x103.constructor.prototype");
 }
 
 var x111 = new Date(2099, 12, 1, 0, 0, 0);
 if (typeof x111.constructor.prototype !== "object") {
-  $FAIL("#11.1: typeof x111.constructor.prototype === 'object'");
+  $ERROR("#11.1: typeof x111.constructor.prototype === 'object'");
 }
 
 var x112 = new Date(2099, 12, 1, 0, 0, 0);
@@ -173,12 +172,12 @@ if (!Date.prototype.isPrototypeOf(x112)) {
 
 var x113 = new Date(2099, 12, 1, 0, 0, 0);
 if(Date.prototype !== x113.constructor.prototype){
-  $FAIL("#11.3: Date.prototype === x113.constructor.prototype");
+  $ERROR("#11.3: Date.prototype === x113.constructor.prototype");
 }
 
 var x121 = new Date(2100, 0, 1, 0, 0, 0);
 if (typeof x121.constructor.prototype !== "object") {
-  $FAIL("#12.1: typeof x121.constructor.prototype === 'object'");
+  $ERROR("#12.1: typeof x121.constructor.prototype === 'object'");
 }
 
 var x122 = new Date(2100, 0, 1, 0, 0, 0);
@@ -188,5 +187,5 @@ if (!Date.prototype.isPrototypeOf(x122)) {
 
 var x123 = new Date(2100, 0, 1, 0, 0, 0);
 if(Date.prototype !== x123.constructor.prototype){
-  $FAIL("#12.3: Date.prototype === x123.constructor.prototype");
+  $ERROR("#12.3: Date.prototype === x123.constructor.prototype");
 }

--- a/test/built-ins/Date/S15.9.3.1_A2_T6.js
+++ b/test/built-ins/Date/S15.9.3.1_A2_T6.js
@@ -8,12 +8,11 @@ info: >
     initial value of Date.prototype
 es5id: 15.9.3.1_A2_T6
 description: 7 arguments, (year, month, date, hours, minutes, seconds, ms)
-includes: [$FAIL.js]
 ---*/
 
 var x11 = new Date(1899, 11, 31, 23, 59, 59, 999);
 if (typeof x11.constructor.prototype !== "object") {
-  $FAIL("#1.1: typeof x11.constructor.prototype === 'object'");
+  $ERROR("#1.1: typeof x11.constructor.prototype === 'object'");
 }
 
 var x12 = new Date(1899, 11, 31, 23, 59, 59, 999);
@@ -23,12 +22,12 @@ if (!Date.prototype.isPrototypeOf(x12)) {
 
 var x13 = new Date(1899, 11, 31, 23, 59, 59, 999);
 if(Date.prototype !== x13.constructor.prototype){
-  $FAIL("#1.3: Date.prototype === x13.constructor.prototype");
+  $ERROR("#1.3: Date.prototype === x13.constructor.prototype");
 }
 
 var x21 = new Date(1899, 12, 1, 0, 0, 0, 0);
 if (typeof x21.constructor.prototype !== "object") {
-  $FAIL("#2.1: typeof x21.constructor.prototype === 'object'");
+  $ERROR("#2.1: typeof x21.constructor.prototype === 'object'");
 }
 
 var x22 = new Date(1899, 12, 1, 0, 0, 0, 0);
@@ -38,12 +37,12 @@ if (!Date.prototype.isPrototypeOf(x22)) {
 
 var x23 = new Date(1899, 12, 1, 0, 0, 0, 0);
 if(Date.prototype !== x23.constructor.prototype){
-  $FAIL("#2.3: Date.prototype === x23.constructor.prototype");
+  $ERROR("#2.3: Date.prototype === x23.constructor.prototype");
 }
 
 var x31 = new Date(1900, 0, 1, 0, 0, 0, 0);
 if (typeof x31.constructor.prototype !== "object") {
-  $FAIL("#3.1: typeof x31.constructor.prototype === 'object'");
+  $ERROR("#3.1: typeof x31.constructor.prototype === 'object'");
 }
 
 var x32 = new Date(1900, 0, 1, 0, 0, 0, 0);
@@ -53,12 +52,12 @@ if (!Date.prototype.isPrototypeOf(x32)) {
 
 var x33 = new Date(1900, 0, 1, 0, 0, 0, 0);
 if(Date.prototype !== x33.constructor.prototype){
-  $FAIL("#3.3: Date.prototype === x33.constructor.prototype");
+  $ERROR("#3.3: Date.prototype === x33.constructor.prototype");
 }
 
 var x41 = new Date(1969, 11, 31, 23, 59, 59, 999);
 if (typeof x41.constructor.prototype !== "object") {
-  $FAIL("#4.1: typeof x41.constructor.prototype === 'object'");
+  $ERROR("#4.1: typeof x41.constructor.prototype === 'object'");
 }
 
 var x42 = new Date(1969, 11, 31, 23, 59, 59, 999);
@@ -68,12 +67,12 @@ if (!Date.prototype.isPrototypeOf(x42)) {
 
 var x43 = new Date(1969, 11, 31, 23, 59, 59, 999);
 if(Date.prototype !== x43.constructor.prototype){
-  $FAIL("#4.3: Date.prototype === x43.constructor.prototype");
+  $ERROR("#4.3: Date.prototype === x43.constructor.prototype");
 }
 
 var x51 = new Date(1969, 12, 1, 0, 0, 0, 0);
 if (typeof x51.constructor.prototype !== "object") {
-  $FAIL("#5.1: typeof x51.constructor.prototype === 'object'");
+  $ERROR("#5.1: typeof x51.constructor.prototype === 'object'");
 }
 
 var x52 = new Date(1969, 12, 1, 0, 0, 0, 0);
@@ -83,12 +82,12 @@ if (!Date.prototype.isPrototypeOf(x52)) {
 
 var x53 = new Date(1969, 12, 1, 0, 0, 0, 0);
 if(Date.prototype !== x53.constructor.prototype){
-  $FAIL("#5.3: Date.prototype === x53.constructor.prototype");
+  $ERROR("#5.3: Date.prototype === x53.constructor.prototype");
 }
 
 var x61 = new Date(1970, 0, 1, 0, 0, 0, 0);
 if (typeof x61.constructor.prototype !== "object") {
-  $FAIL("#6.1: typeof x61.constructor.prototype === 'object'");
+  $ERROR("#6.1: typeof x61.constructor.prototype === 'object'");
 }
 
 var x62 = new Date(1970, 0, 1, 0, 0, 0, 0);
@@ -98,12 +97,12 @@ if (!Date.prototype.isPrototypeOf(x62)) {
 
 var x63 = new Date(1970, 0, 1, 0, 0, 0, 0);
 if(Date.prototype !== x63.constructor.prototype){
-  $FAIL("#6.3: Date.prototype === x63.constructor.prototype");
+  $ERROR("#6.3: Date.prototype === x63.constructor.prototype");
 }
 
 var x71 = new Date(1999, 11, 31, 23, 59, 59, 999);
 if (typeof x71.constructor.prototype !== "object") {
-  $FAIL("#7.1: typeof x71.constructor.prototype === 'object'");
+  $ERROR("#7.1: typeof x71.constructor.prototype === 'object'");
 }
 
 var x72 = new Date(1999, 11, 31, 23, 59, 59, 999);
@@ -113,12 +112,12 @@ if (!Date.prototype.isPrototypeOf(x72)) {
 
 var x73 = new Date(1999, 11, 31, 23, 59, 59, 999);
 if(Date.prototype !== x73.constructor.prototype){
-  $FAIL("#7.3: Date.prototype === x73.constructor.prototype");
+  $ERROR("#7.3: Date.prototype === x73.constructor.prototype");
 }
 
 var x81 = new Date(1999, 12, 1, 0, 0, 0, 0);
 if (typeof x81.constructor.prototype !== "object") {
-  $FAIL("#8.1: typeof x81.constructor.prototype === 'object'");
+  $ERROR("#8.1: typeof x81.constructor.prototype === 'object'");
 }
 
 var x82 = new Date(1999, 12, 1, 0, 0, 0, 0);
@@ -128,12 +127,12 @@ if (!Date.prototype.isPrototypeOf(x82)) {
 
 var x83 = new Date(1999, 12, 1, 0, 0, 0, 0);
 if(Date.prototype !== x83.constructor.prototype){
-  $FAIL("#8.3: Date.prototype === x83.constructor.prototype");
+  $ERROR("#8.3: Date.prototype === x83.constructor.prototype");
 }
 
 var x91 = new Date(2000, 0, 1, 0, 0, 0, 0);
 if (typeof x91.constructor.prototype !== "object") {
-  $FAIL("#9.1: typeof x91.constructor.prototype === 'object'");
+  $ERROR("#9.1: typeof x91.constructor.prototype === 'object'");
 }
 
 var x92 = new Date(2000, 0, 1, 0, 0, 0, 0);
@@ -143,12 +142,12 @@ if (!Date.prototype.isPrototypeOf(x92)) {
 
 var x93 = new Date(2000, 0, 1, 0, 0, 0, 0);
 if(Date.prototype !== x93.constructor.prototype){
-  $FAIL("#9.3: Date.prototype === x93.constructor.prototype");
+  $ERROR("#9.3: Date.prototype === x93.constructor.prototype");
 }
 
 var x101 = new Date(2099, 11, 31, 23, 59, 59, 999);
 if (typeof x101.constructor.prototype !== "object") {
-  $FAIL("#10.1: typeof x101.constructor.prototype === 'object'");
+  $ERROR("#10.1: typeof x101.constructor.prototype === 'object'");
 }
 
 var x102 = new Date(2099, 11, 31, 23, 59, 59, 999);
@@ -158,12 +157,12 @@ if (!Date.prototype.isPrototypeOf(x102)) {
 
 var x103 = new Date(2099, 11, 31, 23, 59, 59, 999);
 if(Date.prototype !== x103.constructor.prototype){
-  $FAIL("#10.3: Date.prototype === x103.constructor.prototype");
+  $ERROR("#10.3: Date.prototype === x103.constructor.prototype");
 }
 
 var x111 = new Date(2099, 12, 1, 0, 0, 0, 0);
 if (typeof x111.constructor.prototype !== "object") {
-  $FAIL("#11.1: typeof x111.constructor.prototype === 'object'");
+  $ERROR("#11.1: typeof x111.constructor.prototype === 'object'");
 }
 
 var x112 = new Date(2099, 12, 1, 0, 0, 0, 0);
@@ -173,12 +172,12 @@ if (!Date.prototype.isPrototypeOf(x112)) {
 
 var x113 = new Date(2099, 12, 1, 0, 0, 0, 0);
 if(Date.prototype !== x113.constructor.prototype){
-  $FAIL("#11.3: Date.prototype === x113.constructor.prototype");
+  $ERROR("#11.3: Date.prototype === x113.constructor.prototype");
 }
 
 var x121 = new Date(2100, 0, 1, 0, 0, 0, 0);
 if (typeof x121.constructor.prototype !== "object") {
-  $FAIL("#12.1: typeof x121.constructor.prototype === 'object'");
+  $ERROR("#12.1: typeof x121.constructor.prototype === 'object'");
 }
 
 var x122 = new Date(2100, 0, 1, 0, 0, 0, 0);
@@ -188,5 +187,5 @@ if (!Date.prototype.isPrototypeOf(x122)) {
 
 var x123 = new Date(2100, 0, 1, 0, 0, 0, 0);
 if(Date.prototype !== x123.constructor.prototype){
-  $FAIL("#12.3: Date.prototype === x123.constructor.prototype");
+  $ERROR("#12.3: Date.prototype === x123.constructor.prototype");
 }

--- a/test/built-ins/Date/S15.9.3.1_A3_T1.1.js
+++ b/test/built-ins/Date/S15.9.3.1_A3_T1.1.js
@@ -9,65 +9,64 @@ es5id: 15.9.3.1_A3_T1.1
 description: >
     Test based on delete prototype.toString - 2 arguments, (year,
     month)
-includes: [$FAIL.js]
 ---*/
 
 var x1 = new Date(1899, 11);
 if (Object.prototype.toString.call(x1) !== "[object Date]") {
-  $FAIL("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x2 = new Date(1899, 12);
 if (Object.prototype.toString.call(x2) !== "[object Date]") {
-  $FAIL("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x3 = new Date(1900, 0);
 if (Object.prototype.toString.call(x3) !== "[object Date]") {
-  $FAIL("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x4 = new Date(1969, 11);
 if (Object.prototype.toString.call(x4) !== "[object Date]") {
-  $FAIL("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x5 = new Date(1969, 12);
 if (Object.prototype.toString.call(x5) !== "[object Date]") {
-  $FAIL("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x6 = new Date(1970, 0);
 if (Object.prototype.toString.call(x6) !== "[object Date]") {
-  $FAIL("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x7 = new Date(1999, 11);
 if (Object.prototype.toString.call(x7) !== "[object Date]") {
-  $FAIL("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x8 = new Date(1999, 12);
 if (Object.prototype.toString.call(x8) !== "[object Date]") {
-  $FAIL("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x9 = new Date(2000, 0);
 if (Object.prototype.toString.call(x9) !== "[object Date]") {
-  $FAIL("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x10 = new Date(2099, 11);
 if (Object.prototype.toString.call(x10) !== "[object Date]") {
-  $FAIL("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x11 = new Date(2099, 12);
 if (Object.prototype.toString.call(x11) !== "[object Date]") {
-  $FAIL("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x12 = new Date(2100, 0);
 if (Object.prototype.toString.call(x12) !== "[object Date]") {
-  $FAIL("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
 }

--- a/test/built-ins/Date/S15.9.3.1_A3_T1.2.js
+++ b/test/built-ins/Date/S15.9.3.1_A3_T1.2.js
@@ -9,67 +9,66 @@ es5id: 15.9.3.1_A3_T1.2
 description: >
     Test based on overwriting prototype.toString - 2 arguments, (year,
     month)
-includes: [$FAIL.js]
 ---*/
 
 Date.prototype.toString = Object.prototype.toString;
 
 var x1 = new Date(1899, 11);
 if (x1.toString() !== "[object Date]") {
-  $FAIL("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x2 = new Date(1899, 12);
 if (x2.toString() !== "[object Date]") {
-  $FAIL("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x3 = new Date(1900, 0);
 if (x3.toString() !== "[object Date]") {
-  $FAIL("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x4 = new Date(1969, 11);
 if (x4.toString() !== "[object Date]") {
-  $FAIL("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x5 = new Date(1969, 12);
 if (x5.toString() !== "[object Date]") {
-  $FAIL("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x6 = new Date(1970, 0);
 if (x6.toString() !== "[object Date]") {
-  $FAIL("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x7 = new Date(1999, 11);
 if (x7.toString() !== "[object Date]") {
-  $FAIL("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x8 = new Date(1999, 12);
 if (x8.toString() !== "[object Date]") {
-  $FAIL("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x9 = new Date(2000, 0);
 if (x9.toString() !== "[object Date]") {
-  $FAIL("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x10 = new Date(2099, 11);
 if (x10.toString() !== "[object Date]") {
-  $FAIL("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x11 = new Date(2099, 12);
 if (x11.toString() !== "[object Date]") {
-  $FAIL("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x12 = new Date(2100, 0);
 if (x12.toString() !== "[object Date]") {
-  $FAIL("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
 }

--- a/test/built-ins/Date/S15.9.3.1_A3_T2.1.js
+++ b/test/built-ins/Date/S15.9.3.1_A3_T2.1.js
@@ -9,65 +9,64 @@ es5id: 15.9.3.1_A3_T2.1
 description: >
     Test based on delete prototype.toString - 3 arguments, (year,
     month, date)
-includes: [$FAIL.js]
 ---*/
 
 var x1 = new Date(1899, 11, 31);
 if (Object.prototype.toString.call(x1) !== "[object Date]") {
-  $FAIL("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x2 = new Date(1899, 12, 1);
 if (Object.prototype.toString.call(x2) !== "[object Date]") {
-  $FAIL("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x3 = new Date(1900, 0, 1);
 if (Object.prototype.toString.call(x3) !== "[object Date]") {
-  $FAIL("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x4 = new Date(1969, 11, 31);
 if (Object.prototype.toString.call(x4) !== "[object Date]") {
-  $FAIL("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x5 = new Date(1969, 12, 1);
 if (Object.prototype.toString.call(x5) !== "[object Date]") {
-  $FAIL("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x6 = new Date(1970, 0, 1);
 if (Object.prototype.toString.call(x6) !== "[object Date]") {
-  $FAIL("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x7 = new Date(1999, 11, 31);
 if (Object.prototype.toString.call(x7) !== "[object Date]") {
-  $FAIL("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x8 = new Date(1999, 12, 1);
 if (Object.prototype.toString.call(x8) !== "[object Date]") {
-  $FAIL("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x9 = new Date(2000, 0, 1);
 if (Object.prototype.toString.call(x9) !== "[object Date]") {
-  $FAIL("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x10 = new Date(2099, 11, 31);
 if (Object.prototype.toString.call(x10) !== "[object Date]") {
-  $FAIL("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x11 = new Date(2099, 12, 1);
 if (Object.prototype.toString.call(x11) !== "[object Date]") {
-  $FAIL("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x12 = new Date(2100, 0, 1);
 if (Object.prototype.toString.call(x12) !== "[object Date]") {
-  $FAIL("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
 }

--- a/test/built-ins/Date/S15.9.3.1_A3_T2.2.js
+++ b/test/built-ins/Date/S15.9.3.1_A3_T2.2.js
@@ -9,67 +9,66 @@ es5id: 15.9.3.1_A3_T2.2
 description: >
     Test based on overwriting prototype.toString - 3 arguments, (year,
     month, date)
-includes: [$FAIL.js]
 ---*/
 
 Date.prototype.toString = Object.prototype.toString;
 
 var x1 = new Date(1899, 11, 31);
 if (x1.toString() !== "[object Date]") {
-  $FAIL("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x2 = new Date(1899, 12, 1);
 if (x2.toString() !== "[object Date]") {
-  $FAIL("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x3 = new Date(1900, 0, 1);
 if (x3.toString() !== "[object Date]") {
-  $FAIL("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x4 = new Date(1969, 11, 31);
 if (x4.toString() !== "[object Date]") {
-  $FAIL("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x5 = new Date(1969, 12, 1);
 if (x5.toString() !== "[object Date]") {
-  $FAIL("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x6 = new Date(1970, 0, 1);
 if (x6.toString() !== "[object Date]") {
-  $FAIL("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x7 = new Date(1999, 11, 31);
 if (x7.toString() !== "[object Date]") {
-  $FAIL("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x8 = new Date(1999, 12, 1);
 if (x8.toString() !== "[object Date]") {
-  $FAIL("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x9 = new Date(2000, 0, 1);
 if (x9.toString() !== "[object Date]") {
-  $FAIL("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x10 = new Date(2099, 11, 31);
 if (x10.toString() !== "[object Date]") {
-  $FAIL("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x11 = new Date(2099, 12, 1);
 if (x11.toString() !== "[object Date]") {
-  $FAIL("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x12 = new Date(2100, 0, 1);
 if (x12.toString() !== "[object Date]") {
-  $FAIL("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
 }

--- a/test/built-ins/Date/S15.9.3.1_A3_T3.1.js
+++ b/test/built-ins/Date/S15.9.3.1_A3_T3.1.js
@@ -9,65 +9,64 @@ es5id: 15.9.3.1_A3_T3.1
 description: >
     Test based on delete prototype.toString - 4 arguments, (year,
     month, date, hours)
-includes: [$FAIL.js]
 ---*/
 
 var x1 = new Date(1899, 11, 31, 23);
 if (Object.prototype.toString.call(x1) !== "[object Date]") {
-  $FAIL("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x2 = new Date(1899, 12, 1, 0);
 if (Object.prototype.toString.call(x2) !== "[object Date]") {
-  $FAIL("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x3 = new Date(1900, 0, 1, 0);
 if (Object.prototype.toString.call(x3) !== "[object Date]") {
-  $FAIL("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x4 = new Date(1969, 11, 31, 23);
 if (Object.prototype.toString.call(x4) !== "[object Date]") {
-  $FAIL("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x5 = new Date(1969, 12, 1, 0);
 if (Object.prototype.toString.call(x5) !== "[object Date]") {
-  $FAIL("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x6 = new Date(1970, 0, 1, 0);
 if (Object.prototype.toString.call(x6) !== "[object Date]") {
-  $FAIL("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x7 = new Date(1999, 11, 31, 23);
 if (Object.prototype.toString.call(x7) !== "[object Date]") {
-  $FAIL("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x8 = new Date(1999, 12, 1, 0);
 if (Object.prototype.toString.call(x8) !== "[object Date]") {
-  $FAIL("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x9 = new Date(2000, 0, 1, 0);
 if (Object.prototype.toString.call(x9) !== "[object Date]") {
-  $FAIL("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x10 = new Date(2099, 11, 31, 23);
 if (Object.prototype.toString.call(x10) !== "[object Date]") {
-  $FAIL("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x11 = new Date(2099, 12, 1, 0);
 if (Object.prototype.toString.call(x11) !== "[object Date]") {
-  $FAIL("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x12 = new Date(2100, 0, 1, 0);
 if (Object.prototype.toString.call(x12) !== "[object Date]") {
-  $FAIL("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
 }

--- a/test/built-ins/Date/S15.9.3.1_A3_T3.2.js
+++ b/test/built-ins/Date/S15.9.3.1_A3_T3.2.js
@@ -9,67 +9,66 @@ es5id: 15.9.3.1_A3_T3.2
 description: >
     Test based on overwriting prototype.toString - 4 arguments, (year,
     month, date, hours)
-includes: [$FAIL.js]
 ---*/
 
 Date.prototype.toString = Object.prototype.toString;
 
 var x1 = new Date(1899, 11, 31, 23);
 if (x1.toString() !== "[object Date]") {
-  $FAIL("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x2 = new Date(1899, 12, 1, 0);
 if (x2.toString() !== "[object Date]") {
-  $FAIL("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x3 = new Date(1900, 0, 1, 0);
 if (x3.toString() !== "[object Date]") {
-  $FAIL("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x4 = new Date(1969, 11, 31, 23);
 if (x4.toString() !== "[object Date]") {
-  $FAIL("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x5 = new Date(1969, 12, 1, 0);
 if (x5.toString() !== "[object Date]") {
-  $FAIL("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x6 = new Date(1970, 0, 1, 0);
 if (x6.toString() !== "[object Date]") {
-  $FAIL("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x7 = new Date(1999, 11, 31, 23);
 if (x7.toString() !== "[object Date]") {
-  $FAIL("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x8 = new Date(1999, 12, 1, 0);
 if (x8.toString() !== "[object Date]") {
-  $FAIL("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x9 = new Date(2000, 0, 1, 0);
 if (x9.toString() !== "[object Date]") {
-  $FAIL("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x10 = new Date(2099, 11, 31, 23);
 if (x10.toString() !== "[object Date]") {
-  $FAIL("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x11 = new Date(2099, 12, 1, 0);
 if (x11.toString() !== "[object Date]") {
-  $FAIL("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x12 = new Date(2100, 0, 1, 0);
 if (x12.toString() !== "[object Date]") {
-  $FAIL("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
 }

--- a/test/built-ins/Date/S15.9.3.1_A3_T4.1.js
+++ b/test/built-ins/Date/S15.9.3.1_A3_T4.1.js
@@ -9,65 +9,64 @@ es5id: 15.9.3.1_A3_T4.1
 description: >
     Test based on delete prototype.toString - 5 arguments, (year,
     month, date, hours, minutes)
-includes: [$FAIL.js]
 ---*/
 
 var x1 = new Date(1899, 11, 31, 23, 59);
 if (Object.prototype.toString.call(x1) !== "[object Date]") {
-  $FAIL("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x2 = new Date(1899, 12, 1, 0, 0);
 if (Object.prototype.toString.call(x2) !== "[object Date]") {
-  $FAIL("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x3 = new Date(1900, 0, 1, 0, 0);
 if (Object.prototype.toString.call(x3) !== "[object Date]") {
-  $FAIL("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x4 = new Date(1969, 11, 31, 23, 59);
 if (Object.prototype.toString.call(x4) !== "[object Date]") {
-  $FAIL("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x5 = new Date(1969, 12, 1, 0, 0);
 if (Object.prototype.toString.call(x5) !== "[object Date]") {
-  $FAIL("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x6 = new Date(1970, 0, 1, 0, 0);
 if (Object.prototype.toString.call(x6) !== "[object Date]") {
-  $FAIL("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x7 = new Date(1999, 11, 31, 23, 59);
 if (Object.prototype.toString.call(x7) !== "[object Date]") {
-  $FAIL("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x8 = new Date(1999, 12, 1, 0, 0);
 if (Object.prototype.toString.call(x8) !== "[object Date]") {
-  $FAIL("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x9 = new Date(2000, 0, 1, 0, 0);
 if (Object.prototype.toString.call(x9) !== "[object Date]") {
-  $FAIL("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x10 = new Date(2099, 11, 31, 23, 59);
 if (Object.prototype.toString.call(x10) !== "[object Date]") {
-  $FAIL("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x11 = new Date(2099, 12, 1, 0, 0);
 if (Object.prototype.toString.call(x11) !== "[object Date]") {
-  $FAIL("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x12 = new Date(2100, 0, 1, 0, 0);
 if (Object.prototype.toString.call(x12) !== "[object Date]") {
-  $FAIL("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
 }

--- a/test/built-ins/Date/S15.9.3.1_A3_T4.2.js
+++ b/test/built-ins/Date/S15.9.3.1_A3_T4.2.js
@@ -9,67 +9,66 @@ es5id: 15.9.3.1_A3_T4.2
 description: >
     Test based on overwriting prototype.toString - 5 arguments, (year,
     month, date, hours, minutes)
-includes: [$FAIL.js]
 ---*/
 
 Date.prototype.toString = Object.prototype.toString;
 
 var x1 = new Date(1899, 11, 31, 23, 59);
 if (x1.toString() !== "[object Date]") {
-  $FAIL("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x2 = new Date(1899, 12, 1, 0, 0);
 if (x2.toString() !== "[object Date]") {
-  $FAIL("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x3 = new Date(1900, 0, 1, 0, 0);
 if (x3.toString() !== "[object Date]") {
-  $FAIL("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x4 = new Date(1969, 11, 31, 23, 59);
 if (x4.toString() !== "[object Date]") {
-  $FAIL("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x5 = new Date(1969, 12, 1, 0, 0);
 if (x5.toString() !== "[object Date]") {
-  $FAIL("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x6 = new Date(1970, 0, 1, 0, 0);
 if (x6.toString() !== "[object Date]") {
-  $FAIL("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x7 = new Date(1999, 11, 31, 23, 59);
 if (x7.toString() !== "[object Date]") {
-  $FAIL("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x8 = new Date(1999, 12, 1, 0, 0);
 if (x8.toString() !== "[object Date]") {
-  $FAIL("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x9 = new Date(2000, 0, 1, 0, 0);
 if (x9.toString() !== "[object Date]") {
-  $FAIL("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x10 = new Date(2099, 11, 31, 23, 59);
 if (x10.toString() !== "[object Date]") {
-  $FAIL("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x11 = new Date(2099, 12, 1, 0, 0);
 if (x11.toString() !== "[object Date]") {
-  $FAIL("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x12 = new Date(2100, 0, 1, 0, 0);
 if (x12.toString() !== "[object Date]") {
-  $FAIL("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
 }

--- a/test/built-ins/Date/S15.9.3.1_A3_T5.1.js
+++ b/test/built-ins/Date/S15.9.3.1_A3_T5.1.js
@@ -7,65 +7,64 @@ info: >
     is set to "Date"
 es5id: 15.9.3.1_A3_T5.1
 description: 6 arguments, (year, month, date, hours, minutes, seconds)
-includes: [$FAIL.js]
 ---*/
 
 var x1 = new Date(1899, 11, 31, 23, 59, 59);
 if (Object.prototype.toString.call(x1) !== "[object Date]") {
-  $FAIL("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x2 = new Date(1899, 12, 1, 0, 0, 0);
 if (Object.prototype.toString.call(x2) !== "[object Date]") {
-  $FAIL("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x3 = new Date(1900, 0, 1, 0, 0, 0);
 if (Object.prototype.toString.call(x3) !== "[object Date]") {
-  $FAIL("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x4 = new Date(1969, 11, 31, 23, 59, 59);
 if (Object.prototype.toString.call(x4) !== "[object Date]") {
-  $FAIL("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x5 = new Date(1969, 12, 1, 0, 0, 0);
 if (Object.prototype.toString.call(x5) !== "[object Date]") {
-  $FAIL("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x6 = new Date(1970, 0, 1, 0, 0, 0);
 if (Object.prototype.toString.call(x6) !== "[object Date]") {
-  $FAIL("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x7 = new Date(1999, 11, 31, 23, 59, 59);
 if (Object.prototype.toString.call(x7) !== "[object Date]") {
-  $FAIL("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x8 = new Date(1999, 12, 1, 0, 0, 0);
 if (Object.prototype.toString.call(x8) !== "[object Date]") {
-  $FAIL("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x9 = new Date(2000, 0, 1, 0, 0, 0);
 if (Object.prototype.toString.call(x9) !== "[object Date]") {
-  $FAIL("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x10 = new Date(2099, 11, 31, 23, 59, 59);
 if (Object.prototype.toString.call(x10) !== "[object Date]") {
-  $FAIL("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x11 = new Date(2099, 12, 1, 0, 0, 0);
 if (Object.prototype.toString.call(x11) !== "[object Date]") {
-  $FAIL("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x12 = new Date(2100, 0, 1, 0, 0, 0);
 if (Object.prototype.toString.call(x12) !== "[object Date]") {
-  $FAIL("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
 }

--- a/test/built-ins/Date/S15.9.3.1_A3_T5.2.js
+++ b/test/built-ins/Date/S15.9.3.1_A3_T5.2.js
@@ -9,67 +9,66 @@ es5id: 15.9.3.1_A3_T5.2
 description: >
     Test based on overwriting prototype.toString - 6 arguments, (year,
     month, date, hours, minutes, seconds)
-includes: [$FAIL.js]
 ---*/
 
 Date.prototype.toString = Object.prototype.toString;
 
 var x1 = new Date(1899, 11, 31, 23, 59, 59);
 if (x1.toString() !== "[object Date]") {
-  $FAIL("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x2 = new Date(1899, 12, 1, 0, 0, 0);
 if (x2.toString() !== "[object Date]") {
-  $FAIL("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x3 = new Date(1900, 0, 1, 0, 0, 0);
 if (x3.toString() !== "[object Date]") {
-  $FAIL("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x4 = new Date(1969, 11, 31, 23, 59, 59);
 if (x4.toString() !== "[object Date]") {
-  $FAIL("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x5 = new Date(1969, 12, 1, 0, 0, 0);
 if (x5.toString() !== "[object Date]") {
-  $FAIL("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x6 = new Date(1970, 0, 1, 0, 0, 0);
 if (x6.toString() !== "[object Date]") {
-  $FAIL("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x7 = new Date(1999, 11, 31, 23, 59, 59);
 if (x7.toString() !== "[object Date]") {
-  $FAIL("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x8 = new Date(1999, 12, 1, 0, 0, 0);
 if (x8.toString() !== "[object Date]") {
-  $FAIL("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x9 = new Date(2000, 0, 1, 0, 0, 0);
 if (x9.toString() !== "[object Date]") {
-  $FAIL("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x10 = new Date(2099, 11, 31, 23, 59, 59);
 if (x10.toString() !== "[object Date]") {
-  $FAIL("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x11 = new Date(2099, 12, 1, 0, 0, 0);
 if (x11.toString() !== "[object Date]") {
-  $FAIL("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x12 = new Date(2100, 0, 1, 0, 0, 0);
 if (x12.toString() !== "[object Date]") {
-  $FAIL("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
 }

--- a/test/built-ins/Date/S15.9.3.1_A3_T6.1.js
+++ b/test/built-ins/Date/S15.9.3.1_A3_T6.1.js
@@ -7,65 +7,64 @@ info: >
     is set to "Date"
 es5id: 15.9.3.1_A3_T6.1
 description: 7 arguments, (year, month, date, hours, minutes, seconds, ms)
-includes: [$FAIL.js]
 ---*/
 
 var x1 = new Date(1899, 11, 31, 23, 59, 59, 999);
 if (Object.prototype.toString.call(x1) !== "[object Date]") {
-  $FAIL("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x2 = new Date(1899, 12, 1, 0, 0, 0, 0);
 if (Object.prototype.toString.call(x2) !== "[object Date]") {
-  $FAIL("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x3 = new Date(1900, 0, 1, 0, 0, 0, 0);
 if (Object.prototype.toString.call(x3) !== "[object Date]") {
-  $FAIL("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x4 = new Date(1969, 11, 31, 23, 59, 59, 999);
 if (Object.prototype.toString.call(x4) !== "[object Date]") {
-  $FAIL("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x5 = new Date(1969, 12, 1, 0, 0, 0, 0);
 if (Object.prototype.toString.call(x5) !== "[object Date]") {
-  $FAIL("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x6 = new Date(1970, 0, 1, 0, 0, 0, 0);
 if (Object.prototype.toString.call(x6) !== "[object Date]") {
-  $FAIL("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x7 = new Date(1999, 11, 31, 23, 59, 59, 999);
 if (Object.prototype.toString.call(x7) !== "[object Date]") {
-  $FAIL("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x8 = new Date(1999, 12, 1, 0, 0, 0, 0);
 if (Object.prototype.toString.call(x8) !== "[object Date]") {
-  $FAIL("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x9 = new Date(2000, 0, 1, 0, 0, 0, 0);
 if (Object.prototype.toString.call(x9) !== "[object Date]") {
-  $FAIL("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x10 = new Date(2099, 11, 31, 23, 59, 59, 999);
 if (Object.prototype.toString.call(x10) !== "[object Date]") {
-  $FAIL("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x11 = new Date(2099, 12, 1, 0, 0, 0, 0);
 if (Object.prototype.toString.call(x11) !== "[object Date]") {
-  $FAIL("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x12 = new Date(2100, 0, 1, 0, 0, 0, 0);
 if (Object.prototype.toString.call(x12) !== "[object Date]") {
-  $FAIL("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
 }

--- a/test/built-ins/Date/S15.9.3.1_A3_T6.2.js
+++ b/test/built-ins/Date/S15.9.3.1_A3_T6.2.js
@@ -9,67 +9,66 @@ es5id: 15.9.3.1_A3_T6.2
 description: >
     Test based on overwriting prototype.toString - 7 arguments, (year,
     month, date, hours, minutes, seconds, ms)
-includes: [$FAIL.js]
 ---*/
 
 Date.prototype.toString = Object.prototype.toString;
 
 var x1 = new Date(1899, 11, 31, 23, 59, 59, 999);
 if (x1.toString() !== "[object Date]") {
-  $FAIL("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x2 = new Date(1899, 12, 1, 0, 0, 0, 0);
 if (x2.toString() !== "[object Date]") {
-  $FAIL("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x3 = new Date(1900, 0, 1, 0, 0, 0, 0);
 if (x3.toString() !== "[object Date]") {
-  $FAIL("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x4 = new Date(1969, 11, 31, 23, 59, 59, 999);
 if (x4.toString() !== "[object Date]") {
-  $FAIL("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x5 = new Date(1969, 12, 1, 0, 0, 0, 0);
 if (x5.toString() !== "[object Date]") {
-  $FAIL("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x6 = new Date(1970, 0, 1, 0, 0, 0, 0);
 if (x6.toString() !== "[object Date]") {
-  $FAIL("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x7 = new Date(1999, 11, 31, 23, 59, 59, 999);
 if (x7.toString() !== "[object Date]") {
-  $FAIL("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x8 = new Date(1999, 12, 1, 0, 0, 0, 0);
 if (x8.toString() !== "[object Date]") {
-  $FAIL("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x9 = new Date(2000, 0, 1, 0, 0, 0, 0);
 if (x9.toString() !== "[object Date]") {
-  $FAIL("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#9: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x10 = new Date(2099, 11, 31, 23, 59, 59, 999);
 if (x10.toString() !== "[object Date]") {
-  $FAIL("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#10: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x11 = new Date(2099, 12, 1, 0, 0, 0, 0);
 if (x11.toString() !== "[object Date]") {
-  $FAIL("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#11: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x12 = new Date(2100, 0, 1, 0, 0, 0, 0);
 if (x12.toString() !== "[object Date]") {
-  $FAIL("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#12: The [[Class]] property of the newly constructed object is set to 'Date'");
 }

--- a/test/built-ins/Date/S15.9.3.1_A5_T1.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T1.js
@@ -15,7 +15,6 @@ info: >
 es5id: 15.9.3.1_A5_T1
 description: 2 arguments, (year, month)
 includes:
-    - $FAIL.js
     - environment.js
     - numeric_conversion.js
     - Date_constants.js
@@ -23,49 +22,49 @@ includes:
 ---*/
 
 if (-2211638400000 !== new Date(1899, 11).valueOf()) {
-  $FAIL("#1: Incorrect value of Date");
+  $ERROR("#1: Incorrect value of Date");
 }
 
 if (-2208960000000 !== new Date(1899, 12).valueOf()) {
-  $FAIL("#2: Incorrect value of Date");
+  $ERROR("#2: Incorrect value of Date");
 }
 
 if (-2208960000000 !== new Date(1900, 0).valueOf()) {
-  $FAIL("#3: Incorrect value of Date");
+  $ERROR("#3: Incorrect value of Date");
 }
 
 if (-2649600000 !== new Date(1969, 11).valueOf()) {
-  $FAIL("#4: Incorrect value of Date");
+  $ERROR("#4: Incorrect value of Date");
 }
 
 if (28800000 !== new Date(1969, 12).valueOf()) {
-  $FAIL("#5: Incorrect value of Date");
+  $ERROR("#5: Incorrect value of Date");
 }
 
 if (28800000 !== new Date(1970, 0).valueOf()) {
-  $FAIL("#6: Incorrect value of Date");
+  $ERROR("#6: Incorrect value of Date");
 }
 
 if (944035200000 !== new Date(1999, 11).valueOf()) {
-  $FAIL("#7: Incorrect value of Date");
+  $ERROR("#7: Incorrect value of Date");
 }
 
 if (946713600000 !== new Date(1999, 12).valueOf()) {
-  $FAIL("#8: Incorrect value of Date");
+  $ERROR("#8: Incorrect value of Date");
 }
 
 if (946713600000 !== new Date(2000, 0).valueOf()) {
-  $FAIL("#9: Incorrect value of Date");
+  $ERROR("#9: Incorrect value of Date");
 }
 
 if (4099795200000 !== new Date(2099, 11).valueOf()) {
-  $FAIL("#10: Incorrect value of Date");
+  $ERROR("#10: Incorrect value of Date");
 }
 
 if (4102473600000 !== new Date(2099, 12).valueOf()) {
-  $FAIL("#11: Incorrect value of Date");
+  $ERROR("#11: Incorrect value of Date");
 }
 
 if (4102473600000 !== new Date(2100, 0).valueOf()) {
-  $FAIL("#12: Incorrect value of Date");
+  $ERROR("#12: Incorrect value of Date");
 }

--- a/test/built-ins/Date/S15.9.3.1_A5_T2.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T2.js
@@ -15,7 +15,6 @@ info: >
 es5id: 15.9.3.1_A5_T2
 description: 3 arguments, (year, month, date)
 includes:
-    - $FAIL.js
     - environment.js
     - numeric_conversion.js
     - Date_constants.js
@@ -23,49 +22,49 @@ includes:
 ---*/
 
 if (-2209046400000 !== new Date(1899, 11, 31).valueOf()) {
-  $FAIL("#1: Incorrect value of Date");
+  $ERROR("#1: Incorrect value of Date");
 }
 
 if (-2208960000000 !== new Date(1899, 12, 1).valueOf()) {
-  $FAIL("#2: Incorrect value of Date");
+  $ERROR("#2: Incorrect value of Date");
 }
 
 if (-2208960000000 !== new Date(1900, 0, 1).valueOf()) {
-  $FAIL("#3: Incorrect value of Date");
+  $ERROR("#3: Incorrect value of Date");
 }
 
 if (-57600000 !== new Date(1969, 11, 31).valueOf()) {
-  $FAIL("#4: Incorrect value of Date");
+  $ERROR("#4: Incorrect value of Date");
 }
 
 if (28800000 !== new Date(1969, 12, 1).valueOf()) {
-  $FAIL("#5: Incorrect value of Date");
+  $ERROR("#5: Incorrect value of Date");
 }
 
 if (28800000 !== new Date(1970, 0, 1).valueOf()) {
-  $FAIL("#6: Incorrect value of Date");
+  $ERROR("#6: Incorrect value of Date");
 }
 
 if (946627200000 !== new Date(1999, 11, 31).valueOf()) {
-  $FAIL("#7: Incorrect value of Date");
+  $ERROR("#7: Incorrect value of Date");
 }
 
 if (946713600000 !== new Date(1999, 12, 1).valueOf()) {
-  $FAIL("#8: Incorrect value of Date");
+  $ERROR("#8: Incorrect value of Date");
 }
 
 if (946713600000 !== new Date(2000, 0, 1).valueOf()) {
-  $FAIL("#9: Incorrect value of Date");
+  $ERROR("#9: Incorrect value of Date");
 }
 
 if (4102387200000 !== new Date(2099, 11, 31).valueOf()) {
-  $FAIL("#10: Incorrect value of Date");
+  $ERROR("#10: Incorrect value of Date");
 }
 
 if (4102473600000 !== new Date(2099, 12, 1).valueOf()) {
-  $FAIL("#11: Incorrect value of Date");
+  $ERROR("#11: Incorrect value of Date");
 }
 
 if (4102473600000 !== new Date(2100, 0, 1).valueOf()) {
-  $FAIL("#12: Incorrect value of Date");
+  $ERROR("#12: Incorrect value of Date");
 }

--- a/test/built-ins/Date/S15.9.3.1_A5_T3.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T3.js
@@ -15,7 +15,6 @@ info: >
 es5id: 15.9.3.1_A5_T3
 description: 4 arguments, (year, month, date, hours)
 includes:
-    - $FAIL.js
     - environment.js
     - numeric_conversion.js
     - Date_constants.js
@@ -23,49 +22,49 @@ includes:
 ---*/
 
 if (-2208963600000 !== new Date(1899, 11, 31, 23).valueOf()) {
-  $FAIL("#1: Incorrect value of Date");
+  $ERROR("#1: Incorrect value of Date");
 }
 
 if (-2208960000000 !== new Date(1899, 12, 1, 0).valueOf()) {
-  $FAIL("#2: Incorrect value of Date");
+  $ERROR("#2: Incorrect value of Date");
 }
 
 if (-2208960000000 !== new Date(1900, 0, 1, 0).valueOf()) {
-  $FAIL("#3: Incorrect value of Date");
+  $ERROR("#3: Incorrect value of Date");
 }
 
 if (25200000 !== new Date(1969, 11, 31, 23).valueOf()) {
-  $FAIL("#4: Incorrect value of Date");
+  $ERROR("#4: Incorrect value of Date");
 }
 
 if (28800000 !== new Date(1969, 12, 1, 0).valueOf()) {
-  $FAIL("#5: Incorrect value of Date");
+  $ERROR("#5: Incorrect value of Date");
 }
 
 if (28800000 !== new Date(1970, 0, 1, 0).valueOf()) {
-  $FAIL("#6: Incorrect value of Date");
+  $ERROR("#6: Incorrect value of Date");
 }
 
 if (946710000000 !== new Date(1999, 11, 31, 23).valueOf()) {
-  $FAIL("#7: Incorrect value of Date");
+  $ERROR("#7: Incorrect value of Date");
 }
 
 if (946713600000 !== new Date(1999, 12, 1, 0).valueOf()) {
-  $FAIL("#8: Incorrect value of Date");
+  $ERROR("#8: Incorrect value of Date");
 }
 
 if (946713600000 !== new Date(2000, 0, 1, 0).valueOf()) {
-  $FAIL("#9: Incorrect value of Date");
+  $ERROR("#9: Incorrect value of Date");
 }
 
 if (4102470000000 !== new Date(2099, 11, 31, 23).valueOf()) {
-  $FAIL("#10: Incorrect value of Date");
+  $ERROR("#10: Incorrect value of Date");
 }
 
 if (4102473600000 !== new Date(2099, 12, 1, 0).valueOf()) {
-  $FAIL("#11: Incorrect value of Date");
+  $ERROR("#11: Incorrect value of Date");
 }
 
 if (4102473600000 !== new Date(2100, 0, 1, 0).valueOf()) {
-  $FAIL("#12: Incorrect value of Date");
+  $ERROR("#12: Incorrect value of Date");
 }

--- a/test/built-ins/Date/S15.9.3.1_A5_T4.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T4.js
@@ -15,7 +15,6 @@ info: >
 es5id: 15.9.3.1_A5_T4
 description: 5 arguments, (year, month, date, hours, minutes)
 includes:
-    - $FAIL.js
     - environment.js
     - numeric_conversion.js
     - Date_constants.js
@@ -23,49 +22,49 @@ includes:
 ---*/
 
 if (-2208960060000 !== new Date(1899, 11, 31, 23, 59).valueOf()) {
-  $FAIL("#1: Incorrect value of Date");
+  $ERROR("#1: Incorrect value of Date");
 }
 
 if (-2208960000000 !== new Date(1899, 12, 1, 0, 0).valueOf()) {
-  $FAIL("#2: Incorrect value of Date");
+  $ERROR("#2: Incorrect value of Date");
 }
 
 if (-2208960000000 !== new Date(1900, 0, 1, 0, 0).valueOf()) {
-  $FAIL("#3: Incorrect value of Date");
+  $ERROR("#3: Incorrect value of Date");
 }
 
 if (28740000 !== new Date(1969, 11, 31, 23, 59).valueOf()) {
-  $FAIL("#4: Incorrect value of Date");
+  $ERROR("#4: Incorrect value of Date");
 }
 
 if (28800000 !== new Date(1969, 12, 1, 0, 0).valueOf()) {
-  $FAIL("#5: Incorrect value of Date");
+  $ERROR("#5: Incorrect value of Date");
 }
 
 if (28800000 !== new Date(1970, 0, 1, 0, 0).valueOf()) {
-  $FAIL("#6: Incorrect value of Date");
+  $ERROR("#6: Incorrect value of Date");
 }
 
 if (946713540000 !== new Date(1999, 11, 31, 23, 59).valueOf()) {
-  $FAIL("#7: Incorrect value of Date");
+  $ERROR("#7: Incorrect value of Date");
 }
 
 if (946713600000 !== new Date(1999, 12, 1, 0, 0).valueOf()) {
-  $FAIL("#8: Incorrect value of Date");
+  $ERROR("#8: Incorrect value of Date");
 }
 
 if (946713600000 !== new Date(2000, 0, 1, 0, 0).valueOf()) {
-  $FAIL("#9: Incorrect value of Date");
+  $ERROR("#9: Incorrect value of Date");
 }
 
 if (4102473540000 !== new Date(2099, 11, 31, 23, 59).valueOf()) {
-  $FAIL("#10: Incorrect value of Date");
+  $ERROR("#10: Incorrect value of Date");
 }
 
 if (4102473600000 !== new Date(2099, 12, 1, 0, 0).valueOf()) {
-  $FAIL("#11: Incorrect value of Date");
+  $ERROR("#11: Incorrect value of Date");
 }
 
 if (4102473600000 !== new Date(2100, 0, 1, 0, 0).valueOf()) {
-  $FAIL("#12: Incorrect value of Date");
+  $ERROR("#12: Incorrect value of Date");
 }

--- a/test/built-ins/Date/S15.9.3.1_A5_T5.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T5.js
@@ -15,7 +15,6 @@ info: >
 es5id: 15.9.3.1_A5_T5
 description: 6 arguments, (year, month, date, hours, minutes, seconds)
 includes:
-    - $FAIL.js
     - environment.js
     - numeric_conversion.js
     - Date_constants.js
@@ -23,49 +22,49 @@ includes:
 ---*/
 
 if (-2208960001000 !== new Date(1899, 11, 31, 23, 59, 59).valueOf()) {
-  $FAIL("#1: Incorrect value of Date");
+  $ERROR("#1: Incorrect value of Date");
 }
 
 if (-2208960000000 !== new Date(1899, 12, 1, 0, 0, 0).valueOf()) {
-  $FAIL("#2: Incorrect value of Date");
+  $ERROR("#2: Incorrect value of Date");
 }
 
 if (-2208960000000 !== new Date(1900, 0, 1, 0, 0, 0).valueOf()) {
-  $FAIL("#3: Incorrect value of Date");
+  $ERROR("#3: Incorrect value of Date");
 }
 
 if (28799000 !== new Date(1969, 11, 31, 23, 59, 59).valueOf()) {
-  $FAIL("#4: Incorrect value of Date");
+  $ERROR("#4: Incorrect value of Date");
 }
 
 if (28800000 !== new Date(1969, 12, 1, 0, 0, 0).valueOf()) {
-  $FAIL("#5: Incorrect value of Date");
+  $ERROR("#5: Incorrect value of Date");
 }
 
 if (28800000 !== new Date(1970, 0, 1, 0, 0, 0).valueOf()) {
-  $FAIL("#6: Incorrect value of Date");
+  $ERROR("#6: Incorrect value of Date");
 }
 
 if (946713599000 !== new Date(1999, 11, 31, 23, 59, 59).valueOf()) {
-  $FAIL("#7: Incorrect value of Date");
+  $ERROR("#7: Incorrect value of Date");
 }
 
 if (946713600000 !== new Date(1999, 12, 1, 0, 0, 0).valueOf()) {
-  $FAIL("#8: Incorrect value of Date");
+  $ERROR("#8: Incorrect value of Date");
 }
 
 if (946713600000 !== new Date(2000, 0, 1, 0, 0, 0).valueOf()) {
-  $FAIL("#9: Incorrect value of Date");
+  $ERROR("#9: Incorrect value of Date");
 }
 
 if (4102473599000 !== new Date(2099, 11, 31, 23, 59, 59).valueOf()) {
-  $FAIL("#10: Incorrect value of Date");
+  $ERROR("#10: Incorrect value of Date");
 }
 
 if (4102473600000 !== new Date(2099, 12, 1, 0, 0, 0).valueOf()) {
-  $FAIL("#11: Incorrect value of Date");
+  $ERROR("#11: Incorrect value of Date");
 }
 
 if (4102473600000 !== new Date(2100, 0, 1, 0, 0, 0).valueOf()) {
-  $FAIL("#12: Incorrect value of Date");
+  $ERROR("#12: Incorrect value of Date");
 }

--- a/test/built-ins/Date/S15.9.3.1_A5_T6.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T6.js
@@ -15,7 +15,6 @@ info: >
 es5id: 15.9.3.1_A5_T6
 description: 7 arguments, (year, month, date, hours, minutes, seconds, ms)
 includes:
-    - $FAIL.js
     - environment.js
     - numeric_conversion.js
     - Date_constants.js
@@ -23,49 +22,49 @@ includes:
 ---*/
 
 if (-2208960000001 !== new Date(1899, 11, 31, 23, 59, 59, 999).valueOf()) {
-  $FAIL("#1: Incorrect value of Date");
+  $ERROR("#1: Incorrect value of Date");
 }
 
 if (-2208960000000 !== new Date(1899, 12, 1, 0, 0, 0, 0).valueOf()) {
-  $FAIL("#2: Incorrect value of Date");
+  $ERROR("#2: Incorrect value of Date");
 }
 
 if (-2208960000000 !== new Date(1900, 0, 1, 0, 0, 0, 0).valueOf()) {
-  $FAIL("#3: Incorrect value of Date");
+  $ERROR("#3: Incorrect value of Date");
 }
 
 if (28799999 !== new Date(1969, 11, 31, 23, 59, 59, 999).valueOf()) {
-  $FAIL("#4: Incorrect value of Date");
+  $ERROR("#4: Incorrect value of Date");
 }
 
 if (28800000 !== new Date(1969, 12, 1, 0, 0, 0, 0).valueOf()) {
-  $FAIL("#5: Incorrect value of Date");
+  $ERROR("#5: Incorrect value of Date");
 }
 
 if (28800000 !== new Date(1970, 0, 1, 0, 0, 0, 0).valueOf()) {
-  $FAIL("#6: Incorrect value of Date");
+  $ERROR("#6: Incorrect value of Date");
 }
 
 if (946713599999 !== new Date(1999, 11, 31, 23, 59, 59, 999).valueOf()) {
-  $FAIL("#7: Incorrect value of Date");
+  $ERROR("#7: Incorrect value of Date");
 }
 
 if (946713600000 !== new Date(1999, 12, 1, 0, 0, 0, 0).valueOf()) {
-  $FAIL("#8: Incorrect value of Date");
+  $ERROR("#8: Incorrect value of Date");
 }
 
 if (946713600000 !== new Date(2000, 0, 1, 0, 0, 0, 0).valueOf()) {
-  $FAIL("#9: Incorrect value of Date");
+  $ERROR("#9: Incorrect value of Date");
 }
 
 if (4102473599999 !== new Date(2099, 11, 31, 23, 59, 59, 999).valueOf()) {
-  $FAIL("#10: Incorrect value of Date");
+  $ERROR("#10: Incorrect value of Date");
 }
 
 if (4102473600000 !== new Date(2099, 12, 1, 0, 0, 0, 0).valueOf()) {
-  $FAIL("#11: Incorrect value of Date");
+  $ERROR("#11: Incorrect value of Date");
 }
 
 if (4102473600000 !== new Date(2100, 0, 1, 0, 0, 0, 0).valueOf()) {
-  $FAIL("#12: Incorrect value of Date");
+  $ERROR("#12: Incorrect value of Date");
 }

--- a/test/built-ins/Date/S15.9.3.1_A6_T1.js
+++ b/test/built-ins/Date/S15.9.3.1_A6_T1.js
@@ -7,7 +7,6 @@ info: >
     with supplied "undefined" argument should be NaN
 es5id: 15.9.3.1_A6_T1
 description: 2 arguments, (year, month)
-includes: [$FAIL.js]
 ---*/
 
 function DateValue(year, month, date, hours, minutes, seconds, ms){
@@ -15,49 +14,49 @@ function DateValue(year, month, date, hours, minutes, seconds, ms){
 }
 
 if (!isNaN(DateValue(1899, 11))) {
-  $FAIL("#1: The value should be NaN");
+  $ERROR("#1: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1899, 12))) {
-  $FAIL("#2: The value should be NaN");
+  $ERROR("#2: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1900, 0))) {
-  $FAIL("#3: The value should be NaN");
+  $ERROR("#3: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1969, 11))) {
-  $FAIL("#4: The value should be NaN");
+  $ERROR("#4: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1969, 12))) {
-  $FAIL("#5: The value should be NaN");
+  $ERROR("#5: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1970, 0))) {
-  $FAIL("#6: The value should be NaN");
+  $ERROR("#6: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1999, 11))) {
-  $FAIL("#7: The value should be NaN");
+  $ERROR("#7: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1999, 12))) {
-  $FAIL("#8: The value should be NaN");
+  $ERROR("#8: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2000, 0))) {
-  $FAIL("#9: The value should be NaN");
+  $ERROR("#9: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2099, 11))) {
-  $FAIL("#10: The value should be NaN");
+  $ERROR("#10: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2099, 12))) {
-  $FAIL("#11: The value should be NaN");
+  $ERROR("#11: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2100, 0))) {
-  $FAIL("#12: The value should be NaN");
+  $ERROR("#12: The value should be NaN");
 }

--- a/test/built-ins/Date/S15.9.3.1_A6_T2.js
+++ b/test/built-ins/Date/S15.9.3.1_A6_T2.js
@@ -7,7 +7,6 @@ info: >
     with supplied "undefined" argument should be NaN
 es5id: 15.9.3.1_A6_T2
 description: 3 arguments, (year, month, date)
-includes: [$FAIL.js]
 ---*/
 
 function DateValue(year, month, date, hours, minutes, seconds, ms){
@@ -15,49 +14,49 @@ function DateValue(year, month, date, hours, minutes, seconds, ms){
 }
 
 if (!isNaN(DateValue(1899, 11, 31))) {
-  $FAIL("#1: The value should be NaN");
+  $ERROR("#1: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1899, 12, 1))) {
-  $FAIL("#2: The value should be NaN");
+  $ERROR("#2: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1900, 0, 1))) {
-  $FAIL("#3: The value should be NaN");
+  $ERROR("#3: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1969, 11, 31))) {
-  $FAIL("#4: The value should be NaN");
+  $ERROR("#4: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1969, 12, 1))) {
-  $FAIL("#5: The value should be NaN");
+  $ERROR("#5: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1970, 0, 1))) {
-  $FAIL("#6: The value should be NaN");
+  $ERROR("#6: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1999, 11, 31))) {
-  $FAIL("#7: The value should be NaN");
+  $ERROR("#7: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1999, 12, 1))) {
-  $FAIL("#8: The value should be NaN");
+  $ERROR("#8: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2000, 0, 1))) {
-  $FAIL("#9: The value should be NaN");
+  $ERROR("#9: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2099, 11, 31))) {
-  $FAIL("#10: The value should be NaN");
+  $ERROR("#10: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2099, 12, 1))) {
-  $FAIL("#11: The value should be NaN");
+  $ERROR("#11: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2100, 0, 1))) {
-  $FAIL("#12: The value should be NaN");
+  $ERROR("#12: The value should be NaN");
 }

--- a/test/built-ins/Date/S15.9.3.1_A6_T3.js
+++ b/test/built-ins/Date/S15.9.3.1_A6_T3.js
@@ -7,7 +7,6 @@ info: >
     with supplied "undefined" argument should be NaN
 es5id: 15.9.3.1_A6_T3
 description: 4 arguments, (year, month, date, hours)
-includes: [$FAIL.js]
 ---*/
 
 function DateValue(year, month, date, hours, minutes, seconds, ms){
@@ -15,49 +14,49 @@ function DateValue(year, month, date, hours, minutes, seconds, ms){
 }
 
 if (!isNaN(DateValue(1899, 11, 31, 23))) {
-  $FAIL("#1: The value should be NaN");
+  $ERROR("#1: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1899, 12, 1, 0))) {
-  $FAIL("#2: The value should be NaN");
+  $ERROR("#2: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1900, 0, 1, 0))) {
-  $FAIL("#3: The value should be NaN");
+  $ERROR("#3: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1969, 11, 31, 23))) {
-  $FAIL("#4: The value should be NaN");
+  $ERROR("#4: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1969, 12, 1, 0))) {
-  $FAIL("#5: The value should be NaN");
+  $ERROR("#5: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1970, 0, 1, 0))) {
-  $FAIL("#6: The value should be NaN");
+  $ERROR("#6: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1999, 11, 31, 23))) {
-  $FAIL("#7: The value should be NaN");
+  $ERROR("#7: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1999, 12, 1, 0))) {
-  $FAIL("#8: The value should be NaN");
+  $ERROR("#8: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2000, 0, 1, 0))) {
-  $FAIL("#9: The value should be NaN");
+  $ERROR("#9: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2099, 11, 31, 23))) {
-  $FAIL("#10: The value should be NaN");
+  $ERROR("#10: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2099, 12, 1, 0))) {
-  $FAIL("#11: The value should be NaN");
+  $ERROR("#11: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2100, 0, 1, 0))) {
-  $FAIL("#12: The value should be NaN");
+  $ERROR("#12: The value should be NaN");
 }

--- a/test/built-ins/Date/S15.9.3.1_A6_T4.js
+++ b/test/built-ins/Date/S15.9.3.1_A6_T4.js
@@ -7,7 +7,6 @@ info: >
     with supplied "undefined" argument should be NaN
 es5id: 15.9.3.1_A6_T4
 description: 5 arguments, (year, month, date, hours, minutes)
-includes: [$FAIL.js]
 ---*/
 
 function DateValue(year, month, date, hours, minutes, seconds, ms){
@@ -15,49 +14,49 @@ function DateValue(year, month, date, hours, minutes, seconds, ms){
 }
 
 if (!isNaN(DateValue(1899, 11, 31, 23, 59))) {
-  $FAIL("#1: The value should be NaN");
+  $ERROR("#1: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1899, 12, 1, 0, 0))) {
-  $FAIL("#2: The value should be NaN");
+  $ERROR("#2: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1900, 0, 1, 0, 0))) {
-  $FAIL("#3: The value should be NaN");
+  $ERROR("#3: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1969, 11, 31, 23, 59))) {
-  $FAIL("#4: The value should be NaN");
+  $ERROR("#4: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1969, 12, 1, 0, 0))) {
-  $FAIL("#5: The value should be NaN");
+  $ERROR("#5: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1970, 0, 1, 0, 0))) {
-  $FAIL("#6: The value should be NaN");
+  $ERROR("#6: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1999, 11, 31, 23, 59))) {
-  $FAIL("#7: The value should be NaN");
+  $ERROR("#7: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1999, 12, 1, 0, 0))) {
-  $FAIL("#8: The value should be NaN");
+  $ERROR("#8: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2000, 0, 1, 0, 0))) {
-  $FAIL("#9: The value should be NaN");
+  $ERROR("#9: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2099, 11, 31, 23, 59))) {
-  $FAIL("#10: The value should be NaN");
+  $ERROR("#10: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2099, 12, 1, 0, 0))) {
-  $FAIL("#11: The value should be NaN");
+  $ERROR("#11: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2100, 0, 1, 0, 0))) {
-  $FAIL("#12: The value should be NaN");
+  $ERROR("#12: The value should be NaN");
 }

--- a/test/built-ins/Date/S15.9.3.1_A6_T5.js
+++ b/test/built-ins/Date/S15.9.3.1_A6_T5.js
@@ -7,7 +7,6 @@ info: >
     with supplied "undefined" argument should be NaN
 es5id: 15.9.3.1_A6_T5
 description: 6 arguments, (year, month, date, hours, minutes, seconds)
-includes: [$FAIL.js]
 ---*/
 
 function DateValue(year, month, date, hours, minutes, seconds, ms){
@@ -15,49 +14,49 @@ function DateValue(year, month, date, hours, minutes, seconds, ms){
 }
 
 if (!isNaN(DateValue(1899, 11, 31, 23, 59, 59))) {
-  $FAIL("#1: The value should be NaN");
+  $ERROR("#1: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1899, 12, 1, 0, 0, 0))) {
-  $FAIL("#2: The value should be NaN");
+  $ERROR("#2: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1900, 0, 1, 0, 0, 0))) {
-  $FAIL("#3: The value should be NaN");
+  $ERROR("#3: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1969, 11, 31, 23, 59, 59))) {
-  $FAIL("#4: The value should be NaN");
+  $ERROR("#4: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1969, 12, 1, 0, 0, 0))) {
-  $FAIL("#5: The value should be NaN");
+  $ERROR("#5: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1970, 0, 1, 0, 0, 0))) {
-  $FAIL("#6: The value should be NaN");
+  $ERROR("#6: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1999, 11, 31, 23, 59, 59))) {
-  $FAIL("#7: The value should be NaN");
+  $ERROR("#7: The value should be NaN");
 }
 
 if (!isNaN(DateValue(1999, 12, 1, 0, 0, 0))) {
-  $FAIL("#8: The value should be NaN");
+  $ERROR("#8: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2000, 0, 1, 0, 0, 0))) {
-  $FAIL("#9: The value should be NaN");
+  $ERROR("#9: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2099, 11, 31, 23, 59, 59))) {
-  $FAIL("#10: The value should be NaN");
+  $ERROR("#10: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2099, 12, 1, 0, 0, 0))) {
-  $FAIL("#11: The value should be NaN");
+  $ERROR("#11: The value should be NaN");
 }
 
 if (!isNaN(DateValue(2100, 0, 1, 0, 0, 0))) {
-  $FAIL("#12: The value should be NaN");
+  $ERROR("#12: The value should be NaN");
 }

--- a/test/built-ins/Date/S15.9.3.2_A1_T1.js
+++ b/test/built-ins/Date/S15.9.3.2_A1_T1.js
@@ -8,150 +8,149 @@ info: >
 es5id: 15.9.3.2_A1_T1
 description: Checking types of newly created objects and it values
 includes:
-    - $FAIL.js
     - Date_constants.js
 ---*/
 
 if (typeof new Date(date_1899_end) !== "object") {
-  $FAIL("#1.1: typeof new Date(date_1899_end) === 'object'");
+  $ERROR("#1.1: typeof new Date(date_1899_end) === 'object'");
 }
 
 if (new Date(date_1899_end) === undefined) {
-  $FAIL("#1.2: new Date(date_1899_end) === undefined");
+  $ERROR("#1.2: new Date(date_1899_end) === undefined");
 }
 
 var x13 = new Date(date_1899_end);
 if(typeof x13 !== "object"){
-  $FAIL("#1.3: typeof new Date(date_1899_end) !== 'object'");
+  $ERROR("#1.3: typeof new Date(date_1899_end) !== 'object'");
 }
 
 var x14 = new Date(date_1899_end);
 if(x14 === undefined){
-  $FAIL("#1.4: new Date(date_1899_end) !== undefined");
+  $ERROR("#1.4: new Date(date_1899_end) !== undefined");
 }
 
 if (typeof new Date(date_1900_start) !== "object") {
-  $FAIL("#2.1: typeof new Date(date_1900_start) === 'object'");
+  $ERROR("#2.1: typeof new Date(date_1900_start) === 'object'");
 }
 
 if (new Date(date_1900_start) === undefined) {
-  $FAIL("#2.2: new Date(date_1900_start) === undefined");
+  $ERROR("#2.2: new Date(date_1900_start) === undefined");
 }
 
 var x23 = new Date(date_1900_start);
 if(typeof x23 !== "object"){
-  $FAIL("#2.3: typeof new Date(date_1900_start) !== 'object'");
+  $ERROR("#2.3: typeof new Date(date_1900_start) !== 'object'");
 }
 
 var x24 = new Date(date_1900_start);
 if(x24 === undefined){
-  $FAIL("#2.4: new Date(date_1900_start) !== undefined");
+  $ERROR("#2.4: new Date(date_1900_start) !== undefined");
 }
 
 if (typeof new Date(date_1969_end) !== "object") {
-  $FAIL("#3.1: typeof new Date(date_1969_end) === 'object'");
+  $ERROR("#3.1: typeof new Date(date_1969_end) === 'object'");
 }
 
 if (new Date(date_1969_end) === undefined) {
-  $FAIL("#3.2: new Date(date_1969_end) === undefined");
+  $ERROR("#3.2: new Date(date_1969_end) === undefined");
 }
 
 var x33 = new Date(date_1969_end);
 if(typeof x33 !== "object"){
-  $FAIL("#3.3: typeof new Date(date_1969_end) !== 'object'");
+  $ERROR("#3.3: typeof new Date(date_1969_end) !== 'object'");
 }
 
 var x34 = new Date(date_1969_end);
 if(x34 === undefined){
-  $FAIL("#3.4: new Date(date_1969_end) !== undefined");
+  $ERROR("#3.4: new Date(date_1969_end) !== undefined");
 }
 
 if (typeof new Date(date_1970_start) !== "object") {
-  $FAIL("#4.1: typeof new Date(date_1970_start) === 'object'");
+  $ERROR("#4.1: typeof new Date(date_1970_start) === 'object'");
 }
 
 if (new Date(date_1970_start) === undefined) {
-  $FAIL("#4.2: new Date(date_1970_start) === undefined");
+  $ERROR("#4.2: new Date(date_1970_start) === undefined");
 }
 
 var x43 = new Date(date_1970_start);
 if(typeof x43 !== "object"){
-  $FAIL("#4.3: typeof new Date(date_1970_start) !== 'object'");
+  $ERROR("#4.3: typeof new Date(date_1970_start) !== 'object'");
 }
 
 var x44 = new Date(date_1970_start);
 if(x44 === undefined){
-  $FAIL("#4.4: new Date(date_1970_start) !== undefined");
+  $ERROR("#4.4: new Date(date_1970_start) !== undefined");
 }
 
 if (typeof new Date(date_1999_end) !== "object") {
-  $FAIL("#5.1: typeof new Date(date_1999_end) === 'object'");
+  $ERROR("#5.1: typeof new Date(date_1999_end) === 'object'");
 }
 
 if (new Date(date_1999_end) === undefined) {
-  $FAIL("#5.2: new Date(date_1999_end) === undefined");
+  $ERROR("#5.2: new Date(date_1999_end) === undefined");
 }
 
 var x53 = new Date(date_1999_end);
 if(typeof x53 !== "object"){
-  $FAIL("#5.3: typeof new Date(date_1999_end) !== 'object'");
+  $ERROR("#5.3: typeof new Date(date_1999_end) !== 'object'");
 }
 
 var x54 = new Date(date_1999_end);
 if(x54 === undefined){
-  $FAIL("#5.4: new Date(date_1999_end) !== undefined");
+  $ERROR("#5.4: new Date(date_1999_end) !== undefined");
 }
 
 if (typeof new Date(date_2000_start) !== "object") {
-  $FAIL("#6.1: typeof new Date(date_2000_start) === 'object'");
+  $ERROR("#6.1: typeof new Date(date_2000_start) === 'object'");
 }
 
 if (new Date(date_2000_start) === undefined) {
-  $FAIL("#6.2: new Date(date_2000_start) === undefined");
+  $ERROR("#6.2: new Date(date_2000_start) === undefined");
 }
 
 var x63 = new Date(date_2000_start);
 if(typeof x63 !== "object"){
-  $FAIL("#6.3: typeof new Date(date_2000_start) !== 'object'");
+  $ERROR("#6.3: typeof new Date(date_2000_start) !== 'object'");
 }
 
 var x64 = new Date(date_2000_start);
 if(x64 === undefined){
-  $FAIL("#6.4: new Date(date_2000_start) !== undefined");
+  $ERROR("#6.4: new Date(date_2000_start) !== undefined");
 }
 
 if (typeof new Date(date_2099_end) !== "object") {
-  $FAIL("#7.1: typeof new Date(date_2099_end) === 'object'");
+  $ERROR("#7.1: typeof new Date(date_2099_end) === 'object'");
 }
 
 if (new Date(date_2099_end) === undefined) {
-  $FAIL("#7.2: new Date(date_2099_end) === undefined");
+  $ERROR("#7.2: new Date(date_2099_end) === undefined");
 }
 
 var x73 = new Date(date_2099_end);
 if(typeof x73 !== "object"){
-  $FAIL("#7.3: typeof new Date(date_2099_end) !== 'object'");
+  $ERROR("#7.3: typeof new Date(date_2099_end) !== 'object'");
 }
 
 var x74 = new Date(date_2099_end);
 if(x74 === undefined){
-  $FAIL("#7.4: new Date(date_2099_end) !== undefined");
+  $ERROR("#7.4: new Date(date_2099_end) !== undefined");
 }
 
 if (typeof new Date(date_2100_start) !== "object") {
-  $FAIL("#8.1: typeof new Date(date_2100_start) === 'object'");
+  $ERROR("#8.1: typeof new Date(date_2100_start) === 'object'");
 }
 
 if (new Date(date_2100_start) === undefined) {
-  $FAIL("#8.2: new Date(date_2100_start) === undefined");
+  $ERROR("#8.2: new Date(date_2100_start) === undefined");
 }
 
 var x83 = new Date(date_2100_start);
 if(typeof x83 !== "object"){
-  $FAIL("#8.3: typeof new Date(date_2100_start) !== 'object'");
+  $ERROR("#8.3: typeof new Date(date_2100_start) !== 'object'");
 }
 
 var x84 = new Date(date_2100_start);
 if(x84 === undefined){
-  $FAIL("#8.4: new Date(date_2100_start) !== undefined");
+  $ERROR("#8.4: new Date(date_2100_start) !== undefined");
 }

--- a/test/built-ins/Date/S15.9.3.2_A2_T1.js
+++ b/test/built-ins/Date/S15.9.3.2_A2_T1.js
@@ -9,13 +9,12 @@ info: >
 es5id: 15.9.3.2_A2_T1
 description: Checking Date.prototype property of newly constructed objects
 includes:
-    - $FAIL.js
     - Date_constants.js
 ---*/
 
 var x11 = new Date(date_1899_end);
 if (typeof x11.constructor.prototype !== "object") {
-  $FAIL("#1.1: typeof x11.constructor.prototype === 'object'");
+  $ERROR("#1.1: typeof x11.constructor.prototype === 'object'");
 }
 
 var x12 = new Date(date_1899_end);
@@ -25,12 +24,12 @@ if (!Date.prototype.isPrototypeOf(x12)) {
 
 var x13 = new Date(date_1899_end);
 if(Date.prototype !== x13.constructor.prototype){
-  $FAIL("#1.3: Date.prototype !== x13.constructor.prototype");
+  $ERROR("#1.3: Date.prototype !== x13.constructor.prototype");
 }
 
 var x21 = new Date(date_1900_start);
 if (typeof x21.constructor.prototype !== "object") {
-  $FAIL("#2.1: typeof x21.constructor.prototype === 'object'");
+  $ERROR("#2.1: typeof x21.constructor.prototype === 'object'");
 }
 
 var x22 = new Date(date_1900_start);
@@ -40,12 +39,12 @@ if (!Date.prototype.isPrototypeOf(x22)) {
 
 var x23 = new Date(date_1900_start);
 if(Date.prototype !== x23.constructor.prototype){
-  $FAIL("#2.3: Date.prototype !== x23.constructor.prototype");
+  $ERROR("#2.3: Date.prototype !== x23.constructor.prototype");
 }
 
 var x31 = new Date(date_1969_end);
 if (typeof x31.constructor.prototype !== "object") {
-  $FAIL("#3.1: typeof x31.constructor.prototype === 'object'");
+  $ERROR("#3.1: typeof x31.constructor.prototype === 'object'");
 }
 
 var x32 = new Date(date_1969_end);
@@ -55,12 +54,12 @@ if (!Date.prototype.isPrototypeOf(x32)) {
 
 var x33 = new Date(date_1969_end);
 if(Date.prototype !== x33.constructor.prototype){
-  $FAIL("#3.3: Date.prototype !== x33.constructor.prototype");
+  $ERROR("#3.3: Date.prototype !== x33.constructor.prototype");
 }
 
 var x41 = new Date(date_1970_start);
 if (typeof x41.constructor.prototype !== "object") {
-  $FAIL("#4.1: typeof x11.constructor.prototype === 'object'");
+  $ERROR("#4.1: typeof x11.constructor.prototype === 'object'");
 }
 
 var x42 = new Date(date_1970_start);
@@ -70,12 +69,12 @@ if (!Date.prototype.isPrototypeOf(x42)) {
 
 var x43 = new Date(date_1970_start);
 if(Date.prototype !== x43.constructor.prototype){
-  $FAIL("#4.3: Date.prototype !== x43.constructor.prototype");
+  $ERROR("#4.3: Date.prototype !== x43.constructor.prototype");
 }
 
 var x51 = new Date(date_1999_end);
 if (typeof x51.constructor.prototype !== "object") {
-  $FAIL("#5.1: typeof x51.constructor.prototype === 'object'");
+  $ERROR("#5.1: typeof x51.constructor.prototype === 'object'");
 }
 
 var x52 = new Date(date_1999_end);
@@ -85,12 +84,12 @@ if (!Date.prototype.isPrototypeOf(x52)) {
 
 var x53 = new Date(date_1999_end);
 if(Date.prototype !== x53.constructor.prototype){
-  $FAIL("#5.3: Date.prototype !== x53.constructor.prototype");
+  $ERROR("#5.3: Date.prototype !== x53.constructor.prototype");
 }
 
 var x61 = new Date(date_2000_start);
 if (typeof x61.constructor.prototype !== "object") {
-  $FAIL("#6.1: typeof x61.constructor.prototype === 'object'");
+  $ERROR("#6.1: typeof x61.constructor.prototype === 'object'");
 }
 
 var x62 = new Date(date_2000_start);
@@ -100,12 +99,12 @@ if (!Date.prototype.isPrototypeOf(x62)) {
 
 var x63 = new Date(date_2000_start);
 if(Date.prototype !== x63.constructor.prototype){
-  $FAIL("#6.3: Date.prototype !== x63.constructor.prototype");
+  $ERROR("#6.3: Date.prototype !== x63.constructor.prototype");
 }
 
 var x71 = new Date(date_2099_end);
 if (typeof x71.constructor.prototype !== "object") {
-  $FAIL("#7.1: typeof x71.constructor.prototype === 'object'");
+  $ERROR("#7.1: typeof x71.constructor.prototype === 'object'");
 }
 
 var x72 = new Date(date_2099_end);
@@ -115,12 +114,12 @@ if (!Date.prototype.isPrototypeOf(x72)) {
 
 var x73 = new Date(date_2099_end);
 if(Date.prototype !== x73.constructor.prototype){
-  $FAIL("#7.3: Date.prototype !== x73.constructor.prototype");
+  $ERROR("#7.3: Date.prototype !== x73.constructor.prototype");
 }
 
 var x81 = new Date(date_2100_start);
 if (typeof x81.constructor.prototype !== "object") {
-  $FAIL("#8.1: typeof x81.constructor.prototype === 'object'");
+  $ERROR("#8.1: typeof x81.constructor.prototype === 'object'");
 }
 
 var x82 = new Date(date_2100_start);
@@ -130,5 +129,5 @@ if (!Date.prototype.isPrototypeOf(x82)) {
 
 var x83 = new Date(date_2100_start);
 if(Date.prototype !== x83.constructor.prototype){
-  $FAIL("#8.3: Date.prototype !== x83.constructor.prototype");
+  $ERROR("#8.3: Date.prototype !== x83.constructor.prototype");
 }

--- a/test/built-ins/Date/S15.9.3.2_A3_T1.1.js
+++ b/test/built-ins/Date/S15.9.3.2_A3_T1.1.js
@@ -8,46 +8,45 @@ info: >
 es5id: 15.9.3.2_A3_T1.1
 description: Test based on delete prototype.toString
 includes:
-    - $FAIL.js
     - Date_constants.js
 ---*/
 
 var x1 = new Date(date_1899_end);
 if (Object.prototype.toString.call(x1) !== "[object Date]") {
-  $FAIL("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x2 = new Date(date_1900_start);
 if (Object.prototype.toString.call(x2) !== "[object Date]") {
-  $FAIL("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x3 = new Date(date_1969_end);
 if (Object.prototype.toString.call(x3) !== "[object Date]") {
-  $FAIL("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x4 = new Date(date_1970_start);
 if (Object.prototype.toString.call(x4) !== "[object Date]") {
-  $FAIL("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x5 = new Date(date_1999_end);
 if (Object.prototype.toString.call(x5) !== "[object Date]") {
-  $FAIL("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x6 = new Date(date_2000_start);
 if (Object.prototype.toString.call(x6) !== "[object Date]") {
-  $FAIL("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x7 = new Date(date_2099_end);
 if (Object.prototype.toString.call(x7) !== "[object Date]") {
-  $FAIL("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x8 = new Date(date_2100_start);
 if (Object.prototype.toString.call(x8) !== "[object Date]") {
-  $FAIL("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
 }

--- a/test/built-ins/Date/S15.9.3.2_A3_T1.2.js
+++ b/test/built-ins/Date/S15.9.3.2_A3_T1.2.js
@@ -8,7 +8,6 @@ info: >
 es5id: 15.9.3.2_A3_T1.2
 description: Test based on overwriting prototype.toString
 includes:
-    - $FAIL.js
     - Date_constants.js
 ---*/
 
@@ -16,40 +15,40 @@ Date.prototype.toString = Object.prototype.toString;
 
 var x1 = new Date(date_1899_end);
 if (x1.toString() !== "[object Date]") {
-  $FAIL("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#1: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x2 = new Date(date_1900_start);
 if (x2.toString() !== "[object Date]") {
-  $FAIL("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#2: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x3 = new Date(date_1969_end);
 if (x3.toString() !== "[object Date]") {
-  $FAIL("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#3: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x4 = new Date(date_1970_start);
 if (x4.toString() !== "[object Date]") {
-  $FAIL("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#4: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x5 = new Date(date_1999_end);
 if (x5.toString() !== "[object Date]") {
-  $FAIL("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#5: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x6 = new Date(date_2000_start);
 if (x6.toString() !== "[object Date]") {
-  $FAIL("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#6: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x7 = new Date(date_2099_end);
 if (x7.toString() !== "[object Date]") {
-  $FAIL("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#7: The [[Class]] property of the newly constructed object is set to 'Date'");
 }
 
 var x8 = new Date(date_2100_start);
 if (x8.toString() !== "[object Date]") {
-  $FAIL("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
+  $ERROR("#8: The [[Class]] property of the newly constructed object is set to 'Date'");
 }

--- a/test/built-ins/Date/UTC/S15.9.4.3_A1_T2.js
+++ b/test/built-ins/Date/UTC/S15.9.4.3_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date property "UTC" has { DontEnum } attributes
 es5id: 15.9.4.3_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.UTC  === false) {
@@ -13,5 +12,5 @@ if (delete Date.UTC  === false) {
 }
 
 if (Date.hasOwnProperty('UTC')) {
-  $FAIL('#2: The Date.UTC property has not the attributes DontDelete');
+  $ERROR('#2: The Date.UTC property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/UTC/S15.9.4.3_A3_T2.js
+++ b/test/built-ins/Date/UTC/S15.9.4.3_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     attributes
 es5id: 15.9.4.3_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.UTC.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.UTC.length  !== true) {
 }
 
 if (Date.UTC.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.UTC.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.UTC.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/parse/S15.9.4.2_A1_T2.js
+++ b/test/built-ins/Date/parse/S15.9.4.2_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date property "parse" has { DontEnum } attributes
 es5id: 15.9.4.2_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.parse  === false) {
@@ -13,5 +12,5 @@ if (delete Date.parse  === false) {
 }
 
 if (Date.hasOwnProperty('parse')) {
-  $FAIL('#2: The Date.parse property has not the attributes DontDelete');
+  $ERROR('#2: The Date.parse property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/parse/S15.9.4.2_A3_T2.js
+++ b/test/built-ins/Date/parse/S15.9.4.2_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     attributes
 es5id: 15.9.4.2_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.parse.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.parse.length  !== true) {
 }
 
 if (Date.parse.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.parse.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.parse.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/S15.9.4.1_A1_T2.js
+++ b/test/built-ins/Date/prototype/S15.9.4.1_A1_T2.js
@@ -22,5 +22,5 @@ try {
 }
 
 if (!Date.hasOwnProperty('prototype')) {
-  $FAIL('#2: The Date.prototype property has the attributes DontDelete');
+  $ERROR('#2: The Date.prototype property has the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/constructor/S15.9.5.1_A1_T2.js
+++ b/test/built-ins/Date/prototype/constructor/S15.9.5.1_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "constructor" has { DontEnum } attributes
 es5id: 15.9.5.1_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.constructor  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.constructor  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('constructor')) {
-  $FAIL('#2: The Date.prototype.constructor property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.constructor property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/constructor/S15.9.5.1_A3_T2.js
+++ b/test/built-ins/Date/prototype/constructor/S15.9.5.1_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.1_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.constructor.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.constructor.length  !== true) {
 }
 
 if (Date.prototype.constructor.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.constructor.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.constructor.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getDate/S15.9.5.14_A1_T2.js
+++ b/test/built-ins/Date/prototype/getDate/S15.9.5.14_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getDate" has { DontEnum } attributes
 es5id: 15.9.5.14_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getDate  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getDate  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getDate')) {
-  $FAIL('#2: The Date.prototype.getDate property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getDate property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getDate/S15.9.5.14_A3_T2.js
+++ b/test/built-ins/Date/prototype/getDate/S15.9.5.14_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.14_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getDate.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getDate.length  !== true) {
 }
 
 if (Date.prototype.getDate.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getDate.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getDate.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getDay/S15.9.5.16_A1_T2.js
+++ b/test/built-ins/Date/prototype/getDay/S15.9.5.16_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getDay" has { DontEnum } attributes
 es5id: 15.9.5.16_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getDay  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getDay  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getDay')) {
-  $FAIL('#2: The Date.prototype.getDay property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getDay property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getDay/S15.9.5.16_A3_T2.js
+++ b/test/built-ins/Date/prototype/getDay/S15.9.5.16_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontEnum } attributes
 es5id: 15.9.5.16_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getDay.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getDay.length  !== true) {
 }
 
 if (Date.prototype.getDay.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getDay.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getDay.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getFullYear/S15.9.5.10_A1_T2.js
+++ b/test/built-ins/Date/prototype/getFullYear/S15.9.5.10_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getFullYear" has { DontEnum } attributes
 es5id: 15.9.5.10_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getFullYear  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getFullYear  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getFullYear')) {
-  $FAIL('#2: The Date.prototype.getFullYear property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getFullYear property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getFullYear/S15.9.5.10_A3_T2.js
+++ b/test/built-ins/Date/prototype/getFullYear/S15.9.5.10_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.10_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getFullYear.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getFullYear.length  !== true) {
 }
 
 if (Date.prototype.getFullYear.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getFullYear.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getFullYear.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getHours/S15.9.5.18_A1_T2.js
+++ b/test/built-ins/Date/prototype/getHours/S15.9.5.18_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getHours" has { DontEnum } attributes
 es5id: 15.9.5.18_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getHours  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getHours  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getHours')) {
-  $FAIL('#2: The Date.prototype.getHours property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getHours property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getHours/S15.9.5.18_A3_T2.js
+++ b/test/built-ins/Date/prototype/getHours/S15.9.5.18_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.18_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getHours.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getHours.length  !== true) {
 }
 
 if (Date.prototype.getHours.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getHours.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getHours.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getMilliseconds/S15.9.5.24_A1_T2.js
+++ b/test/built-ins/Date/prototype/getMilliseconds/S15.9.5.24_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getMilliseconds" has { DontEnum } attributes
 es5id: 15.9.5.24_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getMilliseconds  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getMilliseconds  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getMilliseconds')) {
-  $FAIL('#2: The Date.prototype.getMilliseconds property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getMilliseconds property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getMilliseconds/S15.9.5.24_A3_T2.js
+++ b/test/built-ins/Date/prototype/getMilliseconds/S15.9.5.24_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.24_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getMilliseconds.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getMilliseconds.length  !== true) {
 }
 
 if (Date.prototype.getMilliseconds.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getMilliseconds.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getMilliseconds.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getMinutes/S15.9.5.20_A1_T2.js
+++ b/test/built-ins/Date/prototype/getMinutes/S15.9.5.20_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getMinutes" has { DontEnum } attributes
 es5id: 15.9.5.20_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getMinutes  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getMinutes  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getMinutes')) {
-  $FAIL('#2: The Date.prototype.getMinutes property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getMinutes property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getMinutes/S15.9.5.20_A3_T2.js
+++ b/test/built-ins/Date/prototype/getMinutes/S15.9.5.20_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.20_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getMinutes.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getMinutes.length  !== true) {
 }
 
 if (Date.prototype.getMinutes.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getMinutes.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getMinutes.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getMonth/S15.9.5.12_A1_T2.js
+++ b/test/built-ins/Date/prototype/getMonth/S15.9.5.12_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getMonth" has { DontEnum } attributes
 es5id: 15.9.5.12_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getMonth  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getMonth  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getMonth')) {
-  $FAIL('#2: The Date.prototype.getMonth property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getMonth property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getMonth/S15.9.5.12_A3_T2.js
+++ b/test/built-ins/Date/prototype/getMonth/S15.9.5.12_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.12_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getMonth.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getMonth.length  !== true) {
 }
 
 if (Date.prototype.getMonth.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getMonth.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getMonth.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getSeconds/S15.9.5.22_A1_T2.js
+++ b/test/built-ins/Date/prototype/getSeconds/S15.9.5.22_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getSeconds" has { DontEnum } attributes
 es5id: 15.9.5.22_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getSeconds  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getSeconds  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getSeconds')) {
-  $FAIL('#2: The Date.prototype.getSeconds property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getSeconds property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getSeconds/S15.9.5.22_A3_T2.js
+++ b/test/built-ins/Date/prototype/getSeconds/S15.9.5.22_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.22_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getSeconds.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getSeconds.length  !== true) {
 }
 
 if (Date.prototype.getSeconds.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getSeconds.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getSeconds.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getTime/S15.9.5.9_A1_T2.js
+++ b/test/built-ins/Date/prototype/getTime/S15.9.5.9_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getTime" has { DontEnum } attributes
 es5id: 15.9.5.9_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getTime  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getTime  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getTime')) {
-  $FAIL('#2: The Date.prototype.getTime property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getTime property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getTime/S15.9.5.9_A3_T2.js
+++ b/test/built-ins/Date/prototype/getTime/S15.9.5.9_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.9_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getTime.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getTime.length  !== true) {
 }
 
 if (Date.prototype.getTime.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getTime.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getTime.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getTimezoneOffset/S15.9.5.26_A1_T2.js
+++ b/test/built-ins/Date/prototype/getTimezoneOffset/S15.9.5.26_A1_T2.js
@@ -7,7 +7,6 @@ info: >
     attributes
 es5id: 15.9.5.26_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getTimezoneOffset  === false) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getTimezoneOffset  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getTimezoneOffset')) {
-  $FAIL('#2: The Date.prototype.getTimezoneOffset property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getTimezoneOffset property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getTimezoneOffset/S15.9.5.26_A3_T2.js
+++ b/test/built-ins/Date/prototype/getTimezoneOffset/S15.9.5.26_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.26_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getTimezoneOffset.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getTimezoneOffset.length  !== true) {
 }
 
 if (Date.prototype.getTimezoneOffset.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getTimezoneOffset.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getTimezoneOffset.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCDate/S15.9.5.15_A1_T2.js
+++ b/test/built-ins/Date/prototype/getUTCDate/S15.9.5.15_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getUTCDate" has { DontEnum } attributes
 es5id: 15.9.5.15_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCDate  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getUTCDate  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getUTCDate')) {
-  $FAIL('#2: The Date.prototype.getUTCDate property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCDate property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCDate/S15.9.5.15_A3_T2.js
+++ b/test/built-ins/Date/prototype/getUTCDate/S15.9.5.15_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.15_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCDate.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getUTCDate.length  !== true) {
 }
 
 if (Date.prototype.getUTCDate.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getUTCDate.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCDate.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCDay/S15.9.5.17_A1_T2.js
+++ b/test/built-ins/Date/prototype/getUTCDay/S15.9.5.17_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getUTCDay" has { DontEnum } attributes
 es5id: 15.9.5.17_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCDay  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getUTCDay  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getUTCDay')) {
-  $FAIL('#2: The Date.prototype.getUTCDay property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCDay property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCDay/S15.9.5.17_A3_T2.js
+++ b/test/built-ins/Date/prototype/getUTCDay/S15.9.5.17_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.17_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCDay.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getUTCDay.length  !== true) {
 }
 
 if (Date.prototype.getUTCDay.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getUTCDay.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCDay.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCFullYear/S15.9.5.11_A1_T2.js
+++ b/test/built-ins/Date/prototype/getUTCFullYear/S15.9.5.11_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getUTCFullYear" has { DontEnum } attributes
 es5id: 15.9.5.11_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCFullYear  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getUTCFullYear  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getUTCFullYear')) {
-  $FAIL('#2: The Date.prototype.getUTCFullYear property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCFullYear property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCFullYear/S15.9.5.11_A3_T2.js
+++ b/test/built-ins/Date/prototype/getUTCFullYear/S15.9.5.11_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.11_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCFullYear.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getUTCFullYear.length  !== true) {
 }
 
 if (Date.prototype.getUTCFullYear.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getUTCFullYear.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCFullYear.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCHours/S15.9.5.19_A1_T2.js
+++ b/test/built-ins/Date/prototype/getUTCHours/S15.9.5.19_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getUTCHours" has { DontEnum } attributes
 es5id: 15.9.5.19_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCHours  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getUTCHours  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getUTCHours')) {
-  $FAIL('#2: The Date.prototype.getUTCHours property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCHours property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCHours/S15.9.5.19_A3_T2.js
+++ b/test/built-ins/Date/prototype/getUTCHours/S15.9.5.19_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.19_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCHours.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getUTCHours.length  !== true) {
 }
 
 if (Date.prototype.getUTCHours.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getUTCHours.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCHours.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCMilliseconds/S15.9.5.25_A1_T2.js
+++ b/test/built-ins/Date/prototype/getUTCMilliseconds/S15.9.5.25_A1_T2.js
@@ -7,7 +7,6 @@ info: >
     attributes
 es5id: 15.9.5.25_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCMilliseconds  === false) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getUTCMilliseconds  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getUTCMilliseconds')) {
-  $FAIL('#2: The Date.prototype.getUTCMilliseconds property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCMilliseconds property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCMilliseconds/S15.9.5.25_A3_T2.js
+++ b/test/built-ins/Date/prototype/getUTCMilliseconds/S15.9.5.25_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.25_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCMilliseconds.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getUTCMilliseconds.length  !== true) {
 }
 
 if (Date.prototype.getUTCMilliseconds.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getUTCMilliseconds.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCMilliseconds.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCMinutes/S15.9.5.21_A1_T2.js
+++ b/test/built-ins/Date/prototype/getUTCMinutes/S15.9.5.21_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getUTCMinutes" has { DontEnum } attributes
 es5id: 15.9.5.21_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCMinutes  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getUTCMinutes  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getUTCMinutes')) {
-  $FAIL('#2: The Date.prototype.getUTCMinutes property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCMinutes property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCMinutes/S15.9.5.21_A3_T2.js
+++ b/test/built-ins/Date/prototype/getUTCMinutes/S15.9.5.21_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.21_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCMinutes.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getUTCMinutes.length  !== true) {
 }
 
 if (Date.prototype.getUTCMinutes.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getUTCMinutes.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCMinutes.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCMonth/S15.9.5.13_A1_T2.js
+++ b/test/built-ins/Date/prototype/getUTCMonth/S15.9.5.13_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getUTCMonth" has { DontEnum } attributes
 es5id: 15.9.5.13_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCMonth  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getUTCMonth  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getUTCMonth')) {
-  $FAIL('#2: The Date.prototype.getUTCMonth property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCMonth property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCMonth/S15.9.5.13_A3_T2.js
+++ b/test/built-ins/Date/prototype/getUTCMonth/S15.9.5.13_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.13_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCMonth.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getUTCMonth.length  !== true) {
 }
 
 if (Date.prototype.getUTCMonth.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getUTCMonth.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCMonth.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCSeconds/S15.9.5.23_A1_T2.js
+++ b/test/built-ins/Date/prototype/getUTCSeconds/S15.9.5.23_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "getUTCSeconds" has { DontEnum } attributes
 es5id: 15.9.5.23_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCSeconds  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.getUTCSeconds  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('getUTCSeconds')) {
-  $FAIL('#2: The Date.prototype.getUTCSeconds property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCSeconds property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/getUTCSeconds/S15.9.5.23_A3_T2.js
+++ b/test/built-ins/Date/prototype/getUTCSeconds/S15.9.5.23_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.23_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.getUTCSeconds.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.getUTCSeconds.length  !== true) {
 }
 
 if (Date.prototype.getUTCSeconds.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.getUTCSeconds.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.getUTCSeconds.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setDate/S15.9.5.36_A1_T2.js
+++ b/test/built-ins/Date/prototype/setDate/S15.9.5.36_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "setDate" has { DontEnum } attributes
 es5id: 15.9.5.36_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setDate  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.setDate  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setDate')) {
-  $FAIL('#2: The Date.prototype.setDate property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setDate property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setDate/S15.9.5.36_A3_T2.js
+++ b/test/built-ins/Date/prototype/setDate/S15.9.5.36_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.36_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setDate.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setDate.length  !== true) {
 }
 
 if (Date.prototype.setDate.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setDate.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setDate.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setFullYear/S15.9.5.40_A1_T2.js
+++ b/test/built-ins/Date/prototype/setFullYear/S15.9.5.40_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "setFullYear" has { DontEnum } attributes
 es5id: 15.9.5.40_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setFullYear  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.setFullYear  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setFullYear')) {
-  $FAIL('#2: The Date.prototype.setFullYear property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setFullYear property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setFullYear/S15.9.5.40_A3_T2.js
+++ b/test/built-ins/Date/prototype/setFullYear/S15.9.5.40_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.40_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setFullYear.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setFullYear.length  !== true) {
 }
 
 if (Date.prototype.setFullYear.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setFullYear.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setFullYear.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setHours/S15.9.5.34_A1_T2.js
+++ b/test/built-ins/Date/prototype/setHours/S15.9.5.34_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "setHours" has { DontEnum } attributes
 es5id: 15.9.5.34_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setHours  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.setHours  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setHours')) {
-  $FAIL('#2: The Date.prototype.setHours property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setHours property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setHours/S15.9.5.34_A3_T2.js
+++ b/test/built-ins/Date/prototype/setHours/S15.9.5.34_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.34_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setHours.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setHours.length  !== true) {
 }
 
 if (Date.prototype.setHours.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setHours.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setHours.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setMilliseconds/S15.9.5.28_A1_T2.js
+++ b/test/built-ins/Date/prototype/setMilliseconds/S15.9.5.28_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "setMilliseconds" has { DontEnum } attributes
 es5id: 15.9.5.28_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setMilliseconds  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.setMilliseconds  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setMilliseconds')) {
-  $FAIL('#2: The Date.prototype.setMilliseconds property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setMilliseconds property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setMilliseconds/S15.9.5.28_A3_T2.js
+++ b/test/built-ins/Date/prototype/setMilliseconds/S15.9.5.28_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.28_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setMilliseconds.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setMilliseconds.length  !== true) {
 }
 
 if (Date.prototype.setMilliseconds.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setMilliseconds.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setMilliseconds.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setMinutes/S15.9.5.32_A1_T2.js
+++ b/test/built-ins/Date/prototype/setMinutes/S15.9.5.32_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "setMinutes" has { DontEnum } attributes
 es5id: 15.9.5.32_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setMinutes  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.setMinutes  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setMinutes')) {
-  $FAIL('#2: The Date.prototype.setMinutes property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setMinutes property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setMinutes/S15.9.5.32_A3_T2.js
+++ b/test/built-ins/Date/prototype/setMinutes/S15.9.5.32_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.32_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setMinutes.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setMinutes.length  !== true) {
 }
 
 if (Date.prototype.setMinutes.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setMinutes.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setMinutes.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setMonth/S15.9.5.38_A1_T2.js
+++ b/test/built-ins/Date/prototype/setMonth/S15.9.5.38_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "setMonth" has { DontEnum } attributes
 es5id: 15.9.5.38_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setMonth  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.setMonth  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setMonth')) {
-  $FAIL('#2: The Date.prototype.setMonth property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setMonth property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setMonth/S15.9.5.38_A3_T2.js
+++ b/test/built-ins/Date/prototype/setMonth/S15.9.5.38_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.38_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setMonth.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setMonth.length  !== true) {
 }
 
 if (Date.prototype.setMonth.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setMonth.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setMonth.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setSeconds/S15.9.5.30_A1_T2.js
+++ b/test/built-ins/Date/prototype/setSeconds/S15.9.5.30_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "setSeconds" has { DontEnum } attributes
 es5id: 15.9.5.30_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setSeconds  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.setSeconds  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setSeconds')) {
-  $FAIL('#2: The Date.prototype.setSeconds property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setSeconds property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setSeconds/S15.9.5.30_A3_T2.js
+++ b/test/built-ins/Date/prototype/setSeconds/S15.9.5.30_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.30_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setSeconds.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setSeconds.length  !== true) {
 }
 
 if (Date.prototype.setSeconds.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setSeconds.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setSeconds.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setTime/S15.9.5.27_A1_T2.js
+++ b/test/built-ins/Date/prototype/setTime/S15.9.5.27_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "setTime" has { DontEnum } attributes
 es5id: 15.9.5.27_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setTime  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.setTime  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setTime')) {
-  $FAIL('#2: The Date.prototype.setTime property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setTime property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setTime/S15.9.5.27_A3_T2.js
+++ b/test/built-ins/Date/prototype/setTime/S15.9.5.27_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.27_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setTime.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setTime.length  !== true) {
 }
 
 if (Date.prototype.setTime.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setTime.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setTime.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setUTCDate/S15.9.5.37_A1_T2.js
+++ b/test/built-ins/Date/prototype/setUTCDate/S15.9.5.37_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "setUTCDate" has { DontEnum } attributes
 es5id: 15.9.5.37_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setUTCDate  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.setUTCDate  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setUTCDate')) {
-  $FAIL('#2: The Date.prototype.setUTCDate property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setUTCDate property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setUTCDate/S15.9.5.37_A3_T2.js
+++ b/test/built-ins/Date/prototype/setUTCDate/S15.9.5.37_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.37_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setUTCDate.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setUTCDate.length  !== true) {
 }
 
 if (Date.prototype.setUTCDate.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setUTCDate.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setUTCDate.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setUTCFullYear/S15.9.5.41_A1_T2.js
+++ b/test/built-ins/Date/prototype/setUTCFullYear/S15.9.5.41_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "setUTCFullYear" has { DontEnum } attributes
 es5id: 15.9.5.41_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setUTCFullYear  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.setUTCFullYear  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setUTCFullYear')) {
-  $FAIL('#2: The Date.prototype.setUTCFullYear property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setUTCFullYear property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setUTCFullYear/S15.9.5.41_A3_T2.js
+++ b/test/built-ins/Date/prototype/setUTCFullYear/S15.9.5.41_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.41_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setUTCFullYear.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setUTCFullYear.length  !== true) {
 }
 
 if (Date.prototype.setUTCFullYear.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setUTCFullYear.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setUTCFullYear.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setUTCHours/S15.9.5.35_A1_T2.js
+++ b/test/built-ins/Date/prototype/setUTCHours/S15.9.5.35_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "setUTCHours" has { DontEnum } attributes
 es5id: 15.9.5.35_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setUTCHours  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.setUTCHours  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setUTCHours')) {
-  $FAIL('#2: The Date.prototype.setUTCHours property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setUTCHours property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setUTCHours/S15.9.5.35_A3_T2.js
+++ b/test/built-ins/Date/prototype/setUTCHours/S15.9.5.35_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.35_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setUTCHours.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setUTCHours.length  !== true) {
 }
 
 if (Date.prototype.setUTCHours.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setUTCHours.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setUTCHours.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setUTCMilliseconds/S15.9.5.29_A1_T2.js
+++ b/test/built-ins/Date/prototype/setUTCMilliseconds/S15.9.5.29_A1_T2.js
@@ -7,7 +7,6 @@ info: >
     attributes
 es5id: 15.9.5.29_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setUTCMilliseconds  === false) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setUTCMilliseconds  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setUTCMilliseconds')) {
-  $FAIL('#2: The Date.prototype.setUTCMilliseconds property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setUTCMilliseconds property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setUTCMilliseconds/S15.9.5.29_A3_T2.js
+++ b/test/built-ins/Date/prototype/setUTCMilliseconds/S15.9.5.29_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.29_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setUTCMilliseconds.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setUTCMilliseconds.length  !== true) {
 }
 
 if (Date.prototype.setUTCMilliseconds.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setUTCMilliseconds.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setUTCMilliseconds.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setUTCMinutes/S15.9.5.33_A1_T2.js
+++ b/test/built-ins/Date/prototype/setUTCMinutes/S15.9.5.33_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "setUTCMinutes" has { DontEnum } attributes
 es5id: 15.9.5.33_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setUTCMinutes  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.setUTCMinutes  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setUTCMinutes')) {
-  $FAIL('#2: The Date.prototype.setUTCMinutes property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setUTCMinutes property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setUTCMinutes/S15.9.5.33_A3_T2.js
+++ b/test/built-ins/Date/prototype/setUTCMinutes/S15.9.5.33_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.33_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setUTCMinutes.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setUTCMinutes.length  !== true) {
 }
 
 if (Date.prototype.setUTCMinutes.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setUTCMinutes.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setUTCMinutes.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setUTCMonth/S15.9.5.39_A1_T2.js
+++ b/test/built-ins/Date/prototype/setUTCMonth/S15.9.5.39_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "setUTCMonth" has { DontEnum } attributes
 es5id: 15.9.5.39_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setUTCMonth  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.setUTCMonth  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setUTCMonth')) {
-  $FAIL('#2: The Date.prototype.setUTCMonth property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setUTCMonth property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setUTCMonth/S15.9.5.39_A3_T2.js
+++ b/test/built-ins/Date/prototype/setUTCMonth/S15.9.5.39_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.39_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setUTCMonth.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setUTCMonth.length  !== true) {
 }
 
 if (Date.prototype.setUTCMonth.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setUTCMonth.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setUTCMonth.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setUTCSeconds/S15.9.5.31_A1_T2.js
+++ b/test/built-ins/Date/prototype/setUTCSeconds/S15.9.5.31_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "setUTCSeconds" has { DontEnum } attributes
 es5id: 15.9.5.31_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setUTCSeconds  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.setUTCSeconds  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('setUTCSeconds')) {
-  $FAIL('#2: The Date.prototype.setUTCSeconds property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setUTCSeconds property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/setUTCSeconds/S15.9.5.31_A3_T2.js
+++ b/test/built-ins/Date/prototype/setUTCSeconds/S15.9.5.31_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.31_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.setUTCSeconds.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.setUTCSeconds.length  !== true) {
 }
 
 if (Date.prototype.setUTCSeconds.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.setUTCSeconds.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.setUTCSeconds.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/toDateString/S15.9.5.3_A1_T2.js
+++ b/test/built-ins/Date/prototype/toDateString/S15.9.5.3_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "toDateString" has { DontEnum } attributes
 es5id: 15.9.5.3_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.toDateString  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.toDateString  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('toDateString')) {
-  $FAIL('#2: The Date.prototype.toDateString property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.toDateString property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/toDateString/S15.9.5.3_A3_T2.js
+++ b/test/built-ins/Date/prototype/toDateString/S15.9.5.3_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.3_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.toDateString.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.toDateString.length  !== true) {
 }
 
 if (Date.prototype.toDateString.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.toDateString.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.toDateString.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/toLocaleDateString/S15.9.5.6_A1_T2.js
+++ b/test/built-ins/Date/prototype/toLocaleDateString/S15.9.5.6_A1_T2.js
@@ -7,7 +7,6 @@ info: >
     attributes
 es5id: 15.9.5.6_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.toLocaleDateString  === false) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.toLocaleDateString  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('toLocaleDateString')) {
-  $FAIL('#2: The Date.prototype.toLocaleDateString property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.toLocaleDateString property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/toLocaleDateString/S15.9.5.6_A3_T2.js
+++ b/test/built-ins/Date/prototype/toLocaleDateString/S15.9.5.6_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.6_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.toLocaleDateString.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.toLocaleDateString.length  !== true) {
 }
 
 if (Date.prototype.toLocaleDateString.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.toLocaleDateString.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.toLocaleDateString.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/toLocaleString/S15.9.5.5_A1_T2.js
+++ b/test/built-ins/Date/prototype/toLocaleString/S15.9.5.5_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "toLocaleString" has { DontEnum } attributes
 es5id: 15.9.5.5_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.toLocaleString  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.toLocaleString  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('toLocaleString')) {
-  $FAIL('#2: The Date.prototype.toLocaleString property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.toLocaleString property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/toLocaleString/S15.9.5.5_A3_T2.js
+++ b/test/built-ins/Date/prototype/toLocaleString/S15.9.5.5_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.5_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.toLocaleString.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.toLocaleString.length  !== true) {
 }
 
 if (Date.prototype.toLocaleString.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.toLocaleString.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.toLocaleString.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/toLocaleTimeString/S15.9.5.7_A1_T2.js
+++ b/test/built-ins/Date/prototype/toLocaleTimeString/S15.9.5.7_A1_T2.js
@@ -7,7 +7,6 @@ info: >
     attributes
 es5id: 15.9.5.7_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.toLocaleTimeString  === false) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.toLocaleTimeString  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('toLocaleTimeString')) {
-  $FAIL('#2: The Date.prototype.toLocaleTimeString property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.toLocaleTimeString property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/toLocaleTimeString/S15.9.5.7_A3_T2.js
+++ b/test/built-ins/Date/prototype/toLocaleTimeString/S15.9.5.7_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.7_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.toLocaleTimeString.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.toLocaleTimeString.length  !== true) {
 }
 
 if (Date.prototype.toLocaleTimeString.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.toLocaleTimeString.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.toLocaleTimeString.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/toString/S15.9.5.2_A1_T2.js
+++ b/test/built-ins/Date/prototype/toString/S15.9.5.2_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "toString" has { DontEnum } attributes
 es5id: 15.9.5.2_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.toString  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.toString  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('toString')) {
-  $FAIL('#2: The Date.prototype.toString property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.toString property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/toString/S15.9.5.2_A3_T2.js
+++ b/test/built-ins/Date/prototype/toString/S15.9.5.2_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.2_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.toString.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.toString.length  !== true) {
 }
 
 if (Date.prototype.toString.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.toString.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.toString.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/toTimeString/S15.9.5.4_A1_T2.js
+++ b/test/built-ins/Date/prototype/toTimeString/S15.9.5.4_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "toTimeString" has { DontEnum } attributes
 es5id: 15.9.5.4_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.toTimeString  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.toTimeString  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('toTimeString')) {
-  $FAIL('#2: The Date.prototype.toTimeString property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.toTimeString property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/toTimeString/S15.9.5.4_A3_T2.js
+++ b/test/built-ins/Date/prototype/toTimeString/S15.9.5.4_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.4_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.toTimeString.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.toTimeString.length  !== true) {
 }
 
 if (Date.prototype.toTimeString.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.toTimeString.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.toTimeString.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/toUTCString/S15.9.5.42_A1_T2.js
+++ b/test/built-ins/Date/prototype/toUTCString/S15.9.5.42_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "toUTCString" has { DontEnum } attributes
 es5id: 15.9.5.42_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.toUTCString  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.toUTCString  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('toUTCString')) {
-  $FAIL('#2: The Date.prototype.toUTCString property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.toUTCString property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/toUTCString/S15.9.5.42_A3_T2.js
+++ b/test/built-ins/Date/prototype/toUTCString/S15.9.5.42_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.42_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.toUTCString.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.toUTCString.length  !== true) {
 }
 
 if (Date.prototype.toUTCString.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.toUTCString.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.toUTCString.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/valueOf/S15.9.5.8_A1_T2.js
+++ b/test/built-ins/Date/prototype/valueOf/S15.9.5.8_A1_T2.js
@@ -5,7 +5,6 @@
 info: The Date.prototype property "valueOf" has { DontEnum } attributes
 es5id: 15.9.5.8_A1_T2
 description: Checking absence of DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.valueOf  === false) {
@@ -13,5 +12,5 @@ if (delete Date.prototype.valueOf  === false) {
 }
 
 if (Date.prototype.hasOwnProperty('valueOf')) {
-  $FAIL('#2: The Date.prototype.valueOf property has not the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.valueOf property has not the attributes DontDelete');
 }

--- a/test/built-ins/Date/prototype/valueOf/S15.9.5.8_A3_T2.js
+++ b/test/built-ins/Date/prototype/valueOf/S15.9.5.8_A3_T2.js
@@ -7,7 +7,6 @@ info: >
     DontDelete, DontEnum } attributes
 es5id: 15.9.5.8_A3_T2
 description: Checking DontDelete attribute
-includes: [$FAIL.js]
 ---*/
 
 if (delete Date.prototype.valueOf.length  !== true) {
@@ -15,5 +14,5 @@ if (delete Date.prototype.valueOf.length  !== true) {
 }
 
 if (Date.prototype.valueOf.hasOwnProperty('length')) {
-  $FAIL('#2: The Date.prototype.valueOf.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Date.prototype.valueOf.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Error/prototype/S15.11.4_A3.js
+++ b/test/built-ins/Error/prototype/S15.11.4_A3.js
@@ -6,7 +6,6 @@ info: Since Error prototype object is not function it has no [[Call]] method
 es5id: 15.11.4_A3
 description: Checking if call of Error prototype as a function fails
 includes:
-    - $FAIL.js
     - Test262Error.js
 ---*/
 
@@ -14,7 +13,7 @@ includes:
 //CHECK#1
 try {
 	Error.prototype();
-	$FAIL('#1: "Error.prototype()" lead to throwing exception');
+	$ERROR('#1: "Error.prototype()" lead to throwing exception');
 } catch (e) {
     if (e instanceof Test262Error) throw e;
 }

--- a/test/built-ins/Error/prototype/S15.11.4_A4.js
+++ b/test/built-ins/Error/prototype/S15.11.4_A4.js
@@ -6,7 +6,6 @@ info: Since Error prototype object is not function it has no [[Construct]] metho
 es5id: 15.11.4_A4
 description: Checking if creating "new Error.prototype" fails
 includes:
-    - $FAIL.js
     - Test262Error.js
 ---*/
 
@@ -14,7 +13,7 @@ includes:
 //CHECK#1
 try {
 	var __instance = new Error.prototype;
-	$FAIL('#1: "var __instance = new Error.prototype" lead to throwing exception');
+	$ERROR('#1: "var __instance = new Error.prototype" lead to throwing exception');
 } catch (e) {
     if (e instanceof Test262Error) throw e;
 }

--- a/test/built-ins/Function/S15.3.2.1_A1_T1.js
+++ b/test/built-ins/Function/S15.3.2.1_A1_T1.js
@@ -12,7 +12,6 @@ info: >
     v) Return Result(iv)
 es5id: 15.3.2.1_A1_T1
 description: "The body of the function is \"{toString:function(){throw 7;}}\""
-includes: [$FAIL.js]
 ---*/
 
 var body = {toString:function(){throw 7;}}
@@ -20,7 +19,7 @@ var body = {toString:function(){throw 7;}}
 //CHECK#1
 try {
   var f = new Function(body);
-  $FAIL('#1: When the Function constructor is called with one argument then body be that argument the following step are taken: call ToString(body)');
+  $ERROR('#1: When the Function constructor is called with one argument then body be that argument the following step are taken: call ToString(body)');
 } catch (e) {
   if (e !== 7) {
   	$ERROR('#1.1: When the Function constructor is called with one argument then body be that argument the following step are taken: call ToString(body)');

--- a/test/built-ins/Function/S15.3.2.1_A1_T10.js
+++ b/test/built-ins/Function/S15.3.2.1_A1_T10.js
@@ -12,14 +12,13 @@ info: >
     v) Return Result(iv)
 es5id: 15.3.2.1_A1_T10
 description: Value of the function constructor argument is "null"
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   var f = new Function(null);
 } catch (e) {
-  $FAIL('#1: test fails with error '+e);
+  $ERROR('#1: test fails with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A1_T11.js
+++ b/test/built-ins/Function/S15.3.2.1_A1_T11.js
@@ -12,14 +12,13 @@ info: >
     v) Return Result(iv)
 es5id: 15.3.2.1_A1_T11
 description: Value of the function constructor argument is "undefined"
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   var f = new Function(undefined);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A1_T12.js
+++ b/test/built-ins/Function/S15.3.2.1_A1_T12.js
@@ -12,14 +12,13 @@ info: >
     v) Return Result(iv)
 es5id: 15.3.2.1_A1_T12
 description: Value of the function constructor argument is "void 0"
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   var f = new Function(void 0);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A1_T13.js
+++ b/test/built-ins/Function/S15.3.2.1_A1_T13.js
@@ -12,13 +12,12 @@ info: >
     v) Return Result(iv)
 es5id: 15.3.2.1_A1_T13
 description: Value of the function constructor argument is "{}"
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   var f = new Function({});
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 } catch (e) {
   if (!(e instanceof SyntaxError)) {
   	$ERROR('#1.1: If body is not parsable as FunctionBody then throw a SyntaxError exception');

--- a/test/built-ins/Function/S15.3.2.1_A1_T2.js
+++ b/test/built-ins/Function/S15.3.2.1_A1_T2.js
@@ -14,7 +14,6 @@ es5id: 15.3.2.1_A1_T2
 description: >
     The body of the function is "{toString:function(){return "return
     1;";}}"
-includes: [$FAIL.js]
 ---*/
 
 var body={toString:function(){return "return 1;";}};
@@ -23,7 +22,7 @@ var body={toString:function(){return "return 1;";}};
 try {
   var f = new Function(body);	
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A1_T3.js
+++ b/test/built-ins/Function/S15.3.2.1_A1_T3.js
@@ -12,14 +12,13 @@ info: >
     v) Return Result(iv)
 es5id: 15.3.2.1_A1_T3
 description: Value of the function constructor argument is 1
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   var f = new Function(1);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A1_T4.js
+++ b/test/built-ins/Function/S15.3.2.1_A1_T4.js
@@ -14,14 +14,13 @@ es5id: 15.3.2.1_A1_T4
 description: >
     Value of the function constructor argument is x, where x is
     specified with "undefined"
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   var f = new Function(x);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A1_T5.js
+++ b/test/built-ins/Function/S15.3.2.1_A1_T5.js
@@ -14,7 +14,6 @@ es5id: 15.3.2.1_A1_T5
 description: >
     Value of the function constructor argument is "Object("return
     \'A\'")"
-includes: [$FAIL.js]
 ---*/
 
 var body = Object("return \'A\'");
@@ -23,7 +22,7 @@ var body = Object("return \'A\'");
 try {
   var f = new Function(body);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A1_T6.js
+++ b/test/built-ins/Function/S15.3.2.1_A1_T6.js
@@ -14,14 +14,13 @@ es5id: 15.3.2.1_A1_T6
 description: >
     Value of the function constructor argument is the string "return
     true;"
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   var f = new Function("return true;");
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A1_T7.js
+++ b/test/built-ins/Function/S15.3.2.1_A1_T7.js
@@ -12,7 +12,6 @@ info: >
     v) Return Result(iv)
 es5id: 15.3.2.1_A1_T7
 description: Value of the function constructor argument is "Object(1)"
-includes: [$FAIL.js]
 ---*/
 
 var body = new Object(1);
@@ -21,7 +20,7 @@ var body = new Object(1);
 try {
   var f = new Function(body);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A1_T8.js
+++ b/test/built-ins/Function/S15.3.2.1_A1_T8.js
@@ -12,7 +12,6 @@ info: >
     v) Return Result(iv)
 es5id: 15.3.2.1_A1_T8
 description: Value of the function constructor argument is "var 1=1;"
-includes: [$FAIL.js]
 ---*/
 
 var body = "var 1=1;";
@@ -20,7 +19,7 @@ var body = "var 1=1;";
 //CHECK#1
 try {
   var f = new Function(body);
-  $FAIL('#1: If body is not parsable as FunctionBody then throw a SyntaxError exception');
+  $ERROR('#1: If body is not parsable as FunctionBody then throw a SyntaxError exception');
 } catch (e) {
   if (!(e instanceof SyntaxError)) {
   	$ERROR('#1.1: If body is not parsable as FunctionBody then throw a SyntaxError exception');

--- a/test/built-ins/Function/S15.3.2.1_A2_T1.js
+++ b/test/built-ins/Function/S15.3.2.1_A2_T1.js
@@ -9,14 +9,13 @@ es5id: 15.3.2.1_A2_T1
 description: >
     Values of the function constructor arguments are "arg1", "arg2",
     "arg3", "return arg1+arg2+arg3;"
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   var f = Function("arg1", "arg2", "arg3", "return arg1+arg2+arg3;");
 } catch (e) {
-  $FAIL('#1: test failed');
+  $ERROR('#1: test failed');
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A2_T2.js
+++ b/test/built-ins/Function/S15.3.2.1_A2_T2.js
@@ -9,14 +9,13 @@ es5id: 15.3.2.1_A2_T2
 description: >
     Values of the function constructor arguments are "arg1, arg2",
     "arg3", "return arg1+arg2+arg3;"
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   var f = Function("arg1, arg2", "arg3", "return arg1+arg2+arg3;");
 } catch (e) {
-  $FAIL('#1: test failed');
+  $ERROR('#1: test failed');
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A2_T3.js
+++ b/test/built-ins/Function/S15.3.2.1_A2_T3.js
@@ -9,14 +9,13 @@ es5id: 15.3.2.1_A2_T3
 description: >
     Values of the function constructor arguments are "arg1, arg2,
     arg3", "return arg1+arg2+arg3;"
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   var f = Function("arg1, arg2, arg3", "return arg1+arg2+arg3;");
 } catch (e) {
-  $FAIL('#1: test failed');
+  $ERROR('#1: test failed');
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A2_T4.js
+++ b/test/built-ins/Function/S15.3.2.1_A2_T4.js
@@ -9,7 +9,6 @@ es5id: 15.3.2.1_A2_T4
 description: >
     Values of the function constructor arguments are "return"-s of
     various results
-includes: [$FAIL.js]
 ---*/
 
 var i=0;
@@ -20,7 +19,7 @@ var p={toString:function(){return "arg"+(++i);}};
 try {
   var f = Function(p, p, p, "return arg1+arg2+arg3;");
 } catch (e) {
-  $FAIL('#1: test failed');
+  $ERROR('#1: test failed');
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A2_T5.js
+++ b/test/built-ins/Function/S15.3.2.1_A2_T5.js
@@ -9,7 +9,6 @@ es5id: 15.3.2.1_A2_T5
 description: >
     Values of the function constructor arguments are "return"-s of
     various results and a concotenation of strings
-includes: [$FAIL.js]
 ---*/
 
 var i=0;
@@ -20,7 +19,7 @@ var p={toString:function(){return "arg"+(++i)}};
 try {
   var f = Function(p+","+p,p, "return arg1+arg2+arg3;");
 } catch (e) {
-  $FAIL('#1: test failed');
+  $ERROR('#1: test failed');
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A2_T6.js
+++ b/test/built-ins/Function/S15.3.2.1_A2_T6.js
@@ -9,7 +9,6 @@ es5id: 15.3.2.1_A2_T6
 description: >
     Values of the function constructor arguments are "return"-s of
     various results and a concotenation of strings
-includes: [$FAIL.js]
 ---*/
 
 var i=0;
@@ -20,7 +19,7 @@ var p={toString:function(){return "arg"+(++i)}};
 try {
   var f = Function(p+","+p+","+p, "return arg1+arg2+arg3;");
 } catch (e) {
-  $FAIL('#1: test failed');
+  $ERROR('#1: test failed');
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A3_T1.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T1.js
@@ -17,7 +17,6 @@ description: >
     Values of the function constructor arguments are
     "{toString:function(){throw 1;}}" and "{toString:function(){throw
     'body';}}"
-includes: [$FAIL.js]
 ---*/
 
 var p = {toString:function(){throw 1;}};
@@ -26,7 +25,7 @@ var body = {toString:function(){throw "body";}};
 //CHECK#1
 try {
   var f = new Function(p,body);
-  $FAIL('#1: test failed');
+  $ERROR('#1: test failed');
 } catch (e) {
   if (e !== 1) {
   	$ERROR('#1.1: i) Let Result(i) be the first argument; ii) Let P be ToString(Result(i))');

--- a/test/built-ins/Function/S15.3.2.1_A3_T10.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T10.js
@@ -16,7 +16,6 @@ es5id: 15.3.2.1_A3_T10
 description: >
     Values of the function constructor arguments are
     "{toString:function(){return "z;x"}}" and "return this;"
-includes: [$FAIL.js]
 ---*/
 
 var body = "return this;";
@@ -25,7 +24,7 @@ var p={toString:function(){return "z;x"}};
 //CHECK#1
 try {
   var f = new Function(p,body);
-  $FAIL('#1: If P is not parsable as a FormalParameterList_opt then throw a SyntaxError exception');
+  $ERROR('#1: If P is not parsable as a FormalParameterList_opt then throw a SyntaxError exception');
 } catch (e) {
   if (!(e instanceof SyntaxError)) {
   	$ERROR('#1.1: If P is not parsable as a FormalParameterList_opt then throw a SyntaxError exception');

--- a/test/built-ins/Function/S15.3.2.1_A3_T11.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T11.js
@@ -16,7 +16,6 @@ es5id: 15.3.2.1_A3_T11
 description: >
     Values of the function constructor arguments are "a,b,c" and "void
     0"
-includes: [$FAIL.js]
 ---*/
 
 var p = "a,b,c";
@@ -25,7 +24,7 @@ var p = "a,b,c";
 try {
   var f = new Function(p, void 0);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A3_T12.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T12.js
@@ -16,7 +16,6 @@ es5id: 15.3.2.1_A3_T12
 description: >
     Values of the function constructor arguments are "a,b,c" and
     "undefined"
-includes: [$FAIL.js]
 ---*/
 
 var p = "a,b,c";
@@ -25,7 +24,7 @@ var p = "a,b,c";
 try {
   var f = new Function(p, undefined);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A3_T13.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T13.js
@@ -14,7 +14,6 @@ info: >
     vii) Return Result(vi)
 es5id: 15.3.2.1_A3_T13
 description: Values of the function constructor arguments are "a,b,c" and "null"
-includes: [$FAIL.js]
 ---*/
 
 var p = "a,b,c";
@@ -23,7 +22,7 @@ var p = "a,b,c";
 try {
   var f = new Function(p, null);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A3_T14.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T14.js
@@ -16,7 +16,6 @@ es5id: 15.3.2.1_A3_T14
 description: >
     Values of the function constructor arguments are "a,b,c" and an
     undefined variable
-includes: [$FAIL.js]
 ---*/
 
 var p = "a,b,c";
@@ -25,7 +24,7 @@ var p = "a,b,c";
 try {
   var f = new Function(p, body);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A3_T15.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T15.js
@@ -16,14 +16,13 @@ es5id: 15.3.2.1_A3_T15
 description: >
     Values of the function constructor arguments are are two empty
     strings
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   var f = new Function("", "");
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A3_T2.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T2.js
@@ -16,7 +16,6 @@ es5id: 15.3.2.1_A3_T2
 description: >
     Values of the function constructor arguments are
     "{toString:function(){return 'a';}}" and "return a;"
-includes: [$FAIL.js]
 ---*/
 
 var p = {toString:function(){return "a";}};
@@ -26,7 +25,7 @@ var body = "return a;";
 try {
   var f = new Function(p,body);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A3_T3.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T3.js
@@ -17,7 +17,6 @@ description: >
     Values of the function constructor arguments are
     "{toString:function(){p=1;return "a";}}" and
     "{toString:function(){throw "body";}}"
-includes: [$FAIL.js]
 ---*/
 
 var p = {toString:function(){p=1;return "a";}};
@@ -26,7 +25,7 @@ var body = {toString:function(){throw "body";}};
 //CHECK#1
 try {
   var f = new Function(p,body);
-  $FAIL('#1: test failed');
+  $ERROR('#1: test failed');
 } catch (e) {
   if (e !== "body") {
   	$ERROR('#1.1: i) Let Result(i) be the first argument; ii) Let P be ToString(Result(i))');

--- a/test/built-ins/Function/S15.3.2.1_A3_T4.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T4.js
@@ -16,7 +16,6 @@ es5id: 15.3.2.1_A3_T4
 description: >
     Values of the function constructor arguments are an undefined
     variable and "return 1.1;"
-includes: [$FAIL.js]
 ---*/
 
 var body = "return 1.1;";
@@ -25,7 +24,7 @@ var body = "return 1.1;";
 try {
   var f = new Function(p,body);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A3_T5.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T5.js
@@ -16,7 +16,6 @@ es5id: 15.3.2.1_A3_T5
 description: >
     Values of the function constructor arguments are "void 0" and
     "return \"A\";"
-includes: [$FAIL.js]
 ---*/
 
 var body = "return \"A\";";
@@ -25,7 +24,7 @@ var body = "return \"A\";";
 try {
   var f = new Function(void 0,body);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A3_T6.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T6.js
@@ -16,7 +16,6 @@ es5id: 15.3.2.1_A3_T6
 description: >
     Values of the function constructor arguments are "null" and
     "return true;"
-includes: [$FAIL.js]
 ---*/
 
 var body = "return true;";
@@ -24,7 +23,7 @@ var body = "return true;";
 //CHECK#1
 try {
   var f = new Function(null,body);
-  $FAIL('#1: If P is not parsable as a FormalParameterList_opt then throw a SyntaxError exception');
+  $ERROR('#1: If P is not parsable as a FormalParameterList_opt then throw a SyntaxError exception');
 } catch (e) {
   if (!(e instanceof SyntaxError)) {
   	$ERROR('#1.1: If P is not parsable as a FormalParameterList_opt then throw a SyntaxError exception');

--- a/test/built-ins/Function/S15.3.2.1_A3_T7.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T7.js
@@ -16,7 +16,6 @@ es5id: 15.3.2.1_A3_T7
 description: >
     Values of the function constructor arguments are "Object("a")" and
     "return a;"
-includes: [$FAIL.js]
 ---*/
 
 var body = "return a;";
@@ -27,7 +26,7 @@ var p=Object("a");
 try {
   var f = new Function(p, body);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A3_T8.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T8.js
@@ -16,7 +16,6 @@ es5id: 15.3.2.1_A3_T8
 description: >
     Values of the function constructor arguments are "undefined" and
     "return this;"
-includes: [$FAIL.js]
 ---*/
 
 var body = "return this;";
@@ -25,7 +24,7 @@ var body = "return this;";
 try {
   var f = new Function(undefined,body);
 } catch (e) {
-  $FAIL('#1: test failed with error '+e);
+  $ERROR('#1: test failed with error '+e);
 }
 
 //CHECK#2

--- a/test/built-ins/Function/S15.3.2.1_A3_T9.js
+++ b/test/built-ins/Function/S15.3.2.1_A3_T9.js
@@ -16,7 +16,6 @@ es5id: 15.3.2.1_A3_T9
 description: >
     Values of the function constructor arguments are "1,1" and "return
     this;"
-includes: [$FAIL.js]
 ---*/
 
 var body = "return this;";
@@ -25,7 +24,7 @@ var p="1,1";
 //CHECK#1
 try {
   var f = new Function(p,body);
-  $FAIL('#1: If P is not parsable as a FormalParameterList_opt then throw a SyntaxError exception');
+  $ERROR('#1: If P is not parsable as a FormalParameterList_opt then throw a SyntaxError exception');
 } catch (e) {
   if (!(e instanceof SyntaxError)) {
   	$ERROR('#1.1: If P is not parsable as a FormalParameterList_opt then throw a SyntaxError exception');

--- a/test/built-ins/Function/length/S15.3.5.1_A1_T1.js
+++ b/test/built-ins/Function/length/S15.3.5.1_A1_T1.js
@@ -7,14 +7,13 @@ info: >
     'typical' number of arguments expected by the function
 es5id: 15.3.5.1_A1_T1
 description: Checking length property of Function("arg1,arg2,arg3", null)
-includes: [$FAIL.js]
 ---*/
 
 var f = new Function("arg1,arg2,arg3", null);
 
 //CHECK#1
 if (!(f.hasOwnProperty('length'))) {
-  $FAIL('#1: the function has length property.');
+  $ERROR('#1: the function has length property.');
 }
 
 //CHECK#2

--- a/test/built-ins/Function/length/S15.3.5.1_A1_T2.js
+++ b/test/built-ins/Function/length/S15.3.5.1_A1_T2.js
@@ -9,14 +9,13 @@ es5id: 15.3.5.1_A1_T2
 description: >
     Checking length property of Function("arg1,arg2,arg3","arg4,arg5",
     null)
-includes: [$FAIL.js]
 ---*/
 
 var f = Function("arg1,arg2,arg3","arg4,arg5", null);
 
 //CHECK#1
 if (!(f.hasOwnProperty('length'))) {
-  $FAIL('#1: the function has length property.');
+  $ERROR('#1: the function has length property.');
 }
 
 //CHECK#2

--- a/test/built-ins/Function/length/S15.3.5.1_A1_T3.js
+++ b/test/built-ins/Function/length/S15.3.5.1_A1_T3.js
@@ -9,14 +9,13 @@ es5id: 15.3.5.1_A1_T3
 description: >
     Checking length property of
     Function("arg1,arg2,arg3","arg1,arg2","arg3", null)
-includes: [$FAIL.js]
 ---*/
 
 var f = new Function("arg1,arg2,arg3","arg1,arg2","arg3", null);
 
 //CHECK#1
 if (!(f.hasOwnProperty('length'))) {
-  $FAIL('#1: the function has length property.');
+  $ERROR('#1: the function has length property.');
 }
 
 //CHECK#2

--- a/test/built-ins/Function/length/S15.3.5.1_A2_T1.js
+++ b/test/built-ins/Function/length/S15.3.5.1_A2_T1.js
@@ -7,14 +7,13 @@ es5id: 15.3.5.1_A2_T1
 description: >
     Checking if deleting the length property of
     Function("arg1,arg2,arg3", null) succeeds
-includes: [$FAIL.js]
 ---*/
 
 var f = new Function("arg1,arg2,arg3", null);
 
 //CHECK#1
 if (!(f.hasOwnProperty('length'))) {
-  $FAIL('#1: the function has length property.');
+  $ERROR('#1: the function has length property.');
 }
 
 //CHECK#2

--- a/test/built-ins/Function/length/S15.3.5.1_A2_T2.js
+++ b/test/built-ins/Function/length/S15.3.5.1_A2_T2.js
@@ -7,14 +7,13 @@ es5id: 15.3.5.1_A2_T2
 description: >
     Checking if deleting the length property of
     Function("arg1,arg2,arg3","arg4,arg5", null) succeeds
-includes: [$FAIL.js]
 ---*/
 
 var f =  Function("arg1,arg2,arg3","arg4,arg5", null);
 
 //CHECK#1
 if (!(f.hasOwnProperty('length'))) {
-  $FAIL('#1: the function has length property.');
+  $ERROR('#1: the function has length property.');
 }
 
 delete f.length;

--- a/test/built-ins/Function/length/S15.3.5.1_A2_T3.js
+++ b/test/built-ins/Function/length/S15.3.5.1_A2_T3.js
@@ -7,14 +7,13 @@ es5id: 15.3.5.1_A2_T3
 description: >
     Checking if deleting the length property of
     Function("arg1,arg2,arg3","arg1,arg2","arg3", null) succeeds
-includes: [$FAIL.js]
 ---*/
 
 var f = new Function("arg1,arg2,arg3","arg1,arg2","arg3", null);
 
 //CHECK#1
 if (!(f.hasOwnProperty('length'))) {
-  $FAIL('#1: the function has length property.');
+  $ERROR('#1: the function has length property.');
 }
 
 delete f.length;

--- a/test/built-ins/Function/length/S15.3.5.1_A3_T1.js
+++ b/test/built-ins/Function/length/S15.3.5.1_A3_T1.js
@@ -7,14 +7,14 @@ es5id: 15.3.5.1_A3_T1
 description: >
     Checking if varying the length property of
     Function("arg1,arg2,arg3","arg4,arg5", null) fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 var f = new Function("arg1,arg2,arg3","arg4,arg5", null);
 
 //CHECK#1
 if (!(f.hasOwnProperty('length'))) {
-  $FAIL('#1: the function has length property.');
+  $ERROR('#1: the function has length property.');
 }
 
 var flength = f.length;

--- a/test/built-ins/Function/length/S15.3.5.1_A3_T2.js
+++ b/test/built-ins/Function/length/S15.3.5.1_A3_T2.js
@@ -7,14 +7,14 @@ es5id: 15.3.5.1_A3_T2
 description: >
     Checking if varying the length property of
     Function("arg1,arg2,arg3", null) fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 var f =  Function("arg1,arg2,arg3", null);
 
 //CHECK#1
 if (!(f.hasOwnProperty('length'))) {
-  $FAIL('#1: the function has length property.');
+  $ERROR('#1: the function has length property.');
 }
 
 var flength = f.length;

--- a/test/built-ins/Function/length/S15.3.5.1_A3_T3.js
+++ b/test/built-ins/Function/length/S15.3.5.1_A3_T3.js
@@ -7,14 +7,14 @@ es5id: 15.3.5.1_A3_T3
 description: >
     Checking if varying the length property of
     Function("arg1,arg2,arg3","arg1,arg2","arg3", null) fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 var f = new Function("arg1,arg2,arg3","arg1,arg2","arg3", null);
 
 //CHECK#1
 if (!(f.hasOwnProperty('length'))) {
-  $FAIL('#1: the function has length property.');
+  $ERROR('#1: the function has length property.');
 }
 
 var flength = f.length;

--- a/test/built-ins/Function/length/S15.3.5.1_A4_T1.js
+++ b/test/built-ins/Function/length/S15.3.5.1_A4_T1.js
@@ -7,14 +7,13 @@ es5id: 15.3.5.1_A4_T1
 description: >
     Checking if enumerating the length property of
     Function("arg1,arg2,arg3", null) fails
-includes: [$FAIL.js]
 ---*/
 
 var f = new Function("arg1,arg2,arg3", null);
 
 //CHECK#1
 if (!(f.hasOwnProperty('length'))) {
-  $FAIL('#1: the function has length property.');
+  $ERROR('#1: the function has length property.');
 }
 
 for(var key in f)

--- a/test/built-ins/Function/length/S15.3.5.1_A4_T2.js
+++ b/test/built-ins/Function/length/S15.3.5.1_A4_T2.js
@@ -7,14 +7,13 @@ es5id: 15.3.5.1_A4_T2
 description: >
     Checking if enumerating the length property of
     Function("arg1,arg2,arg3","arg4,arg5", null) fails
-includes: [$FAIL.js]
 ---*/
 
 var f =  Function("arg1,arg2,arg3","arg5,arg4", null);
 
 //CHECK#1
 if (!(f.hasOwnProperty('length'))) {
-  $FAIL('#1: the function has length property.');
+  $ERROR('#1: the function has length property.');
 }
 
 for(var key in f)

--- a/test/built-ins/Function/length/S15.3.5.1_A4_T3.js
+++ b/test/built-ins/Function/length/S15.3.5.1_A4_T3.js
@@ -7,14 +7,13 @@ es5id: 15.3.5.1_A4_T3
 description: >
     Checking if enumerating the length property of
     Function("arg1,arg2,arg3","arg1,arg2","arg3", null) fails
-includes: [$FAIL.js]
 ---*/
 
 var f = new Function("arg1,arg2,arg3","arg1,arg2","arg3", null);
 
 //CHECK#1
 if (!(f.hasOwnProperty('length'))) {
-  $FAIL('#1: the function has length property.');
+  $ERROR('#1: the function has length property.');
 }
 
 for(var key in f)

--- a/test/built-ins/Function/prototype/S15.3.4_A5.js
+++ b/test/built-ins/Function/prototype/S15.3.4_A5.js
@@ -9,13 +9,12 @@ es5id: 15.3.4_A5
 description: Checking if creating "new Function.prototype object" fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 //CHECK#
 try {
   var obj = new Function.prototype;
-  $FAIL('#1: The Function prototype object is itself a Function object without [[Construct]] property: '+e);
+  $ERROR('#1: The Function prototype object is itself a Function object without [[Construct]] property: '+e);
 } catch (e) {
   $PRINT("#1.1: The Function prototype object is itself a Function object without [[Construct]] property "+e);
 

--- a/test/built-ins/Function/prototype/S15.3.5.2_A1_T1.js
+++ b/test/built-ins/Function/prototype/S15.3.5.2_A1_T1.js
@@ -7,14 +7,14 @@ es5id: 15.3.5.2_A1_T1
 description: >
     Checking if deleting the prototype property of Function("", null)
     fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 var f = new Function("", null);
 
 //CHECK#1
 if (!(f.hasOwnProperty('prototype'))) {
-  $FAIL('#1: the function has length property.');
+  $ERROR('#1: the function has length property.');
 }
 
 var fproto = f.prototype;

--- a/test/built-ins/Function/prototype/S15.3.5.2_A1_T2.js
+++ b/test/built-ins/Function/prototype/S15.3.5.2_A1_T2.js
@@ -7,14 +7,14 @@ es5id: 15.3.5.2_A1_T2
 description: >
     Checking if deleting the prototype property of Function(void 0,
     "") fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 var f = Function(void 0, "");
 
 //CHECK#1
 if (!(f.hasOwnProperty('prototype'))) {
-  $FAIL('#1: the function has length property.');
+  $ERROR('#1: the function has length property.');
 }
 
 var fproto = f.prototype;

--- a/test/built-ins/Function/prototype/apply/S15.3.4.3_A10.js
+++ b/test/built-ins/Function/prototype/apply/S15.3.4.3_A10.js
@@ -7,12 +7,12 @@ es5id: 15.3.4.3_A10
 description: >
     Checking if varying the Function.prototype.apply.length property
     fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#1
 if (!(Function.prototype.apply.hasOwnProperty('length'))) {
-  $FAIL('#1: the Function.prototype.apply has length property.');
+  $ERROR('#1: the Function.prototype.apply has length property.');
 }
 
 var obj = Function.prototype.apply.length;

--- a/test/built-ins/Function/prototype/apply/S15.3.4.3_A11.js
+++ b/test/built-ins/Function/prototype/apply/S15.3.4.3_A11.js
@@ -7,12 +7,11 @@ es5id: 15.3.4.3_A11
 description: >
     TChecking if enumerating the Function.prototype.apply.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Function.prototype.apply.hasOwnProperty('length'))) {
-  $FAIL('#0: the Function.prototype.apply has length property.');
+  $ERROR('#0: the Function.prototype.apply has length property.');
 }
 
 

--- a/test/built-ins/Function/prototype/apply/S15.3.4.3_A16.js
+++ b/test/built-ins/Function/prototype/apply/S15.3.4.3_A16.js
@@ -8,7 +8,6 @@ description: >
     A RegExp is not a function, but it may be callable. Iff it is,
     it's typeof should be 'function', in which case apply should
     accept it as a valid this value.
-includes: [$FAIL.js]
 ---*/
 
 var re = (/x/);
@@ -17,7 +16,7 @@ if (typeof re === 'function') {
 } else {
   try {
     Function.prototype.bind.call(re, undefined);
-    $FAIL('#1: If IsCallable(func) is false, ' +
+    $ERROR('#1: If IsCallable(func) is false, ' +
           'then (bind should) throw a TypeError exception');
   } catch (e) {
     if (!(e instanceof TypeError)) {

--- a/test/built-ins/Function/prototype/apply/S15.3.4.3_A1_T1.js
+++ b/test/built-ins/Function/prototype/apply/S15.3.4.3_A1_T1.js
@@ -10,7 +10,6 @@ es5id: 15.3.4.3_A1_T1
 description: >
     Calling "apply" method of the object that does not have a [[Call]]
     property.  Prototype of the object is Function()
-includes: [$FAIL.js]
 ---*/
 
 var proto=Function();
@@ -29,7 +28,7 @@ if (typeof obj.apply !== "function") {
 //CHECK#2
 try {
   obj.apply();
-  $FAIL('#2: If the object does not have a [[Call]] property, a TypeError exception is thrown');
+  $ERROR('#2: If the object does not have a [[Call]] property, a TypeError exception is thrown');
 } catch (e) {
   if (!(e instanceof TypeError)) {
   	$ERROR('#2.1: If the object does not have a [[Call]] property, a TypeError exception is thrown');

--- a/test/built-ins/Function/prototype/apply/S15.3.4.3_A1_T2.js
+++ b/test/built-ins/Function/prototype/apply/S15.3.4.3_A1_T2.js
@@ -10,7 +10,6 @@ es5id: 15.3.4.3_A1_T2
 description: >
     Calling "apply" method of the object that does not have a [[Call]]
     property.  Prototype of the object is Function.prototype
-includes: [$FAIL.js]
 ---*/
 
 function FACTORY(){};
@@ -27,7 +26,7 @@ if (typeof obj.apply !== "function") {
 //CHECK#2
 try {
   obj.apply();
-  $FAIL('#2: If the object does not have a [[Call]] property, a TypeError exception is thrown');
+  $ERROR('#2: If the object does not have a [[Call]] property, a TypeError exception is thrown');
 } catch (e) {
   if (!(e instanceof TypeError)) {
   	$ERROR('#2.1: If the object does not have a [[Call]] property, a TypeError exception is thrown');

--- a/test/built-ins/Function/prototype/apply/S15.3.4.3_A6_T2.js
+++ b/test/built-ins/Function/prototype/apply/S15.3.4.3_A6_T2.js
@@ -7,13 +7,12 @@ info: >
     TypeError exception is thrown
 es5id: 15.3.4.3_A6_T2
 description: argArray is (null,1)
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Function().apply(null,1);
-  $FAIL('#1: if argArray is neither an array nor an arguments object (see 10.1.8), a TypeError exception is thrown');
+  $ERROR('#1: if argArray is neither an array nor an arguments object (see 10.1.8), a TypeError exception is thrown');
 } catch (e) {
   if (!(e instanceof TypeError)) {
   	$ERROR('#1.1: if argArray is neither an array nor an arguments object (see 10.1.8), a TypeError exception is thrown');

--- a/test/built-ins/Function/prototype/apply/S15.3.4.3_A6_T3.js
+++ b/test/built-ins/Function/prototype/apply/S15.3.4.3_A6_T3.js
@@ -7,7 +7,6 @@ info: >
     TypeError exception is thrown
 es5id: 15.3.4.3_A6_T3
 description: argArray is (object,"1,3,4")
-includes: [$FAIL.js]
 ---*/
 
 var obj={};
@@ -15,7 +14,7 @@ var obj={};
 //CHECK#1
 try {
   Function().apply(obj,"1,3,4");
-  $FAIL('#1: if argArray is neither an array nor an arguments object (see 10.1.8), a TypeError exception is thrown');
+  $ERROR('#1: if argArray is neither an array nor an arguments object (see 10.1.8), a TypeError exception is thrown');
 } catch (e) {
   if (!(e instanceof TypeError)) {
   	$ERROR('#1.1: if argArray is neither an array nor an arguments object (see 10.1.8), a TypeError exception is thrown');

--- a/test/built-ins/Function/prototype/apply/S15.3.4.3_A9.js
+++ b/test/built-ins/Function/prototype/apply/S15.3.4.3_A9.js
@@ -9,12 +9,11 @@ es5id: 15.3.4.3_A9
 description: >
     Checking if deleting the Function.prototype.apply.length property
     fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Function.prototype.apply.hasOwnProperty('length'))) {
-  $FAIL('#0: the Function.prototype.apply has length property');
+  $ERROR('#0: the Function.prototype.apply has length property');
 }
 
 //CHECK#1
@@ -24,5 +23,5 @@ if (!delete Function.prototype.apply.length) {
 
 //CHECK#2
 if (Function.prototype.apply.hasOwnProperty('length')) {
-  $FAIL('#2: The Function.prototype.apply.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Function.prototype.apply.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Function/prototype/bind/S15.3.4.5_A16.js
+++ b/test/built-ins/Function/prototype/bind/S15.3.4.5_A16.js
@@ -8,7 +8,6 @@ description: >
     A RegExp is not a function, but it may be callable. Iff it is,
     it's typeof should be 'function', in which case bind should accept
     it as a valid this value.
-includes: [$FAIL.js]
 ---*/
 
 var re = (/x/);
@@ -17,7 +16,7 @@ if (typeof re === 'function') {
 } else {
   try {
     Function.prototype.bind.call(re, undefined);
-    $FAIL('#1: If IsCallable(func) is false, ' +
+    $ERROR('#1: If IsCallable(func) is false, ' +
           'then (bind should) throw a TypeError exception');
   } catch (e) {
     if (!(e instanceof TypeError)) {

--- a/test/built-ins/Function/prototype/call/S15.3.4.4_A10.js
+++ b/test/built-ins/Function/prototype/call/S15.3.4.4_A10.js
@@ -7,12 +7,12 @@ es5id: 15.3.4.4_A10
 description: >
     Checking if varying the Function.prototype.call.length property
     fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#1
 if (!(Function.prototype.call.hasOwnProperty('length'))) {
-  $FAIL('#1: the Function.prototype.call has length property.');
+  $ERROR('#1: the Function.prototype.call has length property.');
 }
 
 var obj = Function.prototype.call.length;

--- a/test/built-ins/Function/prototype/call/S15.3.4.4_A11.js
+++ b/test/built-ins/Function/prototype/call/S15.3.4.4_A11.js
@@ -7,12 +7,11 @@ es5id: 15.3.4.4_A11
 description: >
     Checking if enumerating the Function.prototype.call.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Function.prototype.call.hasOwnProperty('length'))) {
-  $FAIL('#0: the Function.prototype.call has length property.');
+  $ERROR('#0: the Function.prototype.call has length property.');
 }
 
 

--- a/test/built-ins/Function/prototype/call/S15.3.4.4_A16.js
+++ b/test/built-ins/Function/prototype/call/S15.3.4.4_A16.js
@@ -8,7 +8,6 @@ description: >
     A RegExp is not a function, but it may be callable. Iff it is,
     it's typeof should be 'function', in which case call should accept
     it as a valid this value.
-includes: [$FAIL.js]
 ---*/
 
 var re = (/x/);
@@ -17,7 +16,7 @@ if (typeof re === 'function') {
 } else {
   try {
     Function.prototype.bind.call(re, undefined);
-    $FAIL('#1: If IsCallable(func) is false, ' +
+    $ERROR('#1: If IsCallable(func) is false, ' +
           'then (bind should) throw a TypeError exception');
   } catch (e) {
     if (!(e instanceof TypeError)) {

--- a/test/built-ins/Function/prototype/call/S15.3.4.4_A1_T1.js
+++ b/test/built-ins/Function/prototype/call/S15.3.4.4_A1_T1.js
@@ -10,7 +10,6 @@ es5id: 15.3.4.4_A1_T1
 description: >
     Call "call" method of the object that does not have a [[Call]]
     property.  Prototype of the object is Function()
-includes: [$FAIL.js]
 ---*/
 
 var proto=Function();
@@ -29,7 +28,7 @@ if (typeof obj.call !== "function") {
 //CHECK#2
 try {
   obj.call();
-  $FAIL('#2: If the object does not have a [[Call]] property, a TypeError exception is thrown');
+  $ERROR('#2: If the object does not have a [[Call]] property, a TypeError exception is thrown');
 } catch (e) {
   if (!(e instanceof TypeError)) {
   	$ERROR('#2.1: If the object does not have a [[Call]] property, a TypeError exception is thrown');

--- a/test/built-ins/Function/prototype/call/S15.3.4.4_A1_T2.js
+++ b/test/built-ins/Function/prototype/call/S15.3.4.4_A1_T2.js
@@ -10,7 +10,6 @@ es5id: 15.3.4.4_A1_T2
 description: >
     Calling "call" method of the object that does not have a [[Call]]
     property.  Prototype of the object is Function.prototype
-includes: [$FAIL.js]
 ---*/
 
 function FACTORY(){};
@@ -27,7 +26,7 @@ if (typeof obj.call !== "function") {
 //CHECK#2
 try {
   obj.call();
-  $FAIL('#2: If the object does not have a [[Call]] property, a TypeError exception is thrown');
+  $ERROR('#2: If the object does not have a [[Call]] property, a TypeError exception is thrown');
 } catch (e) {
   if (!(e instanceof TypeError)) {
   	$ERROR('#2.1: If the object does not have a [[Call]] property, a TypeError exception is thrown');

--- a/test/built-ins/Function/prototype/call/S15.3.4.4_A9.js
+++ b/test/built-ins/Function/prototype/call/S15.3.4.4_A9.js
@@ -9,12 +9,11 @@ es5id: 15.3.4.4_A9
 description: >
     Checking if deleting the Function.prototype.call.length property
     fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Function.prototype.call.hasOwnProperty('length'))) {
-  $FAIL('#0: the Function.prototype.call has length property');
+  $ERROR('#0: the Function.prototype.call has length property');
 }
 
 //CHECK#1
@@ -24,5 +23,5 @@ if (!delete Function.prototype.call.length) {
 
 //CHECK#2
 if (Function.prototype.call.hasOwnProperty('length')) {
-  $FAIL('#2: The Function.prototype.call.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Function.prototype.call.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Function/prototype/toString/S15.3.4.2_A10.js
+++ b/test/built-ins/Function/prototype/toString/S15.3.4.2_A10.js
@@ -7,12 +7,12 @@ es5id: 15.3.4.2_A10
 description: >
     Checking if varying the Function.prototype.toString.length
     property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#1
 if (!(Function.prototype.toString.hasOwnProperty('length'))) {
-  $FAIL('#1: the Function.prototype.toString has length property.');
+  $ERROR('#1: the Function.prototype.toString has length property.');
 }
 
 var obj = Function.prototype.toString.length;

--- a/test/built-ins/Function/prototype/toString/S15.3.4.2_A7.js
+++ b/test/built-ins/Function/prototype/toString/S15.3.4.2_A7.js
@@ -7,14 +7,13 @@ es5id: 15.3.4.2_A7
 description: Checking if creating "new Function.prototype.toString" fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 var FACTORY = Function.prototype.toString;
 
 try {
   var instance = new FACTORY;
-  $FAIL('#1: Function.prototype.toString can\'t be used as constructor');
+  $ERROR('#1: Function.prototype.toString can\'t be used as constructor');
 } catch (e) {
   $PRINT(e);
 }

--- a/test/built-ins/Function/prototype/toString/S15.3.4.2_A8.js
+++ b/test/built-ins/Function/prototype/toString/S15.3.4.2_A8.js
@@ -7,12 +7,11 @@ es5id: 15.3.4.2_A8
 description: >
     Checking if enumerating the Function.prototype.toString.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Function.prototype.toString.hasOwnProperty('length'))) {
-  $FAIL('#0: the Function.prototype.toString has length property.');
+  $ERROR('#0: the Function.prototype.toString has length property.');
 }
 
 

--- a/test/built-ins/Function/prototype/toString/S15.3.4.2_A9.js
+++ b/test/built-ins/Function/prototype/toString/S15.3.4.2_A9.js
@@ -9,12 +9,11 @@ es5id: 15.3.4.2_A9
 description: >
     Checking if deleting the Function.prototype.toString.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Function.prototype.toString.hasOwnProperty('length'))) {
-  $FAIL('#0: the Function.prototype.toString has length property');
+  $ERROR('#0: the Function.prototype.toString has length property');
 }
 
 //CHECK#1
@@ -24,5 +23,5 @@ if (!delete Function.prototype.toString.length) {
 
 //CHECK#2
 if (Function.prototype.toString.hasOwnProperty('length')) {
-  $FAIL('#2: The Function.prototype.toString.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Function.prototype.toString.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/JSON/parse/S15.12.2_A1.js
+++ b/test/built-ins/JSON/parse/S15.12.2_A1.js
@@ -5,13 +5,12 @@
 info: JSON.parse must create a property with the given property name
 es5id: 15.12.2_A1
 description: Tests that JSON.parse treats "__proto__" as a regular property name
-includes: [$FAIL.js]
 ---*/
 
 var x = JSON.parse('{"__proto__":[]}');
 if (Object.getPrototypeOf(x) !== Object.prototype) {
-  $FAIL('#1: JSON.parse confused by "__proto__"');
+  $ERROR('#1: JSON.parse confused by "__proto__"');
 }
 if (!Array.isArray(x.__proto__)) {
-  $FAIL('#2: JSON.parse did not set "__proto__" as a regular property');
+  $ERROR('#2: JSON.parse did not set "__proto__" as a regular property');
 }

--- a/test/built-ins/Math/atan2/S15.8.2.5_A11.js
+++ b/test/built-ins/Math/atan2/S15.8.2.5_A11.js
@@ -8,7 +8,6 @@ info: >
 es5id: 15.8.2.5_A11
 description: Checking if Math.atan2(-0,x) is an approximation to -PI, where x<0
 includes:
-    - $FAIL.js
     - math_precision.js
     - math_isequal.js
 ---*/
@@ -25,5 +24,5 @@ var xnum = 3;
 for (var i = 0; i < xnum; i++)
 {
 	if (!isEqual(Math.atan2(y,x[i]), - Math.PI))
-		$FAIL("#1: Math.abs(Math.atan2(" + y + ", " + x[i] + ") + Math.PI) >= " + prec);
+		$ERROR("#1: Math.abs(Math.atan2(" + y + ", " + x[i] + ") + Math.PI) >= " + prec);
 }

--- a/test/built-ins/Math/atan2/S15.8.2.5_A12.js
+++ b/test/built-ins/Math/atan2/S15.8.2.5_A12.js
@@ -10,7 +10,6 @@ description: >
     Checking if Math.atan2(y,+0) is an approximation to -PI/2, where
     y<0
 includes:
-    - $FAIL.js
     - math_precision.js
     - math_isequal.js
 ---*/
@@ -27,5 +26,5 @@ var ynum = 3;
 for (var i = 0; i < ynum; i++)
 {
 	if (!isEqual(Math.atan2(y[i],x), -(Math.PI)/2))
-		$FAIL("#1: Math.abs(Math.atan2(" + y[i] + ", " + x + ") + ((Math.PI)/2)) >= " + prec);
+		$ERROR("#1: Math.abs(Math.atan2(" + y[i] + ", " + x + ") + ((Math.PI)/2)) >= " + prec);
 }

--- a/test/built-ins/Math/atan2/S15.8.2.5_A13.js
+++ b/test/built-ins/Math/atan2/S15.8.2.5_A13.js
@@ -10,7 +10,6 @@ description: >
     Checking if Math.atan2(y,-0) is an approximation to -PI/2, where
     y<0
 includes:
-    - $FAIL.js
     - math_precision.js
     - math_isequal.js
 ---*/
@@ -27,5 +26,5 @@ var ynum = 3;
 for (var i = 0; i < ynum; i++)
 {
 	if (!isEqual(Math.atan2(y[i],x), -(Math.PI)/2))
-		$FAIL("#1: Math.abs(Math.atan2(" + y[i] + ", -0) + ((Math.PI)/2)) >= " + prec);
+		$ERROR("#1: Math.abs(Math.atan2(" + y[i] + ", -0) + ((Math.PI)/2)) >= " + prec);
 }

--- a/test/built-ins/Math/atan2/S15.8.2.5_A14.js
+++ b/test/built-ins/Math/atan2/S15.8.2.5_A14.js
@@ -7,7 +7,6 @@ es5id: 15.8.2.5_A14
 description: >
     Checking if Math.atan2(y,x) equals to +0, where y>0 and y is
     finite and x is equal to +Infinity
-includes: [$FAIL.js]
 ---*/
 
 // CHECK#1
@@ -21,5 +20,5 @@ var ynum = 3;
 for (var i = 0; i < ynum; i++)
 {
 	if (Math.atan2(y[i],x) !== +0)
-		$FAIL("#1: Math.atan2(" + y[i] + ", " + x + ") !== +0");
+		$ERROR("#1: Math.atan2(" + y[i] + ", " + x + ") !== +0");
 }

--- a/test/built-ins/Math/atan2/S15.8.2.5_A15.js
+++ b/test/built-ins/Math/atan2/S15.8.2.5_A15.js
@@ -10,7 +10,6 @@ description: >
     Checking if Math.atan2(y,x) is an approximation to +PI, where y>0
     and y is finite and x is equal to -Infinity
 includes:
-    - $FAIL.js
     - math_precision.js
     - math_isequal.js
 ---*/
@@ -26,5 +25,5 @@ var ynum = 3;
 for (var i = 0; i < ynum; i++)
 {
 	if (!isEqual(Math.atan2(y[i],x),Math.PI))
-		$FAIL("#1: Math.abs(Math.atan2(" + y[i] + ", " + x + ") - Math.PI) >= " + prec);
+		$ERROR("#1: Math.abs(Math.atan2(" + y[i] + ", " + x + ") - Math.PI) >= " + prec);
 }

--- a/test/built-ins/Math/atan2/S15.8.2.5_A16.js
+++ b/test/built-ins/Math/atan2/S15.8.2.5_A16.js
@@ -7,7 +7,6 @@ es5id: 15.8.2.5_A16
 description: >
     Checking if Math.atan2(y,x) is -0, where y<0 and y is finite and x
     is equal to +Infinity
-includes: [$FAIL.js]
 ---*/
 
 // CHECK#1
@@ -21,5 +20,5 @@ var ynum = 3;
 for (var i = 0; i < ynum; i++)
 {
 	if (Math.atan2(y[i],x) !== -0)
-		$FAIL("#1: Math.atan2(" + y[i] + ", " + x + ") !== -0");
+		$ERROR("#1: Math.atan2(" + y[i] + ", " + x + ") !== -0");
 }

--- a/test/built-ins/Math/atan2/S15.8.2.5_A17.js
+++ b/test/built-ins/Math/atan2/S15.8.2.5_A17.js
@@ -10,7 +10,6 @@ description: >
     Checking if Math.atan2(y,x) is an approximation to -PI, where y<0
     and y is finite and x is equal to -Infinity
 includes:
-    - $FAIL.js
     - math_precision.js
     - math_isequal.js
 ---*/
@@ -26,5 +25,5 @@ var ynum = 3;
 for (var i = 0; i < ynum; i++)
 {
 	if (!isEqual(Math.atan2(y[i],x), -Math.PI))
-		$FAIL("#1: Math.abs(Math.atan2(" + y[i] + ", " + x + ") + Math.PI) >= " + prec);
+		$ERROR("#1: Math.abs(Math.atan2(" + y[i] + ", " + x + ") + Math.PI) >= " + prec);
 }

--- a/test/built-ins/Math/atan2/S15.8.2.5_A18.js
+++ b/test/built-ins/Math/atan2/S15.8.2.5_A18.js
@@ -10,7 +10,6 @@ description: >
     Checking if Math.atan2(y,x) is an approximation to +PI/2, where y
     is +Infinity and x is finite
 includes:
-    - $FAIL.js
     - math_precision.js
     - math_isequal.js
 ---*/
@@ -30,5 +29,5 @@ var xnum = 6;
 for (var i = 0; i < xnum; i++)
 {
 	if (!isEqual(Math.atan2(y,x[i]), (Math.PI)/2))
-		$FAIL("#1: Math.abs(Math.atan2(" + y + ", " + x[i] + ") - (Math.PI/2)) >= " + prec);
+		$ERROR("#1: Math.abs(Math.atan2(" + y + ", " + x[i] + ") - (Math.PI/2)) >= " + prec);
 }

--- a/test/built-ins/Math/atan2/S15.8.2.5_A19.js
+++ b/test/built-ins/Math/atan2/S15.8.2.5_A19.js
@@ -10,7 +10,6 @@ description: >
     Checking if Math.atan2(y,x) is an approximation to -PI/2, where y
     is -Infinity and x is finite
 includes:
-    - $FAIL.js
     - math_precision.js
     - math_isequal.js
 ---*/
@@ -31,5 +30,5 @@ var xnum = 6;
 for (var i = 0; i < xnum; i++)
 {
 	if (!isEqual(Math.atan2(y,x[i]), -(Math.PI)/2))
-		$FAIL("#1: Math.abs(Math.atan2(" + y + ", " + x[i] + ") + (Math.PI/2)) >= " + prec);
+		$ERROR("#1: Math.abs(Math.atan2(" + y + ", " + x[i] + ") + (Math.PI/2)) >= " + prec);
 }

--- a/test/built-ins/Math/atan2/S15.8.2.5_A2.js
+++ b/test/built-ins/Math/atan2/S15.8.2.5_A2.js
@@ -10,7 +10,6 @@ description: >
     Checking if Math.atan2(y,x) is an approximation to +PI/2, where
     y>0 and x is +0
 includes:
-    - $FAIL.js
     - math_precision.js
     - math_isequal.js
 ---*/
@@ -27,5 +26,5 @@ var ynum = 3;
 for (var i = 0; i < ynum; i++)
 {
 	if (!isEqual(Math.atan2(y[i],x),(Math.PI)/2))
-		$FAIL("#1: Math.abs(Math.atan2(" + y[i] + ", " + x + ") - ((Math.PI)/2)) >= " + prec);
+		$ERROR("#1: Math.abs(Math.atan2(" + y[i] + ", " + x + ") - ((Math.PI)/2)) >= " + prec);
 }

--- a/test/built-ins/Math/atan2/S15.8.2.5_A3.js
+++ b/test/built-ins/Math/atan2/S15.8.2.5_A3.js
@@ -10,7 +10,6 @@ description: >
     Checking if Math.atan2(y,x) is an approximation to +PI/2, where
     y>0 and x is -0
 includes:
-    - $FAIL.js
     - math_precision.js
     - math_isequal.js
 ---*/
@@ -27,5 +26,5 @@ var ynum = 3;
 for (var i = 0; i < ynum; i++)
 {
 	if (!isEqual(Math.atan2(y[i],x), (Math.PI)/2))
-		$FAIL("#1: Math.abs(Math.atan2(" + y[i] + ", " + x + ") - ((Math.PI)/2)) >= " + prec);
+		$ERROR("#1: Math.abs(Math.atan2(" + y[i] + ", " + x + ") - ((Math.PI)/2)) >= " + prec);
 }

--- a/test/built-ins/Math/atan2/S15.8.2.5_A4.js
+++ b/test/built-ins/Math/atan2/S15.8.2.5_A4.js
@@ -5,7 +5,6 @@
 info: If y is +0 and x>0, Math.atan2(y,x) is +0
 es5id: 15.8.2.5_A4
 description: Checking if Math.atan2(y,x) equals to +0, where y is +0 and x>0
-includes: [$FAIL.js]
 ---*/
 
 // CHECK#1
@@ -19,5 +18,5 @@ var xnum = 3;
 for (var i = 0; i < xnum; i++)
 {
 	if (Math.atan2(y,x[i]) !== +0)
-		$FAIL("#1: Math.atan2(" + y + ", " + x[i] + ") !== +0");
+		$ERROR("#1: Math.atan2(" + y + ", " + x[i] + ") !== +0");
 }

--- a/test/built-ins/Math/atan2/S15.8.2.5_A7.js
+++ b/test/built-ins/Math/atan2/S15.8.2.5_A7.js
@@ -10,7 +10,6 @@ description: >
     Checking if Math.atan2(y,x) is an approximation to +PI, where y is
     equal to +0 and x<0
 includes:
-    - $FAIL.js
     - math_precision.js
     - math_isequal.js
 ---*/
@@ -27,5 +26,5 @@ var xnum = 3;
 for (var i = 0; i < xnum; i++)
 {
 	if (!isEqual(Math.atan2(y,x[i]), Math.PI))
-		$FAIL("#1: Math.abs(Math.atan2(" + y + ", " + x[i] + ") - Math.PI) >= " + prec);
+		$ERROR("#1: Math.abs(Math.atan2(" + y + ", " + x[i] + ") - Math.PI) >= " + prec);
 }

--- a/test/built-ins/Math/atan2/S15.8.2.5_A8.js
+++ b/test/built-ins/Math/atan2/S15.8.2.5_A8.js
@@ -5,7 +5,6 @@
 info: If y is equal to -0 and x>0, Math.atan2(y,x) is -0
 es5id: 15.8.2.5_A8
 description: Checking if Math.atan2(y,x) is -0, where y is equal to -0 and x>0
-includes: [$FAIL.js]
 ---*/
 
 // CHECK#1
@@ -19,5 +18,5 @@ var xnum = 3;
 for (var i = 0; i < xnum; i++)
 {
 	if (Math.atan2(y,x[i]) !== -0)
-		$FAIL("#1: Math.atan2(" + y + ", " + x[i] + ") !== -0");
+		$ERROR("#1: Math.atan2(" + y + ", " + x[i] + ") !== -0");
 }

--- a/test/built-ins/Math/cos/S15.8.2.7_A6.js
+++ b/test/built-ins/Math/cos/S15.8.2.7_A6.js
@@ -8,7 +8,6 @@ description: >
     Checking if Math.cos(x) equals to Math.cos(x+n*2*Math.PI) with
     precision 0.000000000003, where n is an integer from 1 to 100 and
     x is one of 10 float point values from -Math.PI to +Math.PI
-includes: [$FAIL.js]
 ---*/
 
 // CHECK#1
@@ -42,7 +41,7 @@ for (i = 0; i < snum; i++)
 		j++;
 		if (Math.abs(Math.cos(curx) - curval) >= prec)
 		{
-			$FAIL("#1: cos is found out to not be periodic:\n Math.abs(Math.cos(" + x[i] + ") - Math.cos(" + x[i] + " + 2*Math.PI*" + j + ")) >= " + prec + "\n Math.cos(" + x[i] + ") === " + curval + "\n Math.cos(" + curx + ") === " + Math.cos(curx));
+			$ERROR("#1: cos is found out to not be periodic:\n Math.abs(Math.cos(" + x[i] + ") - Math.cos(" + x[i] + " + 2*Math.PI*" + j + ")) >= " + prec + "\n Math.cos(" + x[i] + ") === " + curval + "\n Math.cos(" + curx + ") === " + Math.cos(curx));
 		}
 	}
 }

--- a/test/built-ins/Math/pow/S15.8.2.13_A7.js
+++ b/test/built-ins/Math/pow/S15.8.2.13_A7.js
@@ -7,7 +7,6 @@ es5id: 15.8.2.13_A7
 description: >
     Checking if Math.pow(x,y) is NaN, where abs(x)==1 and y is
     +Infinity
-includes: [$FAIL.js]
 ---*/
 
 // CHECK#1
@@ -22,6 +21,6 @@ for (var i = 0; i < xnum; i++)
 {
 	if (!isNaN(Math.pow(x[i],y)))
 	{
-		$FAIL("#1: isNaN(Math.pow(" + x[i] + ", " + y + ")) === false");
+		$ERROR("#1: isNaN(Math.pow(" + x[i] + ", " + y + ")) === false");
 	}
 }

--- a/test/built-ins/Math/pow/S15.8.2.13_A8.js
+++ b/test/built-ins/Math/pow/S15.8.2.13_A8.js
@@ -7,7 +7,6 @@ es5id: 15.8.2.13_A8
 description: >
     Checking if Math.pow(x,y) is NaN, where abs(x)==1 and y is
     -Infinity
-includes: [$FAIL.js]
 ---*/
 
 // CHECK#1
@@ -22,6 +21,6 @@ for (var i = 0; i < xnum; i++)
 {
 	if (!isNaN(Math.pow(x[i],y)))
 	{
-		$FAIL("#1: isNaN(Math.pow(" + x[i] + ", " + y + ")) === false");
+		$ERROR("#1: isNaN(Math.pow(" + x[i] + ", " + y + ")) === false");
 	}
 }

--- a/test/built-ins/Math/sin/S15.8.2.16_A6.js
+++ b/test/built-ins/Math/sin/S15.8.2.16_A6.js
@@ -8,7 +8,6 @@ description: >
     Checking if Math.sin(x) equals to Math.sin(x+n*2*Math.PI) with
     precision 0.000000000003, where n is an integer from 1 to 100 and
     x is one of 10 float point values from 0 to 2*Math.PI
-includes: [$FAIL.js]
 ---*/
 
 // CHECK#1
@@ -42,7 +41,7 @@ for (i = 0; i < snum; i++)
 		j++;
 		if (Math.abs(Math.sin(curx) - curval) >= prec)
 		{
-			$FAIL("#1: sin is found out to not be periodic:\n Math.abs(Math.sin(" + x[i] + ") - Math.sin(" + x[i] + " + 2*Math.PI*" + j + ")) >= " + prec + "\n Math.sin(" + x[i] + ") === " + curval + "\n Math.sin(" + curx + ") === " + Math.sin(curx));
+			$ERROR("#1: sin is found out to not be periodic:\n Math.abs(Math.sin(" + x[i] + ") - Math.sin(" + x[i] + " + 2*Math.PI*" + j + ")) >= " + prec + "\n Math.sin(" + x[i] + ") === " + curval + "\n Math.sin(" + curx + ") === " + Math.sin(curx));
 		}
 	}
 }

--- a/test/built-ins/Math/tan/S15.8.2.18_A6.js
+++ b/test/built-ins/Math/tan/S15.8.2.18_A6.js
@@ -8,7 +8,6 @@ description: >
     Checking if Math.tan(x) equals to Math.tan(x+n*Math.PI) with
     precision 0.000000000003, where n is an integer from 1 to 100 and
     x is one of 10 float point values from 0 to Math.PI
-includes: [$FAIL.js]
 ---*/
 
 // CHECK#1
@@ -42,7 +41,7 @@ for (i = 0; i < snum; i++)
 		j++;
 		if (Math.abs(Math.tan(curx) - curval) >= prec)
 		{
-			$FAIL("#1: tan is found out to not be periodic:\n Math.abs(Math.tan(" + x[i] + ") - Math.tan(" + x[i] + " + 2*Math.PI*" + j + ")) >= " + prec + "\n Math.tan(" + x[i] + ") === " + curval + "\n Math.tan(" + curx + ") === " + Math.tan(curx));
+			$ERROR("#1: tan is found out to not be periodic:\n Math.abs(Math.tan(" + x[i] + ") - Math.tan(" + x[i] + " + 2*Math.PI*" + j + ")) >= " + prec + "\n Math.tan(" + x[i] + ") === " + curval + "\n Math.tan(" + curx + ") === " + Math.tan(curx));
 		}
 	}
 }

--- a/test/built-ins/Number/prototype/S15.7.3.1_A1_T2.js
+++ b/test/built-ins/Number/prototype/S15.7.3.1_A1_T2.js
@@ -7,7 +7,7 @@ info: >
     attributes
 es5id: 15.7.3.1_A1_T2
 description: Checking if deleting the Number.prototype property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 verifyNotConfigurable(Number, "prototype");
@@ -23,5 +23,5 @@ try {
 }
 
 if (!Number.hasOwnProperty('prototype')) {
-  $FAIL('#2: The Number.prototype property has the attributes DontDelete');
+  $ERROR('#2: The Number.prototype property has the attributes DontDelete');
 }

--- a/test/built-ins/Number/prototype/S15.7.3.1_A3.js
+++ b/test/built-ins/Number/prototype/S15.7.3.1_A3.js
@@ -5,13 +5,12 @@
 info: Number.prototype value is not +0
 es5id: 15.7.3.1_A3
 description: Checking value of Number.prototype property
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   (Number.prototype != 0);
-  $FAIL('#1: "(Number.prototype != 0);" lead to throwing exception. Actual: '+(Number.prototype != 0));
+  $ERROR('#1: "(Number.prototype != 0);" lead to throwing exception. Actual: '+(Number.prototype != 0));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "(Number.prototype != 0)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/S15.7.4_A1.js
+++ b/test/built-ins/Number/prototype/S15.7.4_A1.js
@@ -7,7 +7,6 @@ info: >
     (its [[Class]] is "Number") whose value is +0
 es5id: 15.7.4_A1
 description: Checking type and value of Number.prototype property
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
@@ -18,7 +17,7 @@ if (typeof Number.prototype !== "object") {
 //CHECK#2
 try {
   (Number.prototype != 0);
-  $FAIL('#2: "(Number.prototype != 0);" lead to throwing exception. Actual: '+(Number.prototype != 0));
+  $ERROR('#2: "(Number.prototype != 0);" lead to throwing exception. Actual: '+(Number.prototype != 0));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#2.1: "(Number.prototype != 0)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toFixed/S15.7.4.5_A1.1_T01.js
+++ b/test/built-ins/Number/prototype/toFixed/S15.7.4.5_A1.1_T01.js
@@ -7,13 +7,12 @@ info: >
     is undefined, this step produces the value 0)
 es5id: 15.7.4.5_A1.1_T01
 description: calling on Number prototype object
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toFixed();
-  $FAIL('#1: "Number.prototype.toFixed();" lead to throwing exception. Actual: '+Number.prototype.toFixed());
+  $ERROR('#1: "Number.prototype.toFixed();" lead to throwing exception. Actual: '+Number.prototype.toFixed());
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toFixed()" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
@@ -23,7 +22,7 @@ try {
 //CHECK#2
 try {
   Number.prototype.toFixed(0);
-  $FAIL('#2: "Number.prototype.toFixed(0);" lead to throwing exception. Actual: '+Number.prototype.toFixed(0));
+  $ERROR('#2: "Number.prototype.toFixed(0);" lead to throwing exception. Actual: '+Number.prototype.toFixed(0));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#2.1: "Number.prototype.toFixed(0)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
@@ -33,7 +32,7 @@ try {
 //CHECK#3
 try {
   Number.prototype.toFixed(1);
-  $FAIL('#3: "Number.prototype.toFixed(1);" lead to throwing exception. Actual: '+Number.prototype.toFixed(1));
+  $ERROR('#3: "Number.prototype.toFixed(1);" lead to throwing exception. Actual: '+Number.prototype.toFixed(1));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#3.1: "Number.prototype.toFixed(1)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
@@ -43,7 +42,7 @@ try {
 //CHECK#4
 try {
   Number.prototype.toFixed(1.1);
-  $FAIL('#4: "Number.prototype.toFixed(1.1);" lead to throwing exception. Actual: '+Number.prototype.toFixed(1.1));
+  $ERROR('#4: "Number.prototype.toFixed(1.1);" lead to throwing exception. Actual: '+Number.prototype.toFixed(1.1));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#4.1: "Number.prototype.toFixed(1.1)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
@@ -53,7 +52,7 @@ try {
 //CHECK#5
 try {
   Number.prototype.toFixed(0.9);
-  $FAIL('#5: "Number.prototype.toFixed(0.9);" lead to throwing exception. Actual: '+Number.prototype.toFixed(0.9));
+  $ERROR('#5: "Number.prototype.toFixed(0.9);" lead to throwing exception. Actual: '+Number.prototype.toFixed(0.9));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#5.1: "Number.prototype.toFixed(0.9)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
@@ -63,7 +62,7 @@ try {
 //CHECK#6
 try {
   Number.prototype.toFixed("1");
-  $FAIL('#6: "Number.prototype.toFixed("1");" lead to throwing exception. Actual: '+Number.prototype.toFixed("1"));
+  $ERROR('#6: "Number.prototype.toFixed("1");" lead to throwing exception. Actual: '+Number.prototype.toFixed("1"));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#6.1: "Number.prototype.toFixed("1")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
@@ -73,7 +72,7 @@ try {
 //CHECK#7
 try {
   Number.prototype.toFixed("1.1");
-  $FAIL('#7: "Number.prototype.toFixed("1.1");" lead to throwing exception. Actual: '+Number.prototype.toFixed("1.1"));
+  $ERROR('#7: "Number.prototype.toFixed("1.1");" lead to throwing exception. Actual: '+Number.prototype.toFixed("1.1"));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#7.1: "Number.prototype.toFixed("1.1")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
@@ -83,7 +82,7 @@ try {
 //CHECK#8
 try {
   Number.prototype.toFixed("0.9");
-  $FAIL('#8: "Number.prototype.toFixed("0.9");" lead to throwing exception. Actual: '+Number.prototype.toFixed("0.9"));
+  $ERROR('#8: "Number.prototype.toFixed("0.9");" lead to throwing exception. Actual: '+Number.prototype.toFixed("0.9"));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#8.1: "Number.prototype.toFixed("0.9")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
@@ -93,7 +92,7 @@ try {
 //CHECK#9
 try {
   Number.prototype.toFixed(Number.NaN);
-  $FAIL('#9: "Number.prototype.toFixed(Number.NaN);" lead to throwing exception. Actual: '+Number.prototype.toFixed(Number.NaN));
+  $ERROR('#9: "Number.prototype.toFixed(Number.NaN);" lead to throwing exception. Actual: '+Number.prototype.toFixed(Number.NaN));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#9.1: "Number.prototype.toFixed(Number.NaN)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
@@ -103,7 +102,7 @@ try {
 //CHECK#10
 try {
   Number.prototype.toFixed("some string");
-  $FAIL('#10: "Number.prototype.toFixed("some string");" lead to throwing exception. Actual: '+Number.prototype.toFixed("some string"));
+  $ERROR('#10: "Number.prototype.toFixed("some string");" lead to throwing exception. Actual: '+Number.prototype.toFixed("some string"));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#10.1: "Number.prototype.toFixed("some string")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
@@ -113,7 +112,7 @@ try {
 //CHECK#11
 try {
   Number.prototype.toFixed(-0.1);
-  $FAIL('#11: "Number.prototype.toFixed(-0.1);" lead to throwing exception. Actual: '+Number.prototype.toFixed(-0.1));
+  $ERROR('#11: "Number.prototype.toFixed(-0.1);" lead to throwing exception. Actual: '+Number.prototype.toFixed(-0.1));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#11.1: "Number.prototype.toFixed(-0.1)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A1_T01.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A1_T01.js
@@ -8,13 +8,12 @@ info: >
     the resulting string value is returned
 es5id: 15.7.4.2_A1_T01
 description: undefined radix
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString();
-  $FAIL('#1: "Number.prototype.toString();" lead to throwing exception. Actual: '+Number.prototype.toString());
+  $ERROR('#1: "Number.prototype.toString();" lead to throwing exception. Actual: '+Number.prototype.toString());
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString()" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A1_T02.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A1_T02.js
@@ -8,13 +8,12 @@ info: >
     the resulting string value is returned
 es5id: 15.7.4.2_A1_T02
 description: radix is 10
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(10);
-  $FAIL('#1: "Number.prototype.toString(10);" lead to throwing exception. Actual: '+Number.prototype.toString(10));
+  $ERROR('#1: "Number.prototype.toString(10);" lead to throwing exception. Actual: '+Number.prototype.toString(10));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(10)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A1_T03.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A1_T03.js
@@ -8,13 +8,12 @@ info: >
     the resulting string value is returned
 es5id: 15.7.4.2_A1_T03
 description: radix is undefined value
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(undefined);
-  $FAIL('#1: "Number.prototype.toString(undefined);" lead to throwing exception. Actual: '+Number.prototype.toString(undefined));
+  $ERROR('#1: "Number.prototype.toString(undefined);" lead to throwing exception. Actual: '+Number.prototype.toString(undefined));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(undefined)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T01.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T01.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T01
 description: radix is 2
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(2);
-  $FAIL('#1: "Number.prototype.toString(2);" lead to throwing exception. Actual: '+Number.prototype.toString(2));
+  $ERROR('#1: "Number.prototype.toString(2);" lead to throwing exception. Actual: '+Number.prototype.toString(2));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(2)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T02.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T02.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T02
 description: radix is 3
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(3);
-  $FAIL('#1: "Number.prototype.toString(3);" lead to throwing exception. Actual: '+Number.prototype.toString(3));
+  $ERROR('#1: "Number.prototype.toString(3);" lead to throwing exception. Actual: '+Number.prototype.toString(3));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(3)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T03.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T03.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T03
 description: radix is 4
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(4);
-  $FAIL('#1: "Number.prototype.toString(4);" lead to throwing exception. Actual: '+Number.prototype.toString(4));
+  $ERROR('#1: "Number.prototype.toString(4);" lead to throwing exception. Actual: '+Number.prototype.toString(4));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(4)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T04.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T04.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T04
 description: radix is 5
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(5);
-  $FAIL('#1: "Number.prototype.toString(5);" lead to throwing exception. Actual: '+Number.prototype.toString(5));
+  $ERROR('#1: "Number.prototype.toString(5);" lead to throwing exception. Actual: '+Number.prototype.toString(5));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(5)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T05.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T05.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T05
 description: radix is 6
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(6);
-  $FAIL('#1: "Number.prototype.toString(6);" lead to throwing exception. Actual: '+Number.prototype.toString(6));
+  $ERROR('#1: "Number.prototype.toString(6);" lead to throwing exception. Actual: '+Number.prototype.toString(6));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(6)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T06.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T06.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T06
 description: radix is 7
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(7);
-  $FAIL('#1: "Number.prototype.toString(7);" lead to throwing exception. Actual: '+Number.prototype.toString(7));
+  $ERROR('#1: "Number.prototype.toString(7);" lead to throwing exception. Actual: '+Number.prototype.toString(7));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(7)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T07.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T07.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T07
 description: radix is 8
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(8);
-  $FAIL('#1: "Number.prototype.toString(8);" lead to throwing exception. Actual: '+Number.prototype.toString(8));
+  $ERROR('#1: "Number.prototype.toString(8);" lead to throwing exception. Actual: '+Number.prototype.toString(8));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(8)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T08.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T08.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T08
 description: radix is 9
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(9);
-  $FAIL('#1: "Number.prototype.toString(9);" lead to throwing exception. Actual: '+Number.prototype.toString(9));
+  $ERROR('#1: "Number.prototype.toString(9);" lead to throwing exception. Actual: '+Number.prototype.toString(9));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(9)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T09.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T09.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T09
 description: radix is 11
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(11);
-  $FAIL('#1: "Number.prototype.toString(11);" lead to throwing exception. Actual: '+Number.prototype.toString(11));
+  $ERROR('#1: "Number.prototype.toString(11);" lead to throwing exception. Actual: '+Number.prototype.toString(11));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(11)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T10.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T10.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T10
 description: radix is 12
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(12);
-  $FAIL('#1: "Number.prototype.toString(12);" lead to throwing exception. Actual: '+Number.prototype.toString(12));
+  $ERROR('#1: "Number.prototype.toString(12);" lead to throwing exception. Actual: '+Number.prototype.toString(12));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(12)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T11.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T11.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T11
 description: radix is 13
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(13);
-  $FAIL('#1: "Number.prototype.toString(13);" lead to throwing exception. Actual: '+Number.prototype.toString(13));
+  $ERROR('#1: "Number.prototype.toString(13);" lead to throwing exception. Actual: '+Number.prototype.toString(13));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(13)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T12.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T12.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T12
 description: radix is 14
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(14);
-  $FAIL('#1: "Number.prototype.toString(14);" lead to throwing exception. Actual: '+Number.prototype.toString(14));
+  $ERROR('#1: "Number.prototype.toString(14);" lead to throwing exception. Actual: '+Number.prototype.toString(14));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(14)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T13.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T13.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T13
 description: radix is 15
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(15);
-  $FAIL('#1: "Number.prototype.toString(15);" lead to throwing exception. Actual: '+Number.prototype.toString(15));
+  $ERROR('#1: "Number.prototype.toString(15);" lead to throwing exception. Actual: '+Number.prototype.toString(15));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(15)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T14.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T14.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T14
 description: radix is 16
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(16);
-  $FAIL('#1: "Number.prototype.toString(16);" lead to throwing exception. Actual: '+Number.prototype.toString(16));
+  $ERROR('#1: "Number.prototype.toString(16);" lead to throwing exception. Actual: '+Number.prototype.toString(16));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(16)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T15.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T15.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T15
 description: radix is 17
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(17);
-  $FAIL('#1: "Number.prototype.toString(17);" lead to throwing exception. Actual: '+Number.prototype.toString(17));
+  $ERROR('#1: "Number.prototype.toString(17);" lead to throwing exception. Actual: '+Number.prototype.toString(17));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(17)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T16.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T16.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T16
 description: radix is 18
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(18);
-  $FAIL('#1: "Number.prototype.toString(18);" lead to throwing exception. Actual: '+Number.prototype.toString(18));
+  $ERROR('#1: "Number.prototype.toString(18);" lead to throwing exception. Actual: '+Number.prototype.toString(18));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(18)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T17.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T17.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T17
 description: radix is 19
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(19);
-  $FAIL('#1: "Number.prototype.toString(19);" lead to throwing exception. Actual: '+Number.prototype.toString(19));
+  $ERROR('#1: "Number.prototype.toString(19);" lead to throwing exception. Actual: '+Number.prototype.toString(19));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(19)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T18.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T18.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T18
 description: radix is 20
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(20);
-  $FAIL('#1: "Number.prototype.toString(20);" lead to throwing exception. Actual: '+Number.prototype.toString(20));
+  $ERROR('#1: "Number.prototype.toString(20);" lead to throwing exception. Actual: '+Number.prototype.toString(20));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(20)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T19.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T19.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T19
 description: radix is 21
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(21);
-  $FAIL('#1: "Number.prototype.toString(21);" lead to throwing exception. Actual: '+Number.prototype.toString(21));
+  $ERROR('#1: "Number.prototype.toString(21);" lead to throwing exception. Actual: '+Number.prototype.toString(21));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(21)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T20.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T20.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T20
 description: radix is 22
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(22);
-  $FAIL('#1: "Number.prototype.toString(22);" lead to throwing exception. Actual: '+Number.prototype.toString(22));
+  $ERROR('#1: "Number.prototype.toString(22);" lead to throwing exception. Actual: '+Number.prototype.toString(22));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(22)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T21.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T21.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T21
 description: radix is 23
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(23);
-  $FAIL('#1: "Number.prototype.toString(23);" lead to throwing exception. Actual: '+Number.prototype.toString(23));
+  $ERROR('#1: "Number.prototype.toString(23);" lead to throwing exception. Actual: '+Number.prototype.toString(23));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(23)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T22.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T22.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T22
 description: radix is 24
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(24);
-  $FAIL('#1: "Number.prototype.toString(24);" lead to throwing exception. Actual: '+Number.prototype.toString(24));
+  $ERROR('#1: "Number.prototype.toString(24);" lead to throwing exception. Actual: '+Number.prototype.toString(24));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(24)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T23.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T23.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T23
 description: radix is 25
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(25);
-  $FAIL('#1: "Number.prototype.toString(25);" lead to throwing exception. Actual: '+Number.prototype.toString(25));
+  $ERROR('#1: "Number.prototype.toString(25);" lead to throwing exception. Actual: '+Number.prototype.toString(25));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(25)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T24.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T24.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T24
 description: radix is 26
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(26);
-  $FAIL('#1: "Number.prototype.toString(26);" lead to throwing exception. Actual: '+Number.prototype.toString(26));
+  $ERROR('#1: "Number.prototype.toString(26);" lead to throwing exception. Actual: '+Number.prototype.toString(26));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(26)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T25.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T25.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T25
 description: radix is 27
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(27);
-  $FAIL('#1: "Number.prototype.toString(27);" lead to throwing exception. Actual: '+Number.prototype.toString(27));
+  $ERROR('#1: "Number.prototype.toString(27);" lead to throwing exception. Actual: '+Number.prototype.toString(27));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(27)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T26.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T26.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T26
 description: radix is 28
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(28);
-  $FAIL('#1: "Number.prototype.toString(28);" lead to throwing exception. Actual: '+Number.prototype.toString(28));
+  $ERROR('#1: "Number.prototype.toString(28);" lead to throwing exception. Actual: '+Number.prototype.toString(28));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(28)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T27.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T27.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T27
 description: radix is 29
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(29);
-  $FAIL('#1: "Number.prototype.toString(29);" lead to throwing exception. Actual: '+Number.prototype.toString(29));
+  $ERROR('#1: "Number.prototype.toString(29);" lead to throwing exception. Actual: '+Number.prototype.toString(29));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(29)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T28.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T28.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T28
 description: radix is 30
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(30);
-  $FAIL('#1: "Number.prototype.toString(30);" lead to throwing exception. Actual: '+Number.prototype.toString(30));
+  $ERROR('#1: "Number.prototype.toString(30);" lead to throwing exception. Actual: '+Number.prototype.toString(30));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(30)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T29.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T29.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T29
 description: radix is 31
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(31);
-  $FAIL('#1: "Number.prototype.toString(31);" lead to throwing exception. Actual: '+Number.prototype.toString(31));
+  $ERROR('#1: "Number.prototype.toString(31);" lead to throwing exception. Actual: '+Number.prototype.toString(31));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(31)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T30.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T30.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T30
 description: radix is 32
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(32);
-  $FAIL('#1: "Number.prototype.toString(32);" lead to throwing exception. Actual: '+Number.prototype.toString(32));
+  $ERROR('#1: "Number.prototype.toString(32);" lead to throwing exception. Actual: '+Number.prototype.toString(32));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(32)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T31.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T31.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T31
 description: radix is 33
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(33);
-  $FAIL('#1: "Number.prototype.toString(33);" lead to throwing exception. Actual: '+Number.prototype.toString(33));
+  $ERROR('#1: "Number.prototype.toString(33);" lead to throwing exception. Actual: '+Number.prototype.toString(33));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(33)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T32.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T32.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T32
 description: radix is 34
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(34);
-  $FAIL('#1: "Number.prototype.toString(34);" lead to throwing exception. Actual: '+Number.prototype.toString(34));
+  $ERROR('#1: "Number.prototype.toString(34);" lead to throwing exception. Actual: '+Number.prototype.toString(34));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(34)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T33.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T33.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T33
 description: radix is 35
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(35);
-  $FAIL('#1: "Number.prototype.toString(35);" lead to throwing exception. Actual: '+Number.prototype.toString(35));
+  $ERROR('#1: "Number.prototype.toString(35);" lead to throwing exception. Actual: '+Number.prototype.toString(35));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(35)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T34.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T34.js
@@ -7,13 +7,12 @@ info: >
     the result is a string, the choice of which is implementation-dependent
 es5id: 15.7.4.2_A2_T34
 description: radix is 36
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.toString(36);
-  $FAIL('#1: "Number.prototype.toString(36);" lead to throwing exception. Actual: '+Number.prototype.toString(36));
+  $ERROR('#1: "Number.prototype.toString(36);" lead to throwing exception. Actual: '+Number.prototype.toString(36));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.toString(36)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/valueOf/S15.7.4.4_A1_T01.js
+++ b/test/built-ins/Number/prototype/valueOf/S15.7.4.4_A1_T01.js
@@ -5,13 +5,12 @@
 info: Number.prototype.valueOf() returns this number value
 es5id: 15.7.4.4_A1_T01
 description: Call without argument
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.valueOf();
-  $FAIL('#1: "Number.prototype.valueOf();" lead to throwing exception. Actual: '+Number.prototype.valueOf());
+  $ERROR('#1: "Number.prototype.valueOf();" lead to throwing exception. Actual: '+Number.prototype.valueOf());
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.valueOf()" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Number/prototype/valueOf/S15.7.4.4_A1_T02.js
+++ b/test/built-ins/Number/prototype/valueOf/S15.7.4.4_A1_T02.js
@@ -5,13 +5,12 @@
 info: Number.prototype.valueOf() returns this number value
 es5id: 15.7.4.4_A1_T02
 description: calling with argument
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 try {
   Number.prototype.valueOf("argument");
-  $FAIL('#1: "Number.prototype.valueOf("argument");" lead to throwing exception. Actual: '+Number.prototype.valueOf("argument"));
+  $ERROR('#1: "Number.prototype.valueOf("argument");" lead to throwing exception. Actual: '+Number.prototype.valueOf("argument"));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "Number.prototype.valueOf("argument")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/Object/S15.2.1.1_A2_T1.js
+++ b/test/built-ins/Object/S15.2.1.1_A2_T1.js
@@ -7,13 +7,12 @@ info: >
     and the value neither is null nor undefined, and is supplied, return ToObject(value)
 es5id: 15.2.1.1_A2_T1
 description: Calling Object function with boolean argument value
-includes: [$FAIL.js]
 ---*/
 
 var bool = true;
 
 if(typeof bool !== 'boolean'){
-  $FAIL('#1: bool should be boolean primitive');
+  $ERROR('#1: bool should be boolean primitive');
 }
 
 var obj = Object(bool);

--- a/test/built-ins/Object/S15.2.1.1_A2_T4.js
+++ b/test/built-ins/Object/S15.2.1.1_A2_T4.js
@@ -7,14 +7,13 @@ info: >
     and the value neither is null nor undefined, and is supplied, return ToObject(value)
 es5id: 15.2.1.1_A2_T4
 description: Calling Object function with object argument value
-includes: [$FAIL.js]
 ---*/
 
 var obj = {flag:true};
 
 //CHECK#1
 if (typeof(obj) !== 'object') {
-  $FAIL('#1: obj = {flag:true} should be an Object');
+  $ERROR('#1: obj = {flag:true} should be an Object');
 }
 
 var n_obj = Object(obj);

--- a/test/built-ins/Object/S15.2.1.1_A2_T7.js
+++ b/test/built-ins/Object/S15.2.1.1_A2_T7.js
@@ -7,14 +7,13 @@ info: >
     and the value neither is null nor undefined, and is supplied, return ToObject(value)
 es5id: 15.2.1.1_A2_T7
 description: Calling Object function with empty string argument value
-includes: [$FAIL.js]
 ---*/
 
 var str = '';
 
 // CHECK#1
 if (typeof(str) !== 'string') {
-  $FAIL('#1: "" is NOT a String');
+  $ERROR('#1: "" is NOT a String');
 }
 
 var obj = Object(str);

--- a/test/built-ins/Object/S15.2.2.1_A3_T1.js
+++ b/test/built-ins/Object/S15.2.2.1_A3_T1.js
@@ -7,14 +7,13 @@ info: >
     the type of value is String, return ToObject(string)
 es5id: 15.2.2.1_A3_T1
 description: Argument value is a nonempty string
-includes: [$FAIL.js]
 ---*/
 
 var str = 'Obi-Wan Kenobi';
 
 //CHECK#1
 if (typeof str  !== 'string') {
-  $FAIL('#1: "Obi-Wan Kenobi" is NOT a String');
+  $ERROR('#1: "Obi-Wan Kenobi" is NOT a String');
 }
 
 

--- a/test/built-ins/Object/S15.2.2.1_A3_T2.js
+++ b/test/built-ins/Object/S15.2.2.1_A3_T2.js
@@ -7,14 +7,13 @@ info: >
     the type of value is String, return ToObject(string)
 es5id: 15.2.2.1_A3_T2
 description: Argument value is an empty string
-includes: [$FAIL.js]
 ---*/
 
 var str = '';
 
 //CHECK#1
 if (typeof str  !== 'string') {
-  $FAIL('#1: "" is NOT a String');
+  $ERROR('#1: "" is NOT a String');
 }
 
 var n_obj = new Object(str);

--- a/test/built-ins/Object/S15.2.2.1_A4_T1.js
+++ b/test/built-ins/Object/S15.2.2.1_A4_T1.js
@@ -7,14 +7,13 @@ info: >
     the type of value is Boolean, return ToObject(boolean)
 es5id: 15.2.2.1_A4_T1
 description: Argument value is "true"
-includes: [$FAIL.js]
 ---*/
 
 var bool = true;
 
 //CHECK#1
 if (typeof bool  !== 'boolean') {
-  $FAIL('#1: true is NOT a boolean');
+  $ERROR('#1: true is NOT a boolean');
 }
 
 var n_obj = new Object(bool);

--- a/test/built-ins/Object/S15.2.2.1_A4_T2.js
+++ b/test/built-ins/Object/S15.2.2.1_A4_T2.js
@@ -7,14 +7,13 @@ info: >
     the type of value is Boolean, return ToObject(boolean)
 es5id: 15.2.2.1_A4_T2
 description: Argument value is "false"
-includes: [$FAIL.js]
 ---*/
 
 var bool = false;
 
 //CHECK#1
 if (typeof bool  !== 'boolean') {
-  $FAIL('#1: false is NOT a boolean');
+  $ERROR('#1: false is NOT a boolean');
 }
 
 var n_obj = new Object(bool);

--- a/test/built-ins/Object/S15.2.2.1_A5_T1.js
+++ b/test/built-ins/Object/S15.2.2.1_A5_T1.js
@@ -7,14 +7,13 @@ info: >
     the type of value is Number, return ToObject(number)
 es5id: 15.2.2.1_A5_T1
 description: Argument value is any number
-includes: [$FAIL.js]
 ---*/
 
 var num = 1.0;
 
 //CHECK#1
 if (typeof num  !== 'number') {
-  $FAIL('#1: 1.0 is NOT a number');
+  $ERROR('#1: 1.0 is NOT a number');
 }
 
 var n_obj = new Object(num);

--- a/test/built-ins/Object/S15.2.2.1_A5_T2.js
+++ b/test/built-ins/Object/S15.2.2.1_A5_T2.js
@@ -7,14 +7,13 @@ info: >
     the type of value is Number, return ToObject(number)
 es5id: 15.2.2.1_A5_T2
 description: Argument value is NaN
-includes: [$FAIL.js]
 ---*/
 
 var num = NaN;
 
 //CHECK#1
 if (typeof num  !== 'number') {
-  $FAIL('#1: NaN is NOT a number');
+  $ERROR('#1: NaN is NOT a number');
 }
 
 var n_obj = new Object(num);

--- a/test/built-ins/Object/S15.2.2.1_A5_T3.js
+++ b/test/built-ins/Object/S15.2.2.1_A5_T3.js
@@ -7,14 +7,13 @@ info: >
     the type of value is Number, return ToObject(number)
 es5id: 15.2.2.1_A5_T3
 description: Argument value is Infinity
-includes: [$FAIL.js]
 ---*/
 
 var num = Infinity;
 
 //CHECK#1
 if (typeof num  !== 'number') {
-  $FAIL('#1: Infinity is NOT a number');
+  $ERROR('#1: Infinity is NOT a number');
 }
 
 var n_obj = new Object(num);

--- a/test/built-ins/Object/prototype/S15.2.4_A3.js
+++ b/test/built-ins/Object/prototype/S15.2.4_A3.js
@@ -9,13 +9,12 @@ es5id: 15.2.4_A3
 description: Checking if calling Object prototype as a function fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 //CHECK#1
 try {
   Object.prototype();
-  $FAIL('#1: Since Object prototype object is not function it has not [[call]] method');
+  $ERROR('#1: Since Object prototype object is not function it has not [[call]] method');
 } catch (e) {
   $PRINT(e);
 }

--- a/test/built-ins/Object/prototype/S15.2.4_A4.js
+++ b/test/built-ins/Object/prototype/S15.2.4_A4.js
@@ -9,13 +9,12 @@ es5id: 15.2.4_A4
 description: Checking if creating "new Object.prototype" fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 //CHECK#1
 try {
   var instance = new Object.prototype;
-  $FAIL('#1: Since Object prototype object is not function it has not [[create]] method');
+  $ERROR('#1: Since Object prototype object is not function it has not [[create]] method');
 } catch (e) {
   $PRINT(e);
 }

--- a/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A10.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A10.js
@@ -9,12 +9,12 @@ es5id: 15.2.4.5_A10
 description: >
     Checking if varying the Object.prototype.hasOwnProperty.length
     property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#1
 if (!(Object.prototype.hasOwnProperty.hasOwnProperty('length'))) {
-  $FAIL('#1: the Object.prototype.hasOwnProperty has length property.');
+  $ERROR('#1: the Object.prototype.hasOwnProperty has length property.');
 }
 
 var obj = Object.prototype.hasOwnProperty.length;

--- a/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A7.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A7.js
@@ -7,14 +7,13 @@ es5id: 15.2.4.5_A7
 description: Checking if creating "new Object.prototype.hasOwnProperty" fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 var FACTORY = Object.prototype.hasOwnProperty;
 
 try {
   var instance = new FACTORY;
-  $FAIL('#1: Object.prototype.hasOwnProperty can\'t be used as a constructor');
+  $ERROR('#1: Object.prototype.hasOwnProperty can\'t be used as a constructor');
 } catch (e) {
   $PRINT(e);
 

--- a/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A8.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A8.js
@@ -9,12 +9,11 @@ es5id: 15.2.4.5_A8
 description: >
     Checking if enumerating the Object.prototype.hasOwnProperty.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Object.prototype.hasOwnProperty.hasOwnProperty('length'))) {
-  $FAIL('#0: the Object.prototype.hasOwnProperty has length property.');
+  $ERROR('#0: the Object.prototype.hasOwnProperty has length property.');
 }
 
 

--- a/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A9.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A9.js
@@ -9,12 +9,11 @@ es5id: 15.2.4.5_A9
 description: >
     Checking if deleting the Object.prototype.hasOwnProperty.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Object.prototype.hasOwnProperty.hasOwnProperty('length'))) {
-  $FAIL('#0: the Object.prototype.hasOwnProperty has length property');
+  $ERROR('#0: the Object.prototype.hasOwnProperty has length property');
 }
 
 //CHECK#1
@@ -24,5 +23,5 @@ if (!delete Object.prototype.hasOwnProperty.length) {
 
 //CHECK#2
 if (Object.prototype.hasOwnProperty.hasOwnProperty('length')) {
-  $FAIL('#2: The Object.prototype.hasOwnProperty.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Object.prototype.hasOwnProperty.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A10.js
+++ b/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A10.js
@@ -9,12 +9,12 @@ es5id: 15.2.4.6_A10
 description: >
     Checking if varying the Object.prototype.isPrototypeOf.length
     property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#1
 if (!(Object.prototype.isPrototypeOf.hasOwnProperty('length'))) {
-  $FAIL('#1: the Object.prototype.isPrototypeOf has length property');
+  $ERROR('#1: the Object.prototype.isPrototypeOf has length property');
 }
 
 var obj = Object.prototype.isPrototypeOf.length;

--- a/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A7.js
+++ b/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A7.js
@@ -7,14 +7,13 @@ es5id: 15.2.4.6_A7
 description: Checking if creating new "Object.prototype.isPrototypeOf" fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 var FACTORY = Object.prototype.isPrototypeOf;
 
 try {
   var instance = new FACTORY;
-  $FAIL('#1: Object.prototype.isPrototypeOf can\'t be used as a constructor');
+  $ERROR('#1: Object.prototype.isPrototypeOf can\'t be used as a constructor');
 } catch (e) {
   $PRINT(e);
 

--- a/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A8.js
+++ b/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A8.js
@@ -9,12 +9,11 @@ es5id: 15.2.4.6_A8
 description: >
     Checknig if enumerating the Object.prototype.isPrototypeOf.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Object.prototype.isPrototypeOf.hasOwnProperty('length'))) {
-  $FAIL('#0: the Object.prototype.isPrototypeOf has length property');
+  $ERROR('#0: the Object.prototype.isPrototypeOf has length property');
 }
 
 

--- a/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A9.js
+++ b/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A9.js
@@ -9,12 +9,11 @@ es5id: 15.2.4.6_A9
 description: >
     Checking deleting the Object.prototype.isPrototypeOf.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Object.prototype.isPrototypeOf.hasOwnProperty('length'))) {
-  $FAIL('#0: the Object.prototype.isPrototypeOf has length property');
+  $ERROR('#0: the Object.prototype.isPrototypeOf has length property');
 }
 
 //CHECK#1

--- a/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A10.js
+++ b/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A10.js
@@ -9,12 +9,12 @@ es5id: 15.2.4.7_A10
 description: >
     Checking if varying the
     Object.prototype.propertyIsEnumerable.length property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#1
 if (!(Object.prototype.propertyIsEnumerable.hasOwnProperty('length'))) {
-  $FAIL('#1: the Object.prototype.propertyIsEnumerable has length property');
+  $ERROR('#1: the Object.prototype.propertyIsEnumerable has length property');
 }
 
 var obj = Object.prototype.propertyIsEnumerable.length;

--- a/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A7.js
+++ b/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A7.js
@@ -9,14 +9,13 @@ description: >
     fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 var FACTORY = Object.prototype.propertyIsEnumerable;
 
 try {
   var instance = new FACTORY;
-  $FAIL('#1: Object.prototype.propertyIsEnumerable can\'t be used as a constructor');
+  $ERROR('#1: Object.prototype.propertyIsEnumerable can\'t be used as a constructor');
 } catch (e) {
   $PRINT(e);
 

--- a/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A8.js
+++ b/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A8.js
@@ -9,12 +9,11 @@ es5id: 15.2.4.7_A8
 description: >
     Checking if enumerating the
     Object.prototype.propertyIsEnumerable.length property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Object.prototype.propertyIsEnumerable.hasOwnProperty('length'))) {
-  $FAIL('#0: the Object.prototype.propertyIsEnumerable has length property');
+  $ERROR('#0: the Object.prototype.propertyIsEnumerable has length property');
 }
 
 

--- a/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A9.js
+++ b/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A9.js
@@ -9,12 +9,11 @@ es5id: 15.2.4.7_A9
 description: >
     Checking if deleting the
     Object.prototype.propertyIsEnumerable.length property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Object.prototype.propertyIsEnumerable.hasOwnProperty('length'))) {
-  $FAIL('#0: the Object.prototype.propertyIsEnumerable has length property');
+  $ERROR('#0: the Object.prototype.propertyIsEnumerable has length property');
 }
 
 //CHECK#1

--- a/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A10.js
+++ b/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A10.js
@@ -9,12 +9,12 @@ es5id: 15.2.4.3_A10
 description: >
     Checking if varying the Object.prototype.toLocaleString.length
     property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#1
 if (!(Object.prototype.toLocaleString.hasOwnProperty('length'))) {
-  $FAIL('#1: the Object.prototype.toLocaleString has length property.');
+  $ERROR('#1: the Object.prototype.toLocaleString has length property.');
 }
 
 var obj = Object.prototype.toLocaleString.length;

--- a/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A7.js
+++ b/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A7.js
@@ -7,14 +7,13 @@ es5id: 15.2.4.3_A7
 description: Checking if creating "new Object.prototype.toLocaleString" fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 var FACTORY = Object.prototype.toLocaleString;
 
 try {
   var instance = new FACTORY;
-  $FAIL('#1: Object.prototype.toLocaleString can\'t be used as a constructor');
+  $ERROR('#1: Object.prototype.toLocaleString can\'t be used as a constructor');
 } catch (e) {
   $PRINT(e);
 

--- a/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A8.js
+++ b/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A8.js
@@ -9,12 +9,11 @@ es5id: 15.2.4.3_A8
 description: >
     Checking if enumerating the Object.prototype.toLocaleString.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Object.prototype.toLocaleString.hasOwnProperty('length'))) {
-  $FAIL('#0: the Object.prototype.toLocaleString has length property.');
+  $ERROR('#0: the Object.prototype.toLocaleString has length property.');
 }
 
 

--- a/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A9.js
+++ b/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A9.js
@@ -9,12 +9,11 @@ es5id: 15.2.4.3_A9
 description: >
     Checknig if deleting of the Object.prototype.toLocaleString.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Object.prototype.toLocaleString.hasOwnProperty('length'))) {
-  $FAIL('#0: the Object.prototype.toLocaleString has length property');
+  $ERROR('#0: the Object.prototype.toLocaleString has length property');
 }
 
 //CHECK#1
@@ -24,5 +23,5 @@ if (!delete Object.prototype.toLocaleString.length) {
 
 //CHECK#2
 if (Object.prototype.toLocaleString.hasOwnProperty('length')) {
-  $FAIL('#2: The Object.prototype.toLocaleString.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Object.prototype.toLocaleString.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Object/prototype/toString/S15.2.4.2_A10.js
+++ b/test/built-ins/Object/prototype/toString/S15.2.4.2_A10.js
@@ -7,12 +7,12 @@ es5id: 15.2.4.2_A10
 description: >
     Checking if varying the Object.prototype.toString.length property
     fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#1
 if (!(Object.prototype.toString.hasOwnProperty('length'))) {
-  $FAIL('#1: the Object.prototype.toString has length property.');
+  $ERROR('#1: the Object.prototype.toString has length property.');
 }
 
 var obj = Object.prototype.toString.length;

--- a/test/built-ins/Object/prototype/toString/S15.2.4.2_A7.js
+++ b/test/built-ins/Object/prototype/toString/S15.2.4.2_A7.js
@@ -7,14 +7,13 @@ es5id: 15.2.4.2_A7
 description: Checking if creating "new Object.prototype.toString" fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 var FACTORY = Object.prototype.toString;
 
 try {
   var instance = new FACTORY;
-  $FAIL('#1: Object.prototype.toString can\'t be used as a constructor');
+  $ERROR('#1: Object.prototype.toString can\'t be used as a constructor');
 } catch (e) {
   $PRINT(e);
 }

--- a/test/built-ins/Object/prototype/toString/S15.2.4.2_A8.js
+++ b/test/built-ins/Object/prototype/toString/S15.2.4.2_A8.js
@@ -7,12 +7,11 @@ es5id: 15.2.4.2_A8
 description: >
     Checking if enumerating the Object.prototype.toString.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Object.prototype.toString.hasOwnProperty('length'))) {
-  $FAIL('#0: the Object.prototype.toString has length property.');
+  $ERROR('#0: the Object.prototype.toString has length property.');
 }
 
 

--- a/test/built-ins/Object/prototype/toString/S15.2.4.2_A9.js
+++ b/test/built-ins/Object/prototype/toString/S15.2.4.2_A9.js
@@ -9,12 +9,11 @@ es5id: 15.2.4.2_A9
 description: >
     Checknig if deleting of the Object.prototype.toString.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Object.prototype.toString.hasOwnProperty('length'))) {
-  $FAIL('#0: the Object.prototype.toString has length property');
+  $ERROR('#0: the Object.prototype.toString has length property');
 }
 
 //CHECK#1
@@ -24,5 +23,5 @@ if (!delete Object.prototype.toString.length) {
 
 //CHECK#2
 if (Object.prototype.toString.hasOwnProperty('length')) {
-  $FAIL('#2: The Object.prototype.toString.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Object.prototype.toString.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A10.js
+++ b/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A10.js
@@ -7,12 +7,12 @@ es5id: 15.2.4.4_A10
 description: >
     Checking if varying the Object.prototype.valueOf.length property
     fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#1
 if (!(Object.prototype.valueOf.hasOwnProperty('length'))) {
-  $FAIL('#1: the Object.prototype.valueOf has length property.');
+  $ERROR('#1: the Object.prototype.valueOf has length property.');
 }
 
 var obj = Object.prototype.valueOf.length;

--- a/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A7.js
+++ b/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A7.js
@@ -7,14 +7,13 @@ es5id: 15.2.4.4_A7
 description: Checking if creating "new Object.prototype.valueOf" fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 var FACTORY = Object.prototype.valueOf;
 
 try {
   var instance = new FACTORY;
-  $FAIL('#1: Object.prototype.valueOf can\'t be used as a constructor');
+  $ERROR('#1: Object.prototype.valueOf can\'t be used as a constructor');
 } catch (e) {
   $PRINT(e);
 

--- a/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A8.js
+++ b/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A8.js
@@ -7,12 +7,11 @@ es5id: 15.2.4.4_A8
 description: >
     Checking if enumerating the Object.prototype.valueOf.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Object.prototype.valueOf.hasOwnProperty('length'))) {
-  $FAIL('#0: the Object.prototype.valueOf has length property.');
+  $ERROR('#0: the Object.prototype.valueOf has length property.');
 }
 
 

--- a/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A9.js
+++ b/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A9.js
@@ -9,12 +9,11 @@ es5id: 15.2.4.4_A9
 description: >
     Checknig if deleting of the Object.prototype.valueOf.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if (!(Object.prototype.valueOf.hasOwnProperty('length'))) {
-  $FAIL('#0: the Object.prototype.valueOf has length property');
+  $ERROR('#0: the Object.prototype.valueOf has length property');
 }
 
 //CHECK#1
@@ -24,5 +23,5 @@ if (!delete Object.prototype.valueOf.length) {
 
 //CHECK#2
 if (Object.prototype.valueOf.hasOwnProperty('length')) {
-  $FAIL('#2: The Object.prototype.valueOf.length property does not have the attributes DontDelete');
+  $ERROR('#2: The Object.prototype.valueOf.length property does not have the attributes DontDelete');
 }

--- a/test/built-ins/RegExp/prototype/S15.10.5.1_A3.js
+++ b/test/built-ins/RegExp/prototype/S15.10.5.1_A3.js
@@ -5,12 +5,12 @@
 info: The RegExp.prototype property has the attribute DontDelete
 es5id: 15.10.5.1_A3
 description: Checking if deleting the RegExp.prototype property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#0
 if (RegExp.hasOwnProperty('prototype') !== true) {
-	$FAIL('#0: RegExp.hasOwnProperty(\'prototype\') === true');
+	$ERROR('#0: RegExp.hasOwnProperty(\'prototype\') === true');
 }
 
 verifyNotConfigurable(RegExp, "prototype");

--- a/test/built-ins/RegExp/prototype/S15.10.5.1_A4.js
+++ b/test/built-ins/RegExp/prototype/S15.10.5.1_A4.js
@@ -5,12 +5,12 @@
 info: The RegExp.prototype property has the attribute ReadOnly
 es5id: 15.10.5.1_A4
 description: Checking if varying the RegExp.prototype property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#1
 if (RegExp.hasOwnProperty('prototype') !== true) {
-	$FAIL('#1: RegExp.hasOwnProperty(\'prototype\') === true');
+	$ERROR('#1: RegExp.hasOwnProperty(\'prototype\') === true');
 }
 
 var __obj = RegExp.prototype;

--- a/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A10.js
+++ b/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A10.js
@@ -5,12 +5,12 @@
 info: The RegExp.prototype.exec.length property has the attribute ReadOnly
 es5id: 15.10.6.2_A10
 description: Checking if varying the RegExp.prototype.exec.length property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#1
 if (RegExp.prototype.exec.hasOwnProperty('length') !== true) {
-  $FAIL('#1: RegExp.prototype.exec.hasOwnProperty(\'length\') === true');
+  $ERROR('#1: RegExp.prototype.exec.hasOwnProperty(\'length\') === true');
 }
 
 var __obj = RegExp.prototype.exec.length;

--- a/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A11.js
+++ b/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A11.js
@@ -5,12 +5,11 @@
 info: The length property of the exec method is 1
 es5id: 15.10.6.2_A11
 description: Checking RegExp.prototype.exec.length
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (RegExp.prototype.exec.hasOwnProperty("length") !== true) {
-  $FAIL('#1: RegExp.prototype.exec.hasOwnProperty(\'length\') === true');
+  $ERROR('#1: RegExp.prototype.exec.hasOwnProperty(\'length\') === true');
 }
 
 //CHECK#2

--- a/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A12.js
+++ b/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A12.js
@@ -5,14 +5,13 @@
 info: regExp exec() acts like regExp.exec('undefined') (step 2)
 es5id: 15.10.6.2_A12
 description: Checking RegExp.prototype.exec
-includes: [$FAIL.js]
 ---*/
 
 (/foo/).test('xfoox');
 var match = new RegExp('(.|\r|\n)*','').exec()[0];
 if (match === 'xfoox') {
-  $FAIL('#1: regExp.exec() leaks match globally');
+  $ERROR('#1: regExp.exec() leaks match globally');
 }
 if (match !== 'undefined') {
-  $FAIL('#2: regExp.exec() must coerce absent first arg to "undefined"');
+  $ERROR('#2: regExp.exec() must coerce absent first arg to "undefined"');
 }

--- a/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A4_T11.js
+++ b/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A4_T11.js
@@ -9,7 +9,6 @@ es5id: 15.10.6.2_A4_T11
 description: >
     Call first exec, then set re.lastIndex = {valueOf:function(){throw
     "intoint";}} and again call exec
-includes: [$FAIL.js]
 ---*/
 
 var __re = /(?:ab|cd)\d?/g;
@@ -48,7 +47,7 @@ __re.lastIndex = __obj;
 
 //CHECK#5
 try {
-  $FAIL('#5.1: __obj = {valueOf:function(){throw "intoint";}}; __re.lastIndex = __obj; __executed = __re.exec("aacd2233ab12nm444ab42") throw "intoint". Actual: ' + (__re.exec("aacd2233ab12nm444ab42")));
+  $ERROR('#5.1: __obj = {valueOf:function(){throw "intoint";}}; __re.lastIndex = __obj; __executed = __re.exec("aacd2233ab12nm444ab42") throw "intoint". Actual: ' + (__re.exec("aacd2233ab12nm444ab42")));
 } catch (e) {
 	if (e !== "intoint") {
 		$ERROR('#5.2: __obj = {valueOf:function(){throw "intoint";}}; __re.lastIndex = __obj; __executed = __re.exec("aacd2233ab12nm444ab42")  throw "intoint". Actual: ' + (e));

--- a/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A9.js
+++ b/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A9.js
@@ -9,12 +9,11 @@ es5id: 15.10.6.2_A9
 description: >
     Checking if deleting the RegExp.prototype.exec.length property
     fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if ((RegExp.prototype.exec.hasOwnProperty('length') !== true)) {
-  $FAIL('#0: RegExp.prototype.exec.hasOwnProperty(\'length\') === true');
+  $ERROR('#0: RegExp.prototype.exec.hasOwnProperty(\'length\') === true');
 }
 
 //CHECK#1

--- a/test/built-ins/RegExp/prototype/global/S15.10.7.2_A10.js
+++ b/test/built-ins/RegExp/prototype/global/S15.10.7.2_A10.js
@@ -5,14 +5,14 @@
 info: The RegExp.prototype global property does not have a set accessor
 es5id: 15.10.7.2_A10
 description: Checking if varying the global property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 var __re = RegExp.prototype;
 
 //CHECK#1
 if (__re.hasOwnProperty('global') !== true) {
-  $FAIL('#1: __re = RegExp.prototype; __re.hasOwnProperty(\'global\') === true');
+  $ERROR('#1: __re = RegExp.prototype; __re.hasOwnProperty(\'global\') === true');
 }
 
 var __sample = /^|^/;

--- a/test/built-ins/RegExp/prototype/global/S15.10.7.2_A8.js
+++ b/test/built-ins/RegExp/prototype/global/S15.10.7.2_A8.js
@@ -7,14 +7,13 @@ es5id: 15.10.7.2_A8
 description: >
     Checking if enumerating the global property of RegExp.prototype
     fails
-includes: [$FAIL.js]
 ---*/
 
 var __re = RegExp.prototype;
 
 //CHECK#0
 if (__re.hasOwnProperty('global') !== true) {
-  $FAIL('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'global\') === true');
+  $ERROR('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'global\') === true');
 }
 
  //CHECK#1

--- a/test/built-ins/RegExp/prototype/global/S15.10.7.2_A9.js
+++ b/test/built-ins/RegExp/prototype/global/S15.10.7.2_A9.js
@@ -7,14 +7,13 @@ info: >
     DontDelete
 es5id: 15.10.7.2_A9
 description: Checking if deleting the global property succeeds
-includes: [$FAIL.js]
 ---*/
 
 var __re = RegExp.prototype;
 
 //CHECK#0
 if (__re.hasOwnProperty('global') !== true) {
-  $FAIL('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'global\') === true');
+  $ERROR('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'global\') === true');
 }
 
 //CHECK#1

--- a/test/built-ins/RegExp/prototype/ignoreCase/S15.10.7.3_A10.js
+++ b/test/built-ins/RegExp/prototype/ignoreCase/S15.10.7.3_A10.js
@@ -5,14 +5,14 @@
 info: The RegExp.prototype ignoreCase property does not have a set accessor
 es5id: 15.10.7.3_A10
 description: Checking if varying the ignoreCase property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 var __re = RegExp.prototype;
 
 //CHECK#1
 if (__re.hasOwnProperty('ignoreCase') !== true) {
-  $FAIL('#1: __re = RegExp.prototype; __re.hasOwnProperty(\'ignoreCase\') === true');
+  $ERROR('#1: __re = RegExp.prototype; __re.hasOwnProperty(\'ignoreCase\') === true');
 }
 
 var __sample = /a|b|c/;

--- a/test/built-ins/RegExp/prototype/ignoreCase/S15.10.7.3_A8.js
+++ b/test/built-ins/RegExp/prototype/ignoreCase/S15.10.7.3_A8.js
@@ -7,14 +7,13 @@ es5id: 15.10.7.3_A8
 description: >
     Checking if enumerating the ignoreCase property of
     RegExp.prototype fails
-includes: [$FAIL.js]
 ---*/
 
 var __re = RegExp.prototype;
 
 //CHECK#0
 if (__re.hasOwnProperty('ignoreCase') !== true) {
-  $FAIL('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'ignoreCase\') === true');
+  $ERROR('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'ignoreCase\') === true');
 }
 
  //CHECK#1

--- a/test/built-ins/RegExp/prototype/ignoreCase/S15.10.7.3_A9.js
+++ b/test/built-ins/RegExp/prototype/ignoreCase/S15.10.7.3_A9.js
@@ -7,14 +7,13 @@ info: >
     DontDelete
 es5id: 15.10.7.3_A9
 description: Checking if deleting the ignoreCase property succeeds
-includes: [$FAIL.js]
 ---*/
 
 var __re = RegExp.prototype;
 
 //CHECK#0
 if (__re.hasOwnProperty('ignoreCase') !== true) {
-  $FAIL('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'ignoreCase\') === true');
+  $ERROR('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'ignoreCase\') === true');
 }
 
 //CHECK#1

--- a/test/built-ins/RegExp/prototype/lastIndex/S15.10.7.5_A8.js
+++ b/test/built-ins/RegExp/prototype/lastIndex/S15.10.7.5_A8.js
@@ -7,14 +7,13 @@ es5id: 15.10.7.5_A8
 description: >
     Checking if enumerating the lastIndex property of RegExp instance
     fails
-includes: [$FAIL.js]
 ---*/
 
 var __re = new RegExp("A?B");
 
 //CHECK#0
 if (__re.hasOwnProperty('lastIndex') !== true) {
-  $FAIL('#0: __re = new RegExp("A?B"); __re.hasOwnProperty(\'lastIndex\') === true');
+  $ERROR('#0: __re = new RegExp("A?B"); __re.hasOwnProperty(\'lastIndex\') === true');
 }
 
  //CHECK#1

--- a/test/built-ins/RegExp/prototype/lastIndex/S15.10.7.5_A9.js
+++ b/test/built-ins/RegExp/prototype/lastIndex/S15.10.7.5_A9.js
@@ -5,14 +5,14 @@
 info: The RegExp instance lastIndex property has the attribute DontDelete
 es5id: 15.10.7.5_A9
 description: Checking if deleting the lastIndex property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 var __re = new RegExp;
 
 //CHECK#0
 if (__re.hasOwnProperty('lastIndex') !== true) {
-  $FAIL('#0: __re = new RegExp; __re.hasOwnProperty(\'lastIndex\') === true');
+  $ERROR('#0: __re = new RegExp; __re.hasOwnProperty(\'lastIndex\') === true');
 }
 
 verifyNotConfigurable(__re, "lastIndex");

--- a/test/built-ins/RegExp/prototype/multiline/S15.10.7.4_A10.js
+++ b/test/built-ins/RegExp/prototype/multiline/S15.10.7.4_A10.js
@@ -5,14 +5,14 @@
 info: The RegExp.prototype multiline property does not have a set accessor
 es5id: 15.10.7.4_A10
 description: Checking if varying the multiline property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 var __re = RegExp.prototype;
 
 //CHECK#1
 if (__re.hasOwnProperty('multiline') !== true) {
-  $FAIL('#1: __re = RegExp.prototype; __re.hasOwnProperty(\'multiline\') === true');
+  $ERROR('#1: __re = RegExp.prototype; __re.hasOwnProperty(\'multiline\') === true');
 }
 
 var __sample = /\n/;

--- a/test/built-ins/RegExp/prototype/multiline/S15.10.7.4_A8.js
+++ b/test/built-ins/RegExp/prototype/multiline/S15.10.7.4_A8.js
@@ -7,14 +7,13 @@ es5id: 15.10.7.4_A8
 description: >
     Checking if enumerating the multiline property of RegExp.prototype
     fails
-includes: [$FAIL.js]
 ---*/
 
 var __re = RegExp.prototype;
 
 //CHECK#0
 if (__re.hasOwnProperty('multiline') !== true) {
-  $FAIL('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'multiline\') === true');
+  $ERROR('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'multiline\') === true');
 }
 
  //CHECK#1

--- a/test/built-ins/RegExp/prototype/multiline/S15.10.7.4_A9.js
+++ b/test/built-ins/RegExp/prototype/multiline/S15.10.7.4_A9.js
@@ -7,14 +7,13 @@ info: >
     DontDelete
 es5id: 15.10.7.4_A9
 description: Checking if deleting the multiline property succeeds
-includes: [$FAIL.js]
 ---*/
 
 var __re = RegExp.prototype;
 
 //CHECK#0
 if (__re.hasOwnProperty('multiline') !== true) {
-  $FAIL('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'multiline\') === true');
+  $ERROR('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'multiline\') === true');
 }
 
 //CHECK#1

--- a/test/built-ins/RegExp/prototype/source/S15.10.7.1_A10.js
+++ b/test/built-ins/RegExp/prototype/source/S15.10.7.1_A10.js
@@ -5,14 +5,14 @@
 info: The RegExp.prototype source property does not have a set accessor
 es5id: 15.10.7.1_A10
 description: Checking if varying the source property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 var __re = RegExp.prototype;
 
 //CHECK#1
 if (__re.hasOwnProperty('source') !== true) {
-  $FAIL('#1: __re = RegExp.prototype; __re.hasOwnProperty(\'source\') === true');
+  $ERROR('#1: __re = RegExp.prototype; __re.hasOwnProperty(\'source\') === true');
 }
 
 var __sample = /./;

--- a/test/built-ins/RegExp/prototype/source/S15.10.7.1_A8.js
+++ b/test/built-ins/RegExp/prototype/source/S15.10.7.1_A8.js
@@ -7,14 +7,13 @@ es5id: 15.10.7.1_A8
 description: >
     Checking if enumerating the source property of RegExp.prototype
     fails
-includes: [$FAIL.js]
 ---*/
 
 var __re = RegExp.prototype;
 
 //CHECK#0
 if (__re.hasOwnProperty('source') !== true) {
-	$FAIL('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'source\') === true');
+	$ERROR('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'source\') === true');
 }
 
  //CHECK#1

--- a/test/built-ins/RegExp/prototype/source/S15.10.7.1_A9.js
+++ b/test/built-ins/RegExp/prototype/source/S15.10.7.1_A9.js
@@ -7,14 +7,13 @@ info: >
     DontDelete
 es5id: 15.10.7.1_A9
 description: Checking if deleting the source property succeeds
-includes: [$FAIL.js]
 ---*/
 
 var __re = RegExp.prototype;
 
 //CHECK#0
 if (__re.hasOwnProperty('source') !== true) {
-	$FAIL('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'source\') === true');
+	$ERROR('#0: __re = RegExp.prototype; __re.hasOwnProperty(\'source\') === true');
 }
 
 //CHECK#1

--- a/test/built-ins/RegExp/prototype/test/S15.10.6.3_A10.js
+++ b/test/built-ins/RegExp/prototype/test/S15.10.6.3_A10.js
@@ -5,12 +5,12 @@
 info: The RegExp.prototype.test.length property has the attribute ReadOnly
 es5id: 15.10.6.3_A10
 description: Checking if varying the RegExp.prototype.test.length property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#1
 if (RegExp.prototype.test.hasOwnProperty('length') !== true) {
-  $FAIL('#1: RegExp.prototype.test.hasOwnProperty(\'length\') === true');
+  $ERROR('#1: RegExp.prototype.test.hasOwnProperty(\'length\') === true');
 }
 
 var __obj = RegExp.prototype.test.length;

--- a/test/built-ins/RegExp/prototype/test/S15.10.6.3_A11.js
+++ b/test/built-ins/RegExp/prototype/test/S15.10.6.3_A11.js
@@ -5,12 +5,11 @@
 info: The length property of the test method is 1
 es5id: 15.10.6.3_A11
 description: Checking RegExp.prototype.test.length
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (RegExp.prototype.test.hasOwnProperty("length") !== true) {
-  $FAIL('#1: RegExp.prototype.test.hasOwnProperty(\'length\') === true');
+  $ERROR('#1: RegExp.prototype.test.hasOwnProperty(\'length\') === true');
 }
 
 //CHECK#2

--- a/test/built-ins/RegExp/prototype/test/S15.10.6.3_A9.js
+++ b/test/built-ins/RegExp/prototype/test/S15.10.6.3_A9.js
@@ -7,12 +7,11 @@ info: >
     DontDelete
 es5id: 15.10.6.3_A9
 description: Checking if deleting RegExp.prototype.test.length property fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if ((RegExp.prototype.exec.hasOwnProperty('length') !== true)) {
-  $FAIL('#0: RegExp.prototype.exec.hasOwnProperty(\'length\') === true');
+  $ERROR('#0: RegExp.prototype.exec.hasOwnProperty(\'length\') === true');
 }
 
 //CHECK#1

--- a/test/built-ins/RegExp/prototype/toString/S15.10.6.4_A10.js
+++ b/test/built-ins/RegExp/prototype/toString/S15.10.6.4_A10.js
@@ -7,12 +7,12 @@ es5id: 15.10.6.4_A10
 description: >
     Checking if varying the RegExp.prototype.toString.length property
     fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //CHECK#1
 if (RegExp.prototype.toString.hasOwnProperty('length') !== true) {
-	$FAIL('#1: RegExp.prototype.toString.hasOwnProperty(\'length\') === true');
+	$ERROR('#1: RegExp.prototype.toString.hasOwnProperty(\'length\') === true');
 }
 
 var __obj = RegExp.prototype.toString.length;

--- a/test/built-ins/RegExp/prototype/toString/S15.10.6.4_A11.js
+++ b/test/built-ins/RegExp/prototype/toString/S15.10.6.4_A11.js
@@ -5,12 +5,11 @@
 info: The length property of the toString method is 1
 es5id: 15.10.6.4_A11
 description: Checking RegExp.prototype.toString.length
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (RegExp.prototype.toString.hasOwnProperty("length") !== true) {
-	$FAIL('#1: RegExp.prototype.toString.hasOwnProperty(\'length\') === true');
+	$ERROR('#1: RegExp.prototype.toString.hasOwnProperty(\'length\') === true');
 }
 
 //CHECK#2

--- a/test/built-ins/RegExp/prototype/toString/S15.10.6.4_A9.js
+++ b/test/built-ins/RegExp/prototype/toString/S15.10.6.4_A9.js
@@ -9,12 +9,11 @@ es5id: 15.10.6.4_A9
 description: >
     Checking if deleting the RegExp.prototype.toString.length property
     fails
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#0
 if ((RegExp.prototype.toString.hasOwnProperty('length') !== true)) {
-	$FAIL('#0: RegExp.prototype.toString.hasOwnProperty(\'length\') === true');
+	$ERROR('#0: RegExp.prototype.toString.hasOwnProperty(\'length\') === true');
 }
 
 //CHECK#1

--- a/test/built-ins/String/S15.5.5_A1_T1.js
+++ b/test/built-ins/String/S15.5.5_A1_T1.js
@@ -5,7 +5,6 @@
 info: String instance has not [[call]] property
 es5id: 15.5.5_A1_T1
 description: Create new String and try call it
-includes: [$FAIL.js]
 ---*/
 
 var __str = new String;
@@ -14,7 +13,7 @@ var __str = new String;
 //CHECK#1
 try {
   __str();
-  $FAIL('#1: __str = new String; __str() lead to throwing exception');
+  $ERROR('#1: __str = new String; __str() lead to throwing exception');
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/String/S15.5.5_A1_T2.js
+++ b/test/built-ins/String/S15.5.5_A1_T2.js
@@ -5,14 +5,13 @@
 info: String instance has not [[call]] property
 es5id: 15.5.5_A1_T2
 description: Checking if creating new "String("a|b")()" fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 try {
   String("a|b")();
-  $FAIL('#1: String("a|b")() lead to throwing exception');
+  $ERROR('#1: String("a|b")() lead to throwing exception');
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/String/S15.5.5_A2_T1.js
+++ b/test/built-ins/String/S15.5.5_A2_T1.js
@@ -5,7 +5,6 @@
 info: String instance has not [[construct]] property
 es5id: 15.5.5_A2_T1
 description: Create new string object and try new created_string
-includes: [$FAIL.js]
 ---*/
 
 var __str = new Object("");
@@ -14,7 +13,7 @@ var __str = new Object("");
 //CHECK#1
 try {
   new __str;
-  $FAIL('#1: __str = new Object(""); "new __str" lead to throwing exception');
+  $ERROR('#1: __str = new Object(""); "new __str" lead to throwing exception');
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/String/S15.5.5_A2_T2.js
+++ b/test/built-ins/String/S15.5.5_A2_T2.js
@@ -5,14 +5,13 @@
 info: String instance has not [[construct]] property
 es5id: 15.5.5_A2_T2
 description: Checking if creating "new String" fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 try {
   new new String;
-  $FAIL('#1: "new new String" lead to throwing exception');
+  $ERROR('#1: "new new String" lead to throwing exception');
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/String/fromCharCode/S15.5.3.2_A4.js
+++ b/test/built-ins/String/fromCharCode/S15.5.3.2_A4.js
@@ -6,7 +6,6 @@ info: String.fromCharCode has not [[construct]] method
 es5id: 15.5.3.2_A4
 description: Checking if creating "new String.fromCharCode" fails
 includes:
-    - $FAIL.js
     - Test262Error.js
 ---*/
 
@@ -18,7 +17,7 @@ delete String.fromCharCode;
 //CHECK#1
 try {
   var __obj = new __fcc__func(65,66,66,65);
-  $FAIL('#1: __fcc__func = String.fromCharCode; var __obj = new __fcc__func(65,66,66,65) lead to throwing exception');
+  $ERROR('#1: __fcc__func = String.fromCharCode; var __obj = new __fcc__func(65,66,66,65) lead to throwing exception');
 } catch (e) {
     if (e instanceof Test262Error) throw e;
 }

--- a/test/built-ins/String/prototype/S15.5.3.1_A2.js
+++ b/test/built-ins/String/prototype/S15.5.3.1_A2.js
@@ -5,13 +5,12 @@
 info: The String.prototype property has the attribute DontEnum
 es5id: 15.5.3.1_A2
 description: Checking if enumerating the String.prototype property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.hasOwnProperty('prototype'))) {
-  $FAIL('#0: String.hasOwnProperty(\'prototype\') return true. Actual: '+String.hasOwnProperty('prototype'));
+  $ERROR('#0: String.hasOwnProperty(\'prototype\') return true. Actual: '+String.hasOwnProperty('prototype'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/S15.5.3.1_A3.js
+++ b/test/built-ins/String/prototype/S15.5.3.1_A3.js
@@ -5,13 +5,13 @@
 info: The String.prototype property has the attribute DontDelete
 es5id: 15.5.3.1_A3
 description: Checking if deleting the String.prototype property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (!(String.hasOwnProperty('prototype'))) {
-  $FAIL('#1: String.hasOwnProperty(\'prototype\') return true. Actual: '+String.hasOwnProperty('prototype'));
+  $ERROR('#1: String.hasOwnProperty(\'prototype\') return true. Actual: '+String.hasOwnProperty('prototype'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/S15.5.3.1_A4.js
+++ b/test/built-ins/String/prototype/S15.5.3.1_A4.js
@@ -5,13 +5,13 @@
 info: The String.prototype property has the attribute ReadOnly
 es5id: 15.5.3.1_A4
 description: Checking if varying the String.prototype property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (!(String.hasOwnProperty('prototype'))) {
-  $FAIL('#1: String.hasOwnProperty(\'prototype\') return true. Actual: '+String.hasOwnProperty('prototype'));
+  $ERROR('#1: String.hasOwnProperty(\'prototype\') return true. Actual: '+String.hasOwnProperty('prototype'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/S15.5.4_A2.js
+++ b/test/built-ins/String/prototype/S15.5.4_A2.js
@@ -5,14 +5,13 @@
 info: The String prototype object is itself not a String object
 es5id: 15.5.4_A2
 description: Checking String.prototype
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 try {
   (String.prototype !="");
-  $FAIL('#1: "(String.prototype !="");" lead to throwing exception. Actual: '+(String.prototype !=""));
+  $ERROR('#1: "(String.prototype !="");" lead to throwing exception. Actual: '+(String.prototype !=""));
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: "(String.prototype !="")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/String/prototype/charAt/S15.5.4.4_A5.js
+++ b/test/built-ins/String/prototype/charAt/S15.5.4.4_A5.js
@@ -7,7 +7,6 @@ info: >
     the this value as its argument
 es5id: 15.5.4.4_A5
 description: Change toString function, it trow exception, and call charAt()
-includes: [$FAIL.js]
 ---*/
 
 var __obj={
@@ -20,7 +19,7 @@ var __obj={
 //CHECK#1
 try {
   var x = __obj.charAt();
-  $FAIL('#1: __obj={valueOf:1,toString:function(){throw \'intostring\'},charAt:String.prototype.charAt}; "var x = __obj.charAt()" lead to throwing exception');
+  $ERROR('#1: __obj={valueOf:1,toString:function(){throw \'intostring\'},charAt:String.prototype.charAt}; "var x = __obj.charAt()" lead to throwing exception');
 } catch (e) {
   if (e !== 'intostring') {
     $ERROR('#1.1: Exception === \'intostring\'. Actual: exception ==='+e ); 

--- a/test/built-ins/String/prototype/charAt/S15.5.4.4_A7.js
+++ b/test/built-ins/String/prototype/charAt/S15.5.4.4_A7.js
@@ -5,14 +5,13 @@
 info: String.prototype.charAt can't be used as constructor
 es5id: 15.5.4.4_A7
 description: Checking if creating the String.prototype.charAt object fails
-includes: [$FAIL.js]
 ---*/
 
 var __FACTORY = String.prototype.charAt;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: __FACTORY = String.prototype.charAt; "__instance = new __FACTORY" lead to throwing exception');
+  $ERROR('#1: __FACTORY = String.prototype.charAt; "__instance = new __FACTORY" lead to throwing exception');
 } catch (e) {
   if ((e instanceof TypeError) !== true) {
     $ERROR('#1.2: undefined = 1 throw a TypeError. Actual: ' + (e));  

--- a/test/built-ins/String/prototype/charCodeAt/S15.5.4.5_A4.js
+++ b/test/built-ins/String/prototype/charCodeAt/S15.5.4.5_A4.js
@@ -7,7 +7,6 @@ info: >
     it the this value as its argument
 es5id: 15.5.4.5_A4
 description: Change toString function, it trow exception, and call charCodeAt()
-includes: [$FAIL.js]
 ---*/
 
 var __obj={
@@ -20,7 +19,7 @@ var __obj={
 //CHECK#1
 try {
   var x = __obj.charCodeAt();
-  $FAIL('#1:  "var x = __obj.charCodeAt()" lead to throwing exception');
+  $ERROR('#1:  "var x = __obj.charCodeAt()" lead to throwing exception');
 } catch (e) {
   if (e !== 'intostring') {
     $ERROR('#1.1: Exception === \'intostring\'. Actual: exception ==='+e ); 

--- a/test/built-ins/String/prototype/charCodeAt/S15.5.4.5_A7.js
+++ b/test/built-ins/String/prototype/charCodeAt/S15.5.4.5_A7.js
@@ -6,7 +6,6 @@ info: String.prototype.charCodeAt can't be used as constructor
 es5id: 15.5.4.5_A7
 description: Checking if creating the String.prototype.charCodeAt object fails
 includes:
-    - $FAIL.js
     - Test262Error.js
 ---*/
 
@@ -14,7 +13,7 @@ var __FACTORY = String.prototype.charCodeAt;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: __FACTORY = String.prototype.charCodeAt; "__instance = new __FACTORY" lead to throwing exception');
+  $ERROR('#1: __FACTORY = String.prototype.charCodeAt; "__instance = new __FACTORY" lead to throwing exception');
 } catch (e) {
     if (e instanceof Test262Error) throw e;
 }

--- a/test/built-ins/String/prototype/charCodeAt/S15.5.4.5_A8.js
+++ b/test/built-ins/String/prototype/charCodeAt/S15.5.4.5_A8.js
@@ -7,13 +7,12 @@ es5id: 15.5.4.5_A8
 description: >
     Checking if enumerating the String.prototype.charCodeAt.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.charCodeAt.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.charCodeAt.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.charCodeAt.hasOwnProperty('length')); 
+  $ERROR('#0: String.prototype.charCodeAt.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.charCodeAt.hasOwnProperty('length')); 
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/charCodeAt/S15.5.4.5_A9.js
+++ b/test/built-ins/String/prototype/charCodeAt/S15.5.4.5_A9.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.5_A9
 description: >
     Checking if deleting the String.prototype.charCodeAt.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.charCodeAt.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.charCodeAt.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.charCodeAt.hasOwnProperty('length')); 
+  $ERROR('#0: String.prototype.charCodeAt.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.charCodeAt.hasOwnProperty('length')); 
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -31,7 +30,7 @@ if (!delete String.prototype.charCodeAt.length) {
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (String.prototype.charCodeAt.hasOwnProperty('length')) {
-  $FAIL('#2: delete String.prototype.charCodeAt.length; String.prototype.charCodeAt.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.charCodeAt.hasOwnProperty('length')); 
+  $ERROR('#2: delete String.prototype.charCodeAt.length; String.prototype.charCodeAt.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.charCodeAt.hasOwnProperty('length')); 
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/concat/S15.5.4.6_A4_T2.js
+++ b/test/built-ins/String/prototype/concat/S15.5.4.6_A4_T2.js
@@ -7,7 +7,6 @@ info: >
     giving it the this value as its argument
 es5id: 15.5.4.6_A4_T2
 description: Override toString function onto function, that throw exception
-includes: [$FAIL.js]
 ---*/
 
 var __instance = {toString:function(){throw "intostring";}};
@@ -19,7 +18,7 @@ __instance.concat = String.prototype.concat;
 //CHECK#1
 try {
   String.prototype.concat.call(__instance,__obj, notexist);
-  $FAIL('#1: "String.prototype.concat.call(__instance,__obj, notexist)" lead to throwing exception');
+  $ERROR('#1: "String.prototype.concat.call(__instance,__obj, notexist)" lead to throwing exception');
 } catch (e) {
   if (e !== "intostring") {
     $ERROR('#1: e === "intostring". Actual: '+e ); 

--- a/test/built-ins/String/prototype/concat/S15.5.4.6_A7.js
+++ b/test/built-ins/String/prototype/concat/S15.5.4.6_A7.js
@@ -6,7 +6,6 @@ info: String.prototype.concat can't be used as constructor
 es5id: 15.5.4.6_A7
 description: Checking if creating the String.prototype.concat object fails
 includes:
-    - $FAIL.js
     - Test262Error.js
 ---*/
 
@@ -14,7 +13,7 @@ var __FACTORY = String.prototype.concat;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: __FACTORY = String.prototype.concat; "__instance = new __FACTORY" lead throwing exception');
+  $ERROR('#1: __FACTORY = String.prototype.concat; "__instance = new __FACTORY" lead throwing exception');
 } catch (e) {
     if (e instanceof Test262Error) throw e;
 }

--- a/test/built-ins/String/prototype/concat/S15.5.4.6_A8.js
+++ b/test/built-ins/String/prototype/concat/S15.5.4.6_A8.js
@@ -7,13 +7,12 @@ es5id: 15.5.4.6_A8
 description: >
     Checking if enumerating the String.prototype.concat.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.concat.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.concat.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.concat.hasOwnProperty('length')); 
+  $ERROR('#0: String.prototype.concat.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.concat.hasOwnProperty('length')); 
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/concat/S15.5.4.6_A9.js
+++ b/test/built-ins/String/prototype/concat/S15.5.4.6_A9.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.6_A9
 description: >
     Checking if deleting the String.prototype.concat.length property
     fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.concat.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.concat.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.concat.hasOwnProperty('length')); 
+  $ERROR('#0: String.prototype.concat.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.concat.hasOwnProperty('length')); 
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -31,7 +30,7 @@ if (!delete String.prototype.concat.length) {
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (String.prototype.concat.hasOwnProperty('length')) {
-  $FAIL('#2: delete String.prototype.concat.length; String.prototype.concat.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.concat.hasOwnProperty('length')); 
+  $ERROR('#2: delete String.prototype.concat.length; String.prototype.concat.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.concat.hasOwnProperty('length')); 
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/indexOf/S15.5.4.7_A10.js
+++ b/test/built-ins/String/prototype/indexOf/S15.5.4.7_A10.js
@@ -7,13 +7,13 @@ es5id: 15.5.4.7_A10
 description: >
     Checking if varying the String.prototype.indexOf.length property
     fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (!(String.prototype.indexOf.hasOwnProperty('length'))) {
-  $FAIL('#1: String.prototype.indexOf.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.indexOf.hasOwnProperty('length')); 
+  $ERROR('#1: String.prototype.indexOf.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.indexOf.hasOwnProperty('length')); 
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/indexOf/S15.5.4.7_A4_T1.js
+++ b/test/built-ins/String/prototype/indexOf/S15.5.4.7_A4_T1.js
@@ -7,7 +7,6 @@ info: >
     Then Call ToString(searchString) and Call ToNumber(position)
 es5id: 15.5.4.7_A4_T1
 description: Override toString and valueOf functions, valueOf throw exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return "\u0041B";}}
@@ -18,7 +17,7 @@ var __str = "ABB\u0041BABAB";
 //CHECK#1
         try {
           var x = __str.indexOf(__obj, __obj2);
-          $FAIL('#1: "var x = __str.indexOf(__obj, __obj2)" lead to throwing exception');
+          $ERROR('#1: "var x = __str.indexOf(__obj, __obj2)" lead to throwing exception');
         } catch (e) {
           if (e!=="intointeger") {
             $ERROR('#1.1: Exception === "intointeger". Actual: '+e); 

--- a/test/built-ins/String/prototype/indexOf/S15.5.4.7_A4_T2.js
+++ b/test/built-ins/String/prototype/indexOf/S15.5.4.7_A4_T2.js
@@ -9,7 +9,6 @@ es5id: 15.5.4.7_A4_T2
 description: >
     Override toString and valueOf functions, second toString throw
     exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return "\u0041B";}}
@@ -20,7 +19,7 @@ var __str = new String("ABB\u0041BABAB");
 //CHECK#1
     try {
       var x = __str.indexOf(__obj, __obj2);
-      $FAIL('#1: "var x = __str.indexOf(__obj, __obj2)" lead to throwing exception');
+      $ERROR('#1: "var x = __str.indexOf(__obj, __obj2)" lead to throwing exception');
     } catch (e) {
       if (e!=="intointeger") {
         $ERROR('#1.1: Exception === "intointeger". Actual: '+e); 

--- a/test/built-ins/String/prototype/indexOf/S15.5.4.7_A4_T4.js
+++ b/test/built-ins/String/prototype/indexOf/S15.5.4.7_A4_T4.js
@@ -7,7 +7,6 @@ info: >
     Then Call ToString(searchString) and Call ToNumber(position)
 es5id: 15.5.4.7_A4_T4
 description: Override toString and valueOf functions, and they throw exceptions
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){throw "intostr";}};
@@ -19,7 +18,7 @@ Number.prototype.indexOf=String.prototype.indexOf;
 //CHECK#1
     try {
       var x = __instance.indexOf(__obj, __obj2);
-      $FAIL('#1: "var x = __instance.indexOf(__obj, __obj2)" lead to throwing exception');
+      $ERROR('#1: "var x = __instance.indexOf(__obj, __obj2)" lead to throwing exception');
     } catch (e) {
       if (e!=="intostr") {
         $ERROR('#1.1: Exception === "intostr". Actual: '+e); 

--- a/test/built-ins/String/prototype/indexOf/S15.5.4.7_A4_T5.js
+++ b/test/built-ins/String/prototype/indexOf/S15.5.4.7_A4_T5.js
@@ -9,7 +9,6 @@ es5id: 15.5.4.7_A4_T5
 description: >
     Override toString and valueOf functions, first and second valueOf
     throw exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return {};},valueOf:function(){throw "intostr";}};
@@ -24,7 +23,7 @@ var __instance = new __FACTORY(void 0);
 //CHECK#1
 try {
   var x = __instance.indexOf(__obj, __obj2);
-  $FAIL('#1: "var x = __instance.indexOf(__obj, __obj2)" lead to throwing exception');
+  $ERROR('#1: "var x = __instance.indexOf(__obj, __obj2)" lead to throwing exception');
 } catch (e) {
   if (e!=="intostr") {
     $ERROR('#1.1: Exception === "intostr". Actual: '+e); 

--- a/test/built-ins/String/prototype/indexOf/S15.5.4.7_A7.js
+++ b/test/built-ins/String/prototype/indexOf/S15.5.4.7_A7.js
@@ -7,14 +7,13 @@ es5id: 15.5.4.7_A7
 description: Checking if creating the String.prototype.indexOf object fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 var __FACTORY = String.prototype.indexOf;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: var __FACTORY = String.prototype.indexOf; "__instance = new __FACTORY" lead to throwing exception');
+  $ERROR('#1: var __FACTORY = String.prototype.indexOf; "__instance = new __FACTORY" lead to throwing exception');
 } catch (e) {
   if ((e instanceof TypeError) !== true) {
     $ERROR('#1.2: var __FACTORY = String.prototype.indexOf; "__instance = new __FACTORY" throw a TypeError. Actual: ' + (e));  

--- a/test/built-ins/String/prototype/indexOf/S15.5.4.7_A9.js
+++ b/test/built-ins/String/prototype/indexOf/S15.5.4.7_A9.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.7_A9
 description: >
     Checking if deleting the String.prototype.indexOf.length property
     fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.indexOf.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.indexOf.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.indexOf.hasOwnProperty('length')); 
+  $ERROR('#0: String.prototype.indexOf.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.indexOf.hasOwnProperty('length')); 
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -31,7 +30,7 @@ if (!delete String.prototype.indexOf.length) {
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (String.prototype.indexOf.hasOwnProperty('length')) {
-  $FAIL('#2: delete String.prototype.indexOf.length; String.prototype.indexOf.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.indexOf.hasOwnProperty('length')); 
+  $ERROR('#2: delete String.prototype.indexOf.length; String.prototype.indexOf.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.indexOf.hasOwnProperty('length')); 
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A10.js
+++ b/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A10.js
@@ -9,13 +9,13 @@ es5id: 15.5.4.8_A10
 description: >
     Checking if varying the String.prototype.lastIndexOf.length
     property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (!(String.prototype.lastIndexOf.hasOwnProperty('length'))) {
-  $FAIL('#1: String.prototype.lastIndexOf.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.lastIndexOf.hasOwnProperty('length'));
+  $ERROR('#1: String.prototype.lastIndexOf.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.lastIndexOf.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A4_T1.js
+++ b/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A4_T1.js
@@ -7,7 +7,6 @@ info: >
     Then Call ToString(searchString) and Call ToNumber(position)
 es5id: 15.5.4.8_A4_T1
 description: Override toString and valueOf functions, valueOf throw exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return "\u0041B";}}
@@ -18,7 +17,7 @@ var __str = "ABB\u0041BABAB";
 //CHECK#1
         try {
           var x = __str.lastIndexOf(__obj, __obj2);
-          $FAIL('#1: var x = __str.lastIndexOf(__obj, __obj2) lead to throwing exception');
+          $ERROR('#1: var x = __str.lastIndexOf(__obj, __obj2) lead to throwing exception');
         } catch (e) {
           if (e!=="intointeger") {
             $ERROR('#1.1: Exception === "intointeger". Actual: '+e);

--- a/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A4_T2.js
+++ b/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A4_T2.js
@@ -9,7 +9,6 @@ es5id: 15.5.4.8_A4_T2
 description: >
     Override toString and valueOf functions, second toString throw
     exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return "\u0041B";}}
@@ -20,7 +19,7 @@ var __str = new String("ABB\u0041BABAB");
 //CHECK#1
     try {
       var x = __str.lastIndexOf(__obj, __obj2);
-      $FAIL('#1: var x = __str.lastIndexOf(__obj, __obj2) lead to throwing exception');
+      $ERROR('#1: var x = __str.lastIndexOf(__obj, __obj2) lead to throwing exception');
     } catch (e) {
       if (e!=="intointeger") {
         $ERROR('#1.1: Exception === "intointeger". Actual: '+e);

--- a/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A4_T4.js
+++ b/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A4_T4.js
@@ -7,7 +7,6 @@ info: >
     Then Call ToString(searchString) and Call ToNumber(position)
 es5id: 15.5.4.8_A4_T4
 description: Override toString and valueOf functions, and they throw exceptions
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){throw "intostr";}};
@@ -19,7 +18,7 @@ Number.prototype.lastIndexOf=String.prototype.lastIndexOf;
 //CHECK#1
     try {
       var x = __instance.lastIndexOf(__obj, __obj2);
-      $FAIL('#1: var x = __instance.lastIndexOf(__obj, __obj2) lead to throwing exception');
+      $ERROR('#1: var x = __instance.lastIndexOf(__obj, __obj2) lead to throwing exception');
     } catch (e) {
       if (e!=="intostr") {
         $ERROR('#1.1: Exception === "intostr". Actual: '+e);

--- a/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A4_T5.js
+++ b/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A4_T5.js
@@ -9,7 +9,6 @@ es5id: 15.5.4.8_A4_T5
 description: >
     Override toString and valueOf functions, first and second valueOf
     throw exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return {};},valueOf:function(){throw "intostr";}};
@@ -24,7 +23,7 @@ var __instance = new __FACTORY(void 0);
 //CHECK#1
 try {
   var x = __instance.lastIndexOf(__obj, __obj2);
-  $FAIL('#1: var x = __instance.lastIndexOf(__obj, __obj2) lead to throwing exception');
+  $ERROR('#1: var x = __instance.lastIndexOf(__obj, __obj2) lead to throwing exception');
 } catch (e) {
   if (e!=="intostr") {
     $ERROR('#1.1: Exception === "intostr". Actual: '+e);

--- a/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A7.js
+++ b/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A7.js
@@ -7,14 +7,13 @@ es5id: 15.5.4.8_A7
 description: Checking if creating the String.prototype.lastIndexOf object fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 var __FACTORY = String.prototype.lastIndexOf;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: __FACTORY = String.prototype.lastIndexOf; __instance = new __FACTORY lead to throwing exception');
+  $ERROR('#1: __FACTORY = String.prototype.lastIndexOf; __instance = new __FACTORY lead to throwing exception');
 } catch (e) {
   $PRINT(e);
 }

--- a/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A8.js
+++ b/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A8.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.8_A8
 description: >
     Checking if enumerating the String.prototype.lastIndexOf.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.lastIndexOf.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.lastIndexOf.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.lastIndexOf.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.lastIndexOf.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.lastIndexOf.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A9.js
+++ b/test/built-ins/String/prototype/lastIndexOf/S15.5.4.8_A9.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.8_A9
 description: >
     Checking if deleting the String.prototype.lastIndexOf.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.lastIndexOf.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.lastIndexOf.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.lastIndexOf.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.lastIndexOf.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.lastIndexOf.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -31,7 +30,7 @@ if (!delete String.prototype.lastIndexOf.length) {
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (String.prototype.lastIndexOf.hasOwnProperty('length')) {
-  $FAIL('#2: delete String.prototype.lastIndexOf.length; String.prototype.lastIndexOf.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.lastIndexOf.hasOwnProperty('length'));
+  $ERROR('#2: delete String.prototype.lastIndexOf.length; String.prototype.lastIndexOf.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.lastIndexOf.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/localeCompare/S15.5.4.9_A7.js
+++ b/test/built-ins/String/prototype/localeCompare/S15.5.4.9_A7.js
@@ -8,7 +8,6 @@ description: >
     Checking if creating the String.prototype.localeCompare object
     fails
 includes:
-    - $FAIL.js
     - Test262Error.js
 ---*/
 
@@ -16,7 +15,7 @@ var __FACTORY = String.prototype.localeCompare;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: __FACTORY = String.prototype.localeCompare; __instance = new __FACTORY lead to throwing exception');
+  $ERROR('#1: __FACTORY = String.prototype.localeCompare; __instance = new __FACTORY lead to throwing exception');
 } catch (e) {
     if (e instanceof Test262Error) throw e;
 }

--- a/test/built-ins/String/prototype/match/S15.5.4.10_A10.js
+++ b/test/built-ins/String/prototype/match/S15.5.4.10_A10.js
@@ -7,13 +7,13 @@ es5id: 15.5.4.10_A10
 description: >
     Checking if varying the String.prototype.match.length property
     fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (!(String.prototype.match.hasOwnProperty('length'))) {
-  $FAIL('#1: String.prototype.match.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.match.hasOwnProperty('length'));
+  $ERROR('#1: String.prototype.match.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.match.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/match/S15.5.4.10_A1_T11.js
+++ b/test/built-ins/String/prototype/match/S15.5.4.10_A1_T11.js
@@ -7,7 +7,6 @@ es5id: 15.5.4.10_A1_T11
 description: >
     Override toString function, toString throw exception, then call
     match (regexp) function with this object as argument
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){throw "intostr";}}
@@ -17,7 +16,7 @@ var __str = "ABB\u0041BABAB";
 //CHECK#1
         try {
           var x = __str.match(__obj);
-          $FAIL('#1: "var x = __str.match(__obj)" lead to throwing exception');
+          $ERROR('#1: "var x = __str.match(__obj)" lead to throwing exception');
         } catch (e) {
           if (e!=="intostr") {
             $ERROR('#1.1: Exception === "intostr". Actual: '+e);

--- a/test/built-ins/String/prototype/match/S15.5.4.10_A1_T12.js
+++ b/test/built-ins/String/prototype/match/S15.5.4.10_A1_T12.js
@@ -7,7 +7,6 @@ es5id: 15.5.4.10_A1_T12
 description: >
     Override toString and valueOf functions, valueOf throw exception,
     then call match (regexp) function with this object as argument
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return {};},valueOf:function(){throw "intostr";}}
@@ -17,7 +16,7 @@ var __str = new String("ABB\u0041BABAB");
 //CHECK#1
     try {
       var x = __str.match(__obj);
-      $FAIL('#1: "var x = __str.match(__obj)" lead to throwing exception');
+      $ERROR('#1: "var x = __str.match(__obj)" lead to throwing exception');
     } catch (e) {
       if (e!=="intostr") {
         $ERROR('#1.1: Exception === "intostr". Actual: '+e);

--- a/test/built-ins/String/prototype/match/S15.5.4.10_A7.js
+++ b/test/built-ins/String/prototype/match/S15.5.4.10_A7.js
@@ -6,7 +6,6 @@ info: String.prototype.match can't be used as constructor
 es5id: 15.5.4.10_A7
 description: Checking if creating "String.prototype.match object" fails
 includes:
-    - $FAIL.js
     - Test262Error.js
 ---*/
 
@@ -14,7 +13,7 @@ var __FACTORY = String.prototype.match;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: __FACTORY = String.prototype.match; __FACTORY = String.prototype.match; __instance = new __FACTORY lead to throwing exception');
+  $ERROR('#1: __FACTORY = String.prototype.match; __FACTORY = String.prototype.match; __instance = new __FACTORY lead to throwing exception');
 } catch (e) {
     if (e instanceof Test262Error) throw e;
 }

--- a/test/built-ins/String/prototype/match/S15.5.4.10_A8.js
+++ b/test/built-ins/String/prototype/match/S15.5.4.10_A8.js
@@ -7,13 +7,12 @@ es5id: 15.5.4.10_A8
 description: >
     Checking if enumerating the String.prototype.match.length property
     fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.match.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.match.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.match.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.match.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.match.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/match/S15.5.4.10_A9.js
+++ b/test/built-ins/String/prototype/match/S15.5.4.10_A9.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.10_A9
 description: >
     Checking if deleting the String.prototype.match.length property
     fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.match.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.match.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.match.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.match.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.match.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -31,7 +30,7 @@ if (!delete String.prototype.match.length) {
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (String.prototype.match.hasOwnProperty('length')) {
-  $FAIL('#2: delete String.prototype.match.length; String.prototype.match.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.match.hasOwnProperty('length'));
+  $ERROR('#2: delete String.prototype.match.length; String.prototype.match.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.match.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/replace/S15.5.4.11_A10.js
+++ b/test/built-ins/String/prototype/replace/S15.5.4.11_A10.js
@@ -7,13 +7,13 @@ es5id: 15.5.4.11_A10
 description: >
     Checking if varying the String.prototype.replace.length property
     fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (!(String.prototype.replace.hasOwnProperty('length'))) {
-  $FAIL('#1: String.prototype.replace.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.replace.hasOwnProperty('length'));
+  $ERROR('#1: String.prototype.replace.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.replace.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/replace/S15.5.4.11_A12.js
+++ b/test/built-ins/String/prototype/replace/S15.5.4.11_A12.js
@@ -6,7 +6,6 @@ info: Call replaceValue passing undefined as the this value
 es5id: 15.5.4.11_A12
 description: replaceValue tests that its this value is undefined
 flags: [onlyStrict]
-includes: [$FAIL.js]
 ---*/
 
 var global = this;
@@ -14,10 +13,10 @@ var global = this;
   "use strict";
 
   if (this === global) {
-    $FAIL('#1: String replace leaks global');
+    $ERROR('#1: String replace leaks global');
   }
   if (this !== undefined) {
-    $FAIL('#2: replaceValue should be called with this===undefined. ' +
+    $ERROR('#2: replaceValue should be called with this===undefined. ' +
           'Actual: ' + this);
   }
   return 'y';

--- a/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T11.js
+++ b/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T11.js
@@ -8,7 +8,6 @@ description: >
     Call replace (searchValue, replaceValue) function with objects
     arguments of string object. Objects have overrided toString
     function, that throw exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){throw "insearchValue";}};
@@ -19,7 +18,7 @@ var __str = "ABB\u0041BABAB";
 //CHECK#1
         try {
           var x = __str.replace(__obj,__obj2);
-          $FAIL('#1: "var x = __str.replace(__obj,__obj2)" lead to throwing exception');
+          $ERROR('#1: "var x = __str.replace(__obj,__obj2)" lead to throwing exception');
         } catch (e) {
           if (e!=="insearchValue") {
             $ERROR('#1.1: Exception === "insearchValue". Actual: '+e);

--- a/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T12.js
+++ b/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T12.js
@@ -9,7 +9,6 @@ description: >
     arguments of String object.  First objects have overrided toString
     and valueOf functions, valueOf throw exception.  Second objects
     have overrided toString function, that throw exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return {};}, valueOf:function(){throw "insearchValue";}};
@@ -20,7 +19,7 @@ var __str = new String("ABB\u0041BABAB");
 //CHECK#1
     try {
       var x = __str.replace(__obj, __obj2);
-      $FAIL('#1: "var x = __str.replace(__obj,__obj2)" lead to throwing exception');
+      $ERROR('#1: "var x = __str.replace(__obj,__obj2)" lead to throwing exception');
     } catch (e) {
       if (e!=="insearchValue") {
         $ERROR('#1.1: Exception === "insearchValue". Actual: '+e);

--- a/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T13.js
+++ b/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T13.js
@@ -9,7 +9,6 @@ description: >
     arguments of string.  First objects have overrided toString and
     valueOf functions.  Second objects have overrided toString
     function, that throw exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return {};}, valueOf:function(){return 1;}};
@@ -19,7 +18,7 @@ var __obj2 = {toString:function(){throw "inreplaceValue";}};
 //CHECK#1
 try {
     var x = "ABB\u0041BABAB\u0031BBAA".replace(__obj, __obj2);
-    $FAIL('#1: var x = "ABB\\u0041BABAB\\u0031BBAA".replace(__obj,__obj2) lead to throwing exception');
+    $ERROR('#1: var x = "ABB\\u0041BABAB\\u0031BBAA".replace(__obj,__obj2) lead to throwing exception');
 } catch (e) {
     if (e!=="inreplaceValue") {
         $ERROR('#1.1: Exception === "inreplaceValue". Actual: '+e);

--- a/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T15.js
+++ b/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T15.js
@@ -5,7 +5,6 @@
 info: String.prototype.replace (searchValue, replaceValue)
 es5id: 15.5.4.11_A1_T15
 description: Instance is Object, searchValue is regular expression
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return /77/}};
@@ -18,7 +17,7 @@ Object.prototype.replace = String.prototype.replace;
 //CHECK#1
 try {
   var x = __instance.replace(__obj, 1) === "1100.0017001";
-    $FAIL('#1.0: x = __instance.replace(__obj, 1) === "1100.0017001" lead to throwing exception');
+    $ERROR('#1.0: x = __instance.replace(__obj, 1) === "1100.0017001" lead to throwing exception');
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: Exception is instance of TypeError. Actual: '+e);

--- a/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T16.js
+++ b/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T16.js
@@ -5,7 +5,6 @@
 info: String.prototype.replace (searchValue, replaceValue)
 es5id: 15.5.4.11_A1_T16
 description: Instance is Number, searchValue is regular expression
-includes: [$FAIL.js]
 ---*/
 
 var __re = /77/;
@@ -22,7 +21,7 @@ var __obj = {toString:function(){return function(a1,a2,a3){return a2+"z"};}}
 //CHECK#1
 try {
   var x = __instance.replace(__re, __obj) === "1100.007z7001";
-  $FAIL('#1.0: x = __instance.replace(__obj, 1) === "1100.007z7001" lead to throwing exception');
+  $ERROR('#1.0: x = __instance.replace(__obj, 1) === "1100.007z7001" lead to throwing exception');
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: Exception is instance of TypeError. Actual: '+e);

--- a/test/built-ins/String/prototype/replace/S15.5.4.11_A7.js
+++ b/test/built-ins/String/prototype/replace/S15.5.4.11_A7.js
@@ -6,7 +6,6 @@ info: String.prototype.replace can't be used as constructor
 es5id: 15.5.4.11_A7
 description: Checking if creating the String.prototype.replace object fails
 includes:
-    - $FAIL.js
     - Test262Error.js
 ---*/
 
@@ -14,7 +13,7 @@ var __FACTORY = String.prototype.replace;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: __FACTORY = String.prototype.replace; "__instance = new __FACTORY" lead to throwing exception');
+  $ERROR('#1: __FACTORY = String.prototype.replace; "__instance = new __FACTORY" lead to throwing exception');
 } catch (e) {
     if (e instanceof Test262Error) throw e;
 }

--- a/test/built-ins/String/prototype/replace/S15.5.4.11_A8.js
+++ b/test/built-ins/String/prototype/replace/S15.5.4.11_A8.js
@@ -7,13 +7,12 @@ es5id: 15.5.4.11_A8
 description: >
     Checking if enumerating the String.prototype.replace.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.replace.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.replace.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.replace.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.replace.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.replace.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/replace/S15.5.4.11_A9.js
+++ b/test/built-ins/String/prototype/replace/S15.5.4.11_A9.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.11_A9
 description: >
     Checking if deleting the String.prototype.replace.length property
     fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.replace.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.replace.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.replace.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.replace.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.replace.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -31,7 +30,7 @@ if (!delete String.prototype.replace.length) {
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (String.prototype.replace.hasOwnProperty('length')) {
-  $FAIL('#2: delete String.prototype.replace.length; String.prototype.replace.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.replace.hasOwnProperty('length'));
+  $ERROR('#2: delete String.prototype.replace.length; String.prototype.replace.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.replace.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/search/S15.5.4.12_A10.js
+++ b/test/built-ins/String/prototype/search/S15.5.4.12_A10.js
@@ -7,13 +7,13 @@ es5id: 15.5.4.12_A10
 description: >
     Checking if varying the String.prototype.search.length property
     fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (!(String.prototype.search.hasOwnProperty('length'))) {
-  $FAIL('#1: String.prototype.search.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.search.hasOwnProperty('length'));
+  $ERROR('#1: String.prototype.search.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.search.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/search/S15.5.4.12_A1_T11.js
+++ b/test/built-ins/String/prototype/search/S15.5.4.12_A1_T11.js
@@ -7,7 +7,6 @@ es5id: 15.5.4.12_A1_T11
 description: >
     Argument is object, and instance is string.  Object with overrided
     toString function, that throw exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){throw "intostr";}}
@@ -17,7 +16,7 @@ var __str = "ABB\u0041BABAB";
 //CHECK#1
     try {
       var x = __str.search(__obj);
-      $FAIL('#1: var x = __str.search(__obj) lead to throwing exception');
+      $ERROR('#1: var x = __str.search(__obj) lead to throwing exception');
     } catch (e) {
       if (e!=="intostr") {
         $ERROR('#1.1: Exception === "intostr". Actual: '+e);

--- a/test/built-ins/String/prototype/search/S15.5.4.12_A1_T12.js
+++ b/test/built-ins/String/prototype/search/S15.5.4.12_A1_T12.js
@@ -7,7 +7,6 @@ es5id: 15.5.4.12_A1_T12
 description: >
     Argument is object, and instance is string.  Object with overrided
     toString and valueOf functions, valueOf throw exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return {};},valueOf:function(){throw "intostr";}}
@@ -17,7 +16,7 @@ var __str = new String("ABB\u0041BABAB");
 //CHECK#1
     try {
       var x = __str.search(__obj);
-      $FAIL('#1: var x = __str.search(__obj) lead to throwing exception');
+      $ERROR('#1: var x = __str.search(__obj) lead to throwing exception');
     } catch (e) {
       if (e!=="intostr") {
         $ERROR('#1.1: Exception === "intostr". Actual: '+e);

--- a/test/built-ins/String/prototype/search/S15.5.4.12_A7.js
+++ b/test/built-ins/String/prototype/search/S15.5.4.12_A7.js
@@ -7,14 +7,13 @@ es5id: 15.5.4.12_A7
 description: Checking if creating the String.prototype.search object fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 var __FACTORY = String.prototype.search;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: __FACTORY = String.prototype.search; "__instance = new __FACTORY" lead to throwing exception');
+  $ERROR('#1: __FACTORY = String.prototype.search; "__instance = new __FACTORY" lead to throwing exception');
 } catch (e) {
   if ((e instanceof TypeError) !== true) {
     $ERROR('#1.1: __FACTORY = String.prototype.search; "__instance = new __FACTORY" throw a TypeError. Actual: ' + (e));  

--- a/test/built-ins/String/prototype/search/S15.5.4.12_A8.js
+++ b/test/built-ins/String/prototype/search/S15.5.4.12_A8.js
@@ -7,13 +7,12 @@ es5id: 15.5.4.12_A8
 description: >
     Checking if enumerating the String.prototype.search.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.search.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.search.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.search.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.search.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.search.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/search/S15.5.4.12_A9.js
+++ b/test/built-ins/String/prototype/search/S15.5.4.12_A9.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.12_A9
 description: >
     Checking if deleting the String.prototype.search.length property
     fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.search.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.search.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.search.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.search.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.search.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -31,7 +30,7 @@ if (!delete String.prototype.search.length) {
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (String.prototype.search.hasOwnProperty('length')) {
-  $FAIL('#2: delete String.prototype.search.length; String.prototype.search.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.search.hasOwnProperty('length'));
+  $ERROR('#2: delete String.prototype.search.length; String.prototype.search.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.search.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/slice/S15.5.4.13_A10.js
+++ b/test/built-ins/String/prototype/slice/S15.5.4.13_A10.js
@@ -7,13 +7,13 @@ es5id: 15.5.4.13_A10
 description: >
     Checking if varying the String.prototype.slice.length property
     fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (!(String.prototype.slice.hasOwnProperty('length'))) {
-  $FAIL('#1: String.prototype.slice.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.slice.hasOwnProperty('length'));
+  $ERROR('#1: String.prototype.slice.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.slice.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/slice/S15.5.4.13_A1_T11.js
+++ b/test/built-ins/String/prototype/slice/S15.5.4.13_A1_T11.js
@@ -7,7 +7,6 @@ es5id: 15.5.4.13_A1_T11
 description: >
     Arguments are objects, and instance is string, objects have
     overrided valueOf function, that return exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {valueOf:function(){throw "instart";}};
@@ -18,7 +17,7 @@ var __str = "ABB\u0041BABAB";
 //CHECK#1
         try {
           var x = __str.slice(__obj,__obj2);
-          $FAIL('#1: "var x = __str.slice(__obj,__obj2)" lead to throwing exception');
+          $ERROR('#1: "var x = __str.slice(__obj,__obj2)" lead to throwing exception');
         } catch (e) {
           if (e!=="instart") {
             $ERROR('#1.1: Exception === "instart". Actual: '+e);

--- a/test/built-ins/String/prototype/slice/S15.5.4.13_A1_T12.js
+++ b/test/built-ins/String/prototype/slice/S15.5.4.13_A1_T12.js
@@ -9,7 +9,6 @@ description: >
     overrided valueOf function and toString function, that return
     exception.  Second object have overrided valueOf function, that
     return exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {valueOf:function(){return {};}, toString:function(){throw "instart";}};
@@ -20,7 +19,7 @@ var __str = new String("ABB\u0041BABAB");
 //CHECK#1
     try {
       var x = __str.slice(__obj, __obj2);
-      $FAIL('#1: "var x = __str.slice(__obj,__obj2)" lead to throwing exception');
+      $ERROR('#1: "var x = __str.slice(__obj,__obj2)" lead to throwing exception');
     } catch (e) {
       if (e!=="instart") {
         $ERROR('#1.1: Exception === "instart". Actual: '+e);

--- a/test/built-ins/String/prototype/slice/S15.5.4.13_A1_T13.js
+++ b/test/built-ins/String/prototype/slice/S15.5.4.13_A1_T13.js
@@ -8,7 +8,6 @@ description: >
     Arguments are objects, and instance is string.  First object have
     overrided valueOf and toString functions.  Second object have
     overrided toString function, that return exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {valueOf:function(){return {};}, toString:function(){return 1;}};
@@ -18,7 +17,7 @@ var __obj2 = {toString:function(){throw "inend";}};
 //CHECK#1
 try {
     var x = "ABB\u0041BABAB\u0031BBAA".slice(__obj, __obj2);
-    $FAIL('#1: "var x = slice(__obj,__obj2)" lead to throwing exception');
+    $ERROR('#1: "var x = slice(__obj,__obj2)" lead to throwing exception');
 } catch (e) {
     if (e!=="inend") {
         $ERROR('#1.1: Exception === "inend". Actual: '+e);

--- a/test/built-ins/String/prototype/slice/S15.5.4.13_A7.js
+++ b/test/built-ins/String/prototype/slice/S15.5.4.13_A7.js
@@ -7,14 +7,13 @@ es5id: 15.5.4.13_A7
 description: Checking if creating the String.prototype.slice object fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 var __FACTORY = String.prototype.slice;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: __FACTORY = String.prototype.slice; "__instance = new __FACTORY" lead to throwing exception');
+  $ERROR('#1: __FACTORY = String.prototype.slice; "__instance = new __FACTORY" lead to throwing exception');
 } catch (e) {
   $PRINT(e);
 }

--- a/test/built-ins/String/prototype/slice/S15.5.4.13_A8.js
+++ b/test/built-ins/String/prototype/slice/S15.5.4.13_A8.js
@@ -7,13 +7,12 @@ es5id: 15.5.4.13_A8
 description: >
     Checking if enumerating the String.prototype.slice.length property
     fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.slice.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.slice.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.slice.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.slice.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.slice.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/slice/S15.5.4.13_A9.js
+++ b/test/built-ins/String/prototype/slice/S15.5.4.13_A9.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.13_A9
 description: >
     Checking if deleting the String.prototype.slice.length property
     fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.slice.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.slice.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.slice.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.slice.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.slice.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -31,7 +30,7 @@ if (!delete String.prototype.slice.length) {
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (String.prototype.slice.hasOwnProperty('length')) {
-  $FAIL('#2: delete String.prototype.slice.length; String.prototype.slice.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.slice.hasOwnProperty('length'));
+  $ERROR('#2: delete String.prototype.slice.length; String.prototype.slice.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.slice.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/split/S15.5.4.14_A10.js
+++ b/test/built-ins/String/prototype/split/S15.5.4.14_A10.js
@@ -7,13 +7,13 @@ es5id: 15.5.4.14_A10
 description: >
     Checking if varying the String.prototype.split.length property
     fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (!(String.prototype.split.hasOwnProperty('length'))) {
-  $FAIL('#1: String.prototype.split.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.split.hasOwnProperty('length'));
+  $ERROR('#1: String.prototype.split.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.split.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/split/S15.5.4.14_A1_T11.js
+++ b/test/built-ins/String/prototype/split/S15.5.4.14_A1_T11.js
@@ -13,7 +13,6 @@ description: >
     Arguments are objects, and instance is string.  First object have
     overrided toString function.  Second object have overrided valueOf
     function, that throw exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return "\u0041B";}}
@@ -24,7 +23,7 @@ var __str = "ABB\u0041BABAB";
 //CHECK#1
         try {
           var x = __str.split(__obj, __obj2);
-          $FAIL('#1: "var x = __str.split(__obj, __obj2)" lead to throwing exception');
+          $ERROR('#1: "var x = __str.split(__obj, __obj2)" lead to throwing exception');
         } catch (e) {
           if (e!=="intointeger") {
             $ERROR('#1.1: Exception === "intointeger". Actual: '+e);

--- a/test/built-ins/String/prototype/split/S15.5.4.14_A1_T12.js
+++ b/test/built-ins/String/prototype/split/S15.5.4.14_A1_T12.js
@@ -13,7 +13,6 @@ description: >
     Arguments are objects, and instance is string.  First object have
     overrided toString function.  Second object have overrided valueOf
     function and toString function, that throw exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return "\u0041B";}}
@@ -24,7 +23,7 @@ var __str = new String("ABB\u0041BABAB");
 //CHECK#1
     try {
       var x = __str.split(__obj, __obj2);
-      $FAIL('#1: "var x = __str.split(__obj, __obj2)" lead to throwing exception');
+      $ERROR('#1: "var x = __str.split(__obj, __obj2)" lead to throwing exception');
     } catch (e) {
       if (e!=="intointeger") {
         $ERROR('#1.1: Exception === "intointeger". Actual: '+e);

--- a/test/built-ins/String/prototype/split/S15.5.4.14_A1_T14.js
+++ b/test/built-ins/String/prototype/split/S15.5.4.14_A1_T14.js
@@ -13,7 +13,6 @@ description: >
     Arguments are objects, and instance is string.  First object have
     overrided toString function, that throw exception.  Second object
     have overrided valueOf function, that throw exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){throw "intostr";}};
@@ -25,7 +24,7 @@ Number.prototype.split=String.prototype.split;
 //CHECK#1
     try {
       var x = __instance.split(__obj, __obj2);
-      $FAIL('#1: "var x = __instance.split(__obj, __obj2)" lead to throwing exception');
+      $ERROR('#1: "var x = __instance.split(__obj, __obj2)" lead to throwing exception');
     } catch (e) {
       if (e!=="intoint") {
         $ERROR('#1.1: Exception === "intoint". Actual: '+e);

--- a/test/built-ins/String/prototype/split/S15.5.4.14_A1_T15.js
+++ b/test/built-ins/String/prototype/split/S15.5.4.14_A1_T15.js
@@ -14,7 +14,6 @@ description: >
     overrided toString function and valueOf function, that throw
     exception.  Second object have overrided valueOf function, that
     throw exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return {};},valueOf:function(){throw "intostr";}};
@@ -29,7 +28,7 @@ var __instance = new __FACTORY(void 0);
 //CHECK#1
 try {
   var x = __instance.split(__obj, __obj2);
-  $FAIL('#1: "var x = __instance.split(__obj, __obj2)" lead to throwing exception');
+  $ERROR('#1: "var x = __instance.split(__obj, __obj2)" lead to throwing exception');
 } catch (e) {
   if (e!=="intointeger") {
     $ERROR('#1.1: Exception === "intointeger". Actual: '+e);

--- a/test/built-ins/String/prototype/split/S15.5.4.14_A1_T16.js
+++ b/test/built-ins/String/prototype/split/S15.5.4.14_A1_T16.js
@@ -12,7 +12,6 @@ es5id: 15.5.4.14_A1_T16
 description: >
     Argument is object, and instance is Number.  Object have overrided
     toString function, that return regexp
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return /\u0037\u0037/g;}};
@@ -21,7 +20,7 @@ Number.prototype.split=String.prototype.split;
 
 try {
   var __split = 6776767677.006771122677555.split(__obj);
-  $FAIL('#1: "__split = 6776767677.006771122677555.split(__obj)" lead to throwing exception');
+  $ERROR('#1: "__split = 6776767677.006771122677555.split(__obj)" lead to throwing exception');
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: Exception is instance of TypeError. Actual: '+e);

--- a/test/built-ins/String/prototype/split/S15.5.4.14_A7.js
+++ b/test/built-ins/String/prototype/split/S15.5.4.14_A7.js
@@ -6,7 +6,6 @@ info: String.prototype.split can't be used as constructor
 es5id: 15.5.4.14_A7
 description: Checking if creating the String.prototype.split object fails
 includes:
-    - $FAIL.js
     - Test262Error.js
 ---*/
 
@@ -14,7 +13,7 @@ var __FACTORY = String.prototype.split;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: __FACTORY = String.prototype.split; "__instance = new __FACTORY" lead to throwing exception');
+  $ERROR('#1: __FACTORY = String.prototype.split; "__instance = new __FACTORY" lead to throwing exception');
 } catch (e) {
     if (e instanceof Test262Error) throw e;
 }

--- a/test/built-ins/String/prototype/split/S15.5.4.14_A8.js
+++ b/test/built-ins/String/prototype/split/S15.5.4.14_A8.js
@@ -7,13 +7,12 @@ es5id: 15.5.4.14_A8
 description: >
     Checking if enumerating the String.prototype.split.length property
     fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.split.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.split.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.split.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.split.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.split.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/split/S15.5.4.14_A9.js
+++ b/test/built-ins/String/prototype/split/S15.5.4.14_A9.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.14_A9
 description: >
     Checking if deleting the String.prototype.split.length property
     fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.split.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.split.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.split.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.split.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.split.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -31,7 +30,7 @@ if (!delete String.prototype.split.length) {
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (String.prototype.split.hasOwnProperty('length')) {
-  $FAIL('#2: delete String.prototype.split.length; String.prototype.split.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.split.hasOwnProperty('length'));
+  $ERROR('#2: delete String.prototype.split.length; String.prototype.split.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.split.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/substring/S15.5.4.15_A10.js
+++ b/test/built-ins/String/prototype/substring/S15.5.4.15_A10.js
@@ -7,13 +7,13 @@ es5id: 15.5.4.15_A10
 description: >
     Checking if varying the String.prototype.substring.length property
     fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (!(String.prototype.substring.hasOwnProperty('length'))) {
-  $FAIL('#1: String.prototype.substring.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.substring.hasOwnProperty('length'));
+  $ERROR('#1: String.prototype.substring.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.substring.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/substring/S15.5.4.15_A1_T11.js
+++ b/test/built-ins/String/prototype/substring/S15.5.4.15_A1_T11.js
@@ -7,7 +7,6 @@ es5id: 15.5.4.15_A1_T11
 description: >
     Arguments are objects, and instance is string, objects have
     overrided valueOf function, that return exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {valueOf:function(){throw "instart";}};
@@ -18,7 +17,7 @@ var __str = "ABB\u0041BABAB";
 //CHECK#1
         try {
           var x = __str.substring(__obj,__obj2);
-          $FAIL('#1: "var x = __str.substring(__obj,__obj2)" lead to throw exception');
+          $ERROR('#1: "var x = __str.substring(__obj,__obj2)" lead to throw exception');
         } catch (e) {
           if (e!=="instart") {
             $ERROR('#1.1: Exception === "instart". Actual: '+e);

--- a/test/built-ins/String/prototype/substring/S15.5.4.15_A1_T12.js
+++ b/test/built-ins/String/prototype/substring/S15.5.4.15_A1_T12.js
@@ -9,7 +9,6 @@ description: >
     overrided valueOf function and toString function, that return
     exception.  Second object have overrided valueOf function, that
     return exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {valueOf:function(){return {};}, toString:function(){throw "instart";}};
@@ -20,7 +19,7 @@ var __str = new String("ABB\u0041BABAB");
 //CHECK#1
     try {
       var x = __str.substring(__obj, __obj2);
-      $FAIL('#1: "var x = __str.substring(__obj,__obj2)" lead to throw exception');
+      $ERROR('#1: "var x = __str.substring(__obj,__obj2)" lead to throw exception');
     } catch (e) {
       if (e!=="instart") {
         $ERROR('#1.1: Exception ==="instart". Actual: '+e);

--- a/test/built-ins/String/prototype/substring/S15.5.4.15_A1_T13.js
+++ b/test/built-ins/String/prototype/substring/S15.5.4.15_A1_T13.js
@@ -8,7 +8,6 @@ description: >
     Arguments are objects, and instance is string.  First object have
     overrided valueOf and toString functions.  Second object have
     overrided toString function, that return exception
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {valueOf:function(){return {};}, toString:function(){return 1;}};
@@ -18,7 +17,7 @@ var __obj2 = {toString:function(){throw "inend";}};
 //CHECK#1
 try {
     var x = "ABB\u0041BABAB\u0031BBAA".substring(__obj, __obj2);
-    $FAIL('#1: var x = "ABB\\u0041BABAB\\u0031BBAA".substring(__obj,__obj2) lead to throw exception');
+    $ERROR('#1: var x = "ABB\\u0041BABAB\\u0031BBAA".substring(__obj,__obj2) lead to throw exception');
 } catch (e) {
     if (e!=="inend") {
         $ERROR('#1.1: Exception === "inend". Actual: '+e);

--- a/test/built-ins/String/prototype/substring/S15.5.4.15_A7.js
+++ b/test/built-ins/String/prototype/substring/S15.5.4.15_A7.js
@@ -7,14 +7,13 @@ es5id: 15.5.4.15_A7
 description: Checking if creating the String.prototype.substring object fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 var __FACTORY = String.prototype.substring;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: __FACTORY = String.prototype.substring; "__instance = new __FACTORY" lead to throwing exception');
+  $ERROR('#1: __FACTORY = String.prototype.substring; "__instance = new __FACTORY" lead to throwing exception');
 } catch (e) {
   if ((e instanceof TypeError) !== true) {
     $ERROR('#1.2: undefined = 1 throw a TypeError. Actual: ' + (e));  

--- a/test/built-ins/String/prototype/substring/S15.5.4.15_A8.js
+++ b/test/built-ins/String/prototype/substring/S15.5.4.15_A8.js
@@ -7,13 +7,12 @@ es5id: 15.5.4.15_A8
 description: >
     Checking if enumerating the String.prototype.substring.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.substring.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.substring.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.substring.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.substring.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.substring.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/substring/S15.5.4.15_A9.js
+++ b/test/built-ins/String/prototype/substring/S15.5.4.15_A9.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.15_A9
 description: >
     Checking if deleting the String.prototype.substring.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.substring.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.substring.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.substring.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.substring.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.substring.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -31,7 +30,7 @@ if (!delete String.prototype.substring.length) {
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (String.prototype.substring.hasOwnProperty('length')) {
-  $FAIL('#2: delete String.prototype.substring.length; String.prototype.substring.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.substring.hasOwnProperty('length'));
+  $ERROR('#2: delete String.prototype.substring.length; String.prototype.substring.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.substring.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A10.js
+++ b/test/built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A10.js
@@ -9,13 +9,13 @@ es5id: 15.5.4.17_A10
 description: >
     Checking if varying the String.prototype.toLocaleLowerCase.length
     property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (!(String.prototype.toLocaleLowerCase.hasOwnProperty('length'))) {
-  $FAIL('#1: String.prototype.toLocaleLowerCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLocaleLowerCase.hasOwnProperty('length'));
+  $ERROR('#1: String.prototype.toLocaleLowerCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLocaleLowerCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A1_T11.js
+++ b/test/built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A1_T11.js
@@ -7,7 +7,6 @@ es5id: 15.5.4.17_A1_T11
 description: >
     Override toString function, toString throw exception, then call
     toLocaleLowerCase() function for this object
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){throw "intostr";}}
@@ -17,7 +16,7 @@ __obj.toLocaleLowerCase = String.prototype.toLocaleLowerCase;
 //CHECK#1
 try {
   var x = __obj.toLocaleLowerCase();
-   	$FAIL('#1: "var x = __obj.toLocaleLowerCase()" lead to throwing exception');
+   	$ERROR('#1: "var x = __obj.toLocaleLowerCase()" lead to throwing exception');
 } catch (e) {
   if (e!=="intostr") {
     $ERROR('#1.1: Exception === "intostr". Actual: '+e);

--- a/test/built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A1_T12.js
+++ b/test/built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A1_T12.js
@@ -7,7 +7,6 @@ es5id: 15.5.4.17_A1_T12
 description: >
     Override toString and valueOf functions, valueOf throw exception,
     then call toLocaleLowerCase() function for this object
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return {};},valueOf:function(){throw "intostr";}}
@@ -17,7 +16,7 @@ __obj.toLocaleLowerCase = String.prototype.toLocaleLowerCase;
 //CHECK#1
 try {
   var x = __obj.toLocaleLowerCase();
- 	$FAIL('#1: "var x = __obj.toLocaleLowerCase()" lead to throwing exception');
+ 	$ERROR('#1: "var x = __obj.toLocaleLowerCase()" lead to throwing exception');
 } catch (e) {
   if (e!=="intostr") {
     $ERROR('#1.1: Exception === "intostr". Actual: '+e);

--- a/test/built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A7.js
+++ b/test/built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A7.js
@@ -9,14 +9,13 @@ description: >
     fails
 includes:
     - $PRINT.js
-    - $FAIL.js
 ---*/
 
 var __FACTORY = String.prototype.toLocaleLowerCase;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: var __FACTORY = String.prototype.toLocaleLowerCase; "__instance = new __FACTORY" lead to throwing exception');
+  $ERROR('#1: var __FACTORY = String.prototype.toLocaleLowerCase; "__instance = new __FACTORY" lead to throwing exception');
 } catch (e) {
   if ((e instanceof TypeError) !== true) {
     $ERROR('#1.1: var __FACTORY = String.prototype.toLocaleLowerCase; "var __instance = new __FACTORY" throw a TypeError. Actual: ' + (e));  

--- a/test/built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A8.js
+++ b/test/built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A8.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.17_A8
 description: >
     Checking if enumerating the
     String.prototype.toLocaleLowerCase.length property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.toLocaleLowerCase.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.toLocaleLowerCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLocaleLowerCase.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.toLocaleLowerCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLocaleLowerCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A9.js
+++ b/test/built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A9.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.17_A9
 description: >
     Checking if deleting the String.prototype.toLocaleLowerCase.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.toLocaleLowerCase.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.toLocaleLowerCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLocaleLowerCase.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.toLocaleLowerCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLocaleLowerCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -31,7 +30,7 @@ if (!delete String.prototype.toLocaleLowerCase.length) {
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (String.prototype.toLocaleLowerCase.hasOwnProperty('length')) {
-  $FAIL('#2: delete String.prototype.toLocaleLowerCase.length; String.prototype.toLocaleLowerCase.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.toLocaleLowerCase.hasOwnProperty('length'));
+  $ERROR('#2: delete String.prototype.toLocaleLowerCase.length; String.prototype.toLocaleLowerCase.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.toLocaleLowerCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A10.js
+++ b/test/built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A10.js
@@ -9,13 +9,13 @@ es5id: 15.5.4.19_A10
 description: >
     Checking if varying the String.prototype.toLocaleUpperCase.length
     property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (!(String.prototype.toLocaleUpperCase.hasOwnProperty('length'))) {
-  $FAIL('#1: String.prototype.toLocaleUpperCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLocaleUpperCase.hasOwnProperty('length'));
+  $ERROR('#1: String.prototype.toLocaleUpperCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLocaleUpperCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A1_T11.js
+++ b/test/built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A1_T11.js
@@ -7,7 +7,6 @@ es5id: 15.5.4.19_A1_T11
 description: >
     Override toString function, toString throw exception, then call
     toLocaleUpperCase() function for this object
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){throw "intostr";}}
@@ -16,7 +15,7 @@ __obj.toLocaleUpperCase = String.prototype.toLocaleUpperCase;
 //CHECK#1
 try {
   var x = __obj.toLocaleUpperCase();
-  $FAIL('#1: "var x = __obj.toLocaleUpperCase()" lead to throwing exception');
+  $ERROR('#1: "var x = __obj.toLocaleUpperCase()" lead to throwing exception');
 } catch (e) {
   if (e!=="intostr") {
     $ERROR('#1.1: Exception === "intostr". Actual: '+e);

--- a/test/built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A1_T12.js
+++ b/test/built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A1_T12.js
@@ -7,7 +7,6 @@ es5id: 15.5.4.19_A1_T12
 description: >
     Override toString and valueOf functions, valueOf throw exception,
     then call toLocaleUpperCase() function for this object
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return {};},valueOf:function(){throw "intostr";}}
@@ -16,7 +15,7 @@ __obj.toLocaleUpperCase = String.prototype.toLocaleUpperCase;
 //CHECK#1
 try {
   var x = __obj.toLocaleUpperCase();
- 	$FAIL('#1: "var x = __obj.toLocaleUpperCase()" lead to throwing exception');
+ 	$ERROR('#1: "var x = __obj.toLocaleUpperCase()" lead to throwing exception');
 } catch (e) {
   if (e!=="intostr") {
     $ERROR('#1.1: Exception === "intostr". Actual: '+e);

--- a/test/built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A7.js
+++ b/test/built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A7.js
@@ -7,14 +7,13 @@ es5id: 15.5.4.19_A7
 description: >
     Checking if creating the String.prototype.toLocaleUpperCase object
     fails
-includes: [$FAIL.js]
 ---*/
 
 var __FACTORY = String.prototype.toLocaleUpperCase;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: __FACTORY = String.prototype.toLocaleUpperCase; "__instance = new __FACTORY" lead to throwing exception');
+  $ERROR('#1: __FACTORY = String.prototype.toLocaleUpperCase; "__instance = new __FACTORY" lead to throwing exception');
 } catch (e) {
   if ((e instanceof TypeError) !== true) {
     $ERROR('#1.1:  var __instance = new __FACTORY;  Object has no construct lead  a TypeError. Actual: ' + (e));  

--- a/test/built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A8.js
+++ b/test/built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A8.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.19_A8
 description: >
     Checking if enumerating the
     String.prototype.toLocaleUpperCase.length property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.toLocaleUpperCase.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.toLocaleUpperCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLocaleUpperCase.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.toLocaleUpperCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLocaleUpperCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A9.js
+++ b/test/built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A9.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.19_A9
 description: >
     Checking if deleting the String.prototype.toLocaleUpperCase.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.toLocaleUpperCase.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.toLocaleUpperCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLocaleUpperCase.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.toLocaleUpperCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLocaleUpperCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -31,7 +30,7 @@ if (!delete String.prototype.toLocaleUpperCase.length) {
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (String.prototype.toLocaleUpperCase.hasOwnProperty('length')) {
-  $FAIL('#2: delete String.prototype.toLocaleUpperCase.length; String.prototype.toLocaleUpperCase.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.toLocaleUpperCase.hasOwnProperty('length'));
+  $ERROR('#2: delete String.prototype.toLocaleUpperCase.length; String.prototype.toLocaleUpperCase.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.toLocaleUpperCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/toLowerCase/S15.5.4.16_A10.js
+++ b/test/built-ins/String/prototype/toLowerCase/S15.5.4.16_A10.js
@@ -9,13 +9,13 @@ es5id: 15.5.4.16_A10
 description: >
     Checking if varying the String.prototype.toLowerCase.length
     property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (!(String.prototype.toLowerCase.hasOwnProperty('length'))) {
-  $FAIL('#1: String.prototype.toLowerCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLowerCase.hasOwnProperty('length'));
+  $ERROR('#1: String.prototype.toLowerCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLowerCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/toLowerCase/S15.5.4.16_A1_T11.js
+++ b/test/built-ins/String/prototype/toLowerCase/S15.5.4.16_A1_T11.js
@@ -7,7 +7,6 @@ es5id: 15.5.4.16_A1_T11
 description: >
     Override toString function, toString throw exception, then call
     toLowerCase() function for this object
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){throw "intostr";}}
@@ -17,7 +16,7 @@ __obj.toLowerCase = String.prototype.toLowerCase;
 //CHECK#1
 try {
   var x = __obj.toLowerCase();
-   	$FAIL('#1: "var x = __obj.toLowerCase()" lead to throwing exception');
+   	$ERROR('#1: "var x = __obj.toLowerCase()" lead to throwing exception');
 } catch (e) {
   if (e!=="intostr") {
     $ERROR('#1.1: Exception === "intostr". Actual: '+e);

--- a/test/built-ins/String/prototype/toLowerCase/S15.5.4.16_A1_T12.js
+++ b/test/built-ins/String/prototype/toLowerCase/S15.5.4.16_A1_T12.js
@@ -7,7 +7,6 @@ es5id: 15.5.4.16_A1_T12
 description: >
     Override toString and valueOf functions, valueOf throw exception,
     then call toLowerCase() function for this object
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return {};},valueOf:function(){throw "intostr";}}
@@ -17,7 +16,7 @@ __obj.toLowerCase = String.prototype.toLowerCase;
 //CHECK#1
 try {
   var x = __obj.toLowerCase();
- 	$FAIL('#1: "var x = __obj.toLowerCase()" lead to throwing exception');
+ 	$ERROR('#1: "var x = __obj.toLowerCase()" lead to throwing exception');
 } catch (e) {
   if (e!=="intostr") {
     $ERROR('#1.1: Exception === "intostr". Actual: '+e);

--- a/test/built-ins/String/prototype/toLowerCase/S15.5.4.16_A7.js
+++ b/test/built-ins/String/prototype/toLowerCase/S15.5.4.16_A7.js
@@ -5,14 +5,13 @@
 info: String.prototype.toLowerCase can't be used as constructor
 es5id: 15.5.4.16_A7
 description: Checking if creating the String.prototype.toLowerCase object fails
-includes: [$FAIL.js]
 ---*/
 
 var __FACTORY = String.prototype.toLowerCase;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: var __FACTORY = String.prototype.toLowerCase; "__instance = new __FACTORY" lead to throwing exception');
+  $ERROR('#1: var __FACTORY = String.prototype.toLowerCase; "__instance = new __FACTORY" lead to throwing exception');
 } catch (e) {
   if ((e instanceof TypeError) !== true) {
     $ERROR('#1.1: var __FACTORY = String.prototype.toLowerCase; "__instance = new __FACTORY" throws a TypeError. Actual: ' + (e));  

--- a/test/built-ins/String/prototype/toLowerCase/S15.5.4.16_A8.js
+++ b/test/built-ins/String/prototype/toLowerCase/S15.5.4.16_A8.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.16_A8
 description: >
     Checking if enumerating the String.prototype.toLowerCase.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.toLowerCase.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.toLowerCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLowerCase.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.toLowerCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLowerCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/toLowerCase/S15.5.4.16_A9.js
+++ b/test/built-ins/String/prototype/toLowerCase/S15.5.4.16_A9.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.16_A9
 description: >
     Checking if deleting the String.prototype.toLowerCase.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.toLowerCase.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.toLowerCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLowerCase.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.toLowerCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toLowerCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -31,7 +30,7 @@ if (!delete String.prototype.toLowerCase.length) {
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (String.prototype.toLowerCase.hasOwnProperty('length')) {
-  $FAIL('#2: delete String.prototype.toLowerCase.length; String.prototype.toLowerCase.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.toLowerCase.hasOwnProperty('length'));
+  $ERROR('#2: delete String.prototype.toLowerCase.length; String.prototype.toLowerCase.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.toLowerCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/toString/S15.5.4.2_A2_T1.js
+++ b/test/built-ins/String/prototype/toString/S15.5.4.2_A2_T1.js
@@ -8,7 +8,6 @@ info: >
     transferred to other kinds of objects for use as a method
 es5id: 15.5.4.2_A2_T1
 description: Checking if creating variable String.prototype.toString fails
-includes: [$FAIL.js]
 ---*/
 
 var __toString = String.prototype.toString;
@@ -26,7 +25,7 @@ if (typeof __toString !== "function") {
 //CHECK#2
 try {
   var x = __toString();
-  $FAIL('#2: "__toString = String.prototype.toString; var x = __toString();" lead to throwing exception');
+  $ERROR('#2: "__toString = String.prototype.toString; var x = __toString();" lead to throwing exception');
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#2.1: "__toString = String.prototype.toString; var x = __toString();" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/String/prototype/toString/S15.5.4.2_A2_T2.js
+++ b/test/built-ins/String/prototype/toString/S15.5.4.2_A2_T2.js
@@ -8,7 +8,6 @@ info: >
     transferred to other kinds of objects for use as a method
 es5id: 15.5.4.2_A2_T2
 description: Checking if creating the object String.prototype.toString fails
-includes: [$FAIL.js]
 ---*/
 
 var __obj={toString : String.prototype.toString};
@@ -26,7 +25,7 @@ if (typeof __obj["toString"] !== "function") {
 //CHECK#2
 try {
   var x = (__obj == 1);
-  $FAIL('#2: "var x = (__obj == 1)" lead to throwing exception');
+  $ERROR('#2: "var x = (__obj == 1)" lead to throwing exception');
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#2.1: Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/String/prototype/toUpperCase/S15.5.4.18_A10.js
+++ b/test/built-ins/String/prototype/toUpperCase/S15.5.4.18_A10.js
@@ -9,13 +9,13 @@ es5id: 15.5.4.18_A10
 description: >
     Checking if varying the String.prototype.toUpperCase.length
     property fails
-includes: [$FAIL.js, propertyHelper.js]
+includes: [propertyHelper.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (!(String.prototype.toUpperCase.hasOwnProperty('length'))) {
-  $FAIL('#1: String.prototype.toUpperCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toUpperCase.hasOwnProperty('length'));
+  $ERROR('#1: String.prototype.toUpperCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toUpperCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/toUpperCase/S15.5.4.18_A1_T11.js
+++ b/test/built-ins/String/prototype/toUpperCase/S15.5.4.18_A1_T11.js
@@ -7,7 +7,6 @@ es5id: 15.5.4.18_A1_T11
 description: >
     Override toString function, toString throw exception, then call
     toUpperCase() function for this object
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){throw "intostr";}}
@@ -16,7 +15,7 @@ __obj.toUpperCase = String.prototype.toUpperCase;
 //CHECK#1
 try {
   var x = __obj.toUpperCase();
-   	$FAIL('#1: "var x = __obj.toUpperCase()" lead to throwing exception');
+   	$ERROR('#1: "var x = __obj.toUpperCase()" lead to throwing exception');
 } catch (e) {
   if (e!=="intostr") {
     $ERROR('#1.1: Exception === "intostr". Actual: '+e);

--- a/test/built-ins/String/prototype/toUpperCase/S15.5.4.18_A1_T12.js
+++ b/test/built-ins/String/prototype/toUpperCase/S15.5.4.18_A1_T12.js
@@ -7,7 +7,6 @@ es5id: 15.5.4.18_A1_T12
 description: >
     Override toString and valueOf functions, valueOf throw exception,
     then call toUpperCase() function for this object
-includes: [$FAIL.js]
 ---*/
 
 var __obj = {toString:function(){return {};},valueOf:function(){throw "intostr";}}
@@ -16,7 +15,7 @@ __obj.toUpperCase = String.prototype.toUpperCase;
 //CHECK#1
 try {
   var x = __obj.toUpperCase();
- 	$FAIL('#1: "var x = __obj.toUpperCase()" lead to throwing exception');
+ 	$ERROR('#1: "var x = __obj.toUpperCase()" lead to throwing exception');
 } catch (e) {
   if (e!=="intostr") {
     $ERROR('#1.1: Exception === "intostr". Actual: '+e);

--- a/test/built-ins/String/prototype/toUpperCase/S15.5.4.18_A7.js
+++ b/test/built-ins/String/prototype/toUpperCase/S15.5.4.18_A7.js
@@ -5,14 +5,13 @@
 info: String.prototype.toUpperCase can't be used as constructor
 es5id: 15.5.4.18_A7
 description: Checking if creating the String.prototype.toUpperCase object fails
-includes: [$FAIL.js]
 ---*/
 
 var __FACTORY = String.prototype.toUpperCase;
 
 try {
   var __instance = new __FACTORY;
-  $FAIL('#1: var __FACTORY = String.prototype.toUpperCase; "__instance = new __FACTORY" lead to throwing exception');
+  $ERROR('#1: var __FACTORY = String.prototype.toUpperCase; "__instance = new __FACTORY" lead to throwing exception');
 } catch (e) {
   if ((e instanceof TypeError) !== true) {
     $ERROR('#1.1: var __FACTORY = String.prototype.toUpperCase; "__instance = new __FACTORY" throw a TypeError. Actual: ' + (e));  

--- a/test/built-ins/String/prototype/toUpperCase/S15.5.4.18_A8.js
+++ b/test/built-ins/String/prototype/toUpperCase/S15.5.4.18_A8.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.18_A8
 description: >
     Checking if enumerating the String.prototype.toUpperCase.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.toUpperCase.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.toUpperCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toUpperCase.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.toUpperCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toUpperCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/toUpperCase/S15.5.4.18_A9.js
+++ b/test/built-ins/String/prototype/toUpperCase/S15.5.4.18_A9.js
@@ -9,13 +9,12 @@ es5id: 15.5.4.18_A9
 description: >
     Checking if deleting the String.prototype.toUpperCase.length
     property fails
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#0
 if (!(String.prototype.toUpperCase.hasOwnProperty('length'))) {
-  $FAIL('#0: String.prototype.toUpperCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toUpperCase.hasOwnProperty('length'));
+  $ERROR('#0: String.prototype.toUpperCase.hasOwnProperty(\'length\') return true. Actual: '+String.prototype.toUpperCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -31,7 +30,7 @@ if (!delete String.prototype.toUpperCase.length) {
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (String.prototype.toUpperCase.hasOwnProperty('length')) {
-  $FAIL('#2: delete String.prototype.toUpperCase.length; String.prototype.toUpperCase.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.toUpperCase.hasOwnProperty('length'));
+  $ERROR('#2: delete String.prototype.toUpperCase.length; String.prototype.toUpperCase.hasOwnProperty(\'length\') return false. Actual: '+String.prototype.toUpperCase.hasOwnProperty('length'));
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/valueOf/S15.5.4.3_A2_T1.js
+++ b/test/built-ins/String/prototype/valueOf/S15.5.4.3_A2_T1.js
@@ -7,7 +7,6 @@ info: >
     Therefore, it cannot be transferred to other kinds of objects for use as a method
 es5id: 15.5.4.3_A2_T1
 description: Checking if creating variable String.prototype.valueOf fails
-includes: [$FAIL.js]
 ---*/
 
 var __valueOf = String.prototype.valueOf;
@@ -25,7 +24,7 @@ if (typeof __valueOf !== "function") {
 //CHECK#2
 try {
   var x = __valueOf();
-  $FAIL('#2: "__valueOf = String.prototype.valueOf; var x = __valueOf()" lead to throwing exception');
+  $ERROR('#2: "__valueOf = String.prototype.valueOf; var x = __valueOf()" lead to throwing exception');
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#2.1: Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/String/prototype/valueOf/S15.5.4.3_A2_T2.js
+++ b/test/built-ins/String/prototype/valueOf/S15.5.4.3_A2_T2.js
@@ -7,7 +7,6 @@ info: >
     Therefore, it cannot be transferred to other kinds of objects for use as a method
 es5id: 15.5.4.3_A2_T2
 description: Checking if creating the object String.prototype.valueOf fails
-includes: [$FAIL.js]
 ---*/
 
 var __obj={valueOf : String.prototype.valueOf};
@@ -25,7 +24,7 @@ if (typeof __obj["valueOf"] !== "function") {
 //CHECK#2
 try {
   var x = (__obj == 1);
-  $FAIL('#2: "var __obj={valueOf : String.prototype.valueOf}; var x = (__obj == 1)" lead to throwing exception');
+  $ERROR('#2: "var __obj={valueOf : String.prototype.valueOf}; var x = (__obj == 1)" lead to throwing exception');
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#2.1: Exception is instance of TypeError. Actual: exception is '+e);

--- a/test/built-ins/decodeURI/S15.1.3.1_A5.2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A5.2.js
@@ -5,12 +5,11 @@
 info: The length property of decodeURI does not have the attribute DontDelete
 es5id: 15.1.3.1_A5.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (decodeURI.hasOwnProperty('length') !== true) {
-  $FAIL('#1: decodeURI.hasOwnProperty(\'length\') === true. Actual: ' + (decodeURI.hasOwnProperty('length')));
+  $ERROR('#1: decodeURI.hasOwnProperty(\'length\') === true. Actual: ' + (decodeURI.hasOwnProperty('length')));
 }
 
 delete decodeURI.length;

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A5.2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A5.2.js
@@ -7,12 +7,11 @@ info: >
     DontDelete
 es5id: 15.1.3.2_A5.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (decodeURIComponent.hasOwnProperty('length') !== true) {
-  $FAIL('#1: decodeURIComponent.hasOwnProperty(\'length\') === true. Actual: ' + (decodeURIComponent.hasOwnProperty('length')));
+  $ERROR('#1: decodeURIComponent.hasOwnProperty(\'length\') === true. Actual: ' + (decodeURIComponent.hasOwnProperty('length')));
 }
 
 delete decodeURIComponent.length;

--- a/test/built-ins/encodeURI/S15.1.3.3_A5.2.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A5.2.js
@@ -5,12 +5,11 @@
 info: The length property of encodeURI does not have the attribute DontDelete
 es5id: 15.1.3.3_A5.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (encodeURI.hasOwnProperty('length') !== true) {
-  $FAIL('#1: encodeURI.hasOwnProperty(\'length\') === true. Actual: ' + (encodeURI.hasOwnProperty('length')));
+  $ERROR('#1: encodeURI.hasOwnProperty(\'length\') === true. Actual: ' + (encodeURI.hasOwnProperty('length')));
 }
 
 delete encodeURI.length;

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A5.2.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A5.2.js
@@ -7,12 +7,11 @@ info: >
     DontDelete
 es5id: 15.1.3.4_A5.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (encodeURIComponent.hasOwnProperty('length') !== true) {
-  $FAIL('#1: encodeURIComponent.hasOwnProperty(\'length\') === true. Actual: ' + (encodeURIComponent.hasOwnProperty('length')));
+  $ERROR('#1: encodeURIComponent.hasOwnProperty(\'length\') === true. Actual: ' + (encodeURIComponent.hasOwnProperty('length')));
 }
 
 delete encodeURIComponent.length;

--- a/test/built-ins/eval/S15.1.2.1_A4.2.js
+++ b/test/built-ins/eval/S15.1.2.1_A4.2.js
@@ -5,12 +5,11 @@
 info: The length property of eval does not have the attribute DontDelete
 es5id: 15.1.2.1_A4.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (eval.hasOwnProperty('length') !== true) {
-  $FAIL('#1: eval.hasOwnProperty(\'length\') === true. Actual: ' + (eval.hasOwnProperty('length')));
+  $ERROR('#1: eval.hasOwnProperty(\'length\') === true. Actual: ' + (eval.hasOwnProperty('length')));
 }
 
 delete eval.length;

--- a/test/built-ins/isFinite/S15.1.2.5_A2.2.js
+++ b/test/built-ins/isFinite/S15.1.2.5_A2.2.js
@@ -5,12 +5,11 @@
 info: The length property of isFinite does not have the attribute DontDelete
 es5id: 15.1.2.5_A2.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (isFinite.hasOwnProperty('length') !== true) {
-  $FAIL('#1: isFinite.hasOwnProperty(\'length\') === true. Actual: ' + (isFinite.hasOwnProperty('length')));
+  $ERROR('#1: isFinite.hasOwnProperty(\'length\') === true. Actual: ' + (isFinite.hasOwnProperty('length')));
 }
 
 delete isFinite.length;

--- a/test/built-ins/isNaN/S15.1.2.4_A2.2.js
+++ b/test/built-ins/isNaN/S15.1.2.4_A2.2.js
@@ -5,12 +5,11 @@
 info: The length property of isNaN does not have the attribute DontDelete
 es5id: 15.1.2.4_A2.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (isNaN.hasOwnProperty('length') !== true) {
-  $FAIL('#1: isNaN.hasOwnProperty(\'length\') === true. Actual: ' + (isNaN.hasOwnProperty('length')));
+  $ERROR('#1: isNaN.hasOwnProperty(\'length\') === true. Actual: ' + (isNaN.hasOwnProperty('length')));
 }
 
 delete isNaN.length;

--- a/test/built-ins/parseFloat/S15.1.2.3_A7.2.js
+++ b/test/built-ins/parseFloat/S15.1.2.3_A7.2.js
@@ -5,12 +5,11 @@
 info: The length property of parseFloat does not have the attribute DontDelete
 es5id: 15.1.2.3_A7.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (parseFloat.hasOwnProperty('length') !== true) {
-  $FAIL('#1: parseFloat.hasOwnProperty(\'length\') === true. Actual: ' + (parseFloat.hasOwnProperty('length')));
+  $ERROR('#1: parseFloat.hasOwnProperty(\'length\') === true. Actual: ' + (parseFloat.hasOwnProperty('length')));
 }
 
 delete parseFloat.length;

--- a/test/built-ins/parseInt/S15.1.2.2_A9.2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A9.2.js
@@ -5,12 +5,11 @@
 info: The length property of parseInt does not have the attribute DontDelete
 es5id: 15.1.2.2_A9.2
 description: Checking use hasOwnProperty, delete
-includes: [$FAIL.js]
 ---*/
 
 //CHECK#1
 if (parseInt.hasOwnProperty('length') !== true) {
-  $FAIL('#1: parseInt.hasOwnProperty(\'length\') === true. Actual: ' + (parseInt.hasOwnProperty('length')));
+  $ERROR('#1: parseInt.hasOwnProperty(\'length\') === true. Actual: ' + (parseInt.hasOwnProperty('length')));
 }
 
 delete parseInt.length;

--- a/test/language/expressions/instanceof/S15.3.5.3_A2_T2.js
+++ b/test/language/expressions/instanceof/S15.3.5.3_A2_T2.js
@@ -9,7 +9,6 @@ info: >
     iii) O is not an object, throw a TypeError exception
 es5id: 15.3.5.3_A2_T2
 description: F.prototype is undefined, and V is empty object
-includes: [$FAIL.js]
 ---*/
 
 var FACTORY;
@@ -23,7 +22,7 @@ obj={};
 //CHECK#1
 try {
   obj instanceof  FACTORY;
-  $FAIL('#1: O is not an object, throw a TypeError exception');
+  $ERROR('#1: O is not an object, throw a TypeError exception');
 } catch (e) {
   if (!(e instanceof TypeError)) {
   	$ERROR('#1.1: O is not an object, throw a TypeError exception');

--- a/test/language/expressions/instanceof/S15.3.5.3_A2_T5.js
+++ b/test/language/expressions/instanceof/S15.3.5.3_A2_T5.js
@@ -10,7 +10,6 @@ info: >
     throw a TypeError exception
 es5id: 15.3.5.3_A2_T5
 description: F.prototype is void 0, and V is new F
-includes: [$FAIL.js]
 ---*/
 
 var FACTORY;
@@ -26,7 +25,7 @@ FACTORY.prototype = void 0;
 // CHECK#1
 try {
   instance instanceof FACTORY;
-  $FAIL('#1: O is not an object, throw a TypeError exception');
+  $ERROR('#1: O is not an object, throw a TypeError exception');
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: O is not an object, throw a TypeError exception');

--- a/test/language/expressions/instanceof/S15.3.5.3_A2_T6.js
+++ b/test/language/expressions/instanceof/S15.3.5.3_A2_T6.js
@@ -10,7 +10,6 @@ info: >
     throw a TypeError exception
 es5id: 15.3.5.3_A2_T6
 description: F.prototype is string, and V is function
-includes: [$FAIL.js]
 ---*/
 
 var FACTORY;
@@ -22,7 +21,7 @@ FACTORY.prototype = "error";
 try {
   ( function() {
   }) instanceof FACTORY;
-  $FAIL('#1: O is not an object, throw a TypeError exception');
+  $ERROR('#1: O is not an object, throw a TypeError exception');
 } catch (e) {
   if (!(e instanceof TypeError)) {
     $ERROR('#1.1: O is not an object, throw a TypeError exception');

--- a/test/language/statements/function/S13.2.2_A1_T2.js
+++ b/test/language/statements/function/S13.2.2_A1_T2.js
@@ -7,7 +7,6 @@ info: >
     of a new created object through [[Construct]] property
 es5id: 13.2.2_A1_T2
 description: Declaring a function with "var __PROTO = function()"
-includes: [$FAIL.js]
 ---*/
 
 var __MONSTER="monster";
@@ -19,7 +18,7 @@ try{
     __PROTO.type=__MONSTER;
 }
 catch(e){
-    $FAIL('#0: __PROTO.type=__MONSTER does not lead to throwing exception')
+    $ERROR('#0: __PROTO.type=__MONSTER does not lead to throwing exception')
 }
 
 var __FACTORY = function(){};

--- a/test/language/statements/function/S13_A17_T1.js
+++ b/test/language/statements/function/S13_A17_T1.js
@@ -7,14 +7,13 @@ info: >
     appears
 es5id: 13_A17_T1
 description: Trying to call a function before the FunctionExpression appears
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 try{
     var __result = __func();
-	$FAIL("#1.1: var __result = __func() lead to throwing exception");
+	$ERROR("#1.1: var __result = __func() lead to throwing exception");
 } catch(e) {
   if ((e instanceof TypeError) !== true) {
     $ERROR('#1.2: func should throw a TypeError  Actual: ' + (e));  

--- a/test/language/statements/function/S13_A6_T2.js
+++ b/test/language/statements/function/S13_A6_T2.js
@@ -7,7 +7,6 @@ info: >
     the same Identifier
 es5id: 13_A6_T2
 description: Calling a function before it is declared one more time
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
@@ -15,7 +14,7 @@ includes: [$FAIL.js]
 try{
     var __result = __func();
 } catch(e) {
-    $FAIL("#1: Function call can appears in the program before the FunctionDeclaration appears");
+    $ERROR("#1: Function call can appears in the program before the FunctionDeclaration appears");
 }
 if (__result !== "SECOND") {
 	$ERROR('#1.1: __result === "SECOND". Actual: __result ==='+__result);

--- a/test/language/statements/if/S12.5_A4.js
+++ b/test/language/statements/if/S12.5_A4.js
@@ -7,14 +7,13 @@ info: >
     Statement" is evaluated, Statement(s) is(are) evaluated second
 es5id: 12.5_A4
 description: The first statement is "(function(){throw "instatement"})()"
-includes: [$FAIL.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 try {
 	if (true) (function(){throw "instatement"})();
-	$FAIL("#1 failed")
+	$ERROR("#1 failed")
 } catch (e) {
 	if (e !== "instatement") {
 		$ERROR('#1: Exception === "instatement". Actual:  Exception ==='+ e);
@@ -27,7 +26,7 @@ try {
 //CHECK#2
 try {
 	if (false) (function(){throw "truebranch"})(); (function(){throw "missbranch"})();
-	$FAIL("#2 failed")
+	$ERROR("#2 failed")
 } catch (e) {
 	if (e !== "missbranch") {
 		$ERROR('#2: Exception === "missbranch". Actual:  Exception ==='+ e);


### PR DESCRIPTION
This function is equivalent to `$ERROR` (which is automatically included
in test environments). Remove the harness file that defines the
function, remove references to the file from test `includes` lists, and
update scripts to instead invoke the `$ERROR` function.

Resolves gh-126