### PR TITLE
Insert omitted `negative` tag

### DIFF
--- a/test/language/module-code/lex-and-var.js
+++ b/test/language/module-code/lex-and-var.js
@@ -7,6 +7,7 @@ description: >
     ModuleItemList also occurs in the VarDeclaredNames of ModuleItemList.
 flags: [module]
 features: [let]
+negative: [SyntaxError]
 ---*/
 
 let x;


### PR DESCRIPTION
This test exercises an early error, so it should be declared with the
`negative` tag.

Originally identified by @anba here: https://github.com/tc39/test262/pull/300/files#r32065154 . Thanks, André!