### PR TITLE
Fix monkey yaml's handling of carriage return

### DIFF
--- a/tools/packaging/monkeyYaml.py
+++ b/tools/packaging/monkeyYaml.py
@@ -16,7 +16,7 @@ mYamlMultilineList = re.compile(r"^ *- (.*)$")
 def load(str):
     dict = None
 
-    lines = str.split("\n")
+    lines = str.splitlines()
     while lines:
         line = lines.pop(0)
         if myIsAllSpaces(line):

--- a/tools/packaging/test/test_monkeyYaml.py
+++ b/tools/packaging/test/test_monkeyYaml.py
@@ -106,6 +106,10 @@ class TestMonkeyYAMLParsing(unittest.TestCase):
         self.assertEqual(lines, ["baz: bletch"])
         self.assertEqual(value, ["foo", "bar"])
 
+    def test_multiline_list_carriage_return(self):
+        y = "foo:\r\n - bar\r\n - baz"
+        self.assertEqual(monkeyYaml.load(y), yaml.load(y))
+
     def test_oneline_indented(self):
       y = "  foo: bar\n  baz: baf\n"
       self.assertEqual(monkeyYaml.load(y), yaml.load(y))


### PR DESCRIPTION
monkeyYaml didn't split lines correctly leading to \r in resulting
values.

Fixes #295