### PR TITLE
Add tests for Object.assign

### DIFF
--- a/test/built-ins/Object/assign/invoked-as-ctor.js
+++ b/test/built-ins/Object/assign/invoked-as-ctor.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: Invoked as a constructor
+info: >
+    ES6 Section 9.3:
+
+    Built-in function objects that are not identified as constructors do not
+    implement the [[Construct]] internal method unless otherwise specified in
+    the description of a particular function.
+---*/
+
+assert.throws(TypeError, function() {
+  new Object.assign({});
+});

--- a/test/built-ins/Object/assign/length.js
+++ b/test/built-ins/Object/assign/length.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: '`length` property'
+info: >
+    The length property of the assign method is 2.
+
+    ES6 Section 17:
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Object.assign.length, 2, 'The value of `Object.assign.length` is `2`'
+);
+
+verifyNotEnumerable(Object.assign, 'length');
+verifyNotWritable(Object.assign, 'length');
+verifyConfigurable(Object.assign, 'length');

--- a/test/built-ins/Object/assign/name.js
+++ b/test/built-ins/Object/assign/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: '`name` property'
+info: >
+    ES6 Section 17:
+
+    Every built-in Function object, including constructors, that is not
+    identified as an anonymous function has a name property whose value is a
+    String. Unless otherwise specified, this value is the name that is given to
+    the function in this specification.
+
+    [...]
+
+    Unless otherwise specified, the name property of a built-in Function
+    object, if it exists, has the attributes { [[Writable]]: false,
+    [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Object.assign.name,
+  'assign',
+  'The value of `Object.assign.name` is `"assign"`'
+);
+
+verifyNotEnumerable(Object.assign, 'name');
+verifyNotWritable(Object.assign, 'name');
+verifyConfigurable(Object.assign, 'name');
+

--- a/test/built-ins/Object/assign/property-descriptor.js
+++ b/test/built-ins/Object/assign/property-descriptor.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: Object.assign property descriptor
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(typeof Object.assign, 'function');
+
+verifyNotEnumerable(Object, 'assign');
+verifyWritable(Object, 'assign');
+verifyConfigurable(Object, 'assign');

--- a/test/built-ins/Object/assign/source-count-many.js
+++ b/test/built-ins/Object/assign/source-count-many.js
@@ -1,0 +1,69 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: Assigning properties from multiple sources
+includes: [propertyHelper.js]
+---*/
+
+var target = {
+  attr1: 'initial',
+  attr2: 'initial',
+  attr4: 'initial'
+};
+var source2 = {
+  attr2: 'source2',
+  attr3: 'source2',
+  attr5: 'source2'
+};
+var source4 = {
+  attr4: 'source4',
+  attr5: 'source4',
+  attr6: 'source4'
+};
+var result;
+
+result = Object.assign(target, undefined, source2, null, source4);
+
+assert.sameValue(result, target);
+
+assert.sameValue(target.attr1, 'initial', 'initial property unmodified');
+verifyEnumerable(target, 'attr1');
+verifyWritable(target, 'attr1');
+verifyConfigurable(target, 'attr1');
+
+assert.sameValue(
+  target.attr2, 'source2', 'second source may modify an existing property'
+);
+verifyEnumerable(target, 'attr2');
+verifyWritable(target, 'attr2');
+verifyConfigurable(target, 'attr2');
+
+assert.sameValue(
+  target.attr3, 'source2', 'second source may define a new property'
+);
+verifyEnumerable(target, 'attr3');
+verifyWritable(target, 'attr3');
+verifyConfigurable(target, 'attr3');
+
+assert.sameValue(
+  target.attr4, 'source4', 'fourth source may modify an existing property'
+);
+verifyEnumerable(target, 'attr4');
+verifyWritable(target, 'attr4');
+verifyConfigurable(target, 'attr4');
+
+assert.sameValue(target.attr5,
+  'source4',
+  'fourth source may modify a property defined by the second source'
+);
+verifyEnumerable(target, 'attr5');
+verifyWritable(target, 'attr5');
+verifyConfigurable(target, 'attr5');
+
+assert.sameValue(
+  target.attr6, 'source4', 'fourth source may define a new property'
+);
+verifyEnumerable(target, 'attr6');
+verifyWritable(target, 'attr6');
+verifyConfigurable(target, 'attr6');

--- a/test/built-ins/Object/assign/source-count-one.js
+++ b/test/built-ins/Object/assign/source-count-one.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: Assigning properties from a single source
+includes: [propertyHelper.js]
+---*/
+
+var target = { attr1: 'initial', attr2: 'initial' };
+var source = { attr2: 'source', attr3: 'source' };
+var result;
+
+result = Object.assign(target, source);
+
+assert.sameValue(result, target);
+
+assert.sameValue(
+  target.attr1,
+  'initial',
+  'properties not defined by the source are unmodified'
+);
+verifyEnumerable(target, 'attr1');
+verifyWritable(target, 'attr1');
+verifyConfigurable(target, 'attr1');
+
+assert.sameValue(
+  target.attr2, 'source', 'source may modify an existing property'
+);
+verifyEnumerable(target, 'attr2');
+verifyWritable(target, 'attr2');
+verifyConfigurable(target, 'attr2');
+
+assert.sameValue(target.attr3, 'source', 'source may define a new property');
+verifyEnumerable(target, 'attr3');
+verifyWritable(target, 'attr3');
+verifyConfigurable(target, 'attr3');

--- a/test/built-ins/Object/assign/source-count-zero.js
+++ b/test/built-ins/Object/assign/source-count-zero.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: Invoked with a value that can be converted to an object
+info: >
+    1. Let to be ToObject(target).
+    2. ReturnIfAbrupt(to).
+    3. If only one argument was passed, return to.
+features: [Symbol]
+---*/
+
+var target, result;
+
+result = Object.assign(true);
+
+assert(result instanceof Boolean);
+assert.sameValue(result.valueOf(), true);
+
+result = Object.assign(4);
+
+assert(result instanceof Number);
+assert.sameValue(result.valueOf(), 4);
+
+result = Object.assign('str');
+
+assert(result instanceof String);
+assert.sameValue(result.valueOf(), 'str');
+
+target = Symbol('sym');
+result = Object.assign(target);
+
+assert(result !== target, 'result is distinct from target');
+assert(result instanceof Symbol, 'result is a Symbol');
+assert.sameValue(
+  result.toString(), 'Symbol(sym)', 'result is created from target'
+);
+
+target = {};
+result = Object.assign(target);
+
+assert.sameValue(result, target);

--- a/test/built-ins/Object/assign/source-get-attr-error.js
+++ b/test/built-ins/Object/assign/source-get-attr-error.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: Errors thrown during retrieval of source object attributes
+info: >
+    [...]
+    5. For each element nextSource of sources, in ascending index order,
+    [...]
+    c. Repeat for each element nextKey of keys in List order,
+       [...]
+       iii. if desc is not undefined and desc.[[Enumerable]] is true, then
+            1. Let propValue be Get(from, nextKey).
+            2. ReturnIfAbrupt(propValue).
+---*/
+
+var source = {
+  get attr() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  Object.assign({}, source);
+});

--- a/test/built-ins/Object/assign/source-non-enum.js
+++ b/test/built-ins/Object/assign/source-non-enum.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: Does not assign non-enumerable source properties
+info: >
+    [...]
+    5. For each element nextSource of sources, in ascending index order,
+       c. Repeat for each element nextKey of keys in List order,
+          i. Let desc be from.[[GetOwnProperty]](nextKey).
+          ii. ReturnIfAbrupt(desc).
+          iii. if desc is not undefined and desc.[[Enumerable]] is true, then
+---*/
+
+var target = {};
+var source = Object.defineProperty({}, 'attr', {
+  value: 1,
+  enumerable: false
+});
+var result;
+
+result = Object.assign(target, source);
+
+assert.sameValue(Object.hasOwnProperty.call(target, 'attr'), false);
+assert.sameValue(result, target);

--- a/test/built-ins/Object/assign/source-non-object.js
+++ b/test/built-ins/Object/assign/source-non-object.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: Object.assign called a value that cannot be converted to an object
+info: >
+    [...]
+    5. For each element nextSource of sources, in ascending index order,
+       a. If nextSource is undefined or null, let keys be an empty List.
+---*/
+
+var target = {};
+var result;
+
+result = Object.assign(target, null);
+
+assert.sameValue(result, target);
+
+result = Object.assign(target, undefined);
+
+assert.sameValue(result, target);

--- a/test/built-ins/Object/assign/source-own-prop-desc-missing.js
+++ b/test/built-ins/Object/assign/source-own-prop-desc-missing.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: Invoked with a source which does not have a descriptor for an own property
+info: >
+    [...]
+    5. For each element nextSource of sources, in ascending index order,
+       [...]
+       c. Repeat for each element nextKey of keys in List order,
+          i. Let desc be from.[[GetOwnProperty]](nextKey).
+          ii. ReturnIfAbrupt(desc).
+          iii. if desc is not undefined and desc.[[Enumerable]] is true, then
+features: [Proxy]
+---*/
+
+var callCount = 0;
+var target = {};
+var result;
+var source = new Proxy({}, {
+  ownKeys: function() {
+    callCount += 1;
+    return ['missing'];
+  }
+});
+
+result = Object.assign(target, source);
+
+assert.sameValue(callCount, 1, 'Proxy trap was invoked exactly once');
+assert.sameValue(
+  Object.hasOwnProperty.call(target, 'missing'),
+  false,
+  'An own property was not created for a property without a property descriptor'
+);
+assert.sameValue(result, target);

--- a/test/built-ins/Object/assign/source-own-prop-error.js
+++ b/test/built-ins/Object/assign/source-own-prop-error.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: Invoked with a source whose own property descriptor cannot be retrieved
+info: >
+    [...]
+    5. For each element nextSource of sources, in ascending index order,
+       [...]
+       c. Repeat for each element nextKey of keys in List order,
+          i. Let desc be from.[[GetOwnProperty]](nextKey).
+          ii. ReturnIfAbrupt(desc).
+features: [Proxy]
+---*/
+
+var source = new Proxy({ attr: null }, {
+  getOwnPropertyDescriptor: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Object.assign({}, source);
+});

--- a/test/built-ins/Object/assign/source-own-prop-keys-error.js
+++ b/test/built-ins/Object/assign/source-own-prop-keys-error.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: Invoked with a source whose own property keys cannot be retrieved
+info: >
+    [...]
+    5. For each element nextSource of sources, in ascending index order,
+       a. If nextSource is undefined or null, let keys be an empty List.
+       b. Else,
+          i. Let from be ToObject(nextSource).
+          ii. ReturnIfAbrupt(from).
+          iii. Let keys be from.[[OwnPropertyKeys]]().
+          iv. ReturnIfAbrupt(keys).
+features: [Proxy]
+---*/
+
+var source = new Proxy({}, {
+  ownKeys: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Object.assign({}, source);
+});

--- a/test/built-ins/Object/assign/target-non-object.js
+++ b/test/built-ins/Object/assign/target-non-object.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: Invoked with a value that cannot be converted to an object
+info: >
+    1. Let to be ToObject(target).
+    2. ReturnIfAbrupt(to).
+---*/
+
+assert.throws(TypeError, function() {
+  Object.assign();
+});
+
+assert.throws(TypeError, function() {
+  Object.assign(undefined);
+});
+
+assert.throws(TypeError, function() {
+  Object.assign(null);
+});

--- a/test/built-ins/Object/assign/target-set-not-writable.js
+++ b/test/built-ins/Object/assign/target-set-not-writable.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: Errors thrown during definition of target object attributes
+info: >
+    [...]
+    5. For each element nextSource of sources, in ascending index order,
+    [...]
+    c. Repeat for each element nextKey of keys in List order,
+       [...]
+       iii. if desc is not undefined and desc.[[Enumerable]] is true, then
+            [...]
+            3. Let status be Set(to, nextKey, propValue, true).
+            4. ReturnIfAbrupt(status).
+---*/
+
+var target = {};
+Object.defineProperty(target, 'attr', {
+  writable: false
+});
+
+assert.throws(TypeError, function() {
+  Object.assign(target, { attr: 1 });
+});

--- a/test/built-ins/Object/assign/target-set-user-error.js
+++ b/test/built-ins/Object/assign/target-set-user-error.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.1.2.1
+description: Errors thrown during definition of target object attributes
+info: >
+    [...]
+    5. For each element nextSource of sources, in ascending index order,
+    [...]
+    c. Repeat for each element nextKey of keys in List order,
+       [...]
+       iii. if desc is not undefined and desc.[[Enumerable]] is true, then
+            [...]
+            3. Let status be Set(to, nextKey, propValue, true).
+            4. ReturnIfAbrupt(status).
+---*/
+
+var target = {};
+Object.defineProperty(target, 'attr', {
+  set: function(_) {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Object.assign(target, { attr: 1 });
+});


### PR DESCRIPTION
This patch omits a test for step 5.b.ii because I believe it to be unreachable. [I've filed a spec bug to verify](https://bugs.ecmascript.org/show_bug.cgi?id=4391); if I'm mistaken, I will follow up with an additional test.