### PR TITLE
ES6 numeric literals

### DIFF
--- a/test/built-ins/Number/string-binary-literal-invalid.js
+++ b/test/built-ins/Number/string-binary-literal-invalid.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.1.1
+description: Invalid binary literals yield NaN
+info: >
+    BinaryIntegerLiteral ::
+      0b BinaryDigits
+      0B BinaryDigits
+    BinaryDigits ::
+      BinaryDigit
+      BinaryDigits BinaryDigit
+    BinaryDigit :: one of
+      0 1
+---*/
+
+assert.sameValue(Number('0b2'), NaN, 'invalid digit');
+assert.sameValue(Number('00b0'), NaN, 'leading zero');
+assert.sameValue(Number('0b'), NaN, 'omitted digits');

--- a/test/built-ins/Number/string-binary-literal.js
+++ b/test/built-ins/Number/string-binary-literal.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.1.1
+description: Mathematical value of valid binary integer literals
+info: >
+    20.1.1.1 Number ( [ value ] )
+
+    When Number is called with argument number, the following steps are taken:
+
+    1. If no arguments were passed to this function invocation, let n be +0.
+    2. Else, let n be ToNumber(value).
+
+    [...]
+
+    7.1.3.1 ToNumber Applied to the String Type
+
+    All grammar symbols not explicitly defined above have the definitions used
+    in the Lexical Grammar for numeric literals (11.8.3)
+
+    [...]
+
+    The MV of BinaryIntegerLiteral :: 0b BinaryDigits is the MV of
+    BinaryDigits.
+    The MV of BinaryIntegerLiteral :: 0B BinaryDigits is the MV of
+    BinaryDigits.
+    The MV of BinaryDigits :: BinaryDigit is the MV of BinaryDigit.
+    The MV of BinaryDigits :: BinaryDigits BinaryDigit is (the MV of
+    BinaryDigits × 2) plus the MV of BinaryDigit.
+---*/
+
+assert.sameValue(Number('0b0'), 0, 'lower-case head');
+assert.sameValue(Number('0B0'), 0, 'upper-case head');
+assert.sameValue(Number('0b00'), 0, 'lower-case head with leading zeros');
+assert.sameValue(Number('0B00'), 0, 'upper-case head with leading zeros');
+
+assert.sameValue(Number('0b1'), 1, 'lower-case head');
+assert.sameValue(Number('0B1'), 1, 'upper-case head');
+assert.sameValue(Number('0b01'), 1, 'lower-case head with leading zeros');
+assert.sameValue(Number('0B01'), 1, 'upper-case head with leading zeros');
+
+assert.sameValue(Number('0b10'), 2, 'lower-case head');
+assert.sameValue(Number('0B10'), 2, 'upper-case head');
+assert.sameValue(Number('0b010'), 2, 'lower-case head with leading zeros');
+assert.sameValue(Number('0B010'), 2, 'upper-case head with leading zeros');
+
+assert.sameValue(Number('0b11'), 3, 'lower-case head');
+assert.sameValue(Number('0B11'), 3, 'upper-case head');
+assert.sameValue(Number('0b011'), 3, 'lower-case head with leading zeros');
+assert.sameValue(Number('0B011'), 3, 'upper-case head with leading zeros');

--- a/test/built-ins/Number/string-octal-literal-invald.js
+++ b/test/built-ins/Number/string-octal-literal-invald.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.1.1
+description: Invalid octal literals yield NaN
+info: >
+    BinaryIntegerLiteral ::
+      0b BinaryDigits
+      0B BinaryDigits
+    BinaryDigits ::
+      BinaryDigit
+      BinaryDigits BinaryDigit
+    BinaryDigit :: one of
+      0 1
+---*/
+
+assert.sameValue(Number('0o8'), NaN, 'invalid digit');
+assert.sameValue(Number('00o0'), NaN, 'leading zero');
+assert.sameValue(Number('0o'), NaN, 'omitted digits');

--- a/test/built-ins/Number/string-octal-literal.js
+++ b/test/built-ins/Number/string-octal-literal.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.1.1
+description: Mathematical value of valid octal integer literals
+info: >
+    20.1.1.1 Number ( [ value ] )
+
+    When Number is called with argument number, the following steps are taken:
+
+    1. If no arguments were passed to this function invocation, let n be +0.
+    2. Else, let n be ToNumber(value).
+
+    [...]
+
+    7.1.3.1 ToNumber Applied to the String Type
+
+    All grammar symbols not explicitly defined above have the definitions used
+    in the Lexical Grammar for numeric literals (11.8.3)
+
+    [...]
+
+    The MV of OctalIntegerLiteral :: 0o OctalDigits is the MV of OctalDigits.
+    The MV of OctalIntegerLiteral :: 0O OctalDigits is the MV of OctalDigits.
+    The MV of OctalDigits :: OctalDigit is the MV of OctalDigit.
+    The MV of OctalDigits :: OctalDigits OctalDigit is (the MV of OctalDigits ×
+    8) plus the MV of OctalDigit.
+---*/
+
+assert.sameValue(Number('0o0'), 0, 'lower-case head');
+assert.sameValue(Number('0O0'), 0, 'upper-case head');
+assert.sameValue(Number('0o00'), 0, 'lower-case head with leading zeros');
+assert.sameValue(Number('0O00'), 0, 'upper-case head with leading zeros');
+
+assert.sameValue(Number('0o1'), 1, 'lower-case head');
+assert.sameValue(Number('0O1'), 1, 'upper-case head');
+assert.sameValue(Number('0o01'), 1, 'lower-case head with leading zeros');
+assert.sameValue(Number('0O01'), 1, 'upper-case head with leading zeros');
+
+assert.sameValue(Number('0o7'), 7, 'lower-case head');
+assert.sameValue(Number('0O7'), 7, 'upper-case head');
+assert.sameValue(Number('0o07'), 7, 'lower-case head with leading zeros');
+assert.sameValue(Number('0O07'), 7, 'upper-case head with leading zeros');
+
+assert.sameValue(Number('0o10'), 8, 'lower-case head');
+assert.sameValue(Number('0O10'), 8, 'upper-case head');
+assert.sameValue(Number('0o010'), 8, 'lower-case head with leading zeros');
+assert.sameValue(Number('0O010'), 8, 'upper-case head with leading zeros');
+
+assert.sameValue(Number('0o11'), 9, 'lower-case head');
+assert.sameValue(Number('0O11'), 9, 'upper-case head');
+assert.sameValue(Number('0o011'), 9, 'lower-case head with leading zeros');
+assert.sameValue(Number('0O011'), 9, 'upper-case head with leading zeros');
+
+assert.sameValue(Number('0o77'), 63, 'lower-case head');
+assert.sameValue(Number('0O77'), 63, 'upper-case head');
+assert.sameValue(Number('0o077'), 63, 'lower-case head with leading zeros');
+assert.sameValue(Number('0O077'), 63, 'upper-case head with leading zeros');

--- a/test/language/literals/numeric/binary-invalid-digit.js
+++ b/test/language/literals/numeric/binary-invalid-digit.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 11.8.3
+description: Binary-integer-literal-like sequence containing an invalid digit
+info: >
+    BinaryIntegerLiteral ::
+      0b BinaryDigits
+      0B BinaryDigits
+    BinaryDigits ::
+      BinaryDigit
+      BinaryDigits BinaryDigit
+    BinaryDigit :: one of
+      0 1
+negative: SyntaxError
+---*/
+
+0b2;

--- a/test/language/literals/numeric/binary-invalid-leading.js
+++ b/test/language/literals/numeric/binary-invalid-leading.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 11.8.3
+description: Binary-integer-literal-like sequence with a leading 0
+info: >
+    BinaryIntegerLiteral ::
+      0b BinaryDigits
+      0B BinaryDigits
+    BinaryDigits ::
+      BinaryDigit
+      BinaryDigits BinaryDigit
+    BinaryDigit :: one of
+      0 1
+negative: SyntaxError
+---*/
+
+00b0;

--- a/test/language/literals/numeric/binary-invalid-truncated.js
+++ b/test/language/literals/numeric/binary-invalid-truncated.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 11.8.3
+description: Binary-integer-literal-like sequence without any digits
+info: >
+    BinaryIntegerLiteral ::
+      0b BinaryDigits
+      0B BinaryDigits
+    BinaryDigits ::
+      BinaryDigit
+      BinaryDigits BinaryDigit
+    BinaryDigit :: one of
+      0 1
+negative: SyntaxError
+---*/
+
+0b;

--- a/test/language/literals/numeric/binary-invalid-unicode.js
+++ b/test/language/literals/numeric/binary-invalid-unicode.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 11.8.3
+description: Binary-integer-literal-like sequence expressed with unicode escape sequence
+info: >
+    BinaryIntegerLiteral ::
+      0b BinaryDigits
+      0B BinaryDigits
+    BinaryDigits ::
+      BinaryDigit
+      BinaryDigits BinaryDigit
+    BinaryDigit :: one of
+      0 1
+negative: SyntaxError
+---*/
+
+0\u00620;

--- a/test/language/literals/numeric/binary.js
+++ b/test/language/literals/numeric/binary.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 11.8.3.1
+description: Mathematical value of valid binary integer literals
+info: >
+    The MV of BinaryIntegerLiteral :: 0b BinaryDigits is the MV of
+    BinaryDigits.
+    The MV of BinaryIntegerLiteral :: 0B BinaryDigits is the MV of
+    BinaryDigits.
+    The MV of BinaryDigits :: BinaryDigit is the MV of BinaryDigit.
+    The MV of BinaryDigits :: BinaryDigits BinaryDigit is (the MV of
+    BinaryDigits × 2) plus the MV of BinaryDigit.
+---*/
+
+assert.sameValue(0b0, 0, 'lower-case head');
+assert.sameValue(0B0, 0, 'upper-case head');
+assert.sameValue(0b00, 0, 'lower-case head with leading zeros');
+assert.sameValue(0B00, 0, 'upper-case head with leading zeros');
+
+assert.sameValue(0b1, 1, 'lower-case head');
+assert.sameValue(0B1, 1, 'upper-case head');
+assert.sameValue(0b01, 1, 'lower-case head with leading zeros');
+assert.sameValue(0B01, 1, 'upper-case head with leading zeros');
+
+assert.sameValue(0b10, 2, 'lower-case head');
+assert.sameValue(0B10, 2, 'upper-case head');
+assert.sameValue(0b010, 2, 'lower-case head with leading zeros');
+assert.sameValue(0B010, 2, 'upper-case head with leading zeros');
+
+assert.sameValue(0b11, 3, 'lower-case head');
+assert.sameValue(0B11, 3, 'upper-case head');
+assert.sameValue(0b011, 3, 'lower-case head with leading zeros');
+assert.sameValue(0B011, 3, 'upper-case head with leading zeros');

--- a/test/language/literals/numeric/octal-invalid-digit.js
+++ b/test/language/literals/numeric/octal-invalid-digit.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 11.8.3
+description: Octal-integer-literal-like sequence containing an invalid digit
+info: >
+    OctalIntegerLiteral ::
+      0o OctalDigits
+      0O OctalDigits
+    OctalDigits ::
+      OctalDigit
+      OctalDigits OctalDigit
+    OctalDigit :: one of
+      0 1 2 3 4 5 6 7
+negative: SyntaxError
+---*/
+
+0o8;

--- a/test/language/literals/numeric/octal-invalid-leading.js
+++ b/test/language/literals/numeric/octal-invalid-leading.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 11.8.3
+description: Octal-integer-literal-like sequence with a leading 0
+info: >
+    OctalIntegerLiteral ::
+      0o OctalDigits
+      0O OctalDigits
+    OctalDigits ::
+      OctalDigit
+      OctalDigits OctalDigit
+    OctalDigit :: one of
+      0 1 2 3 4 5 6 7
+negative: SyntaxError
+---*/
+
+00o0;

--- a/test/language/literals/numeric/octal-invalid-truncated.js
+++ b/test/language/literals/numeric/octal-invalid-truncated.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 11.8.3
+description: Octal-integer-literal-like sequence without any digits
+info: >
+    OctalIntegerLiteral ::
+      0o OctalDigits
+      0O OctalDigits
+    OctalDigits ::
+      OctalDigit
+      OctalDigits OctalDigit
+    OctalDigit :: one of
+      0 1 2 3 4 5 6 7
+negative: SyntaxError
+---*/
+
+0b;

--- a/test/language/literals/numeric/octal-invalid-unicode.js
+++ b/test/language/literals/numeric/octal-invalid-unicode.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 11.8.3
+description: Octal-integer-literal-like sequence expressed with unicode escape sequence
+info: >
+    OctalIntegerLiteral ::
+      0o OctalDigits
+      0O OctalDigits
+    OctalDigits ::
+      OctalDigit
+      OctalDigits OctalDigit
+    OctalDigit :: one of
+      0 1 2 3 4 5 6 7
+negative: SyntaxError
+---*/
+
+0\u006f0;

--- a/test/language/literals/numeric/octal.js
+++ b/test/language/literals/numeric/octal.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 11.8.3.1
+description: Mathematical value of valid octal integer literals
+info: >
+    The MV of StrNumericLiteral ::: OctalIntegerLiteral is the MV of
+    OctalIntegerLiteral.
+    The MV of OctalIntegerLiteral :: 0o OctalDigits is the MV of OctalDigits.
+    The MV of OctalIntegerLiteral :: 0O OctalDigits is the MV of OctalDigits.
+    The MV of OctalDigits :: OctalDigit is the MV of OctalDigit.
+    The MV of OctalDigits :: OctalDigits OctalDigit is (the MV of OctalDigits ×
+    8) plus the MV of OctalDigit.
+---*/
+
+assert.sameValue(0o0, 0, 'lower-case head');
+assert.sameValue(0O0, 0, 'upper-case head');
+assert.sameValue(0o00, 0, 'lower-case head with leading zeros');
+assert.sameValue(0O00, 0, 'upper-case head with leading zeros');
+
+assert.sameValue(0o1, 1, 'lower-case head');
+assert.sameValue(0O1, 1, 'upper-case head');
+assert.sameValue(0o01, 1, 'lower-case head with leading zeros');
+assert.sameValue(0O01, 1, 'upper-case head with leading zeros');
+
+assert.sameValue(0o7, 7, 'lower-case head');
+assert.sameValue(0O7, 7, 'upper-case head');
+assert.sameValue(0o07, 7, 'lower-case head with leading zeros');
+assert.sameValue(0O07, 7, 'upper-case head with leading zeros');
+
+assert.sameValue(0o10, 8, 'lower-case head');
+assert.sameValue(0O10, 8, 'upper-case head');
+assert.sameValue(0o010, 8, 'lower-case head with leading zeros');
+assert.sameValue(0O010, 8, 'upper-case head with leading zeros');
+
+assert.sameValue(0o11, 9, 'lower-case head');
+assert.sameValue(0O11, 9, 'upper-case head');
+assert.sameValue(0o011, 9, 'lower-case head with leading zeros');
+assert.sameValue(0O011, 9, 'upper-case head with leading zeros');
+
+assert.sameValue(0o77, 63, 'lower-case head');
+assert.sameValue(0O77, 63, 'upper-case head');
+assert.sameValue(0o077, 63, 'lower-case head with leading zeros');
+assert.sameValue(0O077, 63, 'upper-case head with leading zeros');


### PR DESCRIPTION
Add tests for BinaryIntegerLiterals and OctalIntegerLiterals.