### PR TITLE
Remove $PRINT helper function

### DIFF
--- a/harness/$PRINT.js
+++ b/harness/$PRINT.js
@@ -1,4 +1,0 @@
-//adaptors for Test262 framework
-function $PRINT(message) {
-
-}

--- a/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A7.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A7.js
@@ -5,8 +5,6 @@
 info: Object.prototype.hasOwnProperty can't be used as a constructor
 es5id: 15.2.4.5_A7
 description: Checking if creating "new Object.prototype.hasOwnProperty" fails
-includes:
-    - $PRINT.js
 ---*/
 
 var FACTORY = Object.prototype.hasOwnProperty;

--- a/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A1.js
+++ b/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A1.js
@@ -7,7 +7,6 @@ info: >
     V refer to the same object or to objects joined to each other, return true
 es5id: 15.2.4.6_A1
 description: Creating two objects with the same prototype
-includes: [$PRINT.js]
 ---*/
 
 function USER_FACTORY( name ) {
@@ -29,20 +28,22 @@ FORCEDUSER_FACTORY.prototype = proto;
 var luke = new FORCEDUSER_FACTORY("Luke Skywalker", 12);
 //////
 // CHECK#1
-if(proto.isPrototypeOf(luke)){
-  $PRINT('#1: Native ECMAScript objects have an internal property called [[Prototype]].');
-} else {
-  $ERROR('#1: native ECMAScript objects have an internal property called [[Prototype]].');
-}
+assert.sameValue(
+  proto.isPrototypeOf(luke),
+  true,
+  '#1: native ECMAScript objects have an internal property called [[Prototype]].'
+);
+
 //
 /////////
 //////
 // CHECK#2
-if(USER_FACTORY.prototype.isPrototypeOf(luke)){
-  $PRINT('#2: Native ECMAScript objects have an internal property called [[Prototype]].');
-} else {
-  $ERROR('#2: native ECMAScript objects have an internal property called [[Prototype]].');
-}
+assert.sameValue(
+  USER_FACTORY.prototype.isPrototypeOf(luke),
+  true,
+  '#2: native ECMAScript objects have an internal property called [[Prototype]].'
+);
+
 //
 /////////
 //////

--- a/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A7.js
+++ b/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A7.js
@@ -5,8 +5,6 @@
 info: Object.prototype.valueOf can't be used as a constructor
 es5id: 15.2.4.4_A7
 description: Checking if creating "new Object.prototype.valueOf" fails
-includes:
-    - $PRINT.js
 ---*/
 
 var FACTORY = Object.prototype.valueOf;

--- a/test/built-ins/String/prototype/indexOf/S15.5.4.7_A7.js
+++ b/test/built-ins/String/prototype/indexOf/S15.5.4.7_A7.js
@@ -5,8 +5,6 @@
 info: String.prototype.indexOf can't be used as constructor
 es5id: 15.5.4.7_A7
 description: Checking if creating the String.prototype.indexOf object fails
-includes:
-    - $PRINT.js
 ---*/
 
 var __FACTORY = String.prototype.indexOf;
@@ -18,5 +16,4 @@ try {
   if ((e instanceof TypeError) !== true) {
     $ERROR('#1.2: var __FACTORY = String.prototype.indexOf; "__instance = new __FACTORY" throw a TypeError. Actual: ' + (e));  
   }
-  $PRINT(e);
 }

--- a/test/built-ins/String/prototype/search/S15.5.4.12_A7.js
+++ b/test/built-ins/String/prototype/search/S15.5.4.12_A7.js
@@ -5,8 +5,6 @@
 info: String.prototype.search can't be used as constructor
 es5id: 15.5.4.12_A7
 description: Checking if creating the String.prototype.search object fails
-includes:
-    - $PRINT.js
 ---*/
 
 var __FACTORY = String.prototype.search;
@@ -18,5 +16,4 @@ try {
   if ((e instanceof TypeError) !== true) {
     $ERROR('#1.1: __FACTORY = String.prototype.search; "__instance = new __FACTORY" throw a TypeError. Actual: ' + (e));  
   }
-  $PRINT(e);
 }

--- a/test/built-ins/String/prototype/substring/S15.5.4.15_A7.js
+++ b/test/built-ins/String/prototype/substring/S15.5.4.15_A7.js
@@ -5,8 +5,6 @@
 info: String.prototype.substring can't be used as constructor
 es5id: 15.5.4.15_A7
 description: Checking if creating the String.prototype.substring object fails
-includes:
-    - $PRINT.js
 ---*/
 
 var __FACTORY = String.prototype.substring;
@@ -18,5 +16,4 @@ try {
   if ((e instanceof TypeError) !== true) {
     $ERROR('#1.2: undefined = 1 throw a TypeError. Actual: ' + (e));  
   }
-  $PRINT(e);
 }

--- a/test/built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A7.js
+++ b/test/built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A7.js
@@ -7,8 +7,6 @@ es5id: 15.5.4.17_A7
 description: >
     Checking if creating the String.prototype.toLocaleLowerCase object
     fails
-includes:
-    - $PRINT.js
 ---*/
 
 var __FACTORY = String.prototype.toLocaleLowerCase;
@@ -20,5 +18,4 @@ try {
   if ((e instanceof TypeError) !== true) {
     $ERROR('#1.1: var __FACTORY = String.prototype.toLocaleLowerCase; "var __instance = new __FACTORY" throw a TypeError. Actual: ' + (e));  
   }
-  $PRINT(e);
 }

--- a/test/language/function-code/S10.2.1_A4_T2.js
+++ b/test/language/function-code/S10.2.1_A4_T2.js
@@ -9,7 +9,6 @@ info: >
     FormalParameterList properties
 es5id: 10.2.1_A4_T2
 description: Checking existence of a function with declared variable
-includes: [$PRINT.js]
 ---*/
 
 //CHECK#1
@@ -22,9 +21,8 @@ function f1(){
     return 7;
   }
 }
-if(!(f1().constructor.prototype === Function.prototype)){
-  $PRINT('#1: f1() returns function');
-}
+
+assert.sameValue(f1().constructor.prototype, Function.prototype);
 
 //CHECK#2
 function f2(){
@@ -36,6 +34,5 @@ function f2(){
     return 7;
   }
 }
-if(!(f2() === "function")){
-  $PRINT('#2: f2() === "function"');
-}
+
+assert.sameValue(f2(), "function");

--- a/test/language/function-code/S10.2.1_A5.1_T1.js
+++ b/test/language/function-code/S10.2.1_A5.1_T1.js
@@ -9,7 +9,6 @@ info: >
     undefined and whose attributes are determined by the type of code
 es5id: 10.2.1_A5.1_T1
 description: Checking variable existence only
-includes: [$PRINT.js]
 ---*/
 
 //CHECK#1
@@ -19,9 +18,7 @@ function f1(){
   return typeof x;
 }
 
-if(!(f1() === "undefined")){
-  $PRINT('#1: f1() === "undefined"');
-}
+assert.sameValue(f1(), "undefined");
 
 //CHECK#2
 function f2(){
@@ -30,6 +27,4 @@ function f2(){
   return x;
 }
 
-if(!(f2() === undefined)){
-  $PRINT('#1: f2() === undefined');
-}
+assert.sameValue(f2(), undefined);

--- a/test/language/function-code/S10.2.1_A5.1_T2.js
+++ b/test/language/function-code/S10.2.1_A5.1_T2.js
@@ -11,7 +11,6 @@ es5id: 10.2.1_A5.1_T2
 description: >
     Checking existence of the variable object property with formal
     parameter
-includes: [$PRINT.js]
 ---*/
 
 //CHECK#1
@@ -21,9 +20,7 @@ function f1(x){
   return typeof x;
 }
 
-if(!(f1() === "undefined")){
-  $PRINT('#1: f1(1) === "undefined"');
-}
+assert.sameValue(f1(), "undefined");
 
 //CHECK#2
 function f2(x){
@@ -32,6 +29,4 @@ function f2(x){
   return x;
 }
 
-if(!(f2() === undefined)){
-  $PRINT('#1: f2(1) === undefined');
-}
+assert.sameValue(f2(), undefined);

--- a/test/language/function-code/S10.2.1_A5.2_T1.js
+++ b/test/language/function-code/S10.2.1_A5.2_T1.js
@@ -10,7 +10,6 @@ es5id: 10.2.1_A5.2_T1
 description: >
     Checking existence of the variable object property with formal
     parameter
-includes: [$PRINT.js]
 ---*/
 
 //CHECK#1
@@ -20,9 +19,7 @@ function f1(x){
   return typeof x;
 }
 
-if(!(f1(1) === "number")){
-  $PRINT('#1: f1(1) === "number"');
-}
+assert.sameValue(f1(1), "number");
 
 //CHECK#2
 function f2(x){
@@ -31,6 +28,4 @@ function f2(x){
   return x;
 }
 
-if(!(f2(1) === 1)){
-  $PRINT('#1: f2(1) === 1');
-}
+assert.sameValue(f2(1), 1);

--- a/test/language/statements/block/S12.1_A2.js
+++ b/test/language/statements/block/S12.1_A2.js
@@ -8,7 +8,6 @@ info: >
     2. If an exception was thrown, return (throw, V, empty) where V is the exception
 es5id: 12.1_A2
 description: Throwing exception within a Block
-includes: [$PRINT.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////

--- a/test/language/types/number/S8.5_A5.js
+++ b/test/language/types/number/S8.5_A5.js
@@ -5,7 +5,6 @@
 info: NaN not greater or equal zero
 es5id: 8.5_A5
 description: Compare NaN with zero
-includes: [$PRINT.js]
 ---*/
 
 var x = NaN;
@@ -19,8 +18,6 @@ var x_geq_0_ADD_leq_0=(x >= 0.0) + (x <= 0.0);
 // CHECK#1
 if (x_geq_0){
   $ERROR('#1: NaN not greater or equal zero');
-} else {
-  $PRINT('#1: NaN not greater or equal zero');
 }
 //
 ///////////////////////////////////////////////////
@@ -29,8 +26,6 @@ if (x_geq_0){
 // CHECK#2
 if (x_leq_0){
   $ERROR('#2: NaN not less or equal zero');
-} else {
-  $PRINT('#2: NaN not less or equal zero');
 }
 //
 ///////////////////////////////////////////////////
@@ -39,8 +34,6 @@ if (x_leq_0){
 // CHECK#3
 if (x_leq_0_OR_geq_0){
   $ERROR('#3: NaN not less or equal zero OR greater or equal zero');
-} else {
-  $PRINT('#3: NaN not less or equal zero OR greater or equal zero');
 }
 //
 ///////////////////////////////////////////////////
@@ -49,8 +42,6 @@ if (x_leq_0_OR_geq_0){
 // CHECK#4
 if (x_geq_0_ADD_leq_0){
   $ERROR('#4: NaN not less or equal zero ADD greater or equal zero');
-} else {
-  $PRINT('#4: NaN not less or equal zero ADD greater or equal zero');
 }
 //
 ///////////////////////////////////////////////////


### PR DESCRIPTION
@anba [requested this while reviewing another patch](https://github.com/tc39/test262/pull/307#issuecomment-110505474), and I thought it was a good idea. As noted in the commit message, this work also surfaced some tautological tests.

Commit message:

> The `$PRINT` helper function has no effect on test behavior. The
> following tests use it to report assertion outcomes (and as a result
> will fail silently):
>
> - test/language/function-code/S10.2.1_A4_T2.js
> - test/language/function-code/S10.2.1_A5.1_T1.js
> - test/language/function-code/S10.2.1_A5.1_T2.js
> - test/language/function-code/S10.2.1_A5.2_T1.js
>
> Remove the function definition and all references within tests. Update
> tests that use it as an error reporting mechanism to instead use an
> appropriate `assert` helper function.