### PR TITLE
Fix typo in test meta-data

### DIFF
--- a/test/language/module-code/lex-and-var.js
+++ b/test/language/module-code/lex-and-var.js
@@ -7,7 +7,7 @@ description: >
     ModuleItemList also occurs in the VarDeclaredNames of ModuleItemList.
 flags: [module]
 features: [let]
-negative: [SyntaxError]
+negative: SyntaxError
 ---*/
 
 let x;


### PR DESCRIPTION
The `Negative` tag accepts a string value (not a list)

Resolves gh-323