### PR TITLE
Update browser runner to inject `assert.js`

### DIFF
--- a/harness/sth.js
+++ b/harness/sth.js
@@ -27,6 +27,7 @@ function BrowserRunner() {
         errorDetectorFileContents,
         simpleTestAPIContents,
         globalScopeContents,
+        assertContents,
         timerContents,
         startTime,
         harnessDir = "harness/";
@@ -45,6 +46,11 @@ function BrowserRunner() {
             dataType: "text",
             success: function(data){globalScopeContents = data;},
             url:harnessDir+"gs.js"});
+
+    $.ajax({async: false,
+            dataType: "text",
+            success: function(data){assertContents = data;},
+            url:harnessDir+"assert.js"});
     
 	$.ajax({async: false,
 		dataType: "text",
@@ -213,6 +219,10 @@ function BrowserRunner() {
         //idoc.writeln("<script type='text/javascript' src='harness/gs.js' defer>" + "</script>");
         idoc.writeln("<script type='text/javascript'>");
         idoc.writeln(globalScopeContents);
+        idoc.writeln("</script>");
+
+        idoc.writeln("<script type='text/javascript'>");
+        idoc.writeln(assertContents);
         idoc.writeln("</script>");
 
         //this is mainly applicable for consoles that do not have setTimeout support

--- a/tools/packaging/templates/runner.bestPractice.html
+++ b/tools/packaging/templates/runner.bestPractice.html
@@ -11,7 +11,6 @@
 </script>
 <script type="text/javascript" src="harness/sth.js"></script>
 <script type="text/javascript" src="harness/sta.js"></script>
-<script type="text/javascript" src="harness/assert.js"></script>
 <script type="text/javascript" src="harness/jqueryprogressbar.js"></script>
 <script type="text/javascript" src="harness/helper.js"></script>
 <script type="text/javascript" src="harness/jquery.base64.js"></script>

--- a/tools/packaging/templates/runner.intl402.html
+++ b/tools/packaging/templates/runner.intl402.html
@@ -11,7 +11,6 @@
 </script>
 <script type="text/javascript" src="harness/sth.js"></script>
 <script type="text/javascript" src="harness/sta.js"></script>
-<script type="text/javascript" src="harness/assert.js"></script>
 <script type="text/javascript" src="harness/jqueryprogressbar.js"></script>
 <script type="text/javascript" src="harness/helper.js"></script>
 <script type="text/javascript" src="harness/jquery.base64.js"></script>

--- a/tools/packaging/templates/runner.test262.html
+++ b/tools/packaging/templates/runner.test262.html
@@ -11,7 +11,6 @@
 </script>
 <script type="text/javascript" src="harness/sth.js"></script>
 <script type="text/javascript" src="harness/sta.js"></script>
-<script type="text/javascript" src="harness/assert.js"></script>
 <script type="text/javascript" src="harness/jqueryprogressbar.js"></script>
 <script type="text/javascript" src="harness/helper.js"></script>
 <script type="text/javascript" src="harness/jquery.base64.js"></script>


### PR DESCRIPTION
Since the Python runner was updated to include `assert.js` in all tests
unconditionally, a number of tests have been written that implicitly
rely on its presence. The browser runner does not currently provide this
file's contents to these tests, so they fail unconditionally.

Update the browser runner to inject that file's contents into every test
context.

Note: the existing approach to file retrieval (namely loading via
synchronous XHR requests) is inefficient and deprecated in some
browsers. It is honored here for the sake of consistency and to minimize
the changeset necessary to fix the browser runner.