### PR TITLE
Fix bugs in Promise tests

### DIFF
--- a/test/built-ins/Promise/all/S25.4.4.1_A5.1_T1.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A5.1_T1.js
@@ -11,20 +11,17 @@ description: iterator.next throws, causing Promise.all to reject
 ---*/
 
 var iterThrows = {};
-Object.defineProperty(iterThrows, Symbol.iterator, {
-    get: function () {
-        return {
-            next: function () {
-                throw new Error("abrupt completion");
-            }
-        };
-    }
-});
+var error = new Test262Error();
+iterThrows[Symbol.iterator] = function() {
+    return {
+        next: function () {
+            throw error;
+        }
+    };
+};
 
 Promise.all(iterThrows).then(function () {
     $ERROR('Promise unexpectedly resolved: Promise.all(iterThrows) should throw TypeError');
-},function (err) {
-    if (!(err instanceof TypeError)) {
-        $ERROR('Expected TypeError, got ' + err);
-    }
+},function (reason) {
+    assert.sameValue(reason, error);
 }).then($DONE,$DONE);

--- a/test/built-ins/Promise/prototype/then/S25.4.5.3_A3.1_T1.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.5.3_A3.1_T1.js
@@ -14,21 +14,14 @@ var p = Promise.resolve("foo");
 
 Object.defineProperty(p, "constructor", {
     get: function () {
-        throw new Error("abrupt completion");
+        throw new Test262Error();
     }
 });
 
-try {
-    p.then(function () {
-        $ERROR("Should never be called.");
-    }, function () {
-        $ERROR("Should never be called.");
-    });
-} catch (e) {
-    if (!(e instanceof Error)) {
-        $ERROR("Expected Error, got " + e);
-    }
-    if (e.message !== "abrupt completion") {
-        $ERROR("Expected the Error we threw, got " + e);
-    }
-}
+assert.throws(Test262Error, function() {
+  p.then(function() {
+    $ERROR("Should never be called.");
+  }, function() {
+    $ERROR("Should never be called.");
+  });
+});

--- a/test/built-ins/Promise/race/S25.4.4.3_A4.1_T1.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A4.1_T1.js
@@ -8,21 +8,18 @@ description: Promise.race rejects if IteratorStep throws
 ---*/
 
 var iterThrows = {};
-Object.defineProperty(iterThrows, Symbol.iterator, {
-    get: function () {
-        return {
-            next: function () {
-                throw new Error("abrupt completion");
-            }
-        };
-    }
-});
+var error = new Test262Error();
+iterThrows[Symbol.iterator] = function () {
+    return {
+        next: function () {
+            throw error;
+        }
+    };
+};
 
 Promise.race(iterThrows).then(function () {
     $ERROR('Promise unexpectedly fulfilled: Promise.race(iterThrows) should throw TypeError');
-},function (err) {
-    if (!(err instanceof TypeError)) {
-        $ERROR('Expected TypeError, got ' + err);
-    }
+}, function (reason) {
+    assert.sameValue(reason, error);
 }).then($DONE,$DONE);
 


### PR DESCRIPTION
This test's description concerns the behavior of `Promise.all` when the
IteratorStep abstract operation fails due to an abrupt completion
returned by the iterator's `next` method. The test body did not actually
assert that functionality.

Update the test body to correctly define the requisite iterator and
assert that the specific error created is the one thrown from the
invocation of `Promise.all`