### PR TITLE
Remove empty "include" file

### DIFF
--- a/test/built-ins/Date/S15.9.3.1_A5_T1.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T1.js
@@ -15,7 +15,6 @@ info: >
 es5id: 15.9.3.1_A5_T1
 description: 2 arguments, (year, month)
 includes:
-    - environment.js
     - numeric_conversion.js
     - Date_constants.js
     - Date_library.js

--- a/test/built-ins/Date/S15.9.3.1_A5_T2.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T2.js
@@ -15,7 +15,6 @@ info: >
 es5id: 15.9.3.1_A5_T2
 description: 3 arguments, (year, month, date)
 includes:
-    - environment.js
     - numeric_conversion.js
     - Date_constants.js
     - Date_library.js

--- a/test/built-ins/Date/S15.9.3.1_A5_T3.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T3.js
@@ -15,7 +15,6 @@ info: >
 es5id: 15.9.3.1_A5_T3
 description: 4 arguments, (year, month, date, hours)
 includes:
-    - environment.js
     - numeric_conversion.js
     - Date_constants.js
     - Date_library.js

--- a/test/built-ins/Date/S15.9.3.1_A5_T4.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T4.js
@@ -15,7 +15,6 @@ info: >
 es5id: 15.9.3.1_A5_T4
 description: 5 arguments, (year, month, date, hours, minutes)
 includes:
-    - environment.js
     - numeric_conversion.js
     - Date_constants.js
     - Date_library.js

--- a/test/built-ins/Date/S15.9.3.1_A5_T5.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T5.js
@@ -15,7 +15,6 @@ info: >
 es5id: 15.9.3.1_A5_T5
 description: 6 arguments, (year, month, date, hours, minutes, seconds)
 includes:
-    - environment.js
     - numeric_conversion.js
     - Date_constants.js
     - Date_library.js

--- a/test/built-ins/Date/S15.9.3.1_A5_T6.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T6.js
@@ -15,7 +15,6 @@ info: >
 es5id: 15.9.3.1_A5_T6
 description: 7 arguments, (year, month, date, hours, minutes, seconds, ms)
 includes:
-    - environment.js
     - numeric_conversion.js
     - Date_constants.js
     - Date_library.js


### PR DESCRIPTION
The `environment.js` file has been empty since its initial introduction
to this project [1]. It has no effect on any of the contexts in which it
is currently referenced, so it may be safely removed.

[1] be82787a00f8b2de474e1bfb29d65d04af72255f