### PR TITLE
Remove unnecessary "include" file

### DIFF
--- a/harness/fnExists.js
+++ b/harness/fnExists.js
@@ -1,7 +1,0 @@
-//-----------------------------------------------------------------------------
-function fnExists(/*arguments*/) {
-    for (var i = 0; i < arguments.length; i++) {
-        if (typeof (arguments[i]) !== "function") return false;
-    }
-    return true;
-}

--- a/test/language/expressions/delete/11.4.1-5-3.js
+++ b/test/language/expressions/delete/11.4.1-5-3.js
@@ -12,7 +12,6 @@ description: >
 flags: [noStrict]
 includes:
     - runTestCase.js
-    - fnExists.js
 ---*/
 
 function testcase() {
@@ -20,7 +19,7 @@ function testcase() {
 
   // Now, deleting 'foo' directly should fail;
   var d = delete foo;
-  if(d === false && fnExists(foo))
+  if(d === false && typeof foo === 'function')
     return true;
  }
 runTestCase(testcase);


### PR DESCRIPTION
The `fnExists` function defines a generic way to determine if any number
of values are function instances. Because it is only used by a single
test, the additional complexity required by the generalized code (and
the organizational drawbacks to maintaining another "include" file) are
not justified. Remove the file and update the test to assert the
function's existence directly.