### PR TITLE
Implement `raw` flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,9 @@ This tag is for boolean properties associated with the test.
 - **`noStrict`** - only run the test in "sloppy" mode
 - **`module`** - interpret the source text as [module
   code](http://www.ecma-international.org/ecma-262/6.0/#sec-modules)
+- **`raw`** - execute the test without any modification (no helpers will be
+  available); necessary to test the behavior of directive prologue; implies
+  `noStrict`
 
 #### features
 **features**: [list]

--- a/test/language/directive-prologue/10.1.1-2gs.js
+++ b/test/language/directive-prologue/10.1.1-2gs.js
@@ -9,10 +9,10 @@ es5id: 10.1.1-2gs
 description: >
     Strict Mode - Use Strict Directive Prologue is ''use strict''
     which lost the last character ';'
-negative: NotEarlyError
-flags: [noStrict]
+negative: SyntaxError
+flags: [raw]
 ---*/
 
 "use strict"
-throw NotEarlyError;
+throw new Error("This code should not execute");
 var public = 1;

--- a/test/language/directive-prologue/10.1.1-5gs.js
+++ b/test/language/directive-prologue/10.1.1-5gs.js
@@ -9,10 +9,10 @@ es5id: 10.1.1-5gs
 description: >
     Strict Mode - Use Strict Directive Prologue is ''use strict';'
     which appears at the start of the code
-negative: NotEarlyError
-flags: [noStrict]
+negative: SyntaxError
+flags: [raw]
 ---*/
 
 "use strict";
-throw NotEarlyError;
+throw new Error("This code should not execute");
 var public = 1;

--- a/test/language/directive-prologue/10.1.1-8gs.js
+++ b/test/language/directive-prologue/10.1.1-8gs.js
@@ -9,8 +9,8 @@ es5id: 10.1.1-8gs
 description: >
     Strict Mode - Use Strict Directive Prologue is ''use strict';'
     which appears twice in the code
-negative: NotEarlyError
-flags: [noStrict]
+negative: SyntaxError
+flags: [raw]
 ---*/
 
 "use strict";

--- a/test/language/directive-prologue/14.1-4gs.js
+++ b/test/language/directive-prologue/14.1-4gs.js
@@ -10,9 +10,9 @@ description: >
     StrictMode - a Use Strict Directive followed by a strict mode
     violation
 negative: SyntaxError
-flags: [onlyStrict]
+flags: [raw]
 ---*/
 
 "use strict";
-throw NotEarlyError;
+throw new Error("This code should not execute");
 eval = 42;

--- a/test/language/directive-prologue/14.1-5gs.js
+++ b/test/language/directive-prologue/14.1-5gs.js
@@ -10,11 +10,11 @@ description: >
     StrictMode - a Use Strict Directive embedded in a directive
     prologue followed by a strict mode violation
 negative: SyntaxError
-flags: [onlyStrict]
+flags: [raw]
 ---*/
 
 "a";
 "use strict";
 "c";
-throw NotEarlyError;
+throw new Error("This code should not execute");
 eval = 42;

--- a/website/scripts/sth.js
+++ b/website/scripts/sth.js
@@ -272,7 +272,8 @@ function BrowserRunner() {
 BrowserRunner.prototype.compileSource = function(test, code) {
     var flags = test.flags;
 
-    if (flags && flags.indexOf("onlyStrict") > -1) {
+    if (flags && flags.indexOf("raw") === -1 &&
+        flags.indexOf("onlyStrict") > -1) {
         code = "'use strict';\n" + code;
     }
 


### PR DESCRIPTION
Some tests involving the directive prologue are invalidated by source
text transformations that insert executable code in the beginning of the
script. Implement a `raw` flag that allows these tests to opt-out of
this transformation. Update the relevant tests to use this flag (and
remove references to globals only available when code is injected).

Update the Python runner accordingly:

- Do not run tests marked as "raw" in strict mode
- Reject invalid test configurations

Update the browser runner accordingly:

- Do not modify the script body of tests marked as "raw"