### PR TITLE
Fixed invalid configuration block delimiters.

### DIFF
--- a/test/built-ins/Object/assign/ObjectOverride-sameproperty.js
+++ b/test/built-ins/Object/assign/ObjectOverride-sameproperty.js
@@ -1,11 +1,11 @@
 // Copyright 2015 Microsoft Corporation. All rights reserved.
 // This code is governed by the license found in the LICENSE file.
 
-/*--
+/*---
 description: Object properties are assigned to target in ascending index order,
              i.e. a later assignment to the same property overrides an earlier assignment.
 es6id:  19.1.2.1
---*/
+---*/
 
 var target = {a: 1};
 var result = Object.assign(target,{a:2},{a:"c"});

--- a/test/built-ins/Object/assign/Source-Number-Boolen-Symbol.js
+++ b/test/built-ins/Object/assign/Source-Number-Boolen-Symbol.js
@@ -1,11 +1,11 @@
 // Copyright 2015 Microsoft Corporation. All rights reserved.
 // This code is governed by the license found in the LICENSE file.
 
-/*--
+/*---
 description: Number,Boolean,Symbol cannot have own enumerable properties,
              So cannot be Assigned.Here result should be original object.
 es6id:  19.1.2.1.5.c
---*/
+---*/
 
 var target = new Object();
 var result = Object.assign(target,123,true,Symbol('foo'));


### PR DESCRIPTION
Two tests started the configuration block with a /*-- instead of a /*---.