### PR TITLE
Use "monkeyYaml" in all environments

### DIFF
--- a/tools/packaging/parseTestRecord.py
+++ b/tools/packaging/parseTestRecord.py
@@ -113,12 +113,8 @@ def importYamlLoad():
     global yamlLoad
     if yamlLoad:
         return
-    try:
-        import yaml
-        yamlLoad = yaml.load
-    except:
-        monkeyYaml = loadMonkeyYaml()
-        yamlLoad = monkeyYaml.load
+    monkeyYaml = loadMonkeyYaml()
+    yamlLoad = monkeyYaml.load
 
 def loadMonkeyYaml():
     f = None


### PR DESCRIPTION
The "monkeyYaml" parser is intended to serve as a lightweight fallback
to Python's standard YAML parser in contexts where the latter is not
available. Any intentionally-simplified implementation will necessarily
exhibit non-standard behavior for different input, so not all input
accepted by the standard parser will be accepted by "monkeyYaml". If
loaded exclusively in fallback situations, these edge cases can only be
identified (and debugged) in the environments that require the fallback.
This has allowed developers to unknowingly author tests that cause
errors.

Update the test runner to use "monkeyYaml" in all cases, ensuring more
consistent behavior across contexts and precluding this class of
regression.

This depends on gh-346