### PR TITLE
Add tests for RegExp `u` flag

### DIFF
--- a/test/built-ins/RegExp/prototype/Symbol.match/get-unicode-error.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/get-unicode-error.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Errors thrown by `unicode` accessor are forwarded to the runtime for global patterns
+es6id: 21.2.5.6
+info: >
+    21.2.5.6 RegExp.prototype [ @@match ] ( string )
+
+    [...]
+    8. Else global is true,
+       a. Let fullUnicode be ToBoolean(Get(rx, "unicode")).
+       b. ReturnIfAbrupt(fullUnicode).
+features: [Symbol.match]
+---*/
+
+var nonGlobalRe = /./;
+var globalRe = /./g;
+var accessor = function() {
+  throw new Test262Error();
+};
+Object.defineProperty(nonGlobalRe, 'unicode', {
+  get: accessor
+});
+Object.defineProperty(globalRe, 'unicode', {
+  get: accessor
+});
+
+nonGlobalRe[Symbol.match]('');
+
+assert.throws(Test262Error, function() {
+  globalRe[Symbol.match]('');
+});

--- a/test/built-ins/RegExp/prototype/Symbol.match/u-advance-after-empty.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/u-advance-after-empty.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: lastIndex is advanced according to width of astral symbols
+es6id: 21.2.5.6
+info: >
+    21.2.5.6 RegExp.prototype [ @@match ] ( string )
+
+    [...]
+    8. Else global is true,
+       a. Let fullUnicode be ToBoolean(Get(rx, "unicode")).
+       [...]
+       g. Repeat,
+          [...]
+          iv. Else result is not null,
+              [...]
+              5. If matchStr is the empty String, then
+                 [...]
+                 c. Let nextIndex be AdvanceStringIndex(S, thisIndex,
+                    fullUnicode).
+                 d. Let setStatus be Set(rx, "lastIndex", nextIndex, true).
+features: [Symbol.match]
+---*/
+
+var match = /^|\udf06/ug[Symbol.match]('\ud834\udf06');
+
+assert(match !== null);
+assert.sameValue(match.length, 1);
+assert.sameValue(match[0], '');

--- a/test/built-ins/RegExp/prototype/Symbol.replace/get-unicode-error.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/get-unicode-error.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Errors thrown by `unicode` accessor are forwarded to the runtime for global patterns
+es6id: 21.2.5.8
+info: >
+    21.2.5.8 RegExp.prototype [ @@replace ] ( string, replaceValue )
+
+    [...]
+    10. If global is true, then
+        a. Let fullUnicode be ToBoolean(Get(rx, "unicode")).
+        b. ReturnIfAbrupt(fullUnicode).
+features: [Symbol.replace]
+---*/
+
+var nonGlobalRe = /./;
+var globalRe = /./g;
+var accessor = function() {
+  throw new Test262Error();
+};
+Object.defineProperty(nonGlobalRe, 'unicode', {
+  get: accessor
+});
+Object.defineProperty(globalRe, 'unicode', {
+  get: accessor
+});
+
+nonGlobalRe[Symbol.replace]('', '');
+
+assert.throws(Test262Error, function() {
+  globalRe[Symbol.replace]('', '');
+});

--- a/test/built-ins/RegExp/prototype/Symbol.replace/u-advance-after-empty.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/u-advance-after-empty.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: lastIndex is advanced according to width of astral symbols
+es6id: 21.2.5.8
+info: >
+    21.2.5.8 RegExp.prototype [ @@replace ] ( string, replaceValue )
+
+    [...]
+    10. If global is true, then
+        a. Let fullUnicode be ToBoolean(Get(rx, "unicode")).
+        b. ReturnIfAbrupt(fullUnicode).
+    [...]
+    13. Repeat, while done is false
+        [...]
+        d. Else result is not null,
+           [...]
+           iii. Else,
+                [...]
+                3. If matchStr is the empty String, then
+                   [...]
+                   c. Let nextIndex be AdvanceStringIndex(S, thisIndex,
+                      fullUnicode).
+                   d. Let setStatus be Set(rx, "lastIndex", nextIndex, true).
+features: [Symbol.replace]
+---*/
+
+var str = /^|\udf06/ug[Symbol.replace]('\ud834\udf06', 'XXX');
+assert.sameValue(str, 'XXX\ud834\udf06');

--- a/test/built-ins/RegExp/prototype/Symbol.search/u-lastindex-advance.js
+++ b/test/built-ins/RegExp/prototype/Symbol.search/u-lastindex-advance.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Advancement of lastIndex
+es6id: 21.2.5.9
+info: >
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    12. Let flags be the value of R’s [[OriginalFlags]] internal slot.
+    13. If flags contains "u", let fullUnicode be true, else let fullUnicode be
+        false.
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        c. If r is failure, then
+           [...]
+           ii. Let lastIndex be AdvanceStringIndex(S, lastIndex, fullUnicode).
+features: [Symbol.search]
+---*/
+
+assert.sameValue(/\udf06/u[Symbol.search]('\ud834\udf06'), -1);

--- a/test/built-ins/RegExp/prototype/Symbol.split/u-lastindex-adv-thru-failure.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/u-lastindex-adv-thru-failure.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    lastIndex is advanced according to width of astral symbols following match failure
+es6id: 21.2.5.11
+info: >
+    21.2.5.11 RegExp.prototype [ @@split ] ( string, limit )
+
+    [...]
+    7. Let flags be ToString(Get(rx, "flags")).
+    8. ReturnIfAbrupt(flags).
+    9. If flags contains "u", let unicodeMatching be true.
+    10. Else, let unicodeMatching be false.
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        b. ReturnIfAbrupt(setStatus).
+        c. Let z be RegExpExec(splitter, S).
+        d. ReturnIfAbrupt(z).
+        e. If z is null, let q be AdvanceStringIndex(S, q, unicodeMatching).
+features: [Symbol.split]
+---*/
+
+var result = /\udf06/u[Symbol.split]('\ud834\udf06');
+
+assert.sameValue(result.length, 1);

--- a/test/built-ins/RegExp/prototype/Symbol.split/u-lastindex-adv-thru-match.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/u-lastindex-adv-thru-match.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description:
+    lastIndex is advanced according to width of astral symbols following match success
+es6id: 21.2.5.11
+info: >
+    21.2.5.11 RegExp.prototype [ @@split ] ( string, limit )
+
+    [...]
+    7. Let flags be ToString(Get(rx, "flags")).
+    8. ReturnIfAbrupt(flags).
+    9. If flags contains "u", let unicodeMatching be true.
+    10. Else, let unicodeMatching be false.
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        b. ReturnIfAbrupt(setStatus).
+        c. Let z be RegExpExec(splitter, S).
+        d. ReturnIfAbrupt(z).
+        e. If z is null, let q be AdvanceStringIndex(S, q, unicodeMatching).
+        f. Else z is not null,
+           i. Let e be ToLength(Get(splitter, "lastIndex")).
+           ii. ReturnIfAbrupt(e).
+           iii. If e = p, let q be AdvanceStringIndex(S, q, unicodeMatching).
+features: [Symbol.split]
+---*/
+
+var result = /./u[Symbol.split]('\ud834\udf06');
+
+assert.sameValue(result.length, 2);
+assert.sameValue(result[0], '');
+assert.sameValue(result[1], '');

--- a/test/built-ins/RegExp/prototype/exec/u-captured-value.js
+++ b/test/built-ins/RegExp/prototype/exec/u-captured-value.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Encoding of `capturedValue`
+es6id: 21.2.5.2.2
+info: >
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    12. Let flags be the value of R’s [[OriginalFlags]] internal slot.
+    13. If flags contains "u", let fullUnicode be true, else let fullUnicode be
+        false.
+    [...]
+    28. For each integer i such that i > 0 and i ≤ n
+        a. Let captureI be ith element of r's captures List.
+        b. If captureI is undefined, let capturedValue be undefined.
+        c. Else if fullUnicode is true,
+           i. Assert: captureI is a List of code points.
+           ii. Let capturedValue be a string whose code units are the
+               UTF16Encoding (10.1.1) of the code points of captureI.
+        [...]
+        e. Perform CreateDataProperty(A, ToString(i) , capturedValue).
+    29. Return A.
+---*/
+
+var match = /./u.exec('𝌆');
+
+assert(match !== null);
+assert.sameValue(match.length, 1);
+assert.sameValue(match[0].length, 2);
+assert.sameValue(match[0][0], '\ud834');
+assert.sameValue(match[0][1], '\udf06');

--- a/test/built-ins/RegExp/prototype/exec/u-lastindex-adv.js
+++ b/test/built-ins/RegExp/prototype/exec/u-lastindex-adv.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Advancement of lastIndex
+es6id: 21.2.5.2.2
+info: >
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    12. Let flags be the value of R’s [[OriginalFlags]] internal slot.
+    13. If flags contains "u", let fullUnicode be true, else let fullUnicode be
+        false.
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        c. If r is failure, then
+           [...]
+           ii. Let lastIndex be AdvanceStringIndex(S, lastIndex, fullUnicode).
+---*/
+
+assert.sameValue(/\udf06/u.exec('\ud834\udf06'), null);

--- a/test/built-ins/RegExp/prototype/exec/u-lastindex-value.js
+++ b/test/built-ins/RegExp/prototype/exec/u-lastindex-value.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Definition of `lastIndex` property value
+es6id: 21.2.5.2.2
+info: >
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    12. Let flags be the value of R’s [[OriginalFlags]] internal slot.
+    13. If flags contains "u", let fullUnicode be true, else let fullUnicode be
+        false.
+    [...]
+    16. Let e be r's endIndex value.
+    17. If fullUnicode is true, then
+        a. e is an index into the Input character list, derived from S, matched
+           by matcher. Let eUTF be the smallest index into S that corresponds
+           to the character at element e of Input. If e is greater than or
+           equal to the length of Input, then eUTF is the number of code units
+           in S.
+        b. Let e be eUTF.
+    18. If global is true or sticky is true,
+        a. Let setStatus be Set(R, "lastIndex", e, true).
+        b. ReturnIfAbrupt(setStatus).
+---*/
+
+var r = /./ug;
+r.exec('𝌆');
+assert.sameValue(r.lastIndex, 2);

--- a/test/built-ins/RegExp/prototype/flags/u-attr-err.js
+++ b/test/built-ins/RegExp/prototype/flags/u-attr-err.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Errors thrown when retrieving attribute
+es6id: 21.2.5.3
+info: >
+    21.2.5.3 get RegExp.prototype.flags
+
+    [...]
+    13. Let unicode be ToBoolean(Get(R, "unicode")).
+    14. ReturnIfAbrupt(unicode).
+---*/
+
+var re = /./;
+
+Object.defineProperty(re, 'unicode', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  re.flags;
+});

--- a/test/built-ins/RegExp/prototype/flags/u-coercion.js
+++ b/test/built-ins/RegExp/prototype/flags/u-coercion.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Boolean coercion of `unicode` property
+es6id: 21.2.5.3
+info: >
+    21.2.5.3 get RegExp.prototype.flags
+
+    [...]
+    13. Let unicode be ToBoolean(Get(R, "unicode")).
+    14. ReturnIfAbrupt(unicode).
+    15. If unicode is true, append "u" as the last code unit of result.
+features: [Symbol]
+---*/
+
+var r = /./;
+var flags;
+Object.defineProperty(r, 'unicode', { writable: true });
+
+r.unicode = undefined;
+flags = r.flags;
+assert.sameValue(flags.length, 0);
+
+r.unicode = null;
+flags = r.flags;
+assert.sameValue(flags.length, 0);
+
+r.unicode = NaN;
+flags = r.flags;
+assert.sameValue(flags.length, 0);
+
+r.unicode = 86;
+flags = r.flags;
+assert.sameValue(flags.length, 1);
+assert.sameValue(flags[0], 'u');
+
+r.unicode = '';
+flags = r.flags;
+assert.sameValue(flags.length, 0);
+
+r.unicode = 'string';
+flags = r.flags;
+assert.sameValue(flags.length, 1);
+assert.sameValue(flags[0], 'u');
+
+r.unicode = Symbol();
+flags = r.flags;
+assert.sameValue(flags.length, 1);
+assert.sameValue(flags[0], 'u');
+
+r.unicode = {};
+flags = r.flags;
+assert.sameValue(flags.length, 1);
+assert.sameValue(flags[0], 'u');

--- a/test/built-ins/RegExp/prototype/flags/u.js
+++ b/test/built-ins/RegExp/prototype/flags/u.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    'u' entry's presence is determined by `u` flag
+es6id: 21.2.5.3
+info: >
+    21.2.5.3 get RegExp.prototype.flags
+
+    [...]
+    13. Let unicode be ToBoolean(Get(R, "unicode")).
+    14. ReturnIfAbrupt(unicode).
+    15. If unicode is true, append "u" as the last code unit of result.
+---*/
+
+var flags;
+
+flags = /./.flags;
+assert.sameValue(flags.length, 0);
+
+flags = /./u.flags;
+assert.sameValue(flags.length, 1);
+assert.sameValue(flags[0], 'u');

--- a/test/built-ins/RegExp/prototype/unicode/length.js
+++ b/test/built-ins/RegExp/prototype/unicode/length.js
@@ -1,0 +1,28 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 21.2.5.15
+description: >
+    "length" property of `unicode` accessor function
+info: >
+    ES6 section 17: Every built-in Function object, including constructors, has
+    a length property whose value is an integer. Unless otherwise specified,
+    this value is equal to the largest number of named arguments shown in the
+    subclause headings for the function description, including optional
+    parameters.
+
+    [...]
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+var getter = Object.getOwnPropertyDescriptor(RegExp.prototype, 'unicode').get;
+
+assert.sameValue(getter.length, 0);
+
+verifyNotEnumerable(getter, 'length');
+verifyNotWritable(getter, 'length');
+verifyConfigurable(getter, 'length');

--- a/test/built-ins/RegExp/prototype/unicode/name.js
+++ b/test/built-ins/RegExp/prototype/unicode/name.js
@@ -1,0 +1,35 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 21.2.5.15
+description: >
+    "name" property of `unicode` accessor function
+info: >
+    The value of the name property of this function is "get ".
+
+    ES6 section 17:
+
+    Every built-in Function object, including constructors, that is not
+    identified as an anonymous function has a name property whose value is a
+    String.
+
+    [...]
+
+    Functions that are specified as get or set accessor functions of built-in
+    properties have "get " or "set " prepended to the property name string.
+
+    [...]
+
+    Unless otherwise specified, the name property of a built-in
+    Function object, if it exists, has the attributes { [[Writable]]: false,
+    [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+var getter = Object.getOwnPropertyDescriptor(RegExp.prototype, 'unicode').get;
+
+assert.sameValue(getter.name, 'get unicode');
+
+verifyNotEnumerable(getter, 'name');
+verifyNotWritable(getter, 'name');
+verifyConfigurable(getter, 'name');

--- a/test/built-ins/RegExp/prototype/unicode/prop-desc.js
+++ b/test/built-ins/RegExp/prototype/unicode/prop-desc.js
@@ -1,0 +1,15 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 21.2.5.15
+description: >
+    `unicode` property descriptor
+info: >
+    RegExp.prototype.unicode is an accessor property whose set accessor
+    function is undefined.
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(RegExp.prototype, 'unicode');
+
+assert.sameValue(desc.set, undefined);
+assert.sameValue(typeof desc.get, 'function');

--- a/test/built-ins/RegExp/prototype/unicode/this-invald-obj.js
+++ b/test/built-ins/RegExp/prototype/unicode/this-invald-obj.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Invoked on an object without an [[OriginalFlags]] internal slot
+es6id: 21.2.5.15
+info: >
+    21.2.5.15 get RegExp.prototype.unicode
+
+    1. Let R be the this value.
+    2. If Type(R) is not Object, throw a TypeError exception.
+    3. If R does not have an [[OriginalFlags]] internal slot, throw a TypeError
+       exception.
+---*/
+
+var unicode = Object.getOwnPropertyDescriptor(RegExp.prototype, 'unicode').get;
+
+assert.throws(TypeError, function() {
+  unicode.call({});
+});

--- a/test/built-ins/RegExp/prototype/unicode/this-non-obj.js
+++ b/test/built-ins/RegExp/prototype/unicode/this-non-obj.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    `unicode` accessor invoked on a non-object value
+es6id: 21.2.5.15
+info: >
+    21.2.5.15 get RegExp.prototype.unicode
+
+    1. Let R be the this value.
+    2. If Type(R) is not Object, throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var unicode = Object.getOwnPropertyDescriptor(RegExp.prototype, 'unicode').get;
+
+assert.throws(TypeError, function() {
+  unicode.call(undefined);
+});
+
+assert.throws(TypeError, function() {
+  unicode.call(null);
+});
+
+assert.throws(TypeError, function() {
+  unicode.call(true);
+});
+
+assert.throws(TypeError, function() {
+  unicode.call('string');
+});
+
+assert.throws(TypeError, function() {
+  unicode.call(Symbol('s'));
+});
+
+assert.throws(TypeError, function() {
+  unicode.call(4);
+});

--- a/test/built-ins/RegExp/prototype/unicode/this-regexp.js
+++ b/test/built-ins/RegExp/prototype/unicode/this-regexp.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    `unicode` accessor function invoked on a RegExp instance
+es6id: 21.2.5.15
+info: >
+    21.2.5.15 get RegExp.prototype.unicode
+
+    [...]
+    4. Let flags be the value of R’s [[OriginalFlags]] internal slot.
+    5. If flags contains the code unit "u", return true.
+    6. Return false.
+---*/
+
+assert.sameValue(/./.unicode, false);
+assert.sameValue(/./i.unicode, false);
+assert.sameValue(/./g.unicode, false);
+assert.sameValue(/./gi.unicode, false);
+
+assert.sameValue(/./u.unicode, true);
+assert.sameValue(/./iu.unicode, true);
+assert.sameValue(/./ug.unicode, true);
+assert.sameValue(/./iug.unicode, true);

--- a/test/language/literals/regexp/u-astral.js
+++ b/test/language/literals/regexp/u-astral.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Literal astral symbols within a pattern
+es6id: 21.2.2.8.2
+info: >
+    21.2.2.2 Pattern
+
+    The production Pattern :: Disjunction evaluates as follows:
+
+        1. Evaluate Disjunction to obtain a Matcher m.
+        2. Return an internal closure that takes two arguments, a String str
+           and an integer index, and performs the following steps:
+           1. If Unicode is true, let Input be a List consisting of the
+              sequence of code points of str interpreted as a UTF-16 encoded
+              (6.1.4) Unicode string. Otherwise, let Input be a List consisting
+              of the sequence of code units that are the elements of str. Input
+              will be used throughout the algorithms in 21.2.2. Each element of
+              Input is considered to be a character.
+---*/
+
+assert(/𝌆{2}/u.test('𝌆𝌆'), 'quantifier application');
+
+assert(/^[𝌆]$/u.test('𝌆'), 'as a ClassAtom');
+
+var rangeRe = /[💩-💫]/u;
+assert.sameValue(
+  rangeRe.test('\ud83d\udca8'),
+  false,
+  'ClassAtom as lower range boundary, input below (U+1F4A8)'
+);
+assert.sameValue(
+  rangeRe.test('\ud83d\udca9'),
+  true,
+  'ClassAtom as lower range boundary, input match (U+1F4A9)'
+);
+assert.sameValue(
+  rangeRe.test('\ud83d\udcaa'),
+  true,
+  'ClassAtom as upper- and lower-range boundary, input within (U+1F4AA)'
+);
+assert.sameValue(
+  rangeRe.test('\ud83d\udcab'),
+  true,
+  'ClassAtom as upper range boundary, input match (U+1F4AB)'
+);
+assert.sameValue(
+  rangeRe.test('\ud83d\udcac'),
+  false,
+  'ClassAtom as upper range boundary, input above (U+1F4AC)'
+);
+
+assert(/[^𝌆]/u.test('\ud834'), 'Negated character classes (LeadSurrogate)');
+assert(/[^𝌆]/u.test('\udf06'), 'Negated character classes (TrailSurrogate)');

--- a/test/language/literals/regexp/u-case-mapping.js
+++ b/test/language/literals/regexp/u-case-mapping.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Case mapping of astral symbols
+es6id: 21.2.2.8.2
+info: >
+    21.2.2.8.2 Runtime Semantics: Canonicalize ( ch )
+
+    The abstract operation Canonicalize takes a character parameter ch and
+    performs the following steps:
+
+        1. If IgnoreCase is false, return ch.
+        2. If Unicode is true,
+           a. If the file CaseFolding.txt of the Unicode Character Database
+              provides a simple or common case folding mapping for ch, return
+              the result of applying that mapping to ch.
+           b. Else, return ch.
+---*/
+
+assert.sameValue(
+  /\u212a/i.test('k'),
+  false,
+  'Case mapping is not applied in the absence of the `u` flag'
+);
+assert.sameValue(
+  /\u212a/i.test('K'),
+  false,
+  'Case mapping is not applied in the absence of the `u` flag'
+);
+assert.sameValue(
+  /\u212a/u.test('k'),
+  false,
+  'Case mapping is not applied in the absence of the `i` flag'
+);
+assert.sameValue(
+  /\u212a/u.test('K'),
+  false,
+  'Case mapping is not applied in the absence of the `i` flag'
+);
+
+assert(
+  /\u212a/iu.test('k'),
+  'Case mapping is applied in the presence of the `i` and `u` flags'
+);
+assert(
+  /\u212a/iu.test('K'),
+  'Case mapping is applied in the presence of the `i` and `u` flags'
+);

--- a/test/language/literals/regexp/u-dec-esc.js
+++ b/test/language/literals/regexp/u-dec-esc.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: DecimalEscape used with `u` flag
+info: >
+    DecimalEscape is not allowed when the `u` flag is set (regardless of Annex
+    B extensions--see ES6 section B.1.4).
+es6id: 21.2.1
+negative: SyntaxError
+---*/
+
+/\1/u;

--- a/test/language/literals/regexp/u-invalid-char-esc.js
+++ b/test/language/literals/regexp/u-invalid-char-esc.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Invalid character escape with `u` flag
+info: >
+    An unterminated character escape produces a SyntaxError when the `u` flag
+    is set (regardless of Annex B extensions--see ES6 section B.1.4).
+es6id: 21.2.1
+negative: SyntaxError
+---*/
+
+/\c/u;

--- a/test/language/literals/regexp/u-invalid-char-range-a.js
+++ b/test/language/literals/regexp/u-invalid-char-range-a.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Invalid character class range with `u` flag (lower set size > 1)
+info: >
+    21.2.2.15.1 Runtime Semantics: CharacterRange Abstract Operation
+
+    1. If A does not contain exactly one character or B does not contain
+       exactly one character, throw a SyntaxError exception.
+es6id: 21.2.2.15.1
+negative: SyntaxError
+---*/
+
+/[\w-a]/u;

--- a/test/language/literals/regexp/u-invalid-char-range-b.js
+++ b/test/language/literals/regexp/u-invalid-char-range-b.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Invalid character class range with `u` flag (upper set size > 1)
+info: >
+    21.2.2.15.1 Runtime Semantics: CharacterRange Abstract Operation
+
+    1. If A does not contain exactly one character or B does not contain
+       exactly one character, throw a SyntaxError exception.
+es6id: 21.2.2.15.1
+negative: SyntaxError
+---*/
+
+/[a-\w]/u;

--- a/test/language/literals/regexp/u-surrogate-pairs.js
+++ b/test/language/literals/regexp/u-surrogate-pairs.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Out-of-range value of hexadecimal digits in UnicodeEscapeSequence
+es6id: 21.2.2.10
+info: >
+    21.2.2.10 CharacterEscape
+
+    The production RegExpUnicodeEscapeSequence :: u LeadSurrogate \u
+    TrailSurrogate evaluates as follows:
+
+        1. Let lead be the result of evaluating LeadSurrogate.
+        2. Let trail be the result of evaluating TrailSurrogate.
+        3. Let cp be UTF16Decode(lead, trail).
+        4. Return the character whose character value is cp.
+---*/
+
+assert(/^[\ud834\udf06]$/u.test('\ud834\udf06'));

--- a/test/language/literals/regexp/u-unicode-esc-bounds.js
+++ b/test/language/literals/regexp/u-unicode-esc-bounds.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Out-of-range value of hexadecimal digits in UnicodeEscapeSequence
+es6id: 21.2.1.1
+info: >
+    21.2.1.1 Static Semantics: Early Errors
+
+    RegExpUnicodeEscapeSequence :: u{ HexDigits }
+
+        - It is a Syntax Error if the MV of HexDigits > 1114111.
+negative: SyntaxError
+---*/
+
+/\u{ff0000}/u;

--- a/test/language/literals/regexp/u-unicode-esc-non-hex.js
+++ b/test/language/literals/regexp/u-unicode-esc-non-hex.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Non-hexadecimal value within the delimiters of a UnicodeEscapeSequence
+es6id: 21.2.1
+negative: SyntaxError
+---*/
+
+/\u{1,}/u;

--- a/test/language/literals/regexp/u-unicode-esc.js
+++ b/test/language/literals/regexp/u-unicode-esc.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Unicode escape interpreted as the Mathematical Value of HexDigits
+es6id: 21.2.2.10
+info: >
+    21.2.2.10 CharacterEscape
+
+    The production RegExpUnicodeEscapeSequence :: u{ HexDigits } evaluates as
+    follows:
+
+        1. Return the character whose code is the MV of HexDigits.
+---*/
+
+assert(/\u{0}/u.test('\u0000'), 'Minimum value (U+0000)');
+assert(/\u{1}/u.test('\u0001'), 'U+0001');
+assert.sameValue(/\u{1}/u.test('u'), false);
+assert(/\u{3f}/u.test('?'));
+assert(/\u{000000003f}/u.test('?'), 'Leading zeros');
+assert(/\u{3F}/u.test('?'), 'Case insensitivity');
+assert(/\u{10ffff}/u.test('\udbff\udfff'), 'Maxiumum value (U+10ffff)');


### PR DESCRIPTION
I'd like to draw attention to two tests in particular since they both concern a very specific condition (for example, good ol' step 8.g.iv.5.d):

- test/built-ins/RegExp/prototype/Symbol.match/u-lastindex.js
- test/built-ins/RegExp/prototype/Symbol.replace/u-lastindex.js

Despite a careful reading, I'm still not convinced those test cases properly express the detail documented in their info/description. I decided I may have looked at it for too long and that some fresh perspective would help

@mathiasbynens Would you mind taking a look?