### PR TITLE
Add tests for RegExp `y` flag

### DIFF
--- a/test/built-ins/RegExp/prototype/Symbol.match/get-sticky-coerce.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/get-sticky-coerce.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Boolean coercion of `sticky` property
+es6id: 21.2.5.6
+info: >
+    21.2.5.6 RegExp.prototype [ @@match ] ( string )
+
+    [...]
+    5. Let global be ToBoolean(Get(rx, "global")).
+    6. ReturnIfAbrupt(global).
+    7. If global is false, then
+       a. Return RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+features: [Symbol, Symbol.match]
+---*/
+
+var r = /a/;
+Object.defineProperty(r, 'sticky', { writable: true });
+
+r.sticky = undefined;
+assert.notSameValue(r[Symbol.match]('ba'), null);
+
+r.sticky = null;
+assert.notSameValue(r[Symbol.match]('ba'), null);
+
+r.sticky = true;
+assert.sameValue(r[Symbol.match]('ba'), null);
+
+r.sticky = false;
+assert.notSameValue(r[Symbol.match]('ba'), null);
+
+r.sticky = NaN;
+assert.notSameValue(r[Symbol.match]('ba'), null);
+
+r.sticky = 0;
+assert.notSameValue(r[Symbol.match]('ba'), null);
+
+r.sticky = 86;
+assert.sameValue(r[Symbol.match]('ba'), null);
+
+r.sticky = '';
+assert.notSameValue(r[Symbol.match]('ba'), null);
+
+r.sticky = Symbol();
+assert.sameValue(r[Symbol.match]('ba'), null);
+
+r.sticky = {};
+assert.sameValue(r[Symbol.match]('ba'), null);

--- a/test/built-ins/RegExp/prototype/Symbol.match/get-sticky-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/get-sticky-err.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Behavior if error is thrown when accessing `sticky` property
+es6id: 21.2.5.6
+info: >
+    21.2.5.6 RegExp.prototype [ @@match ] ( string )
+
+    [...]
+    5. Let global be ToBoolean(Get(rx, "global")).
+    6. ReturnIfAbrupt(global).
+    7. If global is false, then
+       a. Return RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    9. ReturnIfAbrupt(sticky).
+features: [Symbol.match]
+---*/
+
+var r = /./;
+Object.defineProperty(r, 'sticky', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  r[Symbol.match]();
+});

--- a/test/built-ins/RegExp/prototype/Symbol.match/y-fail-global-return.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/y-fail-global-return.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Accumulates consecutive matches when `g` flag is present
+es6id: 21.2.5.6
+info: >
+    21.2.5.6 RegExp.prototype [ @@match ] ( string )
+
+    [...]
+    5. Let global be ToBoolean(Get(rx, "global")).
+    6. ReturnIfAbrupt(global).
+    7. If global is false, then
+       [...]
+    8. Else global is true,
+       [...]
+       g. Repeat,
+          i. Let result be RegExpExec(rx, S).
+          ii. ReturnIfAbrupt(result).
+          iii. If result is null, then
+               1. If n=0, return null.
+               2. Else, return A.
+          [...]
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              [...]
+              3. Return null.
+features: [Symbol.match]
+---*/
+
+var result = /a/yg[Symbol.match]('aaba');
+
+assert.notSameValue(result, null);
+assert.sameValue(result.length, 2);
+assert.sameValue(result[0], 'a');
+assert.sameValue(result[1], 'a');

--- a/test/built-ins/RegExp/prototype/Symbol.match/y-fail-lastindex-no-write.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/y-fail-lastindex-no-write.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Match failure with non-writable `lastIndex` property
+es6id: 21.2.5.6
+info: >
+    21.2.5.6 RegExp.prototype [ @@match ] ( string )
+
+    [...]
+    5. Let global be ToBoolean(Get(rx, "global")).
+    6. ReturnIfAbrupt(global).
+    7. If global is false, then
+       a. Return RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              1. Let setStatus be Set(R, "lastIndex", 0, true).
+              2. ReturnIfAbrupt(setStatus).
+features: [Symbol.match]
+---*/
+
+var r = /c/y;
+Object.defineProperty(r, 'lastIndex', {
+  writable: false
+});
+
+assert.throws(TypeError, function() {
+  r[Symbol.match]('abc');
+});

--- a/test/built-ins/RegExp/prototype/Symbol.match/y-fail-lastindex.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/y-fail-lastindex.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Resets the `lastIndex` property to zero after a match failure
+es6id: 21.2.5.6
+info: >
+    21.2.5.6 RegExp.prototype [ @@match ] ( string )
+
+    [...]
+    5. Let global be ToBoolean(Get(rx, "global")).
+    6. ReturnIfAbrupt(global).
+    7. If global is false, then
+       a. Return RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              1. Let setStatus be Set(R, "lastIndex", 0, true).
+features: [Symbol.match]
+---*/
+
+var r = /c/y;
+r.lastIndex = 1;
+
+r[Symbol.match]('abc');
+
+assert.sameValue(r.lastIndex, 0);

--- a/test/built-ins/RegExp/prototype/Symbol.match/y-fail-return.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/y-fail-return.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Stops match execution after first match failure
+es6id: 21.2.5.6
+info: >
+    21.2.5.6 RegExp.prototype [ @@match ] ( string )
+
+    [...]
+    5. Let global be ToBoolean(Get(rx, "global")).
+    6. ReturnIfAbrupt(global).
+    7. If global is false, then
+       a. Return RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              [...]
+              3. Return null.
+features: [Symbol.match]
+---*/
+
+assert.sameValue(/b/y[Symbol.match]('ab'), null);

--- a/test/built-ins/RegExp/prototype/Symbol.match/y-init-lastindex.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/y-init-lastindex.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Honors initial value of the `lastIndex` property
+es6id: 21.2.5.6
+info: >
+    21.2.5.6 RegExp.prototype [ @@match ] ( string )
+
+    [...]
+    5. Let global be ToBoolean(Get(rx, "global")).
+    6. ReturnIfAbrupt(global).
+    7. If global is false, then
+       a. Return RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    9. ReturnIfAbrupt(sticky).
+    10. If global is false and sticky is false, let lastIndex be 0.
+features: [Symbol.match]
+---*/
+
+var r = /./y;
+var match;
+r.lastIndex = 1;
+
+match = r[Symbol.match]('abc');
+
+assert.notSameValue(match, null);
+assert.sameValue(match.length, 1);
+assert.sameValue(match[0], 'b');

--- a/test/built-ins/RegExp/prototype/Symbol.match/y-set-lastindex.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/y-set-lastindex.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Sets the `lastIndex` property to the end index of the first match
+es6id: 21.2.5.6
+info: >
+    21.2.5.6 RegExp.prototype [ @@match ] ( string )
+
+    [...]
+    5. Let global be ToBoolean(Get(rx, "global")).
+    6. ReturnIfAbrupt(global).
+    7. If global is false, then
+       a. Return RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    18. If global is true or sticky is true,
+        a. Let setStatus be Set(R, "lastIndex", e, true).
+features: [Symbol.match]
+---*/
+
+var r = /abc/y;
+r[Symbol.match]('abc');
+
+assert.sameValue(r.lastIndex, 3);

--- a/test/built-ins/RegExp/prototype/Symbol.replace/get-sticky-coerce.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/get-sticky-coerce.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Boolean coercion of `sticky` property
+es6id: 21.2.5.8
+info: >
+    21.2.5.8 RegExp.prototype [ @@replace ] ( string, replaceValue )
+
+    [...]
+    13. Repeat, while done is false
+        a. Let result be RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    9. ReturnIfAbrupt(sticky).
+features: [Symbol.replace]
+---*/
+
+var r = /a/;
+Object.defineProperty(r, 'sticky', { writable: true });
+
+r.sticky = undefined;
+assert.sameValue(r[Symbol.replace]('ba', 'x'), 'bx');
+
+r.sticky = null;
+assert.sameValue(r[Symbol.replace]('ba', 'x'), 'bx');
+
+r.sticky = true;
+assert.sameValue(r[Symbol.replace]('ba', 'x'), 'ba');
+
+r.sticky = false;
+assert.sameValue(r[Symbol.replace]('ba', 'x'), 'bx');
+
+r.sticky = NaN;
+assert.sameValue(r[Symbol.replace]('ba', 'x'), 'bx');
+
+r.sticky = 0;
+assert.sameValue(r[Symbol.replace]('ba', 'x'), 'bx');
+
+r.sticky = 86;
+assert.sameValue(r[Symbol.replace]('ba', 'x'), 'ba');
+
+r.sticky = '';
+assert.sameValue(r[Symbol.replace]('ba', 'x'), 'bx');
+
+r.sticky = Symbol();
+assert.sameValue(r[Symbol.replace]('ba', 'x'), 'ba');
+
+r.sticky = {};
+assert.sameValue(r[Symbol.replace]('ba', 'x'), 'ba');

--- a/test/built-ins/RegExp/prototype/Symbol.replace/get-sticky-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/get-sticky-err.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Behavior if error is thrown when accessing `sticky` property
+es6id: 21.2.5.8
+info: >
+    21.2.5.8 RegExp.prototype [ @@replace ] ( string, replaceValue )
+
+    [...]
+    13. Repeat, while done is false
+        a. Let result be RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    9. ReturnIfAbrupt(sticky).
+features: [Symbol.replace]
+---*/
+
+var r = /./;
+Object.defineProperty(r, 'sticky', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  r[Symbol.replace]();
+});

--- a/test/built-ins/RegExp/prototype/Symbol.replace/y-fail-global-return.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/y-fail-global-return.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Replaces consecutive matches when the `g` flag is present
+es6id: 21.2.5.8
+info: >
+    21.2.5.8 RegExp.prototype [ @@replace ] ( string, replaceValue )
+
+    [...]
+    13. Repeat, while done is false
+        a. Let result be RegExpExec(rx, S).
+        b. ReturnIfAbrupt(result).
+        c. If result is null, set done to true.
+        d. Else result is not null,
+           i. Append result to the end of results.
+           ii. If global is false, set done to true.
+           iii. Else,
+                1. Let matchStr be ToString(Get(result, "0")).
+                [...]
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              [...]
+              3. Return null.
+features: [Symbol.replace]
+---*/
+
+assert.sameValue(/a/yg[Symbol.replace]('aaba', 'x'), 'xxba');

--- a/test/built-ins/RegExp/prototype/Symbol.replace/y-fail-lastindex-no-write.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/y-fail-lastindex-no-write.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Match failure with non-writable `lastIndex` property
+es6id: 21.2.5.8
+info: >
+    21.2.5.8 RegExp.prototype [ @@replace ] ( string, replaceValue )
+
+    [...]
+    13. Repeat, while done is false
+        a. Let result be RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              1. Let setStatus be Set(R, "lastIndex", 0, true).
+              2. ReturnIfAbrupt(setStatus).
+features: [Symbol.replace]
+---*/
+
+var r = /c/y;
+Object.defineProperty(r, 'lastIndex', {
+  writable: false
+});
+
+assert.throws(TypeError, function() {
+  r[Symbol.replace]('abc', 'x');
+});

--- a/test/built-ins/RegExp/prototype/Symbol.replace/y-fail-lastindex.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/y-fail-lastindex.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Resets the `lastIndex` property to zero after a match failure
+es6id: 21.2.5.8
+info: >
+    21.2.5.8 RegExp.prototype [ @@replace ] ( string, replaceValue )
+
+    [...]
+    13. Repeat, while done is false
+        a. Let result be RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              1. Let setStatus be Set(R, "lastIndex", 0, true).
+features: [Symbol.replace]
+---*/
+
+var r = /c/y;
+r.lastIndex = 1;
+
+r[Symbol.replace]('abc', 'x');
+
+assert.sameValue(r.lastIndex, 0);

--- a/test/built-ins/RegExp/prototype/Symbol.replace/y-fail-return.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/y-fail-return.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Stops match execution after first match failure
+es6id: 21.2.5.8
+info: >
+    21.2.5.8 RegExp.prototype [ @@replace ] ( string, replaceValue )
+
+    [...]
+    13. Repeat, while done is false
+        a. Let result be RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              [...]
+              3. Return null.
+features: [Symbol.replace]
+---*/
+
+assert.sameValue(/b/y[Symbol.replace]('ab', 'x'), 'ab');

--- a/test/built-ins/RegExp/prototype/Symbol.replace/y-init-lastindex.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/y-init-lastindex.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Honors initial value of the `lastIndex` property
+es6id: 21.2.5.8
+info: >
+    21.2.5.8 RegExp.prototype [ @@replace ] ( string, replaceValue )
+
+    [...]
+    13. Repeat, while done is false
+        a. Let result be RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    9. ReturnIfAbrupt(sticky).
+    10. If global is false and sticky is false, let lastIndex be 0.
+features: [Symbol.replace]
+---*/
+
+var r = /./y;
+r.lastIndex = 1;
+assert.sameValue(r[Symbol.replace]('aaa', 'x'), 'axa');

--- a/test/built-ins/RegExp/prototype/Symbol.replace/y-set-lastindex.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/y-set-lastindex.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Sets the `lastIndex` property to the end index of the first match
+es6id: 21.2.5.8
+info: >
+    21.2.5.8 RegExp.prototype [ @@replace ] ( string, replaceValue )
+
+    [...]
+    13. Repeat, while done is false
+        a. Let result be RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    18. If global is true or sticky is true,
+        a. Let setStatus be Set(R, "lastIndex", e, true).
+features: [Symbol.replace]
+---*/
+
+var r = /abc/y;
+
+r[Symbol.replace]('abc', 'x');
+
+assert.sameValue(r.lastIndex, 3);

--- a/test/built-ins/RegExp/prototype/Symbol.search/get-sticky-coerce.js
+++ b/test/built-ins/RegExp/prototype/Symbol.search/get-sticky-coerce.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Boolean coercion of `sticky` property
+es6id: 21.2.5.9
+info: >
+    21.2.5.9 RegExp.prototype [ @@search ] ( string )
+
+    [...]
+    9. Let result be RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+features: [Symbol, Symbol.search]
+---*/
+
+var r = /a/;
+Object.defineProperty(r, 'sticky', { writable: true });
+
+r.sticky = undefined;
+assert.sameValue(r[Symbol.search]('ba'), 1);
+
+r.sticky = null;
+assert.sameValue(r[Symbol.search]('ba'), 1);
+
+r.sticky = true;
+assert.sameValue(r[Symbol.search]('ba'), -1);
+
+r.sticky = false;
+assert.sameValue(r[Symbol.search]('ba'), 1);
+
+r.sticky = NaN;
+assert.sameValue(r[Symbol.search]('ba'), 1);
+
+r.sticky = 0;
+assert.sameValue(r[Symbol.search]('ba'), 1);
+
+r.sticky = 86;
+assert.sameValue(r[Symbol.search]('ba'), -1);
+
+r.sticky = '';
+assert.sameValue(r[Symbol.search]('ba'), 1);
+
+r.sticky = Symbol();
+assert.sameValue(r[Symbol.search]('ba'), -1);
+
+r.sticky = {};
+assert.sameValue(r[Symbol.search]('ba'), -1);

--- a/test/built-ins/RegExp/prototype/Symbol.search/get-sticky-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.search/get-sticky-err.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Behavior if error is thrown when accessing `sticky` property
+es6id: 21.2.5.9
+info: >
+    21.2.5.9 RegExp.prototype [ @@search ] ( string )
+
+    [...]
+    9. Let result be RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    9. ReturnIfAbrupt(sticky).
+features: [Symbol.search]
+---*/
+
+var r = /./;
+Object.defineProperty(r, 'sticky', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  r[Symbol.search]();
+});

--- a/test/built-ins/RegExp/prototype/Symbol.search/y-fail-return.js
+++ b/test/built-ins/RegExp/prototype/Symbol.search/y-fail-return.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Stops match execution after first match failure
+es6id: 21.2.5.9
+info: >
+    21.2.5.9 RegExp.prototype [ @@search ] ( string )
+
+    [...]
+    9. Let result be RegExpExec(rx, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              [...]
+              3. Return null.
+features: [Symbol.search]
+---*/
+
+assert.sameValue(/a/y[Symbol.search]('ba'), -1);

--- a/test/built-ins/RegExp/prototype/exec/get-sticky-coerce.js
+++ b/test/built-ins/RegExp/prototype/exec/get-sticky-coerce.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Boolean coercion of `sticky` property
+es6id: 21.2.5.2
+info: >
+    21.2.5.2 RegExp.prototype.exec ( string )
+
+    [...]
+    6. Return RegExpBuiltinExec(R, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+features: [Symbol]
+---*/
+
+var r = /a/;
+Object.defineProperty(r, 'sticky', { writable: true });
+
+r.sticky = undefined;
+assert.notSameValue(r.exec('ba'), null);
+
+r.sticky = null;
+assert.notSameValue(r.exec('ba'), null);
+
+r.sticky = true;
+assert.sameValue(r.exec('ba'), null);
+
+r.sticky = false;
+assert.notSameValue(r.exec('ba'), null);
+
+r.sticky = NaN;
+assert.notSameValue(r.exec('ba'), null);
+
+r.sticky = 0;
+assert.notSameValue(r.exec('ba'), null);
+
+r.sticky = 86;
+assert.sameValue(r.exec('ba'), null);
+
+r.sticky = '';
+assert.notSameValue(r.exec('ba'), null);
+
+r.sticky = Symbol();
+assert.sameValue(r.exec('ba'), null);
+
+r.sticky = {};
+assert.sameValue(r.exec('ba'), null);

--- a/test/built-ins/RegExp/prototype/exec/get-sticky-err.js
+++ b/test/built-ins/RegExp/prototype/exec/get-sticky-err.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Behavior if error is thrown when accessing `sticky` property
+es6id: 21.2.5.2
+info: >
+    21.2.5.2 RegExp.prototype.exec ( string )
+
+    [...]
+    6. Return RegExpBuiltinExec(R, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    9. ReturnIfAbrupt(sticky).
+---*/
+
+var r = /./;
+Object.defineProperty(r, 'sticky', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  r.exec();
+});

--- a/test/built-ins/RegExp/prototype/exec/y-fail-lastindex-no-write.js
+++ b/test/built-ins/RegExp/prototype/exec/y-fail-lastindex-no-write.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Match failure with non-writable `lastIndex` property
+es6id: 21.2.5.2
+info: >
+    21.2.5.2 RegExp.prototype.exec ( string )
+
+    [...]
+    6. Return RegExpBuiltinExec(R, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              1. Let setStatus be Set(R, "lastIndex", 0, true).
+              2. ReturnIfAbrupt(setStatus).
+---*/
+
+var r = /c/y;
+Object.defineProperty(r, 'lastIndex', {
+  writable: false
+});
+
+assert.throws(TypeError, function() {
+  r.exec('abc');
+});

--- a/test/built-ins/RegExp/prototype/exec/y-fail-lastindex.js
+++ b/test/built-ins/RegExp/prototype/exec/y-fail-lastindex.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Resets the `lastIndex` property to zero after a match failure
+es6id: 21.2.5.2
+info: >
+    21.2.5.2 RegExp.prototype.exec ( string )
+
+    [...]
+    6. Return RegExpBuiltinExec(R, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              1. Let setStatus be Set(R, "lastIndex", 0, true).
+---*/
+
+var r = /c/y;
+r.lastIndex = 1;
+
+r.exec('abc');
+
+assert.sameValue(r.lastIndex, 0);

--- a/test/built-ins/RegExp/prototype/exec/y-fail-return.js
+++ b/test/built-ins/RegExp/prototype/exec/y-fail-return.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Stops match execution after first match failure
+es6id: 21.2.5.2
+info: >
+    21.2.5.2 RegExp.prototype.exec ( string )
+
+    [...]
+    6. Return RegExpBuiltinExec(R, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              [...]
+              3. Return null.
+---*/
+
+assert.sameValue(/b/y.exec('ab'), null);

--- a/test/built-ins/RegExp/prototype/exec/y-init-lastindex.js
+++ b/test/built-ins/RegExp/prototype/exec/y-init-lastindex.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Honors initial value of the `lastIndex` property
+es6id: 21.2.5.2
+info: >
+    21.2.5.2 RegExp.prototype.exec ( string )
+
+    [...]
+    6. Return RegExpBuiltinExec(R, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    9. ReturnIfAbrupt(sticky).
+    10. If global is false and sticky is false, let lastIndex be 0.
+---*/
+
+var r = /./y;
+var match;
+r.lastIndex = 1;
+
+match = r.exec('abc');
+
+assert(match !== null);
+assert.sameValue(match.length, 1);
+assert.sameValue(match[0], 'b');

--- a/test/built-ins/RegExp/prototype/exec/y-set-lastindex.js
+++ b/test/built-ins/RegExp/prototype/exec/y-set-lastindex.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Sets the `lastIndex` property to the end index of the first match
+es6id: 21.2.5.2
+info: >
+    21.2.5.2 RegExp.prototype.exec ( string )
+
+    [...]
+    6. Return RegExpBuiltinExec(R, S).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    18. If global is true or sticky is true,
+        a. Let setStatus be Set(R, "lastIndex", e, true).
+---*/
+
+var r = /abc/y;
+r.exec('abc');
+
+assert.sameValue(r.lastIndex, 3);

--- a/test/built-ins/RegExp/prototype/flags/y-attr-err.js
+++ b/test/built-ins/RegExp/prototype/flags/y-attr-err.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Behavior if error is thrown when retrieving `sticky` attribute
+es6id: 21.2.5.3
+info: >
+    21.2.5.3 get RegExp.prototype.flags
+
+    16. Let sticky be ToBoolean(Get(R, "sticky")).
+    17. ReturnIfAbrupt(sticky).
+---*/
+
+var re = /./;
+
+Object.defineProperty(re, 'sticky', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  re.flags;
+});

--- a/test/built-ins/RegExp/prototype/flags/y.js
+++ b/test/built-ins/RegExp/prototype/flags/y.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    'y' entry's presence is determined by `y` flag
+es6id: 21.2.5.3
+info: >
+    21.2.5.3 get RegExp.prototype.flags
+
+    16. Let sticky be ToBoolean(Get(R, "sticky")).
+    17. ReturnIfAbrupt(sticky).
+    18. If sticky is true, append "y" as the last code unit of result.
+---*/
+
+var flags;
+
+flags = /./.flags;
+assert.sameValue(flags.length, 0);
+
+flags = /./y.flags;
+assert.sameValue(flags.length, 1);
+assert.sameValue(flags[0], 'y');

--- a/test/built-ins/RegExp/prototype/sticky/prop-desc.js
+++ b/test/built-ins/RegExp/prototype/sticky/prop-desc.js
@@ -1,0 +1,15 @@
+// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 21.2.5.12
+description: >
+    `sticky` property descriptor
+info: >
+    RegExp.prototype.sticky is an accessor property whose set accessor
+    function is undefined.
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(RegExp.prototype, 'sticky');
+
+assert.sameValue(desc.set, undefined);
+assert.sameValue(typeof desc.get, 'function');

--- a/test/built-ins/RegExp/prototype/sticky/this-invalid-obj.js
+++ b/test/built-ins/RegExp/prototype/sticky/this-invalid-obj.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Invoked on an object without an [[OriginalFlags]] internal slot
+es6id: 21.2.5.12
+info: >
+    21.2.5.12 get RegExp.prototype.sticky
+
+    1. Let R be the this value.
+    2. If Type(R) is not Object, throw a TypeError exception.
+    3. If R does not have an [[OriginalFlags]] internal slot, throw a TypeError
+       exception.
+---*/
+
+var sticky = Object.getOwnPropertyDescriptor(RegExp.prototype, 'sticky').get;
+
+assert.throws(TypeError, function() {
+  sticky.call({});
+});

--- a/test/built-ins/RegExp/prototype/sticky/this-non-obj.js
+++ b/test/built-ins/RegExp/prototype/sticky/this-non-obj.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    `sticky` accessor invoked on a non-object value
+es6id: 21.2.5.12
+info: >
+    21.2.5.12 get RegExp.prototype.sticky
+
+    1. Let R be the this value.
+    2. If Type(R) is not Object, throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var sticky = Object.getOwnPropertyDescriptor(RegExp.prototype, 'sticky').get;
+
+assert.throws(TypeError, function() {
+  sticky.call(undefined);
+});
+
+assert.throws(TypeError, function() {
+  sticky.call(null);
+});
+
+assert.throws(TypeError, function() {
+  sticky.call(true);
+});
+
+assert.throws(TypeError, function() {
+  sticky.call('string');
+});
+
+assert.throws(TypeError, function() {
+  sticky.call(Symbol('s'));
+});
+
+assert.throws(TypeError, function() {
+  sticky.call(4);
+});

--- a/test/built-ins/RegExp/prototype/sticky/this-regexp.js
+++ b/test/built-ins/RegExp/prototype/sticky/this-regexp.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    `sticky` accessor function invoked on a RegExp instance
+es6id: 21.2.5.12
+info: >
+    21.2.5.12 get RegExp.prototype.sticky
+
+    4. Let flags be the value of R’s [[OriginalFlags]] internal slot.
+    5. If flags contains the code unit "y", return true.
+    6. Return false.
+---*/
+
+assert.sameValue(/./.sticky, false);
+assert.sameValue(/./i.sticky, false);
+assert.sameValue(/./g.sticky, false);
+assert.sameValue(/./gi.sticky, false);
+
+assert.sameValue(/./y.sticky, true);
+assert.sameValue(/./iy.sticky, true);
+assert.sameValue(/./yg.sticky, true);
+assert.sameValue(/./iyg.sticky, true);

--- a/test/built-ins/RegExp/prototype/test/get-sticky-err.js
+++ b/test/built-ins/RegExp/prototype/test/get-sticky-err.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Behavior if error is thrown when accessing `sticky` property
+es6id: 21.2.5.13
+info: >
+    21.2.5.13 RegExp.prototype.test( S )
+
+    [...]
+    5. Let match be RegExpExec(R, string).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    9. ReturnIfAbrupt(sticky).
+---*/
+
+var r = /./;
+
+Object.defineProperty(r, 'sticky', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  r.test();
+});

--- a/test/built-ins/RegExp/prototype/test/y-fail-lastindex-no-write.js
+++ b/test/built-ins/RegExp/prototype/test/y-fail-lastindex-no-write.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Match failure with non-writable `lastIndex` property
+es6id: 21.2.5.13
+info: >
+    21.2.5.13 RegExp.prototype.test( S )
+
+    [...]
+    5. Let match be RegExpExec(R, string).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              1. Let setStatus be Set(R, "lastIndex", 0, true).
+              2. ReturnIfAbrupt(setStatus).
+---*/
+
+var r = /c/y;
+Object.defineProperty(r, 'lastIndex', {
+  writable: false
+});
+
+assert.throws(TypeError, function() {
+  r.test('abc');
+});

--- a/test/built-ins/RegExp/prototype/test/y-fail-lastindex.js
+++ b/test/built-ins/RegExp/prototype/test/y-fail-lastindex.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Resets the `lastIndex` property to zero after a match failure
+es6id: 21.2.5.13
+info: >
+    21.2.5.13 RegExp.prototype.test( S )
+
+    [...]
+    5. Let match be RegExpExec(R, string).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              1. Let setStatus be Set(R, "lastIndex", 0, true).
+---*/
+
+var r = /c/y;
+r.lastIndex = 1;
+
+r.test('abc');
+
+assert.sameValue(r.lastIndex, 0);

--- a/test/built-ins/RegExp/prototype/test/y-fail-return.js
+++ b/test/built-ins/RegExp/prototype/test/y-fail-return.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Stops match execution after first match failure
+es6id: 21.2.5.13
+info: >
+    21.2.5.13 RegExp.prototype.test( S )
+
+    [...]
+    5. Let match be RegExpExec(R, string).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    15. Repeat, while matchSucceeded is false
+        [...]
+        b. Let r be matcher(S, lastIndex).
+        c. If r is failure, then
+           i. If sticky is true, then
+              [...]
+              3. Return null.
+---*/
+
+assert.sameValue(/b/y.test('ab'), false);

--- a/test/built-ins/RegExp/prototype/test/y-init-lastindex.js
+++ b/test/built-ins/RegExp/prototype/test/y-init-lastindex.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Honors initial value of the `lastIndex` property
+es6id: 21.2.5.13
+info: >
+    21.2.5.13 RegExp.prototype.test( S )
+
+    [...]
+    5. Let match be RegExpExec(R, string).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    4. Let lastIndex be ToLength(Get(R,"lastIndex")).
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    9. ReturnIfAbrupt(sticky).
+    10. If global is false and sticky is false, let lastIndex be 0.
+---*/
+
+var r = /./y;
+r.lastIndex = 1;
+
+assert.sameValue(r.test('a'), false);

--- a/test/built-ins/RegExp/prototype/test/y-set-lastindex.js
+++ b/test/built-ins/RegExp/prototype/test/y-set-lastindex.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Sets the `lastIndex` property to the end index of the first match
+es6id: 21.2.5.13
+info: >
+    21.2.5.13 RegExp.prototype.test( S )
+
+    [...]
+    5. Let match be RegExpExec(R, string).
+
+    21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
+
+    [...]
+    8. Let sticky be ToBoolean(Get(R, "sticky")).
+    [...]
+    18. If global is true or sticky is true,
+        a. Let setStatus be Set(R, "lastIndex", e, true).
+---*/
+
+var r = /abc/y;
+
+r.test('abc');
+
+assert.sameValue(r.lastIndex, 3);

--- a/test/built-ins/RegExp/valid-flags-y.js
+++ b/test/built-ins/RegExp/valid-flags-y.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.3.1
+description: The `y` flag is accepted by the RegExp constructor
+info: >
+    [...]
+    10. Return RegExpInitialize(O, P, F).
+
+    21.2.3.2.2 Runtime Semantics: RegExpInitialize ( obj, pattern, flags )
+
+    [...]
+    7. If F contains any code unit other than "g", "i", "m", "u", or "y" or if
+       it contains the same code unit more than once, throw a SyntaxError
+       exception.
+---*/
+
+new RegExp('abc', 'y');
+new RegExp('abc', 'gy');
+new RegExp('abc', 'iy');
+new RegExp('abc', 'my');
+new RegExp('abc', 'uy');
+new RegExp('abc', 'gimuy');


### PR DESCRIPTION
- I have omitted a test for the name of [`get
  RegExp.prototype.sticky`](http://www.ecma-international.org/ecma-262/6.0/#sec-get-regexp.prototype.sticky)
  since @leobalter has that covered in gh-353.
- ~~[The `sticky` flag will trigger a Set operation to the `lastIndex` property
  in two
  cases](http://www.ecma-international.org/ecma-262/6.0/#sec-regexpbuiltinexec).
  The spec guards each case with an explicit call to ReturnIfAbrupt, but [due
  to the way RegExp objects are
  allocated](http://www.ecma-international.org/ecma-262/6.0/#sec-regexpalloc),
  I don't believe this operation can ever fail (even for wacky RegExp
  subclasses). If anyone has any ideas on how to test that behavior, I'd love
  to add the relevant tests. Otherwise, I'll follow up with a proposal to
  simplify the next version of the spec by removing those lines (or maybe even
  replacing with Asserts) on the ECMAScript bug tracker~~ (@anba pointed me in the right direction below)