### PR TITLE
Negative reform

### DIFF
--- a/test/built-ins/Array/prototype/splice/S15.4.4.12_A6.1_T2.js
+++ b/test/built-ins/Array/prototype/splice/S15.4.4.12_A6.1_T2.js
@@ -5,7 +5,6 @@
 info: Array.prototype.splice sets `length` on `this`
 es5id: 15.4.4.12_A6.1_T2
 description: Array.prototype.splice throws if `length` is read-only
-negative: TypeError
 ---*/
 
 var a = [0, 1, 2];
@@ -14,4 +13,6 @@ Object.defineProperty(a, 'length', {
     writable: false
 });
 
-a.splice(1, 2, 4);
+assert.throws(TypeError, function() {
+  a.splice(1, 2, 4);
+});

--- a/test/built-ins/Function/15.3.5-2gs.js
+++ b/test/built-ins/Function/15.3.5-2gs.js
@@ -9,10 +9,11 @@ es5id: 15.3.5-2gs
 description: >
     StrictMode - error is thrown when reading the 'caller' property of
     a function object
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
 function _15_3_5_1_gs() {}
-_15_3_5_1_gs.caller;
-throw NotEarlyError;
+
+assert.throws(TypeError, function() {
+  _15_3_5_1_gs.caller;
+});

--- a/test/built-ins/Function/15.3.5.4_2-10gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-10gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (New'ed Function constructor includes strict
     directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 var f = new Function("\"use strict\";\nreturn gNonStrict();");
-f();
 
+assert.throws(TypeError, function() {
+    f();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-11gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-11gs.js
@@ -9,11 +9,12 @@ es5id: 15.3.5.4_2-11gs
 description: >
     Strict mode - checking access to strict function caller from
     strict function (eval used within strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
-eval("gNonStrict();");
+assert.throws(TypeError, function() {
+    eval("gNonStrict();");
+});
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-13gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-13gs.js
@@ -9,13 +9,14 @@ es5id: 15.3.5.4_2-13gs
 description: >
     Strict mode - checking access to non-strict function caller from
     strict function (indirect eval used within strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
 var my_eval = eval;
-my_eval("gNonStrict();");
 
+assert.throws(TypeError, function() {
+    my_eval("gNonStrict();");
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-15gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-15gs.js
@@ -10,15 +10,16 @@ description: >
     Strict mode - checking access to strict function caller from
     strict function (New'ed object from FunctionDeclaration defined
     within strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
 function f() {
     return gNonStrict();
 }
-new f();
 
+assert.throws(TypeError, function() {
+    new f();
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-16gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-16gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (New'ed object from FunctionDeclaration
     includes strict directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -18,8 +17,10 @@ function f() {
     "use strict";
     return gNonStrict();
 }
-new f();
 
+assert.throws(TypeError, function() {
+    new f();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-17gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-17gs.js
@@ -10,15 +10,16 @@ description: >
     Strict mode - checking access to strict function caller from
     strict function (New'ed object from FunctionExpression defined
     within strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
 var f = function () {
     return gNonStrict();
 }
-new f();
 
+assert.throws(TypeError, function() {
+    new f();
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-18gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-18gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (New'ed object from FunctionExpression
     includes strict directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -18,8 +17,10 @@ var f = function () {
     "use strict";
     return gNonStrict();
 }
-new f();
 
+assert.throws(TypeError, function() {
+    new f();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-19gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-19gs.js
@@ -10,14 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     strict function (New'ed object from Anonymous FunctionExpression
     defined within strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
-var obj = new (function () {
-    return gNonStrict();
+assert.throws(TypeError, function() {
+    var obj = new (function () {
+        return gNonStrict();
+    });
 });
-
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-1gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-1gs.js
@@ -9,15 +9,16 @@ es5id: 15.3.5.4_2-1gs
 description: >
     Strict mode - checking access to strict function caller from
     strict function (FunctionDeclaration defined within strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
 function f() {
     return gNonStrict();
 }
-f();
 
+assert.throws(TypeError, function() {
+    f();
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-20gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-20gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (New'ed object from Anonymous
     FunctionExpression includes strict directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
-var obj = new (function () {
-    "use strict";
-    return gNonStrict();
+assert.throws(TypeError, function() {
+    var obj = new (function () {
+        "use strict";
+        return gNonStrict();
+    });
 });
 
 

--- a/test/built-ins/Function/15.3.5.4_2-21gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-21gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     strict function (FunctionDeclaration defined within a
     FunctionDeclaration inside strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
@@ -20,8 +19,10 @@ function f1() {
     }
     return f();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-22gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-22gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     strict function (FunctionExpression defined within a
     FunctionDeclaration inside strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
@@ -20,8 +19,10 @@ function f1() {
     }
     return f();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-23gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-23gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     strict function (Anonymous FunctionExpression defined within a
     FunctionDeclaration inside strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
@@ -19,8 +18,10 @@ function f1() {
         return gNonStrict();
     })();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-24gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-24gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     strict function (FunctionDeclaration defined within a
     FunctionExpression inside strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
@@ -20,7 +19,10 @@ var f1 = function () {
     }
     return f();
 }
-f1();
+
+assert.throws(TypeError, function() {
+    f1();
+});
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-25gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-25gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     strict function (FunctionExpression defined within a
     FunctionExpression inside strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
@@ -20,8 +19,10 @@ var f1 = function () {
     }
     return f();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-26gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-26gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     strict function (Anonymous FunctionExpression defined within a
     FunctionExpression inside strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
@@ -19,8 +18,10 @@ var f1 = function () {
         return gNonStrict();
     })();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-27gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-27gs.js
@@ -10,17 +10,17 @@ description: >
     Strict mode - checking access to strict function caller from
     strict function (FunctionDeclaration defined within an Anonymous
     FunctionExpression inside strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
-(function () {
-    function f() {
-        return gNonStrict();
-    }
-    return f();
-})();
-
+assert.throws(TypeError, function() {
+    (function () {
+        function f() {
+            return gNonStrict();
+        }
+        return f();
+    })();
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-28gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-28gs.js
@@ -10,16 +10,17 @@ description: >
     Strict mode - checking access to strict function caller from
     strict function (FunctionExpression defined within an Anonymous
     FunctionExpression inside strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
-(function () {
-    var f = function () {
-        return gNonStrict();
-    }
-    return f();
-})();
+assert.throws(TypeError, function() {
+    (function () {
+        var f = function () {
+            return gNonStrict();
+        }
+        return f();
+    })();
+});
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-29gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-29gs.js
@@ -10,16 +10,16 @@ description: >
     Strict mode - checking access to strict function caller from
     strict function (Anonymous FunctionExpression defined within an
     Anonymous FunctionExpression inside strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
-(function () {
-    return (function () {
-        return gNonStrict();
+assert.throws(TypeError, function() {
+    (function () {
+        return (function () {
+            return gNonStrict();
+        })();
     })();
-})();
-
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-2gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-2gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (FunctionDeclaration includes strict directive
     prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -18,8 +17,10 @@ function f() {
     "use strict";
     return gNonStrict();
 }
-f();
 
+assert.throws(TypeError, function() {
+    f();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-30gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-30gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (FunctionDeclaration defined within a
     FunctionDeclaration with a strict directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -21,8 +20,10 @@ function f1() {
     }
     return f();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-31gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-31gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (FunctionExpression defined within a
     FunctionDeclaration with a strict directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -21,8 +20,10 @@ function f1() {
     }
     return f();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-32gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-32gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (Anonymous FunctionExpression defined within a
     FunctionDeclaration with a strict directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -20,8 +19,10 @@ function f1() {
         return gNonStrict();
     })();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-33gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-33gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (FunctionDeclaration defined within a
     FunctionExpression with a strict directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -21,8 +20,10 @@ var f1 = function () {
     }
     return f();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-34gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-34gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (FunctionExpression defined within a
     FunctionExpression with a strict directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -21,8 +20,10 @@ var f1 = function () {
     }
     return f();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-35gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-35gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (Anonymous FunctionExpression defined within a
     FunctionExpression with a strict directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -20,8 +19,10 @@ var f1 = function () {
         return gNonStrict();
     })();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-36gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-36gs.js
@@ -10,18 +10,18 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (FunctionDeclaration defined within an
     Anonymous FunctionExpression with a strict directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
-(function () {
-    "use strict";
-    function f() {
-        return gNonStrict();
-    }
-    return f();
-})();
-
+assert.throws(TypeError, function() {
+    (function () {
+        "use strict";
+        function f() {
+            return gNonStrict();
+        }
+        return f();
+    })();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-37gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-37gs.js
@@ -10,18 +10,18 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (FunctionExpression defined within an
     Anonymous FunctionExpression with a strict directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
-(function () {
-    "use strict";
-    var f = function () {
-        return gNonStrict();
-    }
-    return f();
-})();
-
+assert.throws(TypeError, function() {
+    (function () {
+        "use strict";
+        var f = function () {
+            return gNonStrict();
+        }
+        return f();
+    })();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-38gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-38gs.js
@@ -10,17 +10,17 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (Anonymous FunctionExpression defined within
     an Anonymous FunctionExpression with a strict directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
-(function () {
-    "use strict";
-    return (function () {
-        return gNonStrict();
+assert.throws(TypeError, function() {
+    (function () {
+        "use strict";
+        return (function () {
+            return gNonStrict();
+        })();
     })();
-})();
-
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-39gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-39gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (FunctionDeclaration with a strict directive
     prologue defined within a FunctionDeclaration)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -22,8 +21,10 @@ function f1() {
     }
     return f();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-3gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-3gs.js
@@ -9,15 +9,16 @@ es5id: 15.3.5.4_2-3gs
 description: >
     Strict mode - checking access to strict function caller from
     strict function (FunctionExpression defined within strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
 var f = function () {
     return gNonStrict();
 }
-f();
 
+assert.throws(TypeError, function() {
+    f();
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-40gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-40gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (FunctionExpression with a strict directive
     prologue defined within a FunctionDeclaration)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -22,8 +21,10 @@ function f1() {
     }
     return f();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-41gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-41gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (Anonymous FunctionExpression with a strict
     directive prologue defined within a FunctionDeclaration)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -21,8 +20,10 @@ function f1() {
         return r;
     })();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-42gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-42gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (FunctionDeclaration with a strict directive
     prologue defined within a FunctionExpression)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -22,8 +21,10 @@ var f1 = function () {
     }
     return f();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-43gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-43gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (FunctionExpression with a strict directive
     prologue defined within a FunctionExpression)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -22,8 +21,10 @@ var f1 = function () {
     }
     return f();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-44gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-44gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (Anonymous FunctionExpression with a strict
     directive prologue defined within a FunctionExpression)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -21,8 +20,10 @@ var f1 = function () {
         return r;
     })();
 }
-f1();
 
+assert.throws(TypeError, function() {
+    f1();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-45gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-45gs.js
@@ -10,19 +10,19 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (FunctionDeclaration with a strict directive
     prologue defined within an Anonymous FunctionExpression)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
-(function () {
-    function f() {
-        "use strict";
-        var r = gNonStrict();
-        return r;
-    }
-    return f();
-})();
-
+assert.throws(TypeError, function() {
+    (function () {
+        function f() {
+            "use strict";
+            var r = gNonStrict();
+            return r;
+        }
+        return f();
+    })();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-46gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-46gs.js
@@ -10,19 +10,19 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (FunctionExpression with a strict directive
     prologue defined within an Anonymous FunctionExpression)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
-(function () {
-    var f = function () {
-        "use strict";
-        var r = gNonStrict();
-        return r;
-    }
-    return f();
-})();
-
+assert.throws(TypeError, function() {
+    (function () {
+        var f = function () {
+            "use strict";
+            var r = gNonStrict();
+            return r;
+        }
+        return f();
+    })();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-47gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-47gs.js
@@ -10,17 +10,18 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (Anonymous FunctionExpression with a strict
     directive prologue defined within an Anonymous FunctionExpression)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
-(function () {
-    return (function () {
-        "use strict";
-        var r = gNonStrict();
-        return r;
+assert.throws(TypeError, function() {
+    (function () {
+        return (function () {
+            "use strict";
+            var r = gNonStrict();
+            return r;
+        })();
     })();
-})();
+});
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-48gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-48gs.js
@@ -9,13 +9,14 @@ es5id: 15.3.5.4_2-48gs
 description: >
     Strict mode - checking access to strict function caller from
     strict function (Literal getter defined within strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
 var o = { get foo() { return gNonStrict(); } }
-o.foo;
 
+assert.throws(TypeError, function() {
+    o.foo;
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-49gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-49gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (Literal getter includes strict directive
     prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 var o = { get foo() { "use strict"; return gNonStrict(); } }
-o.foo;
 
+assert.throws(TypeError, function() {
+    o.foo;
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-4gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-4gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (FunctionExpression includes strict directive
     prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -18,8 +17,10 @@ var f = function () {
     "use strict";
     return gNonStrict();
 }
-f();
 
+assert.throws(TypeError, function() {
+    f();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-50gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-50gs.js
@@ -9,13 +9,14 @@ es5id: 15.3.5.4_2-50gs
 description: >
     Strict mode - checking access to strict function caller from
     strict function (Literal setter defined within strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
 var o = { set foo(stuff) { return gNonStrict(); } }
-o.foo = 7; 
 
+assert.throws(TypeError, function() {
+    o.foo = 7;
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-51gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-51gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (Literal setter includes strict directive
     prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 var o = { set foo(stuff) { "use strict"; return gNonStrict(); } }
-o.foo = 8;
 
+assert.throws(TypeError, function() {
+    o.foo = 8;
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-52gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-52gs.js
@@ -9,14 +9,15 @@ es5id: 15.3.5.4_2-52gs
 description: >
     Strict mode - checking access to strict function caller from
     strict function (Injected getter defined within strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
 var o = {};
 Object.defineProperty(o, "foo",  { get: function() { return gNonStrict(); } });
-o.foo;
 
+assert.throws(TypeError, function() {
+    o.foo;
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-53gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-53gs.js
@@ -10,14 +10,15 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (Injected getter includes strict directive
     prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 var o = {};
 Object.defineProperty(o, "foo", { get: function() { "use strict"; return gNonStrict(); } });
-o.foo;
 
+assert.throws(TypeError, function() {
+    o.foo;
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-54gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-54gs.js
@@ -9,14 +9,15 @@ es5id: 15.3.5.4_2-54gs
 description: >
     Strict mode - checking access to strict function caller from
     strict function (Injected setter defined within strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
 var o = {};
 Object.defineProperty(o, "foo", { set: function(stuff) { return gNonStrict(); } });
-o.foo = 9; 
 
+assert.throws(TypeError, function() {
+    o.foo = 9;
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-55gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-55gs.js
@@ -10,14 +10,15 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (Injected setter includes strict directive
     prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 var o = {};
 Object.defineProperty(o, "foo", { set: function(stuff) { "use strict"; return gNonStrict(); } });
-o.foo = 10;
 
+assert.throws(TypeError, function() {
+    o.foo = 10;
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-56gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-56gs.js
@@ -10,14 +10,15 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     non-strict function declaration)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; var r = gNonStrict(); return r;};
 function foo() { return f();}
-foo();
 
+assert.throws(TypeError, function() {
+    foo();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-57gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-57gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     non-strict eval)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
-eval("f();"); 
 
+assert.throws(TypeError, function() {
+    eval("f();");
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-58gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-58gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     non-strict Function constructor)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; var r = gNonStrict(); return r;};
-Function("return f();")();
 
+assert.throws(TypeError, function() {
+    Function("return f();")();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-59gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-59gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     non-strict new'ed Function constructor)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; var r = gNonStrict(); return r;};
-new Function("return f();")();
 
+assert.throws(TypeError, function() {
+    new Function("return f();")();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-5gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-5gs.js
@@ -10,14 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     strict function (Anonymous FunctionExpression defined within
     strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
-(function () {
-    return gNonStrict();
-})();
-
+assert.throws(TypeError, function() {
+    (function () {
+        return gNonStrict();
+    })();
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-60gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-60gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.apply())
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
-f.apply();
 
+assert.throws(TypeError, function() {
+    f.apply();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-61gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-61gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.apply(null))
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
-f.apply(null);
 
+assert.throws(TypeError, function() {
+    f.apply(null);
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-62gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-62gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.apply(undefined))
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
-f.apply(undefined);
 
+assert.throws(TypeError, function() {
+    f.apply(undefined);
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-63gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-63gs.js
@@ -10,14 +10,15 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.apply(someObject))
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
 var o = {};
-f.apply(o);
 
+assert.throws(TypeError, function() {
+    f.apply(o);
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-64gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-64gs.js
@@ -10,14 +10,15 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.apply(globalObject))
-negative: TypeError
 flags: [noStrict]
 includes: [fnGlobalObject.js]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
-f.apply(fnGlobalObject());
 
+assert.throws(TypeError, function() {
+    f.apply(fnGlobalObject());
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-65gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-65gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.call())
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
-f.call();
 
+assert.throws(TypeError, function() {
+    f.call();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-66gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-66gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.call(null))
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
-f.call(null);
 
+assert.throws(TypeError, function() {
+    f.call(null);
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-67gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-67gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.call(undefined))
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
-f.call(undefined);
 
+assert.throws(TypeError, function() {
+    f.call(undefined);
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-68gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-68gs.js
@@ -10,14 +10,15 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.call(someObject))
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
 var o = {};
-f.call(o); 
 
+assert.throws(TypeError, function() {
+    f.call(o);
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-69gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-69gs.js
@@ -10,14 +10,15 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.call(globalObject))
-negative: TypeError
 flags: [noStrict]
 includes: [fnGlobalObject.js]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
-f.call(fnGlobalObject());
 
+assert.throws(TypeError, function() {
+    f.call(fnGlobalObject());
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-6gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-6gs.js
@@ -10,14 +10,15 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (Anonymous FunctionExpression includes strict
     directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
-(function () {
-    "use strict";
-    return gNonStrict();
-})();
+assert.throws(TypeError, function() {
+    (function () {
+        "use strict";
+        return gNonStrict();
+    })();
+});
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-70gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-70gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.bind()())
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
-f.bind()();
 
+assert.throws(TypeError, function() {
+    f.bind()();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-71gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-71gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.bind(null)())
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
-f.bind(null)();
 
+assert.throws(TypeError, function() {
+    f.bind(null)();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-72gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-72gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.bind(undefined)())
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
-f.bind(undefined)();
 
+assert.throws(TypeError, function() {
+    f.bind(undefined)();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-73gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-73gs.js
@@ -10,14 +10,15 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.bind(someObject)())
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
 var o = {};
-f.bind(o)();
 
+assert.throws(TypeError, function() {
+    f.bind(o)();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-74gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-74gs.js
@@ -10,14 +10,15 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (strict function declaration called by
     Function.prototype.bind(globalObject)())
-negative: TypeError
 flags: [noStrict]
 includes: [fnGlobalObject.js]
 ---*/
 
 function f() { "use strict"; return gNonStrict();};
-f.bind(fnGlobalObject())(); 
 
+assert.throws(TypeError, function() {
+    f.bind(fnGlobalObject())();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-7gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-7gs.js
@@ -9,13 +9,14 @@ es5id: 15.3.5.4_2-7gs
 description: >
     Strict mode - checking access to non-strict function caller from
     strict function (Function constructor defined within strict mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
 var f = Function("return gNonStrict();");
-f();
 
+assert.throws(TypeError, function() {
+    f();
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/15.3.5.4_2-8gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-8gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function (Function constructor includes strict
     directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
 var f = Function("\"use strict\";\nreturn gNonStrict();");
-f();
 
+assert.throws(TypeError, function() {
+    f();
+});
 
 function gNonStrict() {
     return gNonStrict.caller || gNonStrict.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-94gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-94gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict function expression (FunctionDeclaration includes
     strict directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -22,4 +21,7 @@ function f() {
     "use strict";
     return gNonStrict();
 }
-f();
+
+assert.throws(TypeError, function() {
+    f();
+});

--- a/test/built-ins/Function/15.3.5.4_2-95gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-95gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict, constructor-based function (FunctionDeclaration
     includes strict directive prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -20,4 +19,7 @@ function f() {
     "use strict";
     return gNonStrict();
 }
-f();
+
+assert.throws(TypeError, function() {
+    f();
+});

--- a/test/built-ins/Function/15.3.5.4_2-96gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-96gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from
     non-strict property (FunctionDeclaration includes strict directive
     prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -26,4 +25,7 @@ function f() {
     "use strict";
     return o.gNonStrict;
 }
-f();
+
+assert.throws(TypeError, function() {
+    f();
+});

--- a/test/built-ins/Function/15.3.5.4_2-97gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-97gs.js
@@ -10,7 +10,6 @@ description: >
     Strict mode - checking access to strict function caller from bound
     non-strict function (FunctionDeclaration includes strict directive
     prologue)
-negative: TypeError
 flags: [noStrict]
 ---*/
 
@@ -20,8 +19,10 @@ function f() {
     "use strict";
     return gNonStrict();
 }
-f();
 
+assert.throws(TypeError, function() {
+    f();
+});
 
 function gNonStrictBindee() {
     return gNonStrictBindee.caller || gNonStrictBindee.caller.throwTypeError;

--- a/test/built-ins/Function/15.3.5.4_2-9gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-9gs.js
@@ -10,13 +10,14 @@ description: >
     Strict mode - checking access to non-strict function caller from
     strict function (New'ed Function constructor defined within strict
     mode)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
 var f = new Function("return gNonStrict();");
-f();
 
+assert.throws(TypeError, function() {
+    f();
+});
 
 function gNonStrict() {
     return gNonStrict.caller;

--- a/test/built-ins/Function/prototype/apply/S15.3.4.3_A13.js
+++ b/test/built-ins/Function/prototype/apply/S15.3.4.3_A13.js
@@ -4,7 +4,8 @@
 /*---
 es5id: 15.3.4.3_A13
 description: If IsCallable(func) is false, then throw a TypeError exception.
-negative: TypeError
 ---*/
 
-Function.prototype.apply.call(undefined, {}, []);
+assert.throws(TypeError, function() {
+  Function.prototype.apply.call(undefined, {}, []);
+});

--- a/test/built-ins/Function/prototype/apply/S15.3.4.3_A14.js
+++ b/test/built-ins/Function/prototype/apply/S15.3.4.3_A14.js
@@ -4,7 +4,8 @@
 /*---
 es5id: 15.3.4.3_A14
 description: If IsCallable(func) is false, then throw a TypeError exception.
-negative: TypeError
 ---*/
 
-Function.prototype.apply.call(null, {}, []);
+assert.throws(TypeError, function() {
+  Function.prototype.apply.call(null, {}, []);
+});

--- a/test/built-ins/Function/prototype/apply/S15.3.4.3_A15.js
+++ b/test/built-ins/Function/prototype/apply/S15.3.4.3_A15.js
@@ -4,7 +4,8 @@
 /*---
 es5id: 15.3.4.3_A15
 description: If IsCallable(func) is false, then throw a TypeError exception.
-negative: TypeError
 ---*/
 
-Function.prototype.apply.call({}, {}, []);
+assert.throws(TypeError, function() {
+  Function.prototype.apply.call({}, {}, []);
+});

--- a/test/built-ins/Function/prototype/bind/S15.3.4.5_A1.js
+++ b/test/built-ins/Function/prototype/bind/S15.3.4.5_A1.js
@@ -5,10 +5,12 @@
 info: "\"caller\" of bound function is poisoned (step 20)"
 es5id: 15.3.4.5_A1
 description: A bound function should fail to find its "caller"
-negative: TypeError
 ---*/
 
 function foo() { return bar.caller; }
 var bar = foo.bind({});
 function baz() { return bar(); }
-baz();
+
+assert.throws(TypeError, function() {
+  baz();
+});

--- a/test/built-ins/Function/prototype/bind/S15.3.4.5_A13.js
+++ b/test/built-ins/Function/prototype/bind/S15.3.4.5_A13.js
@@ -4,7 +4,8 @@
 /*---
 es5id: 15.3.4.5_A13
 description: If IsCallable(func) is false, then throw a TypeError exception.
-negative: TypeError
 ---*/
 
-Function.prototype.bind.call(undefined, {});
+assert.throws(TypeError, function() {
+  Function.prototype.bind.call(undefined, {});
+});

--- a/test/built-ins/Function/prototype/bind/S15.3.4.5_A14.js
+++ b/test/built-ins/Function/prototype/bind/S15.3.4.5_A14.js
@@ -4,7 +4,8 @@
 /*---
 es5id: 15.3.4.5_A14
 description: If IsCallable(func) is false, then throw a TypeError exception.
-negative: TypeError
 ---*/
 
-Function.prototype.bind.call(null, {});
+assert.throws(TypeError, function() {
+  Function.prototype.bind.call(null, {});
+});

--- a/test/built-ins/Function/prototype/bind/S15.3.4.5_A15.js
+++ b/test/built-ins/Function/prototype/bind/S15.3.4.5_A15.js
@@ -4,7 +4,8 @@
 /*---
 es5id: 15.3.4.5_A15
 description: If IsCallable(func) is false, then throw a TypeError exception.
-negative: TypeError
 ---*/
 
-Function.prototype.bind.call({}, {});
+assert.throws(TypeError, function() {
+  Function.prototype.bind.call({}, {});
+});

--- a/test/built-ins/Function/prototype/bind/S15.3.4.5_A2.js
+++ b/test/built-ins/Function/prototype/bind/S15.3.4.5_A2.js
@@ -5,10 +5,12 @@
 info: "\"arguments\" of bound function is poisoned (step 21)"
 es5id: 15.3.4.5_A2
 description: a bound function should fail to find the bound function "arguments"
-negative: TypeError
 ---*/
 
 function foo() { return bar.arguments; }
 var bar = foo.bind({});
 function baz() { return bar(); }
-baz();
+
+assert.throws(TypeError, function() {
+  baz();
+});

--- a/test/built-ins/Function/prototype/call/S15.3.4.4_A13.js
+++ b/test/built-ins/Function/prototype/call/S15.3.4.4_A13.js
@@ -4,7 +4,8 @@
 /*---
 es5id: 15.3.4.4_A13
 description: If IsCallable(func) is false, then throw a TypeError exception.
-negative: TypeError
 ---*/
 
-Function.prototype.call.call(undefined, {});
+assert.throws(TypeError, function() {
+  Function.prototype.call.call(undefined, {});
+});

--- a/test/built-ins/Function/prototype/call/S15.3.4.4_A14.js
+++ b/test/built-ins/Function/prototype/call/S15.3.4.4_A14.js
@@ -4,7 +4,8 @@
 /*---
 es5id: 15.3.4.4_A14
 description: If IsCallable(func) is false, then throw a TypeError exception.
-negative: TypeError
 ---*/
 
-Function.prototype.call.call(null, {});
+assert.throws(TypeError, function() {
+  Function.prototype.call.call(null, {});
+});

--- a/test/built-ins/Function/prototype/call/S15.3.4.4_A15.js
+++ b/test/built-ins/Function/prototype/call/S15.3.4.4_A15.js
@@ -4,7 +4,8 @@
 /*---
 es5id: 15.3.4.4_A15
 description: If IsCallable(func) is false, then throw a TypeError exception.
-negative: TypeError
 ---*/
 
-Function.prototype.call.call({}, {});
+assert.throws(TypeError, function() {
+  Function.prototype.call.call({}, {});
+});

--- a/test/built-ins/Function/prototype/toString/S15.3.4.2_A12.js
+++ b/test/built-ins/Function/prototype/toString/S15.3.4.2_A12.js
@@ -6,7 +6,8 @@ es5id: 15.3.4.2_A12
 description: >
     The Function.prototype.toString function is not generic; it throws
     a TypeError exception if its this value is not a Function object.
-negative: TypeError
 ---*/
 
-Function.prototype.toString.call(undefined);
+assert.throws(TypeError, function() {
+  Function.prototype.toString.call(undefined);
+});

--- a/test/built-ins/Function/prototype/toString/S15.3.4.2_A13.js
+++ b/test/built-ins/Function/prototype/toString/S15.3.4.2_A13.js
@@ -6,7 +6,8 @@ es5id: 15.3.4.2_A13
 description: >
     The toString function is not generic; it throws a TypeError
     exception if its this value is not a Function object.
-negative: TypeError
 ---*/
 
-Function.prototype.toString.call(null);
+assert.throws(TypeError, function() {
+  Function.prototype.toString.call(null);
+});

--- a/test/built-ins/Function/prototype/toString/S15.3.4.2_A14.js
+++ b/test/built-ins/Function/prototype/toString/S15.3.4.2_A14.js
@@ -6,7 +6,8 @@ es5id: 15.3.4.2_A14
 description: >
     The toString function is not generic; it throws a TypeError
     exception if its this value is not a Function object.
-negative: TypeError
 ---*/
 
-Function.prototype.toString.call({});
+assert.throws(TypeError, function() {
+  Function.prototype.toString.call({});
+});

--- a/test/built-ins/Function/prototype/toString/S15.3.4.2_A15.js
+++ b/test/built-ins/Function/prototype/toString/S15.3.4.2_A15.js
@@ -9,7 +9,8 @@ es5id: 15.3.4.2_A15
 description: >
     Whether or not they are callable, RegExp objects are not Function
     objects, so toString should throw a TypeError.
-negative: TypeError
 ---*/
 
-Function.prototype.toString.call(/x/);
+assert.throws(TypeError, function() {
+  Function.prototype.toString.call(/x/);
+});

--- a/test/built-ins/Function/prototype/toString/S15.3.4.2_A16.js
+++ b/test/built-ins/Function/prototype/toString/S15.3.4.2_A16.js
@@ -10,9 +10,10 @@ description: >
     The String constructor, given an object, should invoke that
     object's toString method as a method, i.e., with its this value
     bound to that object.
-negative: TypeError
 ---*/
 
 var obj = {toString: Function.prototype.toString};
 
-String(obj);
+assert.throws(TypeError, function() {
+  String(obj);
+});

--- a/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A12.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A12.js
@@ -6,7 +6,8 @@ es5id: 15.2.4.5_A12
 description: >
     Let O be the result of calling ToObject passing the this value as
     the argument.
-negative: TypeError
 ---*/
 
-Object.prototype.hasOwnProperty.call(undefined, 'foo');
+assert.throws(TypeError, function() {
+  Object.prototype.hasOwnProperty.call(undefined, 'foo');
+});

--- a/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A13.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/S15.2.4.5_A13.js
@@ -6,7 +6,8 @@ es5id: 15.2.4.5_A13
 description: >
     Let O be the result of calling ToObject passing the this value as
     the argument.
-negative: TypeError
 ---*/
 
-Object.prototype.hasOwnProperty.call(null, 'foo');
+assert.throws(TypeError, function() {
+  Object.prototype.hasOwnProperty.call(null, 'foo');
+});

--- a/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A12.js
+++ b/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A12.js
@@ -6,7 +6,8 @@ es5id: 15.2.4.6_A12
 description: >
     Let O be the result of calling ToObject passing the this value as
     the argument.
-negative: TypeError
 ---*/
 
-Object.prototype.isPrototypeOf.call(undefined, {});
+assert.throws(TypeError, function() {
+  Object.prototype.isPrototypeOf.call(undefined, {});
+});

--- a/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A13.js
+++ b/test/built-ins/Object/prototype/isPrototypeOf/S15.2.4.6_A13.js
@@ -6,7 +6,8 @@ es5id: 15.2.4.6_A13
 description: >
     Let O be the result of calling ToObject passing the this value as
     the argument.
-negative: TypeError
 ---*/
 
-Object.prototype.isPrototypeOf.call(null, {});
+assert.throws(TypeError, function() {
+  Object.prototype.isPrototypeOf.call(null, {});
+});

--- a/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A12.js
+++ b/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A12.js
@@ -6,7 +6,8 @@ es5id: 15.2.4.7_A12
 description: >
     Let O be the result of calling ToObject passing the this value as
     the argument.
-negative: TypeError
 ---*/
 
-Object.prototype.propertyIsEnumerable.call(undefined, 'foo');
+assert.throws(TypeError, function() {
+  Object.prototype.propertyIsEnumerable.call(undefined, 'foo');
+});

--- a/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A13.js
+++ b/test/built-ins/Object/prototype/propertyIsEnumerable/S15.2.4.7_A13.js
@@ -6,7 +6,8 @@ es5id: 15.2.4.7_A13
 description: >
     Let O be the result of calling ToObject passing the this value as
     the argument.
-negative: TypeError
 ---*/
 
-Object.prototype.propertyIsEnumerable.call(null, 'foo');
+assert.throws(TypeError, function() {
+  Object.prototype.propertyIsEnumerable.call(null, 'foo');
+});

--- a/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A12.js
+++ b/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A12.js
@@ -6,7 +6,8 @@ es5id: 15.2.4.3_A12
 description: >
     Let O be the result of calling ToObject passing the this value as
     the argument.
-negative: TypeError
 ---*/
 
-Object.prototype.toLocaleString.call(undefined);
+assert.throws(TypeError, function() {
+  Object.prototype.toLocaleString.call(undefined);
+});

--- a/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A13.js
+++ b/test/built-ins/Object/prototype/toLocaleString/S15.2.4.3_A13.js
@@ -6,7 +6,8 @@ es5id: 15.2.4.3_A13
 description: >
     Let O be the result of calling ToObject passing the this value as
     the argument.
-negative: TypeError
 ---*/
 
-Object.prototype.toLocaleString.call(null);
+assert.throws(TypeError, function() {
+  Object.prototype.toLocaleString.call(null);
+});

--- a/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A12.js
+++ b/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A12.js
@@ -7,7 +7,8 @@ info: >
     argument.
 es5id: 15.2.4.4_A12
 description: Checking Object.prototype.valueOf invoked by the 'call' property.
-negative: TypeError
 ---*/
 
-Object.prototype.valueOf.call(undefined);
+assert.throws(TypeError, function() {
+    Object.prototype.valueOf.call(undefined);
+});

--- a/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A13.js
+++ b/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A13.js
@@ -7,7 +7,8 @@ info: >
     argument.
 es5id: 15.2.4.4_A13
 description: Checking Object.prototype.valueOf invoked by the 'call' property.
-negative: TypeError
 ---*/
 
-Object.prototype.valueOf.call(null);
+assert.throws(TypeError, function() {
+  Object.prototype.valueOf.call(null);
+});

--- a/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A14.js
+++ b/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A14.js
@@ -7,7 +7,8 @@ info: >
     argument.
 es5id: 15.2.4.4_A14
 description: Checking Object.prototype.valueOf invoked by the 'call' property.
-negative: TypeError
 ---*/
 
-(1,Object.prototype.valueOf)();
+assert.throws(TypeError, function() {
+    (1,Object.prototype.valueOf)();
+});

--- a/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A15.js
+++ b/test/built-ins/Object/prototype/valueOf/S15.2.4.4_A15.js
@@ -7,8 +7,10 @@ info: >
     argument.
 es5id: 15.2.4.4_A15
 description: Checking Object.prototype.valueOf when called as a global function.
-negative: TypeError
 ---*/
 
 var v = Object.prototype.valueOf;
-v();
+
+assert.throws(TypeError, function() {
+    v();
+});

--- a/test/built-ins/Promise/S25.4.3.1_A2.1_T1.js
+++ b/test/built-ins/Promise/S25.4.3.1_A2.1_T1.js
@@ -7,7 +7,8 @@ info: >
 es6id: S25.4.3.1_A2.1_T1
 author: Sam Mikes
 description: Promise.call("non-object") throws TypeError
-negative: TypeError
 ---*/
 
-Promise.call("non-object", function () {});
+assert.throws(TypeError, function() {
+  Promise.call("non-object", function () {});
+});

--- a/test/built-ins/Promise/S25.4.3.1_A3.1_T1.js
+++ b/test/built-ins/Promise/S25.4.3.1_A3.1_T1.js
@@ -7,7 +7,8 @@ info: >
 es6id: S25.4.3.1_A3.1_T1
 author: Sam Mikes
 description: new Promise("not callable") throws TypeError
-negative: TypeError
 ---*/
 
-new Promise("not callable");
+assert.throws(TypeError, function() {
+  new Promise("not callable");
+});

--- a/test/built-ins/Promise/all/S25.4.4.1_A4.1_T1.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A4.1_T1.js
@@ -5,7 +5,6 @@
 info: >
     Promise.all should throw if 'this' does not conform to Promise constructor
 es6id: S25.4.4.1_A4.1_T1
-negative: TypeError
 description: this must conform to Promise constructor in Promise.all
 author: Sam Mikes
 ---*/
@@ -13,4 +12,6 @@ author: Sam Mikes
 function ZeroArgConstructor() {
 }
 
-Promise.all.call(ZeroArgConstructor, []);
+assert.throws(TypeError, function() {
+  Promise.all.call(ZeroArgConstructor, []);
+});

--- a/test/built-ins/Promise/prototype/S25.4.5_A1.1_T1.js
+++ b/test/built-ins/Promise/prototype/S25.4.5_A1.1_T1.js
@@ -7,7 +7,8 @@ info: >
 es6id: S25.4.5_A1.1_T1
 author: Sam Mikes
 description: Promise prototype does not have [[PromiseState]] internal slot
-negative: TypeError
 ---*/
 
-Promise.call(Promise.prototype, function () {});
+assert.throws(TypeError, function() {
+  Promise.call(Promise.prototype, function () {});
+});

--- a/test/built-ins/Promise/prototype/then/S25.4.5.3_A2.1_T1.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.5.3_A2.1_T1.js
@@ -7,10 +7,10 @@ info: >
 es6id: S25.4.5.3_A2.1_T1
 author: Sam Mikes
 description: Promise.prototype.then throw if 'this' is non-Object
-negative: TypeError
 ---*/
 
 var p = new Promise(function () {});
 
-p.then.call(3, function () {}, function () {});
-
+assert.throws(TypeError, function() {
+  p.then.call(3, function () {}, function () {});
+});

--- a/test/built-ins/Promise/prototype/then/S25.4.5.3_A2.1_T2.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.5.3_A2.1_T2.js
@@ -7,7 +7,6 @@ info: >
 es6id: S25.4.5.3_A2.1_T2
 author: Sam Mikes
 description: Promise.prototype.then throw if 'this' is non-Promise Object
-negative: TypeError
 ---*/
 
 function ZeroArgConstructor() {
@@ -15,4 +14,6 @@ function ZeroArgConstructor() {
 
 var z = new ZeroArgConstructor();
 
-Promise.then.call(z, function () {}, function () {});
+assert.throws(TypeError, function() {
+  Promise.then.call(z, function () {}, function () {});
+});

--- a/test/built-ins/Promise/race/S25.4.4.3_A3.1_T1.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A3.1_T1.js
@@ -9,10 +9,11 @@ info: >
 es6id: S25.4.4.3_A3.1_T1
 author: Sam Mikes
 description: Promise.race throws if 'this' does not conform to Promise constructor
-negative: TypeError
 ---*/
 
 function ZeroArgConstructor() {
 }
 
-Promise.race.call(ZeroArgConstructor, [3]);
+assert.throws(TypeError, function() {
+  Promise.race.call(ZeroArgConstructor, [3]);
+});

--- a/test/built-ins/Promise/race/S25.4.4.3_A3.1_T2.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A3.1_T2.js
@@ -9,9 +9,10 @@ info: >
 es6id: S25.4.4.3_A3.1_T2
 author: Sam Mikes
 description: Promise.race throws TypeError, even on empty array, when 'this' does not conform to Promise constructor
-negative: TypeError
 ---*/
 
 function BadPromiseConstructor(f) { f(undefined, undefined); }
 
-Promise.race.call(BadPromiseConstructor, []);
+assert.throws(TypeError, function() {
+  Promise.race.call(BadPromiseConstructor, []);
+});

--- a/test/built-ins/Promise/reject/S25.4.4.4_A3.1_T1.js
+++ b/test/built-ins/Promise/reject/S25.4.4.4_A3.1_T1.js
@@ -7,10 +7,11 @@ info: >
 es6id: S25.4.4.4_A3.1_T1
 author: Sam Mikes
 description: Promise.reject throws TypeError for bad 'this'
-negative: TypeError
 ---*/
 
 function ZeroArgConstructor() {
 }
 
-Promise.reject.call(ZeroArgConstructor, 4);
+assert.throws(TypeError, function() {
+  Promise.reject.call(ZeroArgConstructor, 4);
+});

--- a/test/built-ins/global/S15.1_A1_T1.js
+++ b/test/built-ins/global/S15.1_A1_T1.js
@@ -7,7 +7,10 @@ es5id: 15.1_A1_T1
 description: >
     It is not possible to use the global object as a constructor  with
     the new operator
-negative: TypeError
 ---*/
 
-new this;
+var global = this;
+
+assert.throws(TypeError, function() {
+    new global;
+});

--- a/test/built-ins/global/S15.1_A1_T2.js
+++ b/test/built-ins/global/S15.1_A1_T2.js
@@ -7,7 +7,10 @@ es5id: 15.1_A1_T2
 description: >
     It is not possible to use the global object as a constructor  with
     the new operator
-negative: TypeError
 ---*/
 
-new this();
+var global = this;
+
+assert.throws(TypeError, function() {
+    new global();
+});

--- a/test/built-ins/global/S15.1_A2_T1.js
+++ b/test/built-ins/global/S15.1_A2_T1.js
@@ -5,7 +5,10 @@
 info: The global object does not have a [[Call]] property
 es5id: 15.1_A2_T1
 description: It is not possible to invoke the global object as a function
-negative: TypeError
 ---*/
 
-this();
+var global = this;
+
+assert.throws(TypeError, function() {
+    global();
+});

--- a/test/language/arguments-object/10.6-2gs.js
+++ b/test/language/arguments-object/10.6-2gs.js
@@ -9,11 +9,13 @@ es5id: 10.6-2gs
 description: >
     Strict Mode - arguments.callee cannot be accessed in a strict
     function
-negative: .
 flags: [onlyStrict]
 ---*/
 
 function f_10_6_1_gs(){
     return arguments.callee;
 }
-f_10_6_1_gs();
+
+assert.throws(TypeError, function() {
+    f_10_6_1_gs();
+});

--- a/test/language/asi/S7.9_A5.7_T1.js
+++ b/test/language/asi/S7.9_A5.7_T1.js
@@ -12,12 +12,14 @@ info: >
 
 es5id: 7.9_A5.7_T1
 description: Try use Variable1 \n ++ \n ++ \n Variable2 construction
-negative: ReferenceError
 ---*/
 
 var x=0, y=0;
+
+assert.throws(ReferenceError, function() {
 var z=
 x
 ++
 ++
 y
+});

--- a/test/language/asi/S7.9_A7_T7.js
+++ b/test/language/asi/S7.9_A7_T7.js
@@ -5,9 +5,9 @@
 info: Check Var Statement for automatic semicolon insertion
 es5id: 7.9_A7_T7
 description: Checking if execution of "var x \n y" passes
-negative: ReferenceError
 ---*/
 
-//CHECK#1
+assert.throws(ReferenceError, function() {
 var x 
 y
+});

--- a/test/language/eval-code/10.4.2.1-1gs.js
+++ b/test/language/eval-code/10.4.2.1-1gs.js
@@ -10,10 +10,10 @@ description: >
     Strict Mode - eval code cannot instantiate variable in the
     variable environment of the calling context that invoked the eval
     if the code of the calling context is strict code
-negative: ReferenceError
 flags: [onlyStrict]
 ---*/
 
 eval("var x = 7;");
-x = 9;
-throw NotEarlyError;
+assert.throws(ReferenceError, function() {
+  x = 9;
+});

--- a/test/language/expressions/assignment/11.13.1-4-28gs.js
+++ b/test/language/expressions/assignment/11.13.1-4-28gs.js
@@ -9,8 +9,9 @@ es5id: 11.13.1-4-28gs
 description: >
     Strict Mode - TypeError is thrown if the identifier 'Math.PI'
     appears as the LeftHandSideExpression of simple assignment(=)
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
-Math.PI = 20;
+assert.throws(TypeError, function() {
+  Math.PI = 20;
+});

--- a/test/language/expressions/assignment/11.13.1-4-29gs.js
+++ b/test/language/expressions/assignment/11.13.1-4-29gs.js
@@ -9,8 +9,9 @@ es5id: 11.13.1-4-29gs
 description: >
     Strict Mode - SyntaxError is thrown if the identifier 'Math.PI'
     appears as the LeftHandSideExpression of simple assignment(=)
-negative: .
 flags: [onlyStrict]
 ---*/
 
-Math.PI = 20;
+assert.throws(TypeError, function() {
+  Math.PI = 20;
+});

--- a/test/language/expressions/void/S11.4.2_A2_T2.js
+++ b/test/language/expressions/void/S11.4.2_A2_T2.js
@@ -5,8 +5,8 @@
 info: Operator "void" uses GetValue
 es5id: 11.4.2_A2_T2
 description: If GetBase(x) is null, throw ReferenceError
-negative: ReferenceError
 ---*/
 
-//CHECK#1
-void x;
+assert.throws(ReferenceError, function() {
+  void x;
+});

--- a/test/language/line-terminators/S7.3_A3.1_T1.js
+++ b/test/language/line-terminators/S7.3_A3.1_T1.js
@@ -2,11 +2,11 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-info: Single line comments can not contain LINE FEED (U+000A) inside
+info: Single line comments are terminated by the LINE FEED (U+000A) character
 es5id: 7.3_A3.1_T1
 description: Insert LINE FEED (\u000A) into single line comment
-negative: ReferenceError
 ---*/
 
-// CHECK#1
-eval("// single line \u000A comment");
+assert.throws(Test262Error, function() {
+  eval("// single line \u000A throw new Test262Error();");
+});

--- a/test/language/line-terminators/S7.3_A3.2_T1.js
+++ b/test/language/line-terminators/S7.3_A3.2_T1.js
@@ -5,8 +5,7 @@
 info: Single line comments can not contain CARRIAGE RETURN (U+000D) inside
 es5id: 7.3_A3.2_T1
 description: Insert CARRIAGE RETURN (\u000D) into single line comment
-negative: ReferenceError
+negative: SyntaxError
 ---*/
 
-// CHECK#1
-eval("// single line \u000D comment");
+// single line comment  ??? (invalid)

--- a/test/language/line-terminators/S7.3_A3.3_T1.js
+++ b/test/language/line-terminators/S7.3_A3.3_T1.js
@@ -2,11 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-info: Single line comments can not contain LINE SEPARATOR (U+2028) inside
+info: >
+    Single line comments are terminated by the LINE SEPARATOR (U+2028)
+    character
 es5id: 7.3_A3.3_T1
 description: Insert LINE SEPARATOR (\u2028) into single line comment
-negative: ReferenceError
+negative: SyntaxError
 ---*/
 
-// CHECK#1
-eval("// single line \u2028 comment");
+// single line LS> ??? (invalid)

--- a/test/language/line-terminators/S7.3_A3.4_T1.js
+++ b/test/language/line-terminators/S7.3_A3.4_T1.js
@@ -5,8 +5,7 @@
 info: Single line comments can not contain PARAGRAPH SEPARATOR (U+2029) inside
 es5id: 7.3_A3.4_T1
 description: Insert PARAGRAPH SEPARATOR (\u2029) into single line comment
-negative: ReferenceError
+negative: SyntaxError
 ---*/
 
-// CHECK#1
-eval("// single line \u2029 comment");
+// single line PS> ??? (invalid)

--- a/test/language/literals/numeric/S7.8.3_A4.1_T1.js
+++ b/test/language/literals/numeric/S7.8.3_A4.1_T1.js
@@ -5,8 +5,8 @@
 info: "DecimalLiteral :: ExponentPart is incorrect"
 es5id: 7.8.3_A4.1_T1
 description: "ExponentPart :: e DecimalDigits"
-negative: ReferenceError
 ---*/
 
-//CHECK#1
-e1
+assert.throws(ReferenceError, function() {
+  e1
+});

--- a/test/language/literals/numeric/S7.8.3_A4.1_T2.js
+++ b/test/language/literals/numeric/S7.8.3_A4.1_T2.js
@@ -5,8 +5,8 @@
 info: "DecimalLiteral :: ExponentPart is incorrect"
 es5id: 7.8.3_A4.1_T2
 description: "ExponentPart :: E DecimalDigits"
-negative: ReferenceError
 ---*/
 
-//CHECK#1
-E1
+assert.throws(ReferenceError, function() {
+  E1
+});

--- a/test/language/literals/numeric/S7.8.3_A4.1_T3.js
+++ b/test/language/literals/numeric/S7.8.3_A4.1_T3.js
@@ -5,8 +5,8 @@
 info: "DecimalLiteral :: ExponentPart is incorrect"
 es5id: 7.8.3_A4.1_T3
 description: "ExponentPart :: e DecimalDigits"
-negative: ReferenceError
 ---*/
 
-//CHECK#1
-e-1
+assert.throws(ReferenceError, function() {
+  e-1
+});

--- a/test/language/literals/numeric/S7.8.3_A4.1_T4.js
+++ b/test/language/literals/numeric/S7.8.3_A4.1_T4.js
@@ -5,8 +5,8 @@
 info: "DecimalLiteral :: ExponentPart is incorrect"
 es5id: 7.8.3_A4.1_T4
 description: "ExponentPart :: E DecimalDigits"
-negative: ReferenceError
 ---*/
 
-//CHECK#1
-E-1
+assert.throws(ReferenceError, function() {
+  E-1
+});

--- a/test/language/literals/numeric/S7.8.3_A4.1_T5.js
+++ b/test/language/literals/numeric/S7.8.3_A4.1_T5.js
@@ -5,8 +5,8 @@
 info: "DecimalLiteral :: ExponentPart is incorrect"
 es5id: 7.8.3_A4.1_T5
 description: "ExponentPart :: e DecimalDigits"
-negative: ReferenceError
 ---*/
 
-//CHECK#1
-e+1
+assert.throws(ReferenceError, function() {
+  e+1
+});

--- a/test/language/literals/numeric/S7.8.3_A4.1_T6.js
+++ b/test/language/literals/numeric/S7.8.3_A4.1_T6.js
@@ -5,8 +5,8 @@
 info: "DecimalLiteral :: ExponentPart is incorrect"
 es5id: 7.8.3_A4.1_T6
 description: "ExponentPart :: E DecimalDigits"
-negative: ReferenceError
 ---*/
 
-//CHECK#1
-E+1
+assert.throws(ReferenceError, function() {
+  E+1
+});

--- a/test/language/literals/numeric/S7.8.3_A4.1_T7.js
+++ b/test/language/literals/numeric/S7.8.3_A4.1_T7.js
@@ -5,8 +5,8 @@
 info: "DecimalLiteral :: ExponentPart is incorrect"
 es5id: 7.8.3_A4.1_T7
 description: "ExponentPart :: e 0"
-negative: ReferenceError
 ---*/
 
-//CHECK#1
-e0
+assert.throws(ReferenceError, function() {
+  e0
+});

--- a/test/language/literals/numeric/S7.8.3_A4.1_T8.js
+++ b/test/language/literals/numeric/S7.8.3_A4.1_T8.js
@@ -5,8 +5,8 @@
 info: "DecimalLiteral :: ExponentPart is incorrect"
 es5id: 7.8.3_A4.1_T8
 description: "ExponentPart :: E 0"
-negative: ReferenceError
 ---*/
 
-//CHECK#1
-E0
+assert.throws(ReferenceError, function() {
+  E0
+});

--- a/test/language/object-literal/not-defined.js
+++ b/test/language/object-literal/not-defined.js
@@ -4,6 +4,8 @@
 es6id: 12.2.5
 description: >
     Throws when IdentifierReference is undefined
-negative: ReferenceError
 ---*/
-var o = {notDefined};
+
+assert.throws(ReferenceError, function() {
+  var o = {notDefined};
+});

--- a/test/language/statements/class/name-binding/in-extends-expression-assigned.js
+++ b/test/language/statements/class/name-binding/in-extends-expression-assigned.js
@@ -4,6 +4,7 @@
 es6id: 14.5
 description: >
     class name binding in extends expression, assigned
-negative: ReferenceError
 ---*/
-var x = (class x extends x {});
+assert.throws(ReferenceError, function() {
+  var x = (class x extends x {});
+});

--- a/test/language/statements/class/name-binding/in-extends-expression-grouped.js
+++ b/test/language/statements/class/name-binding/in-extends-expression-grouped.js
@@ -4,6 +4,8 @@
 es6id: 14.5
 description: >
     class name binding in extends expression, grouped
-negative: ReferenceError
 ---*/
-(class x extends x {});
+
+assert.throws(ReferenceError, function() {
+  (class x extends x {});
+});

--- a/test/language/statements/class/name-binding/in-extends-expression.js
+++ b/test/language/statements/class/name-binding/in-extends-expression.js
@@ -4,6 +4,7 @@
 es6id: 14.5
 description: >
     class name binding in extends expression
-negative: ReferenceError
 ---*/
-class x extends x {}
+assert.throws(ReferenceError, function() {
+  class x extends x {}
+});

--- a/test/language/statements/const/block-local-closure-get-before-initialization.js
+++ b/test/language/statements/const/block-local-closure-get-before-initialization.js
@@ -9,7 +9,11 @@ negative: ReferenceError
 ---*/
 {
   function f() { return x + 1; }
-  f();
+
+  assert.throws(ReferenceError, function() {
+    f();
+  });
+
   const x = 1;
 }
 

--- a/test/language/statements/const/block-local-use-before-initialization-in-declaration-statement.js
+++ b/test/language/statements/const/block-local-use-before-initialization-in-declaration-statement.js
@@ -5,8 +5,9 @@ es6id: 13.1
 description: >
     const: block local use before initialization in declaration statement.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
-{
-  const x = x + 1;
-}
+assert.throws(ReferenceError, function() {
+  {
+    const x = x + 1;
+  }
+});

--- a/test/language/statements/const/block-local-use-before-initialization-in-prior-statement.js
+++ b/test/language/statements/const/block-local-use-before-initialization-in-prior-statement.js
@@ -5,8 +5,10 @@ es6id: 13.1
 description: >
     const: block local use before initialization in prior statement.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
-{
-  x; const x = 1;
-}
+
+assert.throws(ReferenceError, function() {
+  {
+    x; const x = 1;
+  }
+});

--- a/test/language/statements/const/function-local-closure-get-before-initialization.js
+++ b/test/language/statements/const/function-local-closure-get-before-initialization.js
@@ -5,10 +5,13 @@ es6id: 13.1
 description: >
     const: function local closure [[Get]] before initialization.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
 (function() {
   function f() { return x + 1; }
-  f();
+
+  assert.throws(ReferenceError, function() {
+    f();
+  });
+
   const x = 1;
 }());

--- a/test/language/statements/const/function-local-use-before-initialization-in-declaration-statement.js
+++ b/test/language/statements/const/function-local-use-before-initialization-in-declaration-statement.js
@@ -5,8 +5,9 @@ es6id: 13.1
 description: >
     const: function local use before initialization in declaration statement.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
-(function() {
-  const x = x + 1;
-}());
+assert.throws(ReferenceError, function() {
+  (function() {
+    const x = x + 1;
+  }());
+});

--- a/test/language/statements/const/function-local-use-before-initialization-in-prior-statement.js
+++ b/test/language/statements/const/function-local-use-before-initialization-in-prior-statement.js
@@ -5,8 +5,9 @@ es6id: 13.1
 description: >
     const: function local use before initialization in prior statement.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
-(function() {
-  x; const x = 1;
-}());
+assert.throws(ReferenceError, function() {
+  (function() {
+    x; const x = 1;
+  }());
+});

--- a/test/language/statements/const/global-closure-get-before-initialization.js
+++ b/test/language/statements/const/global-closure-get-before-initialization.js
@@ -5,8 +5,12 @@ es6id: 13.1
 description: >
     const: global closure [[Get]] before initialization.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
+
 function f() { return x + 1; }
-f();
+
+assert.throws(ReferenceError, function() {
+  f();
+});
+
 const x = 1;

--- a/test/language/statements/const/syntax/const-invalid-assignment-next-expression-for.js
+++ b/test/language/statements/const/syntax/const-invalid-assignment-next-expression-for.js
@@ -4,7 +4,8 @@
 es6id: 13.6.3.7_S5.a.i
 description: >
     const: invalid assignment in next expression
-negative: TypeError
 ---*/
 
-for (const i = 0; i < 1; i++) {}
+assert.throws(TypeError, function() {
+  for (const i = 0; i < 1; i++) {}
+});

--- a/test/language/statements/const/syntax/const-invalid-assignment-statement-body-for-in.js
+++ b/test/language/statements/const/syntax/const-invalid-assignment-statement-body-for-in.js
@@ -4,7 +4,8 @@
 es6id: 13.6.4.10_S1.a.i
 description: >
     const: invalid assignment in Statement body
-negative: TypeError
 ---*/
 
-for (const x in [1, 2, 3]) { x++ }
+assert.throws(TypeError, function() {
+  for (const x in [1, 2, 3]) { x++ }
+});

--- a/test/language/statements/const/syntax/const-invalid-assignment-statement-body-for-of.js
+++ b/test/language/statements/const/syntax/const-invalid-assignment-statement-body-for-of.js
@@ -4,7 +4,8 @@
 es6id: 13.6.4.10_S1.a.i
 description: >
     const: invalid assignment in Statement body
-negative: TypeError
 ---*/
 
-for (const x of [1, 2, 3]) { x++ }
+assert.throws(TypeError, function() {
+  for (const x of [1, 2, 3]) { x++ }
+});

--- a/test/language/statements/for-in/const-bound-names-fordecl-tdz-for-in.js
+++ b/test/language/statements/for-in/const-bound-names-fordecl-tdz-for-in.js
@@ -4,9 +4,9 @@
 es6id: 13.6.4.12_S2
 description: >
     ForIn/Of: Bound names of ForDeclaration are in TDZ (for-of)
-negative: ReferenceError
 ---*/
 
-let x = 1;
-for (const x in { x }) {}
-
+assert.throws(ReferenceError, function() {
+  let x = 1;
+  for (const x in { x }) {}
+});

--- a/test/language/statements/for-in/let-bound-names-fordecl-tdz-for-in.js
+++ b/test/language/statements/for-in/let-bound-names-fordecl-tdz-for-in.js
@@ -4,9 +4,9 @@
 es6id: 13.6.4.12_S2
 description: >
     ForIn/Of: Bound names of ForDeclaration are in TDZ (for-of)
-negative: ReferenceError
 ---*/
 
-let x = 1;
-for (let x in { x }) {}
-
+assert.throws(ReferenceError, function() {
+  let x = 1;
+  for (let x in { x }) {}
+});

--- a/test/language/statements/for-of/const-bound-names-fordecl-tdz-for-of.js
+++ b/test/language/statements/for-of/const-bound-names-fordecl-tdz-for-of.js
@@ -4,9 +4,9 @@
 es6id: 13.6.4.12_S2
 description: >
     ForIn/Of: Bound names of ForDeclaration are in TDZ (for-of)
-negative: ReferenceError
 ---*/
 
-let x = 1;
-for (const x of [x]) {}
-
+assert.throws(ReferenceError, function() {
+  let x = 1;
+  for (const x of [x]) {}
+});

--- a/test/language/statements/for-of/let-bound-names-fordecl-tdz-for-of.js
+++ b/test/language/statements/for-of/let-bound-names-fordecl-tdz-for-of.js
@@ -4,9 +4,9 @@
 es6id: 13.6.4.12_S2
 description: >
     ForIn/Of: Bound names of ForDeclaration are in TDZ (for-of)
-negative: ReferenceError
 ---*/
 
-let x = 1;
-for (let x of [x]) {}
-
+assert.throws(ReferenceError, function() {
+  let x = 1;
+  for (let x of [x]) {}
+});

--- a/test/language/statements/function/13.2-19-b-3gs.js
+++ b/test/language/statements/function/13.2-19-b-3gs.js
@@ -9,9 +9,11 @@ es5id: 13.2-19-b-3gs
 description: >
     StrictMode - error is thrown when assign a value to the 'caller'
     property of a function object
-negative: TypeError
 flags: [onlyStrict]
 ---*/
 
 function _13_2_19_b_3_gs() {}
-_13_2_19_b_3_gs.caller = 1;
+
+assert.throws(TypeError, function() {
+  _13_2_19_b_3_gs.caller = 1;
+});

--- a/test/language/statements/let/block-local-closure-get-before-initialization.js
+++ b/test/language/statements/let/block-local-closure-get-before-initialization.js
@@ -5,10 +5,13 @@ es6id: 13.1
 description: >
     let: block local closure [[Get]] before initialization.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
 {
   function f() { return x + 1; }
-  f();
+
+  assert.throws(ReferenceError, function() {
+    f();
+  });
+
   let x;
 }

--- a/test/language/statements/let/block-local-closure-set-before-initialization.js
+++ b/test/language/statements/let/block-local-closure-set-before-initialization.js
@@ -5,10 +5,13 @@ es6id: 13.1
 description: >
     let: block local closure [[Set]] before initialization.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
 {
   function f() { x = 1; }
-  f();
+
+  assert.throws(ReferenceError, function() {
+    f();
+  });
+
   let x;
 }

--- a/test/language/statements/let/block-local-use-before-initialization-in-declaration-statement.js
+++ b/test/language/statements/let/block-local-use-before-initialization-in-declaration-statement.js
@@ -5,8 +5,9 @@ es6id: 13.1
 description: >
     let: block local use before initialization in declaration statement.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
-{
-  let x = x + 1;
-}
+assert.throws(ReferenceError, function() {
+  {
+    let x = x + 1;
+  }
+});

--- a/test/language/statements/let/block-local-use-before-initialization-in-prior-statement.js
+++ b/test/language/statements/let/block-local-use-before-initialization-in-prior-statement.js
@@ -5,8 +5,9 @@ es6id: 13.1
 description: >
     let: block local use before initialization in prior statement.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
-{
-  x; let x;
-}
+assert.throws(ReferenceError, function() {
+  {
+    x; let x;
+  }
+});

--- a/test/language/statements/let/function-local-closure-get-before-initialization.js
+++ b/test/language/statements/let/function-local-closure-get-before-initialization.js
@@ -5,10 +5,13 @@ es6id: 13.1
 description: >
     let: function local closure [[Get]] before initialization.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
 (function() {
   function f() { return x + 1; }
-  f();
+
+  assert.throws(ReferenceError, function() {
+    f();
+  });
+
   let x;
 }());

--- a/test/language/statements/let/function-local-closure-set-before-initialization.js
+++ b/test/language/statements/let/function-local-closure-set-before-initialization.js
@@ -5,10 +5,13 @@ es6id: 13.1
 description: >
     let: function local closure [[Set]] before initialization.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
 (function() {
   function f() { x = 1; }
-  f();
+
+  assert.throws(ReferenceError, function() {
+    f();
+  });
+
   let x;
 }());

--- a/test/language/statements/let/function-local-use-before-initialization-in-declaration-statement.js
+++ b/test/language/statements/let/function-local-use-before-initialization-in-declaration-statement.js
@@ -5,8 +5,9 @@ es6id: 13.1
 description: >
     let: function local use before initialization in declaration statement.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
-(function() {
-  let x = x + 1;
-}());
+assert.throws(ReferenceError, function() {
+  (function() {
+    let x = x + 1;
+  }());
+});

--- a/test/language/statements/let/function-local-use-before-initialization-in-prior-statement.js
+++ b/test/language/statements/let/function-local-use-before-initialization-in-prior-statement.js
@@ -5,8 +5,9 @@ es6id: 13.1
 description: >
     let: function local use before initialization in prior statement.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
-(function() {
-  x; let x;
-}());
+assert.throws(ReferenceError, function() {
+  (function() {
+    x; let x;
+  }());
+});

--- a/test/language/statements/let/global-closure-get-before-initialization.js
+++ b/test/language/statements/let/global-closure-get-before-initialization.js
@@ -5,8 +5,11 @@ es6id: 13.1
 description: >
     let: global closure [[Get]] before initialization.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
 function f() { return x + 1; }
-f();
+
+assert.throws(ReferenceError, function() {
+  f();
+});
+
 let x;

--- a/test/language/statements/let/global-closure-set-before-initialization.js
+++ b/test/language/statements/let/global-closure-set-before-initialization.js
@@ -5,8 +5,11 @@ es6id: 13.1
 description: >
     let: global closure [[Set]] before initialization.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
 function f() { x = 1; }
-f();
+
+assert.throws(ReferenceError, function() {
+  f();
+});
+
 let x;

--- a/test/language/statements/throw/S12.13_A1.js
+++ b/test/language/statements/throw/S12.13_A1.js
@@ -5,7 +5,15 @@
 info: Sanity test for throw statement
 es5id: 12.13_A1
 description: Trying to throw exception with "throw"
-negative: expected_message
 ---*/
 
-throw "expected_message";
+var inCatch = false;
+
+try {
+  throw "expected_message";
+} catch (err) {
+  assert.sameValue(err, "expected_message");
+  inCatch = true;
+}
+
+assert.sameValue(inCatch, true);

--- a/test/language/types/object/S8.6.2_A7.js
+++ b/test/language/types/object/S8.6.2_A7.js
@@ -7,11 +7,8 @@ info: >
     constructors. Math object is NOT constructor
 es5id: 8.6.2_A7
 description: Checking if execution of "var objMath=new Math" passes
-negative: TypeError
 ---*/
 
-//////////////////////////////////////////////////////////////////////////////
-//CHECK#1
-var objMath=new Math;
-
-//////////////////////////////////////////////////////////////////////////////
+assert.throws(TypeError, function() {
+  var objMath=new Math;
+});

--- a/test/language/types/reference/8.7.2-3-a-1gs.js
+++ b/test/language/types/reference/8.7.2-3-a-1gs.js
@@ -9,8 +9,9 @@ es5id: 8.7.2-3-a-1gs
 description: >
     Strict Mode - ReferenceError is thrown if LeftHandSide evaluate to
     an unresolvable Reference
-negative: .
 flags: [onlyStrict]
 ---*/
 
-b = 11;
+assert.throws(ReferenceError, function() {
+  b = 11;
+});

--- a/test/language/types/reference/8.7.2-3-a-2gs.js
+++ b/test/language/types/reference/8.7.2-3-a-2gs.js
@@ -9,10 +9,11 @@ es5id: 8.7.2-3-a-2gs
 description: >
     Strict Mode - 'runtime' error is thrown before LeftHandSide
     evaluates to an unresolvable Reference
-negative: Test262Error
 flags: [onlyStrict]
 includes: [Test262Error.js]
 ---*/
 
-throw new Test262Error();
-b = 11;
+assert.throws(Test262Error, function() {
+  throw new Test262Error();
+  b = 11;
+});

--- a/test/language/types/string/S8.4_A7.1.js
+++ b/test/language/types/string/S8.4_A7.1.js
@@ -5,7 +5,8 @@
 info: <LF> between chunks of one string not allowed
 es5id: 8.4_A7.1
 description: Insert <LF> between chunks of one string
-negative: ReferenceError
 ---*/
 
-eval("var x = asdf\u000Aghjk");
+assert.throws(ReferenceError, function() {
+  eval("var x = asdf\u000Aghjk");
+});

--- a/test/language/types/string/S8.4_A7.2.js
+++ b/test/language/types/string/S8.4_A7.2.js
@@ -5,7 +5,8 @@
 info: <CR> between chunks of one string not allowed
 es5id: 8.4_A7.2
 description: Insert <CR> between chunks of one string
-negative: ReferenceError
 ---*/
 
-eval("var x = asdf\u000Dghjk");
+assert.throws(ReferenceError, function() {
+  eval("var x = asdf\u000Dghjk");
+});

--- a/test/language/types/string/S8.4_A7.3.js
+++ b/test/language/types/string/S8.4_A7.3.js
@@ -5,7 +5,8 @@
 info: <PS> between chunks of one string not allowed
 es5id: 8.4_A7.3
 description: Insert <PS> between chunks of one string
-negative: ReferenceError
 ---*/
 
-eval("var x = asdf\u2028ghjk");
+assert.throws(ReferenceError, function() {
+  eval("var x = asdf\u2028ghjk");
+});

--- a/test/language/types/string/S8.4_A7.4.js
+++ b/test/language/types/string/S8.4_A7.4.js
@@ -5,7 +5,8 @@
 info: <LS> between chunks of one string not allowed
 es5id: 8.4_A7.4
 description: Insert <LS> between chunks of one string
-negative: ReferenceError
 ---*/
 
-eval("var x = asdf\u2029ghjk");
+assert.throws(ReferenceError, function() {
+  eval("var x = asdf\u2029ghjk");
+});


### PR DESCRIPTION
Re-factor tests for runtime errors to express their expectations using
`assert.throws`. This change is in service of gh-196 as it almost completely
limits the use of the `negative` frontmatter to only those tests that fail
prior to code execution.

Some tests explicitly concern the generation of errors in global code--these
cannot be refactored use use the `assert.throws` helper method without
fundamentally changing the behavior under test:

- test/language/statements/const/global-use-before-initialization-in-declaration-statement.js
- test/language/statements/const/global-use-before-initialization-in-prior-statement.js
- test/language/statements/let/global-use-before-initialization-in-declaration-statement.js
- test/language/statements/let/global-use-before-initialization-in-prior-statement.js

I think we can address this with finer-grained control over `negative`, but
that extension can be designed and implemented separately.

It probably makes sense to squash this into a single commit prior to landing,
but I left the history as-is in case seeing the changes broken down by error
type aids the review process.