### PR TITLE
Reinforce test for the use of ToLength(lastIndex) in RegExp

### DIFF
--- a/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A5_T3.js
+++ b/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A5_T3.js
@@ -1,38 +1,38 @@
-// Copyright 2009 the Sputnik authors.  All rights reserved.
+// Copyright 2015 the V8 project authors.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 info: >
-    RegExp.prototype.exec behavior depends on global property.
-    Let global is true and let I = If ToLength(lastIndex).
-    Then if I>length then set lastIndex to 0 and return null
+    RegExp.prototype.exec behavior depends on the lastIndex property:
+    ToLength(lastIndex) is the starting point for the search, so
+    negative numbers result in searching from 0.
 es5id: 15.10.6.2_A5_T3
 description: "Set lastIndex to -1 and call /(?:ab|cd)\\d?/g.exec(\"aacd22 \")"
 ---*/
 
 var __re = /(?:ab|cd)\d?/g;
 __re.lastIndex=-1;
-var __executed = __re.test("aacd22 ");
+var __executed = __re.exec("aacd22 ");
 
 //CHECK#1
-if (!__executed) {
-	$ERROR('#1: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.test("aacd22 "); __executed === true');
+if (__executed[0] !== "cd2") {
+	$ERROR('#1: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.exec("aacd22 "); __executed[0] === "cd2"');
 }
 
 //CHECK#2
 if (__re.lastIndex !== 5) {
-	$ERROR('#2: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.test("aacd22 "); __re.lastIndex === 5. Actual: ' + (__re.lastIndex));
+	$ERROR('#2: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.exec("aacd22 "); __re.lastIndex === 5. Actual: ' + (__re.lastIndex));
 }
 
 __re.lastIndex=-100;
-__executed = __re.test("aacd22 ");
+__executed = __re.exec("aacd22 ");
 
 //CHECK#3
-if (!__executed) {
-	$ERROR('#3: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.test("aacd22 "); __re.lastIndex=-100; __executed = __re.test("aacd22 "); __executed === true');
+if (__executed[0] !== "cd2") {
+	$ERROR('#3: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.exec("aacd22 "); __re.lastIndex=-100; __executed = __re.exec("aacd22 "); __executed[0] === "cd2"');
 }
 
 //CHECK#4
 if (__re.lastIndex !== 5) {
-	$ERROR('#4: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.test("aacd22 "); __re.lastIndex=-100; __executed = __re.test("aacd22 "); __re.lastIndex === 5. Actual: ' + (__re.lastIndex));
+	$ERROR('#4: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.exec("aacd22 "); __re.lastIndex=-100; __executed = __re.exec("aacd22 "); __re.lastIndex === 5. Actual: ' + (__re.lastIndex));
 }

--- a/test/built-ins/RegExp/prototype/test/S15.10.6.3_A1_T22.js
+++ b/test/built-ins/RegExp/prototype/test/S15.10.6.3_A1_T22.js
@@ -1,0 +1,38 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: >
+    RegExp.prototype.test behavior depends on the lastIndex property:
+    ToLength(lastIndex) is the starting point for the search, so
+    negative numbers result in searching from 0.
+es5id: 15.10.6.3_A1_T22
+description: "Set lastIndex to -1 and call /(?:ab|cd)\\d?/g.test(\"aacd22 \")"
+---*/
+
+var __re = /(?:ab|cd)\d?/g;
+__re.lastIndex=-1;
+var __executed = __re.test("aacd22 ");
+
+//CHECK#1
+if (!__executed) {
+	$ERROR('#1: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.test("aacd22 "); __executed === true');
+}
+
+//CHECK#2
+if (__re.lastIndex !== 5) {
+	$ERROR('#2: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.test("aacd22 "); __re.lastIndex === 5. Actual: ' + (__re.lastIndex));
+}
+
+__re.lastIndex=-100;
+__executed = __re.test("aacd22 ");
+
+//CHECK#3
+if (!__executed) {
+	$ERROR('#3: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.test("aacd22 "); __re.lastIndex=-100; __executed = __re.test("aacd22 "); __executed === true');
+}
+
+//CHECK#4
+if (__re.lastIndex !== 5) {
+	$ERROR('#4: __re = /(?:ab|cd)\\d?/g; __re.lastIndex=-1; __executed = __re.test("aacd22 "); __re.lastIndex=-100; __executed = __re.test("aacd22 "); __re.lastIndex === 5. Actual: ' + (__re.lastIndex));
+}


### PR DESCRIPTION
Previously, test262 had only a test that ensured that ToLength (for
example, rather than ToInteger) was used in test'ing a RegExp, not
in calls to exec. Although in the ES5 and ES2015 specs there is only
one code path, in some implementations, ToLength is called in from
separate code paths. This patch makes a new test for exec'ing a
RegExp and ensures that ToLength is called.