### PR TITLE
Add tests for @@isConcatSpreadable

### DIFF
--- a/test/built-ins/Array/prototype/concat/is-concat-spreadable-get-err.js
+++ b/test/built-ins/Array/prototype/concat/is-concat-spreadable-get-err.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+description: Error thrown when accessing `Symbol.isConcatSpreadable` property
+info: >
+    1. Let O be ToObject(this value).
+    2. ReturnIfAbrupt(O).
+    3. Let A be ArraySpeciesCreate(O, 0).
+    4. ReturnIfAbrupt(A).
+    5. Let n be 0.
+    6. Let items be a List whose first element is O and whose subsequent
+       elements are, in left to right order, the arguments that were passed to
+       this function invocation.
+    7. Repeat, while items is not empty
+      a. Remove the first element from items and let E be the value of the element.
+      b. Let spreadable be IsConcatSpreadable(E).
+      c. ReturnIfAbrupt(spreadable).
+
+    ES6 22.1.3.1.1: Runtime Semantics: IsConcatSpreadable ( O )
+
+    1. If Type(O) is not Object, return false.
+    2. Let spreadable be Get(O, @@isConcatSpreadable).
+    3. ReturnIfAbrupt(spreadable).
+features: [Symbol.isConcatSpreadable]
+---*/
+
+var o = {};
+
+Object.defineProperty(o, Symbol.isConcatSpreadable, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Array.prototype.concat.call(o);
+});

--- a/test/built-ins/Array/prototype/concat/is-concat-spreadable-val-falsey.js
+++ b/test/built-ins/Array/prototype/concat/is-concat-spreadable-val-falsey.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+description: >
+    The `Symbol.isConcatSpreadable` property is defined and coerces to `false`
+info: >
+    1. Let O be ToObject(this value).
+    2. ReturnIfAbrupt(O).
+    3. Let A be ArraySpeciesCreate(O, 0).
+    4. ReturnIfAbrupt(A).
+    5. Let n be 0.
+    6. Let items be a List whose first element is O and whose subsequent
+       elements are, in left to right order, the arguments that were passed to
+       this function invocation.
+    7. Repeat, while items is not empty
+      a. Remove the first element from items and let E be the value of the element.
+      b. Let spreadable be IsConcatSpreadable(E).
+      c. ReturnIfAbrupt(spreadable).
+      d. If spreadable is true, then
+         [...]
+      e. Else E is added as a single item rather than spread,
+         [...]
+
+    ES6 22.1.3.1.1: Runtime Semantics: IsConcatSpreadable ( O )
+
+    1. If Type(O) is not Object, return false.
+    2. Let spreadable be Get(O, @@isConcatSpreadable).
+    3. ReturnIfAbrupt(spreadable).
+    4. If spreadable is not undefined, return ToBoolean(spreadable).
+features: [Symbol.isConcatSpreadable]
+---*/
+
+var item = [1, 2];
+var result;
+
+item[Symbol.isConcatSpreadable] = null;
+result = [].concat(item);
+assert.sameValue(result.length, 1);
+assert.sameValue(result[0], item);
+
+item[Symbol.isConcatSpreadable] = false;
+result = [].concat(item);
+assert.sameValue(result.length, 1);
+assert.sameValue(result[0], item);
+
+item[Symbol.isConcatSpreadable] = 0;
+result = [].concat(item);
+assert.sameValue(result.length, 1);
+assert.sameValue(result[0], item);
+
+item[Symbol.isConcatSpreadable] = NaN;
+result = [].concat(item);
+assert.sameValue(result.length, 1);
+assert.sameValue(result[0], item);

--- a/test/built-ins/Array/prototype/concat/is-concat-spreadable-val-truthy.js
+++ b/test/built-ins/Array/prototype/concat/is-concat-spreadable-val-truthy.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+description: >
+    The `Symbol.isConcatSpreadable` property is defined and coerces to `true`
+info: >
+    1. Let O be ToObject(this value).
+    2. ReturnIfAbrupt(O).
+    3. Let A be ArraySpeciesCreate(O, 0).
+    4. ReturnIfAbrupt(A).
+    5. Let n be 0.
+    6. Let items be a List whose first element is O and whose subsequent
+       elements are, in left to right order, the arguments that were passed to
+       this function invocation.
+    7. Repeat, while items is not empty
+      a. Remove the first element from items and let E be the value of the element.
+      b. Let spreadable be IsConcatSpreadable(E).
+      c. ReturnIfAbrupt(spreadable).
+      d. If spreadable is true, then
+         [...]
+
+    ES6 22.1.3.1.1: Runtime Semantics: IsConcatSpreadable ( O )
+
+    1. If Type(O) is not Object, return false.
+    2. Let spreadable be Get(O, @@isConcatSpreadable).
+    3. ReturnIfAbrupt(spreadable).
+    4. If spreadable is not undefined, return ToBoolean(spreadable).
+features: [Symbol, Symbol.isConcatSpreadable]
+---*/
+
+var item = {};
+var result;
+
+item[Symbol.isConcatSpreadable] = true;
+result = [].concat(item);
+assert.sameValue(result.length, 0);
+
+item[Symbol.isConcatSpreadable] = 86;
+result = [].concat(item);
+assert.sameValue(result.length, 0);
+
+item[Symbol.isConcatSpreadable] = 'string';
+result = [].concat(item);
+assert.sameValue(result.length, 0);
+
+item[Symbol.isConcatSpreadable] = Symbol();
+result = [].concat(item);
+assert.sameValue(result.length, 0);
+
+item[Symbol.isConcatSpreadable] = {};
+result = [].concat(item);
+assert.sameValue(result.length, 0);

--- a/test/built-ins/Array/prototype/concat/is-concat-spreadable-val-undefined.js
+++ b/test/built-ins/Array/prototype/concat/is-concat-spreadable-val-undefined.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+description: >
+    The `Symbol.isConcatSpreadable` property is defined as the value `undefined`
+info: >
+    1. Let O be ToObject(this value).
+    2. ReturnIfAbrupt(O).
+    3. Let A be ArraySpeciesCreate(O, 0).
+    4. ReturnIfAbrupt(A).
+    5. Let n be 0.
+    6. Let items be a List whose first element is O and whose subsequent
+       elements are, in left to right order, the arguments that were passed to
+       this function invocation.
+    7. Repeat, while items is not empty
+      a. Remove the first element from items and let E be the value of the element.
+      b. Let spreadable be IsConcatSpreadable(E).
+      c. ReturnIfAbrupt(spreadable).
+      d. If spreadable is true, then
+         [...]
+      e. Else E is added as a single item rather than spread,
+         [...]
+
+    ES6 22.1.3.1.1: Runtime Semantics: IsConcatSpreadable ( O )
+
+    1. If Type(O) is not Object, return false.
+    2. Let spreadable be Get(O, @@isConcatSpreadable).
+    3. ReturnIfAbrupt(spreadable).
+    4. If spreadable is not undefined, return ToBoolean(spreadable).
+    5. Return IsArray(O).
+features: [Symbol.isConcatSpreadable]
+---*/
+
+var item = [];
+var result;
+
+item[Symbol.isConcatSpreadable] = undefined;
+result = [].concat(item);
+
+assert.sameValue(result.length, 0);

--- a/test/built-ins/Symbol/isConcatSpreadable/prop-desc.js
+++ b/test/built-ins/Symbol/isConcatSpreadable/prop-desc.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.4.2.3
+description: Property descriptor
+info: >
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+features: [Symbol.isConcatSpreadable]
+---*/
+
+assert.sameValue(typeof Symbol.isConcatSpreadable, 'symbol');
+verifyNotEnumerable(Symbol, 'isConcatSpreadable');
+verifyNotWritable(Symbol, 'isConcatSpreadable');
+verifyNotConfigurable(Symbol, 'isConcatSpreadable');


### PR DESCRIPTION
`test/built-ins/Array/prototype/concat/is-concat-spreadable-val-undefined.js` is prone to false positives, but I want to make sure that implementers don't simply coerce any "own" property.