### PR TITLE
Fix 11.13.1-4-29gs.js incorrect comment explanation (master)

### DIFF
--- a/test/language/expressions/assignment/11.13.1-4-29gs.js
+++ b/test/language/expressions/assignment/11.13.1-4-29gs.js
@@ -7,7 +7,7 @@
 /*---
 es5id: 11.13.1-4-29gs
 description: >
-    Strict Mode - SyntaxError is thrown if the identifier 'Math.PI'
+    Strict Mode - TypeError is thrown if the identifier 'Math.PI'
     appears as the LeftHandSideExpression of simple assignment(=)
 negative: .
 flags: [onlyStrict]


### PR DESCRIPTION
SyntaxError => TypeError for writing to a non-writeable field.

Fixes #372 for master