### PR TITLE
Add tests for @@iterator

### DIFF
--- a/test/built-ins/Array/from/get-iter-method-err.js
+++ b/test/built-ins/Array/from/get-iter-method-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: Error accessing items' `Symbol.iterator` attribute
+info: >
+    [...]
+    4. Let usingIterator be GetMethod(items, @@iterator).
+    5. ReturnIfAbrupt(usingIterator).
+features: [Symbol.iterator]
+---*/
+
+var items = {};
+Object.defineProperty(items, Symbol.iterator, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Array.from(items);
+});

--- a/test/built-ins/Array/from/iter-adv-err.js
+++ b/test/built-ins/Array/from/iter-adv-err.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: Error advancing iterator
+info: >
+    [...]
+    6. If usingIterator is not undefined, then
+       [...]
+       g. Repeat
+          i. Let Pk be ToString(k).
+          ii. Let next be IteratorStep(iterator).
+          iii. ReturnIfAbrupt(next).
+features: [Symbol.iterator]
+---*/
+
+var items = {};
+items[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      throw new Test262Error();
+    }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  Array.from(items);
+});

--- a/test/built-ins/Array/from/iter-cstm-ctor-err.js
+++ b/test/built-ins/Array/from/iter-cstm-ctor-err.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: >
+    Error creating object with custom constructor (traversed via iterator)
+info: >
+    [...]
+    6. If usingIterator is not undefined, then
+       a. If IsConstructor(C) is true, then
+          i. Let A be Construct(C).
+       b. Else,
+          i. Let A be ArrayCreate(0).
+       c. ReturnIfAbrupt(A).
+features: [Symbol.iterator]
+---*/
+
+var C = function() {
+  throw new Test262Error();
+};
+var items = {};
+items[Symbol.iterator] = function() {};
+
+assert.throws(Test262Error, function() {
+  Array.from.call(C, items);
+});

--- a/test/built-ins/Array/from/iter-cstm-ctor.js
+++ b/test/built-ins/Array/from/iter-cstm-ctor.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: Creating object with custom constructor (traversed via iterator)
+info: >
+    [...]
+    6. If usingIterator is not undefined, then
+       a. If IsConstructor(C) is true, then
+          i. Let A be Construct(C).
+       b. Else,
+          i. Let A be ArrayCreate(0).
+       c. ReturnIfAbrupt(A).
+features: [Symbol.iterator]
+---*/
+
+var thisVal, args;
+var callCount = 0;
+var C = function() {
+  thisVal = this;
+  args = arguments;
+  callCount += 1;
+};
+var result;
+var items = {};
+items[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { done: true };
+    }
+  };
+};
+
+result = Array.from.call(C, items);
+
+assert(
+  result instanceof C, 'Constructed value is an instance of the constructor'
+);
+assert.sameValue(
+  result.constructor,
+  C,
+  'Constructed value correctly defines a `constructor` property'
+);
+assert.sameValue(callCount, 1, 'Constructor invoked exactly once');
+assert.sameValue(thisVal, result, 'Constructed value is returned');
+assert.sameValue(args.length, 0, 'Constructor invoked without arguments');

--- a/test/built-ins/Array/from/iter-get-iter-err.js
+++ b/test/built-ins/Array/from/iter-get-iter-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: Error creating iterator object
+info: >
+    [...]
+    6. If usingIterator is not undefined, then
+       [...]
+       d. Let iterator be GetIterator(items, usingIterator).
+       e. ReturnIfAbrupt(iterator).
+features: [Symbol.iterator]
+---*/
+
+var items = {};
+items[Symbol.iterator] = function() {
+  throw new Test262Error();
+};
+
+assert.throws(Test262Error, function() {
+  Array.from(items);
+});

--- a/test/built-ins/Array/from/iter-get-iter-val-err.js
+++ b/test/built-ins/Array/from/iter-get-iter-val-err.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: Error retrieving value of iterator result
+info: >
+    [...]
+    6. If usingIterator is not undefined, then
+       [...]
+       g. Repeat
+          [...]
+          v. Let nextValue be IteratorValue(next).
+          vi. ReturnIfAbrupt(nextValue).
+features: [Symbol.iterator]
+---*/
+
+var items = {};
+var poisonedValue = {};
+Object.defineProperty(poisonedValue, 'value', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+items[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return poisonedValue;
+    }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  Array.from(items);
+});

--- a/test/built-ins/Array/from/iter-map-fn-args.js
+++ b/test/built-ins/Array/from/iter-map-fn-args.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: >
+    Arguments of mapping function (traversed via iterator)
+info: >
+    [...]
+    2. If mapfn is undefined, let mapping be false.
+    3. else
+       a. If IsCallable(mapfn) is false, throw a TypeError exception.
+       b. If thisArg was supplied, let T be thisArg; else let T be undefined.
+       c. Let mapping be true
+    [...]
+    6. If usingIterator is not undefined, then
+       [...]
+       g. Repeat
+          [...]
+          vii. If mapping is true, then
+               1. Let mappedValue be Call(mapfn, T, «nextValue, k»).
+               2. If mappedValue is an abrupt completion, return
+                  IteratorClose(iterator, mappedValue).
+               3. Let mappedValue be mappedValue.[[value]].
+features: [Symbol.iterator]
+---*/
+
+var args = [];
+var firstResult = { done: false, value: {} };
+var secondResult = { done: false, value: {} };
+var mapFn = function(value, idx) {
+  args.push(arguments);
+};
+var items = {};
+var nextResult = firstResult;
+var nextNextResult = secondResult;
+
+items[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      var result = nextResult;
+      nextResult = nextNextResult;
+      nextNextResult = { done: true };
+
+      return result;
+    }
+  };
+};
+
+Array.from(items, mapFn);
+
+assert.sameValue(args.length, 2, 'Iteration count');
+
+assert.sameValue(args[0].length, 2, 'First iteration: arguments length');
+assert.sameValue(
+  args[0][0], firstResult.value, 'First iteration: first argument'
+);
+assert.sameValue(args[0][1], 0, 'First iteration: second argument');
+
+assert.sameValue(args[1].length, 2, 'Second iteration: arguments length');
+assert.sameValue(
+  args[1][0], secondResult.value, 'Second iteration: first argument'
+);
+assert.sameValue(args[1][1], 1, 'Second iteration: second argument');

--- a/test/built-ins/Array/from/iter-map-fn-err.js
+++ b/test/built-ins/Array/from/iter-map-fn-err.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: Error invoking map function (traversed via iterator)
+info: >
+    [...]
+    6. If usingIterator is not undefined, then
+       [...]
+       g. Repeat
+          [...]
+          vii. If mapping is true, then
+               1. Let mappedValue be Call(mapfn, T, «nextValue, k»).
+               2. If mappedValue is an abrupt completion, return
+                  IteratorClose(iterator, mappedValue).
+features: [Symbol.iterator]
+---*/
+
+var closeCount = 0;
+var mapFn = function() {
+  throw new Test262Error();
+};
+var items = {};
+items[Symbol.iterator] = function() {
+  return {
+    return: function() {
+      closeCount += 1;
+    },
+    next: function() {
+      return {
+        done: false
+      };
+    }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  Array.from(items, mapFn);
+});
+
+assert.sameValue(closeCount, 1);

--- a/test/built-ins/Array/from/iter-map-fn-return.js
+++ b/test/built-ins/Array/from/iter-map-fn-return.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: Value returned by mapping function (traversed via iterator)
+info: >
+    [...]
+    2. If mapfn is undefined, let mapping be false.
+    3. else
+       a. If IsCallable(mapfn) is false, throw a TypeError exception.
+       b. If thisArg was supplied, let T be thisArg; else let T be undefined.
+       c. Let mapping be true
+    [...]
+    6. If usingIterator is not undefined, then
+       [...]
+       g. Repeat
+          [...]
+          vii. If mapping is true, then
+               1. Let mappedValue be Call(mapfn, T, «nextValue, k»).
+               2. If mappedValue is an abrupt completion, return
+                  IteratorClose(iterator, mappedValue).
+               3. Let mappedValue be mappedValue.[[value]].
+features: [Symbol.iterator]
+---*/
+
+var thisVals = [];
+var nextResult = { done: false, value: {} };
+var nextNextResult = { done: false, value: {} };
+var firstReturnVal = {};
+var secondReturnVal = {};
+var mapFn = function(value, idx) {
+  var returnVal = nextReturnVal;
+  nextReturnVal = nextNextReturnVal;
+  nextNextReturnVal = null;
+  return returnVal;
+};
+var nextReturnVal = firstReturnVal;
+var nextNextReturnVal = secondReturnVal;
+var items = {};
+var result;
+
+items[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      var result = nextResult;
+      nextResult = nextNextResult;
+      nextNextResult = { done: true };
+
+      return result;
+    }
+  };
+};
+
+result = Array.from(items, mapFn);
+
+assert.sameValue(result.length, 2);
+assert.sameValue(result[0], firstReturnVal);
+assert.sameValue(result[1], secondReturnVal);

--- a/test/built-ins/Array/from/iter-map-fn-this-arg.js
+++ b/test/built-ins/Array/from/iter-map-fn-this-arg.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: >
+    `this` value of mapping function with custom `this` argument (traversed via iterator)
+info: >
+    [...]
+    2. If mapfn is undefined, let mapping be false.
+    3. else
+       a. If IsCallable(mapfn) is false, throw a TypeError exception.
+       b. If thisArg was supplied, let T be thisArg; else let T be undefined.
+       c. Let mapping be true
+    [...]
+    6. If usingIterator is not undefined, then
+       [...]
+       g. Repeat
+          [...]
+          vii. If mapping is true, then
+               1. Let mappedValue be Call(mapfn, T, «nextValue, k»).
+features: [Symbol.iterator]
+---*/
+
+var thisVals = [];
+var nextResult = { done: false, value: {} };
+var nextNextResult = { done: false, value: {} };
+var mapFn = function() {
+  thisVals.push(this);
+};
+var items = {};
+var thisVal = {};
+
+items[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      var result = nextResult;
+      nextResult = nextNextResult;
+      nextNextResult = { done: true };
+
+      return result;
+    }
+  };
+};
+
+Array.from(items, mapFn, thisVal);
+
+assert.sameValue(thisVals.length, 2);
+assert.sameValue(thisVals[0], thisVal, 'First iteration `this` value');
+assert.sameValue(thisVals[1], thisVal, 'Second iteration `this` value');

--- a/test/built-ins/Array/from/iter-map-fn-this-non-strict.js
+++ b/test/built-ins/Array/from/iter-map-fn-this-non-strict.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: >
+    `this` value of mapping function in non-strict mode (traversed via iterator)
+info: >
+    [...]
+    2. If mapfn is undefined, let mapping be false.
+    3. else
+       a. If IsCallable(mapfn) is false, throw a TypeError exception.
+       b. If thisArg was supplied, let T be thisArg; else let T be undefined.
+       c. Let mapping be true
+    [...]
+    6. If usingIterator is not undefined, then
+       [...]
+       g. Repeat
+          [...]
+          vii. If mapping is true, then
+               1. Let mappedValue be Call(mapfn, T, «nextValue, k»).
+features: [Symbol.iterator]
+flags: [noStrict]
+---*/
+
+var thisVals = [];
+var nextResult = { done: false, value: {} };
+var nextNextResult = { done: false, value: {} };
+var mapFn = function() {
+  thisVals.push(this);
+};
+var items = {};
+var global = function() { return this; }();
+
+items[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      var result = nextResult;
+      nextResult = nextNextResult;
+      nextNextResult = { done: true };
+
+      return result;
+    }
+  };
+};
+
+Array.from(items, mapFn);
+
+assert.sameValue(thisVals.length, 2);
+assert.sameValue(thisVals[0], global, 'First iteration `this` value');
+assert.sameValue(thisVals[1], global, 'Second iteration `this` value');

--- a/test/built-ins/Array/from/iter-map-fn-this-strict.js
+++ b/test/built-ins/Array/from/iter-map-fn-this-strict.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: >
+    `this` value of mapping function in strict mode (traversed via iterator)
+info: >
+    [...]
+    2. If mapfn is undefined, let mapping be false.
+    3. else
+       a. If IsCallable(mapfn) is false, throw a TypeError exception.
+       b. If thisArg was supplied, let T be thisArg; else let T be undefined.
+       c. Let mapping be true
+    [...]
+    6. If usingIterator is not undefined, then
+       [...]
+       g. Repeat
+          [...]
+          vii. If mapping is true, then
+               1. Let mappedValue be Call(mapfn, T, «nextValue, k»).
+features: [Symbol.iterator]
+flags: [onlyStrict]
+---*/
+
+var thisVals = [];
+var nextResult = { done: false, value: {} };
+var nextNextResult = { done: false, value: {} };
+var mapFn = function() {
+  thisVals.push(this);
+};
+var items = {};
+
+items[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      var result = nextResult;
+      nextResult = nextNextResult;
+      nextNextResult = { done: true };
+
+      return result;
+    }
+  };
+};
+
+Array.from(items, mapFn);
+
+assert.sameValue(thisVals.length, 2);
+assert.sameValue(thisVals[0], undefined, 'First iteration `this` value');
+assert.sameValue(thisVals[1], undefined, 'Second iteration `this` value');

--- a/test/built-ins/Array/from/iter-set-elem-prop-err.js
+++ b/test/built-ins/Array/from/iter-set-elem-prop-err.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: Error setting property on result value (traversed via iterator)
+info: >
+    [...]
+    6. If usingIterator is not undefined, then
+       [...]
+       g. Repeat
+          [...]
+          ix. Let defineStatus be CreateDataPropertyOrThrow(A, Pk,
+              mappedValue).
+          x. If defineStatus is an abrupt completion, return
+             IteratorClose(iterator, defineStatus).
+features: [Symbol.iterator]
+---*/
+
+var C = function() {
+  Object.defineProperty(this, '0', { configurable: false });
+};
+var closeCount = 0;
+var items = {};
+var nextResult = { done: false };
+
+items[Symbol.iterator] = function() {
+  return {
+    return: function() {
+      closeCount += 1;
+    },
+    next: function() {
+      var result = nextResult;
+
+      nextResult = { done: true };
+
+      return result;
+    }
+  };
+};
+
+assert.throws(TypeError, function() {
+  Array.from.call(C, items);
+});
+
+assert.sameValue(closeCount, 1);

--- a/test/built-ins/Array/from/iter-set-elem-prop.js
+++ b/test/built-ins/Array/from/iter-set-elem-prop.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: Setting property on result value (traversed via iterator)
+info: >
+    [...]
+    6. If usingIterator is not undefined, then
+       [...]
+       g. Repeat
+          [...]
+          ix. Let defineStatus be CreateDataPropertyOrThrow(A, Pk,
+              mappedValue).
+features: [Symbol.iterator]
+---*/
+
+var items = {};
+var firstIterResult = { done: false, value: {} };
+var secondIterResult = { done: false, value: {} };
+var thirdIterResult = { done: true, value: {} };
+var nextIterResult = firstIterResult;
+var nextNextIterResult = secondIterResult;
+var result;
+
+items[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      var result = nextIterResult;
+
+      nextIterResult = nextNextIterResult;
+      nextNextIterResult = thirdIterResult;
+
+      return result;
+    }
+  };
+};
+
+result = Array.from(items);
+
+assert.sameValue(result[0], firstIterResult.value);
+assert.sameValue(result[1], secondIterResult.value);

--- a/test/built-ins/Array/from/iter-set-length-err.js
+++ b/test/built-ins/Array/from/iter-set-length-err.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: Error setting length of object (traversed via iterator)
+info: >
+    [...]
+    6. If usingIterator is not undefined, then
+       [...]
+       g. Repeat
+          [...]
+          iv. If next is false, then
+              1. Let setStatus be Set(A, "length", k, true).
+              2. ReturnIfAbrupt(setStatus).
+features: [Symbol.iterator]
+---*/
+
+var C = function() {};
+var items = {};
+Object.defineProperty(C.prototype, 'length', {
+  set: function(_) {
+    throw new Test262Error();
+  }
+});
+items[Symbol.iterator] = function() {
+  return {
+    next: function() { return { done: true }; }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  Array.from.call(C, items);
+});

--- a/test/built-ins/Array/from/iter-set-length.js
+++ b/test/built-ins/Array/from/iter-set-length.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.2.1
+description: Setting length of object (traversed via iterator)
+info: >
+    [...]
+    6. If usingIterator is not undefined, then
+       [...]
+       g. Repeat
+          [...]
+          iv. If next is false, then
+              1. Let setStatus be Set(A, "length", k, true).
+              2. ReturnIfAbrupt(setStatus).
+              3. Return A.
+features: [Symbol.iterator]
+---*/
+
+var items = {};
+var result, nextIterResult, lastIterResult;
+items[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      var result = nextIterResult;
+      nextIterResult = lastIterResult;
+      return result;
+    }
+  };
+};
+
+nextIterResult = lastIterResult = { done: true };
+result = Array.from(items);
+
+assert.sameValue(result.length, 0);
+
+nextIterResult = { done: false };
+lastIterResult = { done: true };
+result = Array.from(items);
+
+assert.sameValue(result.length, 1);

--- a/test/built-ins/Array/prototype/values/length.js
+++ b/test/built-ins/Array/prototype/values/length.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.29
+description: Array.prototype.values `length` property
+info: >
+    ES6 Section 17:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this value
+    is equal to the largest number of named arguments shown in the subclause
+    headings for the function description, including optional parameters.
+
+    [...]
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Array.prototype.values.length, 0);
+
+verifyNotEnumerable(Array.prototype.values, 'length');
+verifyNotWritable(Array.prototype.values, 'length');
+verifyConfigurable(Array.prototype.values, 'length');

--- a/test/built-ins/Array/prototype/values/name.js
+++ b/test/built-ins/Array/prototype/values/name.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.29
+description: Array.prototype.values `name` property
+info: >
+    ES6 Section 17:
+
+    Every built-in Function object, including constructors, that is not
+    identified as an anonymous function has a name property whose value is a
+    String. Unless otherwise specified, this value is the name that is given to
+    the function in this specification.
+
+    [...]
+
+    Unless otherwise specified, the name property of a built-in Function
+    object, if it exists, has the attributes { [[Writable]]: false,
+    [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Array.prototype.values.name, 'values');
+
+verifyNotEnumerable(Array.prototype.values, 'name');
+verifyNotWritable(Array.prototype.values, 'name');
+verifyConfigurable(Array.prototype.values, 'name');

--- a/test/built-ins/Array/prototype/values/prop-desc.js
+++ b/test/built-ins/Array/prototype/values/prop-desc.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.29
+description: Array.prototype.values property descriptor
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(typeof Array.prototype.values, 'function');
+
+verifyNotEnumerable(Array.prototype, 'values');
+verifyWritable(Array.prototype, 'values');
+verifyConfigurable(Array.prototype, 'values');

--- a/test/built-ins/Array/prototype/values/this-val-non-obj-coercible.js
+++ b/test/built-ins/Array/prototype/values/this-val-non-obj-coercible.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.29
+description: >
+    `this` value not object coercible
+info: >
+    1. Let O be ToObject(this value).
+    2. ReturnIfAbrupt(O).
+---*/
+
+assert.throws(TypeError, function() {
+  Array.prototype.values.call(undefined);
+});
+
+assert.throws(TypeError, function() {
+  Array.prototype.values.call(null);
+});

--- a/test/built-ins/IteratorPrototype/Symbol.iterator/length.js
+++ b/test/built-ins/IteratorPrototype/Symbol.iterator/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 25.1.2.1
+description: Length of IteratorPrototype[ @@iterator ]
+info: >
+    ES6 Section 17:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this value
+    is equal to the largest number of named arguments shown in the subclause
+    headings for the function description, including optional parameters.
+
+    [...]
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+features: [Symbol.iterator]
+includes: [propertyHelper.js]
+---*/
+
+var IteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([][Symbol.iterator]())
+);
+
+assert.sameValue(IteratorPrototype[Symbol.iterator].length, 0);
+
+verifyNotEnumerable(IteratorPrototype[Symbol.iterator], 'length');
+verifyNotWritable(IteratorPrototype[Symbol.iterator], 'length');
+verifyConfigurable(IteratorPrototype[Symbol.iterator], 'length');

--- a/test/built-ins/IteratorPrototype/Symbol.iterator/name.js
+++ b/test/built-ins/IteratorPrototype/Symbol.iterator/name.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 25.1.2.1
+description: Descriptor for `name` property
+info: >
+  The value of the name property of this function is "[Symbol.iterator]".
+
+  ES6 Section 17: ECMAScript Standard Built-in Objects
+
+  Every built-in Function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value is a
+  String. Unless otherwise specified, this value is the name that is given to
+  the function in this specification.
+
+  [...]
+
+  Unless otherwise specified, the name property of a built-in Function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+features: [Symbol.iterator]
+includes: [propertyHelper.js]
+---*/
+
+var IteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([][Symbol.iterator]())
+);
+
+assert.sameValue(IteratorPrototype[Symbol.iterator].name, '[Symbol.iterator]');
+
+verifyNotEnumerable(IteratorPrototype[Symbol.iterator], 'name');
+verifyNotWritable(IteratorPrototype[Symbol.iterator], 'name');
+verifyConfigurable(IteratorPrototype[Symbol.iterator], 'name');

--- a/test/built-ins/IteratorPrototype/Symbol.iterator/prop-desc.js
+++ b/test/built-ins/IteratorPrototype/Symbol.iterator/prop-desc.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 25.1.2.1
+description: Property descriptor
+info: >
+    ES6 Section 17
+
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+features: [Symbol.iterator]
+includes: [propertyHelper.js]
+---*/
+
+var IteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([][Symbol.iterator]())
+);
+
+assert.sameValue(typeof IteratorPrototype[Symbol.iterator], 'function');
+verifyNotEnumerable(IteratorPrototype, Symbol.iterator);
+verifyWritable(IteratorPrototype, Symbol.iterator);
+verifyConfigurable(IteratorPrototype, Symbol.iterator);

--- a/test/built-ins/IteratorPrototype/Symbol.iterator/return-val.js
+++ b/test/built-ins/IteratorPrototype/Symbol.iterator/return-val.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 25.1.2.1
+description: Descriptor for `name` property
+info: >
+    1. Return the this value.
+features: [Symbol.iterator]
+---*/
+
+var IteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([][Symbol.iterator]())
+);
+var thisValue = {};
+
+assert.sameValue(
+  IteratorPrototype[Symbol.iterator].call(thisValue),
+  thisValue
+);

--- a/test/built-ins/String/prototype/Symbol.iterator/length.js
+++ b/test/built-ins/String/prototype/Symbol.iterator/length.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 25.1.3.27
+description: Length of String.prototype[ @@iterator ]
+info: >
+    ES6 Section 17:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this value
+    is equal to the largest number of named arguments shown in the subclause
+    headings for the function description, including optional parameters.
+
+    [...]
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+features: [Symbol.iterator]
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(String.prototype[Symbol.iterator].length, 0);
+
+verifyNotEnumerable(String.prototype[Symbol.iterator], 'length');
+verifyNotWritable(String.prototype[Symbol.iterator], 'length');
+verifyConfigurable(String.prototype[Symbol.iterator], 'length');

--- a/test/built-ins/String/prototype/Symbol.iterator/name.js
+++ b/test/built-ins/String/prototype/Symbol.iterator/name.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 25.1.3.27
+description: Descriptor for `name` property
+info: >
+  The value of the name property of this function is "[Symbol.iterator]".
+
+  ES6 Section 17: ECMAScript Standard Built-in Objects
+
+  Every built-in Function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value is a
+  String. Unless otherwise specified, this value is the name that is given to
+  the function in this specification.
+
+  [...]
+
+  Unless otherwise specified, the name property of a built-in Function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+features: [Symbol.iterator]
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(String.prototype[Symbol.iterator].name, '[Symbol.iterator]');
+
+verifyNotEnumerable(String.prototype[Symbol.iterator], 'name');
+verifyNotWritable(String.prototype[Symbol.iterator], 'name');
+verifyConfigurable(String.prototype[Symbol.iterator], 'name');

--- a/test/built-ins/String/prototype/Symbol.iterator/prop-desc.js
+++ b/test/built-ins/String/prototype/Symbol.iterator/prop-desc.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 25.1.3.27
+description: Property descriptor
+info: >
+    ES6 Section 17
+
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+features: [Symbol.iterator]
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(typeof String.prototype[Symbol.iterator], 'function');
+verifyNotEnumerable(String.prototype, Symbol.iterator);
+verifyWritable(String.prototype, Symbol.iterator);
+verifyConfigurable(String.prototype, Symbol.iterator);

--- a/test/built-ins/String/prototype/Symbol.iterator/this-val-non-obj-coercible.js
+++ b/test/built-ins/String/prototype/Symbol.iterator/this-val-non-obj-coercible.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 25.1.3.27
+description: The `this` value cannot be coerced into an object
+info: >
+    1. Let O be RequireObjectCoercible(this value).
+    2. Let S be ToString(O).
+    3. ReturnIfAbrupt(S).
+features: [Symbol.iterator]
+---*/
+
+assert.throws(TypeError, function() {
+  String.prototype[Symbol.iterator].call(undefined);
+});
+
+assert.throws(TypeError, function() {
+  String.prototype[Symbol.iterator].call(null);
+});

--- a/test/built-ins/String/prototype/Symbol.iterator/this-val-to-str-err.js
+++ b/test/built-ins/String/prototype/Symbol.iterator/this-val-to-str-err.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 25.1.3.27
+description: Error thrown coercing `this` value to a string
+info: >
+    1. Let O be RequireObjectCoercible(this value).
+    2. Let S be ToString(O).
+    3. ReturnIfAbrupt(S).
+features: [Symbol.iterator]
+---*/
+
+var obj = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  String.prototype[Symbol.iterator].call(obj);
+});

--- a/test/built-ins/Symbol/iterator/prop-desc.js
+++ b/test/built-ins/Symbol/iterator/prop-desc.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.4.2.4
+description: >
+    `Symbol.iterator` property descriptor
+info: >
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+features: [Symbol.iterator]
+---*/
+
+assert.sameValue(typeof Symbol.iterator, 'symbol');
+verifyNotEnumerable(Symbol, 'iterator');
+verifyNotWritable(Symbol, 'iterator');
+verifyNotConfigurable(Symbol, 'iterator');


### PR DESCRIPTION
Because the well-known `@@iterator` Symbol is used in many parts of the ES6 specification, it already has substantial coverage in Test262. See, for instance:

- [`language/statements/for-of`](https://github.com/tc39/test262/tree/d62f3a82b97dba22a0be2798fbe34548e96a439f/test/language/statements/for-of)
- [`built-ins/ArrayIteratorPrototype`](https://github.com/tc39/test262/tree/d62f3a82b97dba22a0be2798fbe34548e96a439f/test/built-ins/ArrayIteratorPrototype)
- [`built-ins/MapIteratorPrototype`](https://github.com/tc39/test262/tree/d62f3a82b97dba22a0be2798fbe34548e96a439f/test/built-ins/MapIteratorPrototype)
- [`built-ins/SetIteratorPrototype`](https://github.com/tc39/test262/tree/d62f3a82b97dba22a0be2798fbe34548e96a439f/test/built-ins/SetIteratorPrototype)
- [`built-ins/StringIteratorPrototype`](https://github.com/tc39/test262/tree/d62f3a82b97dba22a0be2798fbe34548e96a439f/test/built-ins/StringIteratorPrototype)
- [`built-ins/Map`](https://github.com/tc39/test262/tree/d62f3a82b97dba22a0be2798fbe34548e96a439f/test/built-ins/Map)
- [`built-ins/Set`](https://github.com/tc39/test262/tree/d62f3a82b97dba22a0be2798fbe34548e96a439f/test/built-ins/Set)
- [`built-ins/WeakMap`](https://github.com/tc39/test262/tree/d62f3a82b97dba22a0be2798fbe34548e96a439f/test/built-ins/WeakMap)
- [`built-ins/WeakSet`](https://github.com/tc39/test262/tree/d62f3a82b97dba22a0be2798fbe34548e96a439f/test/built-ins/WeakSet)

This changeset fills out the coverage to include other sections that reference the Symbol. Exceptions:

- [%TypedArray%.prototype[@@iterator]](http://www.ecma-international.org/ecma-262/6.0/#sec-%typedarray%.prototype-@@iterator):
  Testing this thoroughly will involve testing each of [the nine TypedArray
  element
  types](http://www.ecma-international.org/ecma-262/6.0/#sec-typedarray-objects),
  and doing *that* in a sustainable way requires some maintenance strategy
  (see for example gh-276).
- [Module namespace @@iterator](http://www.ecma-international.org/ecma-262/6.0/#sec-@@iterator):
  I don't think this is testable in the absence of a loader (I'd welcome
  suggestions, though!)

This patch has only minor duplication with the recently-opened [gh-376 ("update tests for Array.from")](https://github.com/tc39/test262/pull/376) because the tests for `Array.from` included here are limited to the effect of the `Symbol.iterator` property.

@bterlson: I've organized the changes into separate commits according to the built-in under test. I could see merging this as a single commit, but I could also see splitting it up into separate pull requests for each commit. I'm happy to proceed in whatever way you prefer.