### PR TITLE
Change license headers to standard format

### DIFF
--- a/test/annexB/templates/legacy-octal-escape-sequence-non-strict.js
+++ b/test/annexB/templates/legacy-octal-escape-sequence-non-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8

--- a/test/annexB/templates/legacy-octal-escape-sequence-strict.js
+++ b/test/annexB/templates/legacy-octal-escape-sequence-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8

--- a/test/built-ins/Array/prototype/sort/bug_596_1.js
+++ b/test/built-ins/Array/prototype/sort/bug_596_1.js
@@ -1,25 +1,5 @@
-// Copyright (c) 2014, Thomas Dahlstrom All rights reserved. Redistribution
-// and use in source and binary forms, with or without modification, are
-// permitted provided that the following conditions are met:
-// // 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission. 
-// // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Thomas Dahlstrom. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 description: >

--- a/test/built-ins/Array/prototype/sort/bug_596_2.js
+++ b/test/built-ins/Array/prototype/sort/bug_596_2.js
@@ -1,25 +1,5 @@
-// Copyright (c) 2014, Thomas Dahlstrom All rights reserved. Redistribution
-// and use in source and binary forms, with or without modification, are
-// permitted provided that the following conditions are met:
-// // 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission. 
-// // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Thomas Dahlstrom. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 description: >

--- a/test/built-ins/ArrayIteratorPrototype/next/Float32Array.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/Float32Array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 22.1.5.2.1

--- a/test/built-ins/ArrayIteratorPrototype/next/Float64Array.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/Float64Array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 22.1.5.2.1

--- a/test/built-ins/ArrayIteratorPrototype/next/Int16Array.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/Int16Array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 22.1.5.2.1

--- a/test/built-ins/ArrayIteratorPrototype/next/Int32Array.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/Int32Array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 22.1.5.2.1

--- a/test/built-ins/ArrayIteratorPrototype/next/Int8Array.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/Int8Array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 22.1.5.2.1

--- a/test/built-ins/ArrayIteratorPrototype/next/Uint16Array.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/Uint16Array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 22.1.5.2.1

--- a/test/built-ins/ArrayIteratorPrototype/next/Uint32Array.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/Uint32Array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 22.1.5.2.1

--- a/test/built-ins/ArrayIteratorPrototype/next/Uint8Array.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/Uint8Array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 22.1.5.2.1

--- a/test/built-ins/ArrayIteratorPrototype/next/Uint8ClampedArray.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/Uint8ClampedArray.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 22.1.5.2.1

--- a/test/built-ins/ArrayIteratorPrototype/next/args-mapped-expansion-after-exhaustion.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/args-mapped-expansion-after-exhaustion.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 9.4.4.7 S22

--- a/test/built-ins/ArrayIteratorPrototype/next/args-mapped-expansion-before-exhaustion.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/args-mapped-expansion-before-exhaustion.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 9.4.4.7 S22

--- a/test/built-ins/ArrayIteratorPrototype/next/args-mapped-iteration.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/args-mapped-iteration.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 9.4.4.7 S22

--- a/test/built-ins/ArrayIteratorPrototype/next/args-mapped-truncation-before-exhaustion.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/args-mapped-truncation-before-exhaustion.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 9.4.4.7 S22

--- a/test/built-ins/ArrayIteratorPrototype/next/args-unmapped-expansion-after-exhaustion.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/args-unmapped-expansion-after-exhaustion.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 9.4.4.6 S7

--- a/test/built-ins/ArrayIteratorPrototype/next/args-unmapped-expansion-before-exhaustion.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/args-unmapped-expansion-before-exhaustion.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 9.4.4.6 S7

--- a/test/built-ins/ArrayIteratorPrototype/next/args-unmapped-iteration.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/args-unmapped-iteration.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 9.4.4.6 S7

--- a/test/built-ins/ArrayIteratorPrototype/next/args-unmapped-truncation-before-exhaustion.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/args-unmapped-truncation-before-exhaustion.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 9.4.4.6 S7

--- a/test/built-ins/Boolean/symbol-coercion.js
+++ b/test/built-ins/Boolean/symbol-coercion.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 7.1.2

--- a/test/built-ins/Map/symbol-as-entry-key.js
+++ b/test/built-ins/Map/symbol-as-entry-key.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.4

--- a/test/built-ins/Math/clz32/Math.clz32.js
+++ b/test/built-ins/Math/clz32/Math.clz32.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.11

--- a/test/built-ins/Math/clz32/Math.clz32_1.js
+++ b/test/built-ins/Math/clz32/Math.clz32_1.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.11

--- a/test/built-ins/Math/clz32/Math.clz32_2.js
+++ b/test/built-ins/Math/clz32/Math.clz32_2.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.11

--- a/test/built-ins/Math/fround/Math.fround_Infinity.js
+++ b/test/built-ins/Math/fround/Math.fround_Infinity.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.17

--- a/test/built-ins/Math/fround/Math.fround_NaN.js
+++ b/test/built-ins/Math/fround/Math.fround_NaN.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.17

--- a/test/built-ins/Math/fround/Math.fround_Zero.js
+++ b/test/built-ins/Math/fround/Math.fround_Zero.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.17

--- a/test/built-ins/Math/hypot/Math.hypot_Infinity.js
+++ b/test/built-ins/Math/hypot/Math.hypot_Infinity.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.18

--- a/test/built-ins/Math/hypot/Math.hypot_InfinityNaN.js
+++ b/test/built-ins/Math/hypot/Math.hypot_InfinityNaN.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.18

--- a/test/built-ins/Math/hypot/Math.hypot_NaN.js
+++ b/test/built-ins/Math/hypot/Math.hypot_NaN.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.18

--- a/test/built-ins/Math/hypot/Math.hypot_NegInfinity.js
+++ b/test/built-ins/Math/hypot/Math.hypot_NegInfinity.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.18

--- a/test/built-ins/Math/hypot/Math.hypot_NoArgs.js
+++ b/test/built-ins/Math/hypot/Math.hypot_NoArgs.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.18

--- a/test/built-ins/Math/hypot/Math.hypot_Success.js
+++ b/test/built-ins/Math/hypot/Math.hypot_Success.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.18

--- a/test/built-ins/Math/hypot/Math.hypot_Success_2.js
+++ b/test/built-ins/Math/hypot/Math.hypot_Success_2.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.18

--- a/test/built-ins/Math/hypot/Math.hypot_Zero_2.js
+++ b/test/built-ins/Math/hypot/Math.hypot_Zero_2.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.18

--- a/test/built-ins/Math/hypot/Math.hypot_lengthProp.js
+++ b/test/built-ins/Math/hypot/Math.hypot_lengthProp.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.18

--- a/test/built-ins/Math/trunc/Math.trunc_Infinity.js
+++ b/test/built-ins/Math/trunc/Math.trunc_Infinity.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.35

--- a/test/built-ins/Math/trunc/Math.trunc_NaN.js
+++ b/test/built-ins/Math/trunc/Math.trunc_NaN.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.35

--- a/test/built-ins/Math/trunc/Math.trunc_NegDecimal.js
+++ b/test/built-ins/Math/trunc/Math.trunc_NegDecimal.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.35

--- a/test/built-ins/Math/trunc/Math.trunc_PosDecimal.js
+++ b/test/built-ins/Math/trunc/Math.trunc_PosDecimal.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.35

--- a/test/built-ins/Math/trunc/Math.trunc_Success.js
+++ b/test/built-ins/Math/trunc/Math.trunc_Success.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.35

--- a/test/built-ins/Math/trunc/Math.trunc_Zero.js
+++ b/test/built-ins/Math/trunc/Math.trunc_Zero.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.2.2.35

--- a/test/built-ins/Number/isInteger/Number.isInteger_Double.js
+++ b/test/built-ins/Number/isInteger/Number.isInteger_Double.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.1.2.3

--- a/test/built-ins/Number/isInteger/Number.isInteger_Infinity.js
+++ b/test/built-ins/Number/isInteger/Number.isInteger_Infinity.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.1.2.3

--- a/test/built-ins/Number/isInteger/Number.isInteger_NaN.js
+++ b/test/built-ins/Number/isInteger/Number.isInteger_NaN.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.1.2.3

--- a/test/built-ins/Number/isInteger/Number.isInteger_NonNumber.js
+++ b/test/built-ins/Number/isInteger/Number.isInteger_NonNumber.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.1.2.3

--- a/test/built-ins/Number/isInteger/Number.isInteger_String.js
+++ b/test/built-ins/Number/isInteger/Number.isInteger_String.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.1.2.3

--- a/test/built-ins/Number/isInteger/Number.isInteger_Success.js
+++ b/test/built-ins/Number/isInteger/Number.isInteger_Success.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.1.2.3

--- a/test/built-ins/Number/isNaN/Number.isNaN_Boolean.js
+++ b/test/built-ins/Number/isNaN/Number.isNaN_Boolean.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.1.2.4

--- a/test/built-ins/Number/isNaN/Number.isNaN_NaN.js
+++ b/test/built-ins/Number/isNaN/Number.isNaN_NaN.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.1.2.4

--- a/test/built-ins/Number/isNaN/Number.isNaN_Object.js
+++ b/test/built-ins/Number/isNaN/Number.isNaN_Object.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.1.2.4

--- a/test/built-ins/Number/isNaN/Number.isNaN_String.js
+++ b/test/built-ins/Number/isNaN/Number.isNaN_String.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 es6id: 20.1.2.4

--- a/test/built-ins/Number/symbol-number-coercion.js
+++ b/test/built-ins/Number/symbol-number-coercion.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 7.1.3

--- a/test/built-ins/Object/defineProperty/symbol-data-property-configurable.js
+++ b/test/built-ins/Object/defineProperty/symbol-data-property-configurable.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.1.2.4

--- a/test/built-ins/Object/defineProperty/symbol-data-property-default-non-strict.js
+++ b/test/built-ins/Object/defineProperty/symbol-data-property-default-non-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.1.2.4

--- a/test/built-ins/Object/defineProperty/symbol-data-property-default-strict.js
+++ b/test/built-ins/Object/defineProperty/symbol-data-property-default-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.1.2.4

--- a/test/built-ins/Object/defineProperty/symbol-data-property-writable.js
+++ b/test/built-ins/Object/defineProperty/symbol-data-property-writable.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.1.2.4

--- a/test/built-ins/Object/freeze/frozen-object-contains-symbol-properties-non-strict.js
+++ b/test/built-ins/Object/freeze/frozen-object-contains-symbol-properties-non-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.1.2.5

--- a/test/built-ins/Object/freeze/frozen-object-contains-symbol-properties-strict.js
+++ b/test/built-ins/Object/freeze/frozen-object-contains-symbol-properties-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.1.2.5

--- a/test/built-ins/Object/getOwnPropertySymbols/object-contains-symbol-property-with-description.js
+++ b/test/built-ins/Object/getOwnPropertySymbols/object-contains-symbol-property-with-description.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.1.2.8

--- a/test/built-ins/Object/getOwnPropertySymbols/object-contains-symbol-property-without-description.js
+++ b/test/built-ins/Object/getOwnPropertySymbols/object-contains-symbol-property-without-description.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.1.2.8

--- a/test/built-ins/Object/is/symbol-object-is-same-value.js
+++ b/test/built-ins/Object/is/symbol-object-is-same-value.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 7.2.

--- a/test/built-ins/Object/preventExtensions/symbol-object-contains-symbol-properties-non-strict.js
+++ b/test/built-ins/Object/preventExtensions/symbol-object-contains-symbol-properties-non-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.4

--- a/test/built-ins/Object/preventExtensions/symbol-object-contains-symbol-properties-strict.js
+++ b/test/built-ins/Object/preventExtensions/symbol-object-contains-symbol-properties-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.4

--- a/test/built-ins/Object/seal/symbol-object-contains-symbol-properties-non-strict.js
+++ b/test/built-ins/Object/seal/symbol-object-contains-symbol-properties-non-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.4

--- a/test/built-ins/Object/seal/symbol-object-contains-symbol-properties-strict.js
+++ b/test/built-ins/Object/seal/symbol-object-contains-symbol-properties-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.4

--- a/test/built-ins/Object/symbol_object-returns-fresh-symbol.js
+++ b/test/built-ins/Object/symbol_object-returns-fresh-symbol.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.1.1.1_S3

--- a/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Fail.js
+++ b/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Fail.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 author: Ryan Lewis

--- a/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Fail_2.js
+++ b/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Fail_2.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 author: Ryan Lewis

--- a/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Success.js
+++ b/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Success.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 author: Ryan Lewis

--- a/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_2.js
+++ b/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_2.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 author: Ryan Lewis

--- a/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_3.js
+++ b/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_3.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 author: Ryan Lewis

--- a/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_4.js
+++ b/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_4.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 author: Ryan Lewis

--- a/test/built-ins/String/prototype/includes/String.prototype.includes_FailBadLocation.js
+++ b/test/built-ins/String/prototype/includes/String.prototype.includes_FailBadLocation.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 author: Ryan Lewis

--- a/test/built-ins/String/prototype/includes/String.prototype.includes_FailLocation.js
+++ b/test/built-ins/String/prototype/includes/String.prototype.includes_FailLocation.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 author: Ryan Lewis

--- a/test/built-ins/String/prototype/includes/String.prototype.includes_FailMissingLetter.js
+++ b/test/built-ins/String/prototype/includes/String.prototype.includes_FailMissingLetter.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 author: Ryan Lewis

--- a/test/built-ins/String/prototype/includes/String.prototype.includes_Success.js
+++ b/test/built-ins/String/prototype/includes/String.prototype.includes_Success.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 author: Ryan Lewis

--- a/test/built-ins/String/prototype/includes/String.prototype.includes_SuccessNoLocation.js
+++ b/test/built-ins/String/prototype/includes/String.prototype.includes_SuccessNoLocation.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 author: Ryan Lewis

--- a/test/built-ins/String/prototype/includes/String.prototype.includes_lengthProp.js
+++ b/test/built-ins/String/prototype/includes/String.prototype.includes_lengthProp.js
@@ -1,8 +1,5 @@
-// Copyright (c) 2014, Ryan Lewis All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014 Ryan Lewis. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 author: Ryan Lewis

--- a/test/built-ins/String/raw/special-characters.js
+++ b/test/built-ins/String/raw/special-characters.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 21.1.2.4

--- a/test/built-ins/String/raw/zero-literal-segments.js
+++ b/test/built-ins/String/raw/zero-literal-segments.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 21.1.2.4

--- a/test/built-ins/String/symbol-string-coercion.js
+++ b/test/built-ins/String/symbol-string-coercion.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.4.3.2

--- a/test/built-ins/StringIteratorPrototype/Symbol.toStringTag.js
+++ b/test/built-ins/StringIteratorPrototype/Symbol.toStringTag.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 21.1.5.2.1

--- a/test/built-ins/StringIteratorPrototype/ancestry.js
+++ b/test/built-ins/StringIteratorPrototype/ancestry.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 21.1.5.2

--- a/test/built-ins/StringIteratorPrototype/next/next-iteration-surrogate-pairs.js
+++ b/test/built-ins/StringIteratorPrototype/next/next-iteration-surrogate-pairs.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 21.1.5.2.1

--- a/test/built-ins/StringIteratorPrototype/next/next-iteration.js
+++ b/test/built-ins/StringIteratorPrototype/next/next-iteration.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 21.1.5.2.1

--- a/test/built-ins/StringIteratorPrototype/next/next-missing-internal-slots.js
+++ b/test/built-ins/StringIteratorPrototype/next/next-missing-internal-slots.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 21.1.5.2.1 S 3

--- a/test/built-ins/Symbol/auto-boxing-non-strict.js
+++ b/test/built-ins/Symbol/auto-boxing-non-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.4

--- a/test/built-ins/Symbol/auto-boxing-strict.js
+++ b/test/built-ins/Symbol/auto-boxing-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.4

--- a/test/built-ins/Symbol/constructor.js
+++ b/test/built-ins/Symbol/constructor.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.4.3.1

--- a/test/built-ins/Symbol/prototype/@@toStringTag/@@toStringTag.js
+++ b/test/built-ins/Symbol/prototype/@@toStringTag/@@toStringTag.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.4.3.2

--- a/test/built-ins/Symbol/prototype/intrinsic.js
+++ b/test/built-ins/Symbol/prototype/intrinsic.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.4.3

--- a/test/built-ins/Symbol/prototype/toString/toString-default-attributes-non-strict.js
+++ b/test/built-ins/Symbol/prototype/toString/toString-default-attributes-non-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.4

--- a/test/built-ins/Symbol/prototype/toString/toString-default-attributes-strict.js
+++ b/test/built-ins/Symbol/prototype/toString/toString-default-attributes-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.4

--- a/test/built-ins/Symbol/prototype/toString/toString.js
+++ b/test/built-ins/Symbol/prototype/toString/toString.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 19.4.3.2

--- a/test/built-ins/WeakSet/symbol-disallowed-as-weakset-key.js
+++ b/test/built-ins/WeakSet/symbol-disallowed-as-weakset-key.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 23.4.3.1_S2

--- a/test/language/arguments-object/mapped/Symbol.iterator.js
+++ b/test/language/arguments-object/mapped/Symbol.iterator.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 9.4.4.7 S22

--- a/test/language/arguments-object/unmapped/Symbol.iterator.js
+++ b/test/language/arguments-object/unmapped/Symbol.iterator.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 9.4.4.6 S7

--- a/test/language/expressions/assignment/destructuring/obj-id-identifier-yield-expr.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-identifier-yield-expr.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
 /*---
 description: >
     `yield` is not a valid IdentifierReference in an AssignmentProperty within

--- a/test/language/expressions/assignment/destructuring/obj-id-identifier-yield-ident-invalid.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-identifier-yield-ident-invalid.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
 /*---
 description: >
     `yield` is not a valid IdentifierReference in an AssignmentProperty within

--- a/test/language/expressions/assignment/destructuring/obj-id-identifier-yield-ident-valid.js
+++ b/test/language/expressions/assignment/destructuring/obj-id-identifier-yield-ident-valid.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
 /*---
 description: >
     `yield` is a valid IdentifierReference in an AssignmentProperty outside of

--- a/test/language/expressions/conditional/symbol-conditional-evaluation.js
+++ b/test/language/expressions/conditional/symbol-conditional-evaluation.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.12.3

--- a/test/language/expressions/equals/symbol-abstract-equality-comparison.js
+++ b/test/language/expressions/equals/symbol-abstract-equality-comparison.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 7.2.12

--- a/test/language/expressions/equals/symbol-strict-equality-comparison.js
+++ b/test/language/expressions/equals/symbol-strict-equality-comparison.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 7.2.13

--- a/test/language/expressions/logical-and/symbol-logical-and-evaluation.js
+++ b/test/language/expressions/logical-and/symbol-logical-and-evaluation.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.12.3

--- a/test/language/expressions/logical-not/symbol-logical-not-evaluation.js
+++ b/test/language/expressions/logical-not/symbol-logical-not-evaluation.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.5.12.1

--- a/test/language/expressions/logical-or/symbol-logical-or-evaluation.js
+++ b/test/language/expressions/logical-or/symbol-logical-or-evaluation.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.12.3

--- a/test/language/expressions/object/prop-def-id-eval-error-2.js
+++ b/test/language/expressions/object/prop-def-id-eval-error-2.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5.9

--- a/test/language/expressions/object/prop-def-id-eval-error.js
+++ b/test/language/expressions/object/prop-def-id-eval-error.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5.9

--- a/test/language/expressions/object/prop-def-id-get-error.js
+++ b/test/language/expressions/object/prop-def-id-get-error.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5.9

--- a/test/language/expressions/object/prop-def-id-valid.js
+++ b/test/language/expressions/object/prop-def-id-valid.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5.9

--- a/test/language/expressions/tagged-template/cache-differing-expressions-eval.js
+++ b/test/language/expressions/tagged-template/cache-differing-expressions-eval.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8

--- a/test/language/expressions/tagged-template/cache-differing-expressions-new-function.js
+++ b/test/language/expressions/tagged-template/cache-differing-expressions-new-function.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8

--- a/test/language/expressions/tagged-template/cache-differing-expressions.js
+++ b/test/language/expressions/tagged-template/cache-differing-expressions.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8

--- a/test/language/expressions/tagged-template/cache-differing-raw-strings.js
+++ b/test/language/expressions/tagged-template/cache-differing-raw-strings.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8

--- a/test/language/expressions/tagged-template/cache-differing-string-count.js
+++ b/test/language/expressions/tagged-template/cache-differing-string-count.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8

--- a/test/language/expressions/tagged-template/cache-identical-source-eval.js
+++ b/test/language/expressions/tagged-template/cache-identical-source-eval.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8

--- a/test/language/expressions/tagged-template/cache-identical-source-new-function.js
+++ b/test/language/expressions/tagged-template/cache-identical-source-new-function.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8

--- a/test/language/expressions/tagged-template/cache-identical-source.js
+++ b/test/language/expressions/tagged-template/cache-identical-source.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8

--- a/test/language/expressions/tagged-template/call-expression-argument-list-evaluation.js
+++ b/test/language/expressions/tagged-template/call-expression-argument-list-evaluation.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.3.7

--- a/test/language/expressions/tagged-template/call-expression-context-no-strict.js
+++ b/test/language/expressions/tagged-template/call-expression-context-no-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.3.7

--- a/test/language/expressions/tagged-template/call-expression-context-strict.js
+++ b/test/language/expressions/tagged-template/call-expression-context-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.3.7

--- a/test/language/expressions/tagged-template/chained-application.js
+++ b/test/language/expressions/tagged-template/chained-application.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.3.7

--- a/test/language/expressions/tagged-template/constructor-invocation.js
+++ b/test/language/expressions/tagged-template/constructor-invocation.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.3.7

--- a/test/language/expressions/tagged-template/member-expression-argument-list-evaluation.js
+++ b/test/language/expressions/tagged-template/member-expression-argument-list-evaluation.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.3.7

--- a/test/language/expressions/tagged-template/member-expression-context.js
+++ b/test/language/expressions/tagged-template/member-expression-context.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.3.7

--- a/test/language/expressions/tagged-template/template-object-frozen-non-strict.js
+++ b/test/language/expressions/tagged-template/template-object-frozen-non-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.3.7

--- a/test/language/expressions/tagged-template/template-object-frozen-strict.js
+++ b/test/language/expressions/tagged-template/template-object-frozen-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.3.7

--- a/test/language/expressions/tagged-template/template-object.js
+++ b/test/language/expressions/tagged-template/template-object.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.3.7

--- a/test/language/expressions/template-literal/evaluation-order.js
+++ b/test/language/expressions/template-literal/evaluation-order.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8

--- a/test/language/expressions/template-literal/invalid-hexidecimal-character-escape-sequence-truncated.js
+++ b/test/language/expressions/template-literal/invalid-hexidecimal-character-escape-sequence-truncated.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.8.6.1

--- a/test/language/expressions/template-literal/invalid-legacy-octal-escape-sequence.js
+++ b/test/language/expressions/template-literal/invalid-legacy-octal-escape-sequence.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 16.1

--- a/test/language/expressions/template-literal/invalid-unicode-escape-sequence-truncated.js
+++ b/test/language/expressions/template-literal/invalid-unicode-escape-sequence-truncated.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.8.6

--- a/test/language/expressions/template-literal/literal-expr-abrupt.js
+++ b/test/language/expressions/template-literal/literal-expr-abrupt.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/literal-expr-function.js
+++ b/test/language/expressions/template-literal/literal-expr-function.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/literal-expr-member-expr.js
+++ b/test/language/expressions/template-literal/literal-expr-member-expr.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/literal-expr-method.js
+++ b/test/language/expressions/template-literal/literal-expr-method.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/literal-expr-obj.js
+++ b/test/language/expressions/template-literal/literal-expr-obj.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/literal-expr-primitive.js
+++ b/test/language/expressions/template-literal/literal-expr-primitive.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/literal-expr-template.js
+++ b/test/language/expressions/template-literal/literal-expr-template.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/literal-expr-tostr-error.js
+++ b/test/language/expressions/template-literal/literal-expr-tostr-error.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-many-expr-abrupt.js
+++ b/test/language/expressions/template-literal/middle-list-many-expr-abrupt.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-many-expr-function.js
+++ b/test/language/expressions/template-literal/middle-list-many-expr-function.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-many-expr-member-expr.js
+++ b/test/language/expressions/template-literal/middle-list-many-expr-member-expr.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-many-expr-method.js
+++ b/test/language/expressions/template-literal/middle-list-many-expr-method.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-many-expr-obj.js
+++ b/test/language/expressions/template-literal/middle-list-many-expr-obj.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-many-expr-primitive.js
+++ b/test/language/expressions/template-literal/middle-list-many-expr-primitive.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-many-expr-template.js
+++ b/test/language/expressions/template-literal/middle-list-many-expr-template.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-many-expr-tostr-error.js
+++ b/test/language/expressions/template-literal/middle-list-many-expr-tostr-error.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-one-expr-abrupt.js
+++ b/test/language/expressions/template-literal/middle-list-one-expr-abrupt.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-one-expr-function.js
+++ b/test/language/expressions/template-literal/middle-list-one-expr-function.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-one-expr-member-expr.js
+++ b/test/language/expressions/template-literal/middle-list-one-expr-member-expr.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-one-expr-method.js
+++ b/test/language/expressions/template-literal/middle-list-one-expr-method.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-one-expr-obj.js
+++ b/test/language/expressions/template-literal/middle-list-one-expr-obj.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-one-expr-primitive.js
+++ b/test/language/expressions/template-literal/middle-list-one-expr-primitive.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-one-expr-template.js
+++ b/test/language/expressions/template-literal/middle-list-one-expr-template.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/middle-list-one-expr-tostr-error.js
+++ b/test/language/expressions/template-literal/middle-list-one-expr-tostr-error.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/no-sub.js
+++ b/test/language/expressions/template-literal/no-sub.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.8.5

--- a/test/language/expressions/template-literal/tv-character-escape-sequence.js
+++ b/test/language/expressions/template-literal/tv-character-escape-sequence.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.8.6.1

--- a/test/language/expressions/template-literal/tv-hex-escape-sequence.js
+++ b/test/language/expressions/template-literal/tv-hex-escape-sequence.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.8.6.1

--- a/test/language/expressions/template-literal/tv-line-continuation.js
+++ b/test/language/expressions/template-literal/tv-line-continuation.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.8.6.1

--- a/test/language/expressions/template-literal/tv-line-terminator-sequence.js
+++ b/test/language/expressions/template-literal/tv-line-terminator-sequence.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.8.6.1

--- a/test/language/expressions/template-literal/tv-no-substitution.js
+++ b/test/language/expressions/template-literal/tv-no-substitution.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.8.6.1

--- a/test/language/expressions/template-literal/tv-null-character-escape-sequence.js
+++ b/test/language/expressions/template-literal/tv-null-character-escape-sequence.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.8.6.1

--- a/test/language/expressions/template-literal/tv-template-character.js
+++ b/test/language/expressions/template-literal/tv-template-character.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.8.6.1

--- a/test/language/expressions/template-literal/tv-template-characters.js
+++ b/test/language/expressions/template-literal/tv-template-characters.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.8.6.1

--- a/test/language/expressions/template-literal/tv-template-head.js
+++ b/test/language/expressions/template-literal/tv-template-head.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.8.6.1

--- a/test/language/expressions/template-literal/tv-template-middle.js
+++ b/test/language/expressions/template-literal/tv-template-middle.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.8.6.1

--- a/test/language/expressions/template-literal/tv-template-tail.js
+++ b/test/language/expressions/template-literal/tv-template-tail.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.8.6.1

--- a/test/language/expressions/template-literal/tv-utf16-escape-sequence.js
+++ b/test/language/expressions/template-literal/tv-utf16-escape-sequence.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.8.6.1

--- a/test/language/expressions/template-literal/tv-zwnbsp.js
+++ b/test/language/expressions/template-literal/tv-zwnbsp.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 11.1.8.6.1

--- a/test/language/expressions/typeof/symbol.js
+++ b/test/language/expressions/typeof/symbol.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2013 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.5.6.1

--- a/test/language/import/dup-bound-names.js
+++ b/test/language/import/dup-bound-names.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 15.2.1.1

--- a/test/language/module-code/dup-export-decl.js
+++ b/test/language/module-code/dup-export-decl.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 15.2.1.1

--- a/test/language/module-code/dup-export-dflt.js
+++ b/test/language/module-code/dup-export-dflt.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 15.2.1.1

--- a/test/language/module-code/dup-export-id-as.js
+++ b/test/language/module-code/dup-export-id-as.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 15.2.1.1

--- a/test/language/module-code/dup-export-id.js
+++ b/test/language/module-code/dup-export-id.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 15.2.1.1

--- a/test/language/module-code/dup-lables.js
+++ b/test/language/module-code/dup-lables.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 15.2.1.1

--- a/test/language/module-code/dup-lex.js
+++ b/test/language/module-code/dup-lex.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 10.2.1

--- a/test/language/module-code/export-unresolvable.js
+++ b/test/language/module-code/export-unresolvable.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 15.2.1.1

--- a/test/language/module-code/import-as-stmt-list-item.js
+++ b/test/language/module-code/import-as-stmt-list-item.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 15.2

--- a/test/language/module-code/lex-and-var.js
+++ b/test/language/module-code/lex-and-var.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 10.2.1

--- a/test/language/module-code/new-target.js
+++ b/test/language/module-code/new-target.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 15.2.1.1

--- a/test/language/module-code/super.js
+++ b/test/language/module-code/super.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 15.2.1.1

--- a/test/language/module-code/undef-break.js
+++ b/test/language/module-code/undef-break.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 15.2.1.1

--- a/test/language/module-code/undef-continue.js
+++ b/test/language/module-code/undef-continue.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 15.2.1.1

--- a/test/language/object-literal/concise-generator.js
+++ b/test/language/object-literal/concise-generator.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5

--- a/test/language/object-literal/descriptor.js
+++ b/test/language/object-literal/descriptor.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5

--- a/test/language/object-literal/getter.js
+++ b/test/language/object-literal/getter.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5

--- a/test/language/object-literal/identifier-reference-property-get-access.js
+++ b/test/language/object-literal/identifier-reference-property-get-access.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5

--- a/test/language/object-literal/let-non-strict-access.js
+++ b/test/language/object-literal/let-non-strict-access.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5

--- a/test/language/object-literal/let-non-strict-syntax.js
+++ b/test/language/object-literal/let-non-strict-syntax.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5

--- a/test/language/object-literal/method.js
+++ b/test/language/object-literal/method.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5

--- a/test/language/object-literal/not-defined.js
+++ b/test/language/object-literal/not-defined.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5

--- a/test/language/object-literal/properties-names-eval-arguments.js
+++ b/test/language/object-literal/properties-names-eval-arguments.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5

--- a/test/language/object-literal/setter.js
+++ b/test/language/object-literal/setter.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5

--- a/test/language/object-literal/yield-non-strict-access.js
+++ b/test/language/object-literal/yield-non-strict-access.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5

--- a/test/language/object-literal/yield-non-strict-syntax.js
+++ b/test/language/object-literal/yield-non-strict-syntax.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 12.2.5

--- a/test/language/statements/for-of/arguments-mapped-aliasing.js
+++ b/test/language/statements/for-of/arguments-mapped-aliasing.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/arguments-mapped-mutation.js
+++ b/test/language/statements/for-of/arguments-mapped-mutation.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/arguments-mapped.js
+++ b/test/language/statements/for-of/arguments-mapped.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/arguments-unmapped-aliasing.js
+++ b/test/language/statements/for-of/arguments-unmapped-aliasing.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/arguments-unmapped-mutation.js
+++ b/test/language/statements/for-of/arguments-unmapped-mutation.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/arguments-unmapped.js
+++ b/test/language/statements/for-of/arguments-unmapped.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/float32array-mutate.js
+++ b/test/language/statements/for-of/float32array-mutate.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/float32array.js
+++ b/test/language/statements/for-of/float32array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/float64array-mutate.js
+++ b/test/language/statements/for-of/float64array-mutate.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/float64array.js
+++ b/test/language/statements/for-of/float64array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/int16array-mutate.js
+++ b/test/language/statements/for-of/int16array-mutate.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/int16array.js
+++ b/test/language/statements/for-of/int16array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/int32array-mutate.js
+++ b/test/language/statements/for-of/int32array-mutate.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/int32array.js
+++ b/test/language/statements/for-of/int32array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/int8array-mutate.js
+++ b/test/language/statements/for-of/int8array-mutate.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/int8array.js
+++ b/test/language/statements/for-of/int8array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/uint16array-mutate.js
+++ b/test/language/statements/for-of/uint16array-mutate.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/uint16array.js
+++ b/test/language/statements/for-of/uint16array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/uint32array-mutate.js
+++ b/test/language/statements/for-of/uint32array-mutate.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/uint32array.js
+++ b/test/language/statements/for-of/uint32array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/uint8array-mutate.js
+++ b/test/language/statements/for-of/uint8array-mutate.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/uint8array.js
+++ b/test/language/statements/for-of/uint8array.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/uint8clampedarray-mutate.js
+++ b/test/language/statements/for-of/uint8clampedarray-mutate.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/for-of/uint8clampedarray.js
+++ b/test/language/statements/for-of/uint8clampedarray.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4

--- a/test/language/statements/let/syntax/identifier-let-allowed-as-lefthandside-expression-strict.js
+++ b/test/language/statements/let/syntax/identifier-let-allowed-as-lefthandside-expression-strict.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// Copyright (C) 2011 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.0.1

--- a/test/language/statements/let/syntax/identifier-let-disallowed-as-boundname.js
+++ b/test/language/statements/let/syntax/identifier-let-disallowed-as-boundname.js
@@ -1,4 +1,4 @@
-// Copyright (C) Copyright 2011 the V8 project authors. All rights reserved.
+// Copyright (C) 2011 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 es6id: 13.6.4.1


### PR DESCRIPTION
The helper script for #384 identified some other files with non-standard or missing license headers. 