### PR TITLE
Fix test regressions

### DIFF
--- a/test/built-ins/Function/15.3.5.4_2-10gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-10gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-var f = new Function("\"use strict\";\nreturn gNonStrict();");
+var f = new Function("\"use strict\";\ngNonStrict();");
 
 assert.throws(TypeError, function() {
     f();

--- a/test/built-ins/Function/15.3.5.4_2-15gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-15gs.js
@@ -14,7 +14,7 @@ flags: [onlyStrict]
 ---*/
 
 function f() {
-    return gNonStrict();
+    gNonStrict();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-16gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-16gs.js
@@ -15,7 +15,7 @@ flags: [noStrict]
 
 function f() {
     "use strict";
-    return gNonStrict();
+    gNonStrict();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-17gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-17gs.js
@@ -14,7 +14,7 @@ flags: [onlyStrict]
 ---*/
 
 var f = function () {
-    return gNonStrict();
+    gNonStrict();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-18gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-18gs.js
@@ -15,7 +15,7 @@ flags: [noStrict]
 
 var f = function () {
     "use strict";
-    return gNonStrict();
+    gNonStrict();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-19gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-19gs.js
@@ -15,7 +15,7 @@ flags: [onlyStrict]
 
 assert.throws(TypeError, function() {
     var obj = new (function () {
-        return gNonStrict();
+        gNonStrict();
     });
 });
 

--- a/test/built-ins/Function/15.3.5.4_2-1gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-1gs.js
@@ -13,7 +13,7 @@ flags: [onlyStrict]
 ---*/
 
 function f() {
-    return gNonStrict();
+    gNonStrict();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-20gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-20gs.js
@@ -16,7 +16,7 @@ flags: [noStrict]
 assert.throws(TypeError, function() {
     var obj = new (function () {
         "use strict";
-        return gNonStrict();
+        gNonStrict();
     });
 });
 

--- a/test/built-ins/Function/15.3.5.4_2-21gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-21gs.js
@@ -15,9 +15,9 @@ flags: [onlyStrict]
 
 function f1() {
     function f() {
-        return gNonStrict();
+        gNonStrict();
     }
-    return f();
+    f();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-22gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-22gs.js
@@ -15,9 +15,9 @@ flags: [onlyStrict]
 
 function f1() {
     var f = function () {
-        return gNonStrict();
+        gNonStrict();
     }
-    return f();
+    f();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-23gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-23gs.js
@@ -14,8 +14,8 @@ flags: [onlyStrict]
 ---*/
 
 function f1() {
-    return (function () {
-        return gNonStrict();
+    (function () {
+        gNonStrict();
     })();
 }
 

--- a/test/built-ins/Function/15.3.5.4_2-24gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-24gs.js
@@ -15,9 +15,9 @@ flags: [onlyStrict]
 
 var f1 = function () {
     function f() {
-        return gNonStrict();
+        gNonStrict();
     }
-    return f();
+    f();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-25gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-25gs.js
@@ -15,9 +15,9 @@ flags: [onlyStrict]
 
 var f1 = function () {
     var f = function () {
-        return gNonStrict();
+        gNonStrict();
     }
-    return f();
+    f();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-26gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-26gs.js
@@ -14,8 +14,8 @@ flags: [onlyStrict]
 ---*/
 
 var f1 = function () {
-    return (function () {
-        return gNonStrict();
+    (function () {
+        gNonStrict();
     })();
 }
 

--- a/test/built-ins/Function/15.3.5.4_2-27gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-27gs.js
@@ -16,9 +16,9 @@ flags: [onlyStrict]
 assert.throws(TypeError, function() {
     (function () {
         function f() {
-            return gNonStrict();
+            gNonStrict();
         }
-        return f();
+        f();
     })();
 });
 

--- a/test/built-ins/Function/15.3.5.4_2-28gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-28gs.js
@@ -16,9 +16,9 @@ flags: [onlyStrict]
 assert.throws(TypeError, function() {
     (function () {
         var f = function () {
-            return gNonStrict();
+            gNonStrict();
         }
-        return f();
+        f();
     })();
 });
 

--- a/test/built-ins/Function/15.3.5.4_2-29gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-29gs.js
@@ -15,8 +15,8 @@ flags: [onlyStrict]
 
 assert.throws(TypeError, function() {
     (function () {
-        return (function () {
-            return gNonStrict();
+        (function () {
+            gNonStrict();
         })();
     })();
 });

--- a/test/built-ins/Function/15.3.5.4_2-2gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-2gs.js
@@ -15,7 +15,7 @@ flags: [noStrict]
 
 function f() {
     "use strict";
-    return gNonStrict();
+    gNonStrict();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-30gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-30gs.js
@@ -16,9 +16,9 @@ flags: [noStrict]
 function f1() {
     "use strict";
     function f() {
-        return gNonStrict();
+        gNonStrict();
     }
-    return f();
+    f();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-31gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-31gs.js
@@ -16,9 +16,9 @@ flags: [noStrict]
 function f1() {
     "use strict";
     var f = function () {
-        return gNonStrict();
+        gNonStrict();
     }
-    return f();
+    f();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-32gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-32gs.js
@@ -15,8 +15,8 @@ flags: [noStrict]
 
 function f1() {
     "use strict";
-    return (function () {
-        return gNonStrict();
+    (function () {
+        gNonStrict();
     })();
 }
 

--- a/test/built-ins/Function/15.3.5.4_2-33gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-33gs.js
@@ -16,9 +16,9 @@ flags: [noStrict]
 var f1 = function () {
     "use strict";
     function f() {
-        return gNonStrict();
+        gNonStrict();
     }
-    return f();
+    f();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-34gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-34gs.js
@@ -16,9 +16,9 @@ flags: [noStrict]
 var f1 = function () {
     "use strict";
     var f = function () {
-        return gNonStrict();
+        gNonStrict();
     }
-    return f();
+    f();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-35gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-35gs.js
@@ -15,8 +15,8 @@ flags: [noStrict]
 
 var f1 = function () {
     "use strict";
-    return (function () {
-        return gNonStrict();
+    (function () {
+        gNonStrict();
     })();
 }
 

--- a/test/built-ins/Function/15.3.5.4_2-36gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-36gs.js
@@ -17,9 +17,9 @@ assert.throws(TypeError, function() {
     (function () {
         "use strict";
         function f() {
-            return gNonStrict();
+            gNonStrict();
         }
-        return f();
+        f();
     })();
 });
 

--- a/test/built-ins/Function/15.3.5.4_2-37gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-37gs.js
@@ -17,9 +17,9 @@ assert.throws(TypeError, function() {
     (function () {
         "use strict";
         var f = function () {
-            return gNonStrict();
+            gNonStrict();
         }
-        return f();
+        f();
     })();
 });
 

--- a/test/built-ins/Function/15.3.5.4_2-38gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-38gs.js
@@ -16,8 +16,8 @@ flags: [noStrict]
 assert.throws(TypeError, function() {
     (function () {
         "use strict";
-        return (function () {
-            return gNonStrict();
+        (function () {
+            gNonStrict();
         })();
     })();
 });

--- a/test/built-ins/Function/15.3.5.4_2-39gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-39gs.js
@@ -16,8 +16,7 @@ flags: [noStrict]
 function f1() {
     function f() {
         "use strict";
-        var r = gNonStrict();
-        return r;
+        gNonStrict();
     }
     return f();
 }

--- a/test/built-ins/Function/15.3.5.4_2-3gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-3gs.js
@@ -13,7 +13,7 @@ flags: [onlyStrict]
 ---*/
 
 var f = function () {
-    return gNonStrict();
+    gNonStrict();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-40gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-40gs.js
@@ -16,8 +16,7 @@ flags: [noStrict]
 function f1() {
     var f = function () {
         "use strict";
-        var r = gNonStrict();
-        return r;
+        gNonStrict();
     }
     return f();
 }

--- a/test/built-ins/Function/15.3.5.4_2-41gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-41gs.js
@@ -16,8 +16,7 @@ flags: [noStrict]
 function f1() {
     return (function () {
         "use strict";
-        var r = gNonStrict();
-        return r;
+        gNonStrict();
     })();
 }
 

--- a/test/built-ins/Function/15.3.5.4_2-42gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-42gs.js
@@ -16,8 +16,7 @@ flags: [noStrict]
 var f1 = function () {
     function f() {
         "use strict";
-        var r = gNonStrict();
-        return r;
+        gNonStrict();
     }
     return f();
 }

--- a/test/built-ins/Function/15.3.5.4_2-43gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-43gs.js
@@ -16,8 +16,7 @@ flags: [noStrict]
 var f1 = function () {
     var f = function () {
         "use strict";
-        var r = gNonStrict();
-        return r;
+        gNonStrict();
     }
     return f();
 }

--- a/test/built-ins/Function/15.3.5.4_2-44gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-44gs.js
@@ -16,8 +16,7 @@ flags: [noStrict]
 var f1 = function () {
     return (function () {
         "use strict";
-        var r = gNonStrict();
-        return r;
+        gNonStrict();
     })();
 }
 

--- a/test/built-ins/Function/15.3.5.4_2-45gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-45gs.js
@@ -17,8 +17,7 @@ assert.throws(TypeError, function() {
     (function () {
         function f() {
             "use strict";
-            var r = gNonStrict();
-            return r;
+            gNonStrict();
         }
         return f();
     })();

--- a/test/built-ins/Function/15.3.5.4_2-46gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-46gs.js
@@ -17,8 +17,7 @@ assert.throws(TypeError, function() {
     (function () {
         var f = function () {
             "use strict";
-            var r = gNonStrict();
-            return r;
+            gNonStrict();
         }
         return f();
     })();

--- a/test/built-ins/Function/15.3.5.4_2-47gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-47gs.js
@@ -17,8 +17,7 @@ assert.throws(TypeError, function() {
     (function () {
         return (function () {
             "use strict";
-            var r = gNonStrict();
-            return r;
+            gNonStrict();
         })();
     })();
 });

--- a/test/built-ins/Function/15.3.5.4_2-48gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-48gs.js
@@ -12,7 +12,7 @@ description: >
 flags: [onlyStrict]
 ---*/
 
-var o = { get foo() { return gNonStrict(); } }
+var o = { get foo() { gNonStrict(); } }
 
 assert.throws(TypeError, function() {
     o.foo;

--- a/test/built-ins/Function/15.3.5.4_2-49gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-49gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-var o = { get foo() { "use strict"; return gNonStrict(); } }
+var o = { get foo() { "use strict"; gNonStrict(); } }
 
 assert.throws(TypeError, function() {
     o.foo;

--- a/test/built-ins/Function/15.3.5.4_2-4gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-4gs.js
@@ -15,7 +15,7 @@ flags: [noStrict]
 
 var f = function () {
     "use strict";
-    return gNonStrict();
+    gNonStrict();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-50gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-50gs.js
@@ -12,7 +12,7 @@ description: >
 flags: [onlyStrict]
 ---*/
 
-var o = { set foo(stuff) { return gNonStrict(); } }
+var o = { set foo(stuff) { gNonStrict(); } }
 
 assert.throws(TypeError, function() {
     o.foo = 7;

--- a/test/built-ins/Function/15.3.5.4_2-51gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-51gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-var o = { set foo(stuff) { "use strict"; return gNonStrict(); } }
+var o = { set foo(stuff) { "use strict"; gNonStrict(); } }
 
 assert.throws(TypeError, function() {
     o.foo = 8;

--- a/test/built-ins/Function/15.3.5.4_2-52gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-52gs.js
@@ -13,7 +13,7 @@ flags: [onlyStrict]
 ---*/
 
 var o = {};
-Object.defineProperty(o, "foo",  { get: function() { return gNonStrict(); } });
+Object.defineProperty(o, "foo",  { get: function() { gNonStrict(); } });
 
 assert.throws(TypeError, function() {
     o.foo;

--- a/test/built-ins/Function/15.3.5.4_2-53gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-53gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 ---*/
 
 var o = {};
-Object.defineProperty(o, "foo", { get: function() { "use strict"; return gNonStrict(); } });
+Object.defineProperty(o, "foo", { get: function() { "use strict"; gNonStrict(); } });
 
 assert.throws(TypeError, function() {
     o.foo;

--- a/test/built-ins/Function/15.3.5.4_2-54gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-54gs.js
@@ -13,7 +13,7 @@ flags: [onlyStrict]
 ---*/
 
 var o = {};
-Object.defineProperty(o, "foo", { set: function(stuff) { return gNonStrict(); } });
+Object.defineProperty(o, "foo", { set: function(stuff) { gNonStrict(); } });
 
 assert.throws(TypeError, function() {
     o.foo = 9;

--- a/test/built-ins/Function/15.3.5.4_2-55gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-55gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 ---*/
 
 var o = {};
-Object.defineProperty(o, "foo", { set: function(stuff) { "use strict"; return gNonStrict(); } });
+Object.defineProperty(o, "foo", { set: function(stuff) { "use strict"; gNonStrict(); } });
 
 assert.throws(TypeError, function() {
     o.foo = 10;

--- a/test/built-ins/Function/15.3.5.4_2-56gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-56gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; var r = gNonStrict(); return r;};
+function f() { "use strict"; gNonStrict(); };
 function foo() { return f();}
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-57gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-57gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict(); };
 
 assert.throws(TypeError, function() {
     eval("f();");

--- a/test/built-ins/Function/15.3.5.4_2-58gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-58gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; var r = gNonStrict(); return r;};
+function f() { "use strict"; gNonStrict(); };
 
 assert.throws(TypeError, function() {
     Function("return f();")();

--- a/test/built-ins/Function/15.3.5.4_2-59gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-59gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; var r = gNonStrict(); return r;};
+function f() { "use strict"; gNonStrict(); };
 
 assert.throws(TypeError, function() {
     new Function("return f();")();

--- a/test/built-ins/Function/15.3.5.4_2-5gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-5gs.js
@@ -15,7 +15,7 @@ flags: [onlyStrict]
 
 assert.throws(TypeError, function() {
     (function () {
-        return gNonStrict();
+        gNonStrict();
     })();
 });
 

--- a/test/built-ins/Function/15.3.5.4_2-60gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-60gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
     f.apply();

--- a/test/built-ins/Function/15.3.5.4_2-61gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-61gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
     f.apply(null);

--- a/test/built-ins/Function/15.3.5.4_2-62gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-62gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
     f.apply(undefined);

--- a/test/built-ins/Function/15.3.5.4_2-63gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-63gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 var o = {};
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-64gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-64gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 includes: [fnGlobalObject.js]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
     f.apply(fnGlobalObject());

--- a/test/built-ins/Function/15.3.5.4_2-65gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-65gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
     f.call();

--- a/test/built-ins/Function/15.3.5.4_2-66gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-66gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
     f.call(null);

--- a/test/built-ins/Function/15.3.5.4_2-67gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-67gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
     f.call(undefined);

--- a/test/built-ins/Function/15.3.5.4_2-68gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-68gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 var o = {};
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-69gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-69gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 includes: [fnGlobalObject.js]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
     f.call(fnGlobalObject());

--- a/test/built-ins/Function/15.3.5.4_2-6gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-6gs.js
@@ -16,7 +16,7 @@ flags: [noStrict]
 assert.throws(TypeError, function() {
     (function () {
         "use strict";
-        return gNonStrict();
+        gNonStrict();
     })();
 });
 

--- a/test/built-ins/Function/15.3.5.4_2-70gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-70gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
     f.bind()();

--- a/test/built-ins/Function/15.3.5.4_2-71gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-71gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
     f.bind(null)();

--- a/test/built-ins/Function/15.3.5.4_2-72gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-72gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
     f.bind(undefined)();

--- a/test/built-ins/Function/15.3.5.4_2-73gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-73gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 var o = {};
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-74gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-74gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 includes: [fnGlobalObject.js]
 ---*/
 
-function f() { "use strict"; return gNonStrict();};
+function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
     f.bind(fnGlobalObject())();

--- a/test/built-ins/Function/15.3.5.4_2-75gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-75gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 ---*/
 
 function f() { return gNonStrict();};
-function foo() { "use strict"; return f();}
+function foo() { "use strict"; f();}
 foo(); 
 
 

--- a/test/built-ins/Function/15.3.5.4_2-77gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-77gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 ---*/
 
 function f() {return gNonStrict();};
-(function () {"use strict"; return Function("return f();")(); })();
+(function () {"use strict"; Function("return f();")(); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-79gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-79gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 ---*/
 
 function f() { return gNonStrict();};
-(function () {"use strict"; return f.apply();})();
+(function () {"use strict"; f.apply();})();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-80gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-80gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 ---*/
 
 function f() { return gNonStrict();};
-(function () {"use strict"; return f.apply(null); })();
+(function () {"use strict"; f.apply(null); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-81gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-81gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 ---*/
 
 function f() { return gNonStrict();};
-(function () {"use strict"; return f.apply(undefined); })();
+(function () {"use strict"; f.apply(undefined); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-82gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-82gs.js
@@ -15,7 +15,7 @@ flags: [noStrict]
 
 function f() { return gNonStrict();};
 var o = {};
-(function () {"use strict"; return f.apply(o); })();
+(function () {"use strict"; f.apply(o); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-83gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-83gs.js
@@ -15,7 +15,7 @@ includes: [fnGlobalObject.js]
 ---*/
 
 function f() { return gNonStrict();};
-(function () {"use strict"; return f.apply(fnGlobalObject()); })();
+(function () {"use strict"; f.apply(fnGlobalObject()); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-84gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-84gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 ---*/
 
 function f() { return gNonStrict();};
-(function () {"use strict"; return f.call();})();
+(function () {"use strict"; f.call();})();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-85gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-85gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 ---*/
 
 function f() { return gNonStrict();};
-(function () {"use strict"; return f.call(null);})();
+(function () {"use strict"; f.call(null);})();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-86gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-86gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 ---*/
 
 function f() { return gNonStrict();};
-(function () {"use strict"; return f.call(undefined); })();
+(function () {"use strict"; f.call(undefined); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-87gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-87gs.js
@@ -15,7 +15,7 @@ flags: [noStrict]
 
 function f() { return gNonStrict();};
 var o = {};
-(function () {"use strict"; return f.call(o); })();
+(function () {"use strict"; f.call(o); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-88gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-88gs.js
@@ -15,7 +15,7 @@ includes: [fnGlobalObject.js]
 ---*/
 
 function f() { return gNonStrict();};
-(function () {"use strict"; return f.call(fnGlobalObject()); })();
+(function () {"use strict"; f.call(fnGlobalObject()); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-89gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-89gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 ---*/
 
 function f() { return gNonStrict();};
-(function () {"use strict"; return f.bind()();})();
+(function () {"use strict"; f.bind()();})();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-8gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-8gs.js
@@ -13,7 +13,7 @@ description: >
 flags: [noStrict]
 ---*/
 
-var f = Function("\"use strict\";\nreturn gNonStrict();");
+var f = Function("\"use strict\";\ngNonStrict();");
 
 assert.throws(TypeError, function() {
     f();

--- a/test/built-ins/Function/15.3.5.4_2-90gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-90gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 ---*/
 
 function f() { return gNonStrict();};
-(function () {"use strict"; return f.bind(null)(); })();
+(function () {"use strict"; f.bind(null)(); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-91gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-91gs.js
@@ -14,7 +14,7 @@ flags: [noStrict]
 ---*/
 
 function f() { return gNonStrict();};
-(function () {"use strict"; return f.bind(undefined)(); })();
+(function () {"use strict"; f.bind(undefined)(); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-92gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-92gs.js
@@ -15,7 +15,7 @@ flags: [noStrict]
 
 function f() { return gNonStrict();};
 var o = {};
-(function () {"use strict"; return f.bind(o)(); })();
+(function () {"use strict"; f.bind(o)(); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-93gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-93gs.js
@@ -15,7 +15,7 @@ includes: [fnGlobalObject.js]
 ---*/
 
 function f() { return gNonStrict();};
-(function () {"use strict"; return f.bind(fnGlobalObject())(); })();
+(function () {"use strict"; f.bind(fnGlobalObject())(); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-94gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-94gs.js
@@ -19,7 +19,7 @@ var gNonStrict = function () {
 
 function f() {
     "use strict";
-    return gNonStrict();
+    gNonStrict();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-95gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-95gs.js
@@ -17,7 +17,7 @@ var gNonStrict = Function("return gNonStrict.caller || gNonStrict.caller.throwTy
 
 function f() {
     "use strict";
-    return gNonStrict();
+    gNonStrict();
 }
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Function/15.3.5.4_2-97gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-97gs.js
@@ -17,7 +17,7 @@ var gNonStrict = gNonStrictBindee.bind(null);
 
 function f() {
     "use strict";
-    return gNonStrict();
+    gNonStrict();
 }
 
 assert.throws(TypeError, function() {

--- a/test/language/asi/S7.9_A5.7_T1.js
+++ b/test/language/asi/S7.9_A5.7_T1.js
@@ -12,14 +12,12 @@ info: >
 
 es5id: 7.9_A5.7_T1
 description: Try use Variable1 \n ++ \n ++ \n Variable2 construction
+negative: ReferenceError
 ---*/
 
 var x=0, y=0;
-
-assert.throws(ReferenceError, function() {
 var z=
 x
 ++
 ++
 y
-});

--- a/test/language/statements/const/block-local-closure-get-before-initialization.js
+++ b/test/language/statements/const/block-local-closure-get-before-initialization.js
@@ -5,7 +5,6 @@ es6id: 13.1
 description: >
     const: block local closure [[Get]] before initialization.
     (TDZ, Temporal Dead Zone)
-negative: ReferenceError
 ---*/
 {
   function f() { return x + 1; }


### PR DESCRIPTION
- Add missing 'negative: ReferenceError' in S7.9_A5.7_T1
- Remove stale 'negative: ReferenceError' in block-local-closure-get-before-initialization
- Remove all tail-call expressions in test/built-ins/Function
- And update code in test/built-ins/Function to use 'f()' instead of 'var r = f(); return r'

Fixes #383