### PR TITLE
Add tests for Reflect

### DIFF
--- a/test/built-ins/Reflect/Reflect.js
+++ b/test/built-ins/Reflect/Reflect.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1
+description: >
+  The Reflect object is an ordinary object.
+info: >
+  26.1 The Reflect Object
+
+  The Reflect object is the %Reflect% intrinsic object and the initial value of
+  the Reflect property of the global object. The Reflect object is an ordinary
+  object.
+
+  The Reflect object is not a function object. It does not have a [[Construct]]
+  internal method; it is not possible to use the Reflect object as a constructor
+  with the new operator. The Reflect object also does not have a [[Call]]
+  internal method; it is not possible to invoke the Reflect object as a
+  function.
+---*/
+
+assert.sameValue(typeof Reflect, 'object', '`typeof Reflect` is `"object"`');
+
+// Reflect is not callable
+assert.throws(TypeError, function() {
+  Reflect();
+});
+
+// Reflect doesn't have a constructor
+assert.throws(TypeError, function() {
+  new Reflect();
+});

--- a/test/built-ins/Reflect/apply/apply.js
+++ b/test/built-ins/Reflect/apply/apply.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.1
+description: >
+  Reflect.apply is configurable, writable and not enumerable.
+info: >
+  26.1.1 Reflect.apply ( target, thisArgument, argumentsList )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Reflect, 'apply');
+verifyWritable(Reflect, 'apply');
+verifyConfigurable(Reflect, 'apply');

--- a/test/built-ins/Reflect/apply/arguments-list-is-not-array-like.js
+++ b/test/built-ins/Reflect/apply/arguments-list-is-not-array-like.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.1
+description: >
+  Return abrupt if argumentsList is not an ArrayLike object.
+info: >
+  26.1.1 Reflect.apply ( target, thisArgument, argumentsList )
+
+  ...
+  2. Let args be CreateListFromArrayLike(argumentsList).
+  3. ReturnIfAbrupt(args).
+  ...
+
+  7.3.17 CreateListFromArrayLike (obj [, elementTypes] )
+
+  ...
+  3. If Type(obj) is not Object, throw a TypeError exception.
+  4. Let len be ToLength(Get(obj, "length")).
+  5. ReturnIfAbrupt(len).
+  ...
+---*/
+
+function fn() {}
+var o = {};
+
+Object.defineProperty(o, 'length', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.apply(fn, 1, o);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.apply(fn, 1, 1);
+});

--- a/test/built-ins/Reflect/apply/call-target.js
+++ b/test/built-ins/Reflect/apply/call-target.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.1
+description: >
+  Call target with thisArgument and argumentsList
+info: >
+  26.1.1 Reflect.apply ( target, thisArgument, argumentsList )
+
+  ...
+  4. Perform PrepareForTailCall().
+  5. Return Call(target, thisArgument, args).
+---*/
+
+var o = {};
+var count = 0;
+var results, args;
+function fn() {
+  count++;
+  results = {
+    thisArg: this,
+    args: arguments
+  };
+}
+
+Reflect.apply(fn, o, ['arg1', 2, , null]);
+
+assert.sameValue(count, 1, 'Called target once');
+assert.sameValue(results.thisArg, o, 'Called target with `o` as `this` object');
+assert.sameValue(results.args.length, 4, 'Called target with 4 arguments');
+assert.sameValue(results.args[0], 'arg1');
+assert.sameValue(results.args[1], 2);
+assert.sameValue(results.args[2], undefined);
+assert.sameValue(results.args[3], null);

--- a/test/built-ins/Reflect/apply/length.js
+++ b/test/built-ins/Reflect/apply/length.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.1
+description: >
+  Reflect.apply.length value and property descriptor
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.apply.length, 3,
+  'The value of `Reflect.apply.length` is `3`'
+);
+
+verifyNotEnumerable(Reflect.apply, 'length');
+verifyNotWritable(Reflect.apply, 'length');
+verifyConfigurable(Reflect.apply, 'length');

--- a/test/built-ins/Reflect/apply/name.js
+++ b/test/built-ins/Reflect/apply/name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.1
+description: >
+  Reflect.apply.name value and property descriptor
+info: >
+  26.1.1 Reflect.apply ( target, thisArgument, argumentsList )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.apply.name, 'apply',
+  'The value of `Reflect.apply.name` is `"apply"`'
+);
+
+verifyNotEnumerable(Reflect.apply, 'name');
+verifyNotWritable(Reflect.apply, 'name');
+verifyConfigurable(Reflect.apply, 'name');

--- a/test/built-ins/Reflect/apply/return-target-call-result.js
+++ b/test/built-ins/Reflect/apply/return-target-call-result.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.1
+description: >
+  Return target result
+info: >
+  26.1.1 Reflect.apply ( target, thisArgument, argumentsList )
+
+  ...
+  4. Perform PrepareForTailCall().
+  5. Return Call(target, thisArgument, args).
+---*/
+
+var o = {};
+function fn() {
+  return o;
+}
+
+var result = Reflect.apply(fn, 1, []);
+
+assert.sameValue(result, o);

--- a/test/built-ins/Reflect/apply/target-is-not-callable-throws.js
+++ b/test/built-ins/Reflect/apply/target-is-not-callable-throws.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.1
+description: >
+  Throws a TypeError if `target` is not callable.
+info: >
+  26.1.1 Reflect.apply ( target, thisArgument, argumentsList )
+
+  1. If IsCallable(target) is false, throw a TypeError exception.
+  ...
+
+  7.2.3 IsCallable ( argument )
+
+  1. ReturnIfAbrupt(argument).
+  2. If Type(argument) is not Object, return false.
+  3. If argument has a [[Call]] internal method, return true.
+  4. Return false.
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.apply(1, 1, []);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.apply(null, 1, []);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.apply({}, 1, []);
+});

--- a/test/built-ins/Reflect/construct/arguments-list-is-not-array-like.js
+++ b/test/built-ins/Reflect/construct/arguments-list-is-not-array-like.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.2
+description: >
+  Return abrupt if argumentsList is not an ArrayLike object.
+info: >
+  26.1.2 Reflect.construct ( target, argumentsList [, newTarget] )
+
+  ...
+  4. Let args be CreateListFromArrayLike(argumentsList).
+  5. ReturnIfAbrupt(args).
+  ...
+
+  7.3.17 CreateListFromArrayLike (obj [, elementTypes] )
+
+  ...
+  3. If Type(obj) is not Object, throw a TypeError exception.
+  4. Let len be ToLength(Get(obj, "length")).
+  5. ReturnIfAbrupt(len).
+  ...
+---*/
+
+function fn() {}
+var o = {};
+
+Object.defineProperty(o, 'length', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.construct(fn, o);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.construct(fn, 1);
+});

--- a/test/built-ins/Reflect/construct/construct.js
+++ b/test/built-ins/Reflect/construct/construct.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.2
+description: >
+  Reflect.construct is configurable, writable and not enumerable.
+info: >
+  26.1.2 Reflect.construct ( target, argumentsList [, newTarget] )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Reflect, 'construct');
+verifyWritable(Reflect, 'construct');
+verifyConfigurable(Reflect, 'construct');

--- a/test/built-ins/Reflect/construct/length.js
+++ b/test/built-ins/Reflect/construct/length.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.2
+description: >
+  Reflect.construct.length value and property descriptor
+info: >
+  26.1.2 Reflect.construct ( target, argumentsList [, newTarget] )
+
+  The length property of the construct function is 2.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.construct.length, 2,
+  'The value of `Reflect.construct.length` is `2`'
+);
+
+verifyNotEnumerable(Reflect.construct, 'length');
+verifyNotWritable(Reflect.construct, 'length');
+verifyConfigurable(Reflect.construct, 'length');

--- a/test/built-ins/Reflect/construct/name.js
+++ b/test/built-ins/Reflect/construct/name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.2
+description: >
+  Reflect.construct.name value and property descriptor
+info: >
+  26.1.2 Reflect.construct ( target, argumentsList [, newTarget] )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.construct.name, 'construct',
+  'The value of `Reflect.construct.name` is `"construct"`'
+);
+
+verifyNotEnumerable(Reflect.construct, 'name');
+verifyNotWritable(Reflect.construct, 'name');
+verifyConfigurable(Reflect.construct, 'name');

--- a/test/built-ins/Reflect/construct/newtarget-is-not-constructor-throws.js
+++ b/test/built-ins/Reflect/construct/newtarget-is-not-constructor-throws.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.2
+description: >
+  Throws a TypeError if `newTarget` is not a constructor.
+info: >
+  26.1.2 Reflect.construct ( target, argumentsList [, newTarget] )
+
+  ...
+  2. If newTarget is not present, let newTarget be target.
+  3. Else, if IsConstructor(newTarget) is false, throw a TypeError exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.construct(function() {}, [], 1);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.construct(function() {}, [], null);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.construct(function() {}, [], {});
+});
+
+assert.throws(TypeError, function() {
+  Reflect.construct(function() {}, [], Date.now);
+});

--- a/test/built-ins/Reflect/construct/return-with-newtarget-argument.js
+++ b/test/built-ins/Reflect/construct/return-with-newtarget-argument.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.2
+description: >
+  Return target result using newTarget argument.
+info: >
+  26.1.2 Reflect.construct ( target, argumentsList [, newTarget] )
+
+  ...
+  2. If newTarget is not present, let newTarget be target.
+  ...
+  6. Return Construct(target, args, newTarget).
+---*/
+
+var o = {};
+var internPrototype;
+function fn() {
+  this.o = o;
+  internPrototype = Object.getPrototypeOf(this);
+}
+
+var result = Reflect.construct(fn, [], Array);
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert.sameValue(
+  internPrototype, Array.prototype,
+  'prototype of this from within the constructor function is Array.prototype'
+);
+assert.sameValue(result.o, o);

--- a/test/built-ins/Reflect/construct/return-without-newtarget-argument.js
+++ b/test/built-ins/Reflect/construct/return-without-newtarget-argument.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.2
+description: >
+  Return target result
+info: >
+  26.1.2 Reflect.construct ( target, argumentsList [, newTarget] )
+
+  ...
+  2. If newTarget is not present, let newTarget be target.
+  ...
+  6. Return Construct(target, args, newTarget).
+---*/
+
+var o = {};
+function fn() {
+  this.o = o;
+}
+
+var result = Reflect.construct(fn, []);
+
+assert.sameValue(result.o, o);
+assert(result instanceof fn);

--- a/test/built-ins/Reflect/construct/target-is-not-constructor-throws.js
+++ b/test/built-ins/Reflect/construct/target-is-not-constructor-throws.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.2
+description: >
+  Throws a TypeError if `target` is not a constructor.
+info: >
+  26.1.2 Reflect.construct ( target, argumentsList [, newTarget] )
+
+  1. If IsConstructor(target) is false, throw a TypeError exception.
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.construct(1, []);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.construct(null, []);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.construct({}, []);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.construct(Date.now, []);
+});

--- a/test/built-ins/Reflect/construct/use-arguments-list.js
+++ b/test/built-ins/Reflect/construct/use-arguments-list.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.2
+description: >
+  Construct with given argumentsList
+info: >
+  26.1.2 Reflect.construct ( target, argumentsList [, newTarget] )
+
+  ...
+  2. If newTarget is not present, let newTarget be target.
+  ...
+  6. Return Construct(target, args, newTarget).
+---*/
+
+function fn() {
+  this.args = arguments;
+}
+
+var result = Reflect.construct(fn, [42, 'Mike', 'Leo']);
+
+assert.sameValue(result.args.length, 3, 'result.args.length');
+assert.sameValue(result.args[0], 42);
+assert.sameValue(result.args[1], 'Mike');
+assert.sameValue(result.args[2], 'Leo');

--- a/test/built-ins/Reflect/defineProperty/define-properties.js
+++ b/test/built-ins/Reflect/defineProperty/define-properties.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.3
+description: >
+  Define properties from the attributes object.
+info: >
+  26.1.3 Reflect.defineProperty ( target, propertyKey, attributes )
+
+  ...
+  6. Return target.[[DefineOwnProperty]](key, desc).
+includes: [propertyHelper.js]
+---*/
+
+var o = {};
+var desc;
+
+Reflect.defineProperty(o, 'p1', {
+  value: 42,
+  writable: true,
+  enumerable: true
+});
+
+assert.sameValue(o.p1, 42);
+
+verifyWritable(o, 'p1');
+verifyNotConfigurable(o, 'p1');
+verifyEnumerable(o, 'p1');
+
+var f1 = function() {};
+var f2 = function() {};
+Reflect.defineProperty(o, 'p2', {
+  get: f1,
+  set: f2
+});
+
+desc = Object.getOwnPropertyDescriptor(o, 'p2');
+assert.sameValue(desc.get, f1);
+assert.sameValue(desc.set, f2);

--- a/test/built-ins/Reflect/defineProperty/define-symbol-properties.js
+++ b/test/built-ins/Reflect/defineProperty/define-symbol-properties.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.3
+description: >
+  Define symbol properties.
+info: >
+  26.1.3 Reflect.defineProperty ( target, propertyKey, attributes )
+
+  ...
+  2. Let key be ToPropertyKey(propertyKey).
+  ...
+
+  7.1.14 ToPropertyKey ( argument )
+
+  ...
+  3. If Type(key) is Symbol, then
+    a. Return key.
+  ...
+features: [Symbol]
+---*/
+
+var o = {};
+var desc;
+
+var s1 = Symbol('1');
+
+Reflect.defineProperty(o, s1, {
+  value: 42,
+  writable: true,
+  enumerable: true
+});
+
+assert.sameValue(o[s1], 42);
+
+desc = Object.getOwnPropertyDescriptor(o, s1);
+
+assert.sameValue(desc.writable, true);
+assert.sameValue(desc.configurable, false);
+assert.sameValue(desc.enumerable, true);
+
+var s2 = Symbol('2');
+
+var f1 = function() {};
+var f2 = function() {};
+Reflect.defineProperty(o, s2, {
+  get: f1,
+  set: f2
+});
+
+desc = Object.getOwnPropertyDescriptor(o, s2);
+assert.sameValue(desc.get, f1);
+assert.sameValue(desc.set, f2);

--- a/test/built-ins/Reflect/defineProperty/defineProperty.js
+++ b/test/built-ins/Reflect/defineProperty/defineProperty.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.3
+description: >
+  Reflect.defineProperty is configurable, writable and not enumerable.
+info: >
+  26.1.3 Reflect.defineProperty ( target, propertyKey, attributes )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Reflect, 'defineProperty');
+verifyWritable(Reflect, 'defineProperty');
+verifyConfigurable(Reflect, 'defineProperty');

--- a/test/built-ins/Reflect/defineProperty/length.js
+++ b/test/built-ins/Reflect/defineProperty/length.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.3
+description: >
+  Reflect.defineProperty.length value and property descriptor
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.defineProperty.length, 3,
+  'The value of `Reflect.defineProperty.length` is `3`'
+);
+
+verifyNotEnumerable(Reflect.defineProperty, 'length');
+verifyNotWritable(Reflect.defineProperty, 'length');
+verifyConfigurable(Reflect.defineProperty, 'length');

--- a/test/built-ins/Reflect/defineProperty/name.js
+++ b/test/built-ins/Reflect/defineProperty/name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.3
+description: >
+  Reflect.defineProperty.name value and property descriptor
+info: >
+  26.1.3 Reflect.defineProperty ( target, propertyKey, attributes )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.defineProperty.name, 'defineProperty',
+  'The value of `Reflect.defineProperty.name` is `"defineProperty"`'
+);
+
+verifyNotEnumerable(Reflect.defineProperty, 'name');
+verifyNotWritable(Reflect.defineProperty, 'name');
+verifyConfigurable(Reflect.defineProperty, 'name');

--- a/test/built-ins/Reflect/defineProperty/return-abrupt-from-attributes.js
+++ b/test/built-ins/Reflect/defineProperty/return-abrupt-from-attributes.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.3
+description: >
+  Return abrupt from ToPropertyDescriptor(attributes).
+info: >
+  26.1.3 Reflect.defineProperty ( target, propertyKey, attributes )
+
+  ...
+  4. Let desc be ToPropertyDescriptor(attributes).
+  5. ReturnIfAbrupt(desc).
+  ...
+---*/
+
+var attributes = {};
+
+Object.defineProperty(attributes, 'enumerable', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.defineProperty({}, 'a', attributes);
+});

--- a/test/built-ins/Reflect/defineProperty/return-abrupt-from-property-key.js
+++ b/test/built-ins/Reflect/defineProperty/return-abrupt-from-property-key.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.3
+description: >
+  Return abrupt from ToPropertyKey(propertyKey)
+info: >
+  26.1.3 Reflect.defineProperty ( target, propertyKey, attributes )
+
+  ...
+  2. Let key be ToPropertyKey(propertyKey).
+  3. ReturnIfAbrupt(key).
+  ...
+---*/
+
+var p = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  Reflect.defineProperty({}, p);
+});

--- a/test/built-ins/Reflect/defineProperty/return-abrupt-from-result.js
+++ b/test/built-ins/Reflect/defineProperty/return-abrupt-from-result.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.3
+description: >
+  Return abrupt result on defining a property.
+info: >
+  26.1.3 Reflect.defineProperty ( target, propertyKey, attributes )
+
+  ...
+  6. Return target.[[DefineOwnProperty]](key, desc).
+  ...
+
+  9.1.6.1 OrdinaryDefineOwnProperty (O, P, Desc)
+
+  1. Let current be O.[[GetOwnProperty]](P).
+  2. ReturnIfAbrupt(current).
+  ...
+features: [Proxy]
+---*/
+
+var o = {};
+var p = new Proxy(o, {
+  defineProperty: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.defineProperty(p, 'p1', {});
+});

--- a/test/built-ins/Reflect/defineProperty/return-boolean.js
+++ b/test/built-ins/Reflect/defineProperty/return-boolean.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.3
+description: >
+  Return boolean result of the property definition.
+info: >
+  26.1.3 Reflect.defineProperty ( target, propertyKey, attributes )
+
+  ...
+  6. Return target.[[DefineOwnProperty]](key, desc).
+---*/
+
+var o = {};
+
+o.p1 = 'foo';
+assert.sameValue(Reflect.defineProperty(o, 'p1', {}), true);
+assert.sameValue(o.hasOwnProperty('p1'), true);
+
+assert.sameValue(Reflect.defineProperty(o, 'p2', {value: 42}), true);
+assert.sameValue(o.hasOwnProperty('p2'), true);
+
+Object.freeze(o);
+
+assert.sameValue(Reflect.defineProperty(o, 'p2', {value: 43}), false);
+assert.sameValue(o.p2, 42);
+
+assert.sameValue(Reflect.defineProperty(o, 'p3', {}), false);
+assert.sameValue(o.hasOwnProperty('p4'), false);
+
+assert.sameValue(Reflect.defineProperty(o, 'p4', {value: 1}), false);
+assert.sameValue(o.hasOwnProperty('p4'), false);

--- a/test/built-ins/Reflect/defineProperty/target-is-not-object-throws.js
+++ b/test/built-ins/Reflect/defineProperty/target-is-not-object-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.3
+description: >
+  Throws a TypeError if target is not an Object.
+info: >
+  26.1.3 Reflect.defineProperty ( target, propertyKey, attributes )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.defineProperty(1, 'p', {});
+});
+
+assert.throws(TypeError, function() {
+  Reflect.defineProperty(null, 'p', {});
+});
+
+assert.throws(TypeError, function() {
+  Reflect.defineProperty(undefined, 'p', {});
+});
+
+assert.throws(TypeError, function() {
+  Reflect.defineProperty('', 'p', {});
+});

--- a/test/built-ins/Reflect/defineProperty/target-is-symbol-throws.js
+++ b/test/built-ins/Reflect/defineProperty/target-is-symbol-throws.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.3
+description: >
+  Throws a TypeError if target is a Symbol
+info: >
+  26.1.3 Reflect.defineProperty ( target, propertyKey, attributes )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.defineProperty(Symbol(1), 'p', {});
+});

--- a/test/built-ins/Reflect/deleteProperty/delete-properties.js
+++ b/test/built-ins/Reflect/deleteProperty/delete-properties.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.4
+description: >
+  Delete property.
+info: >
+  26.1.4 Reflect.deleteProperty ( target, propertyKey )
+
+  ...
+  4. Return target.[[Delete]](key).
+---*/
+
+var o = {
+  prop: 42
+};
+
+Reflect.deleteProperty(o, 'prop');
+
+assert.sameValue(o.hasOwnProperty('prop'), false);

--- a/test/built-ins/Reflect/deleteProperty/delete-symbol-properties.js
+++ b/test/built-ins/Reflect/deleteProperty/delete-symbol-properties.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.4
+description: >
+  Delete a symbol property.
+info: >
+  26.1.4 Reflect.deleteProperty ( target, propertyKey )
+
+  ...
+  2. Let key be ToPropertyKey(propertyKey).
+  ...
+
+  7.1.14 ToPropertyKey ( argument )
+
+  ...
+  3. If Type(key) is Symbol, then
+    a. Return key.
+  ...
+features: [Symbol]
+---*/
+
+var s = Symbol('1');
+var o = {};
+o[s] = 42;
+
+Reflect.deleteProperty(o, s);
+
+assert.sameValue(o.hasOwnProperty(s), false);
+assert.sameValue(o[s], undefined);

--- a/test/built-ins/Reflect/deleteProperty/deleteProperty.js
+++ b/test/built-ins/Reflect/deleteProperty/deleteProperty.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.4
+description: >
+  Reflect.deleteProperty is configurable, writable and not enumerable.
+info: >
+  26.1.4 Reflect.deleteProperty ( target, propertyKey )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Reflect, 'deleteProperty');
+verifyWritable(Reflect, 'deleteProperty');
+verifyConfigurable(Reflect, 'deleteProperty');

--- a/test/built-ins/Reflect/deleteProperty/length.js
+++ b/test/built-ins/Reflect/deleteProperty/length.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.4
+description: >
+  Reflect.deleteProperty.length value and property descriptor
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.deleteProperty.length, 2,
+  'The value of `Reflect.deleteProperty.length` is `2`'
+);
+
+verifyNotEnumerable(Reflect.deleteProperty, 'length');
+verifyNotWritable(Reflect.deleteProperty, 'length');
+verifyConfigurable(Reflect.deleteProperty, 'length');

--- a/test/built-ins/Reflect/deleteProperty/name.js
+++ b/test/built-ins/Reflect/deleteProperty/name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.4
+description: >
+  Reflect.deleteProperty.name value and property descriptor
+info: >
+  26.1.4 Reflect.deleteProperty ( target, propertyKey )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.deleteProperty.name, 'deleteProperty',
+  'The value of `Reflect.deleteProperty.name` is `"deleteProperty"`'
+);
+
+verifyNotEnumerable(Reflect.deleteProperty, 'name');
+verifyNotWritable(Reflect.deleteProperty, 'name');
+verifyConfigurable(Reflect.deleteProperty, 'name');

--- a/test/built-ins/Reflect/deleteProperty/return-abrupt-from-property-key.js
+++ b/test/built-ins/Reflect/deleteProperty/return-abrupt-from-property-key.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.4
+description: >
+  Return abrupt from ToPropertyKey(propertyKey)
+info: >
+  26.1.4 Reflect.deleteProperty ( target, propertyKey )
+
+  ...
+  2. Let key be ToPropertyKey(propertyKey).
+  3. ReturnIfAbrupt(key).
+  ...
+---*/
+
+var p = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  Reflect.deleteProperty({}, p);
+});

--- a/test/built-ins/Reflect/deleteProperty/return-abrupt-from-result.js
+++ b/test/built-ins/Reflect/deleteProperty/return-abrupt-from-result.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.4
+description: >
+  Return abrupt result from deleting a property.
+info: >
+  26.1.4 Reflect.deleteProperty ( target, propertyKey )
+
+  ...
+  6. Return target.[[DefineOwnProperty]](key, desc).
+  ...
+features: [Proxy]
+---*/
+
+var o = {};
+var p = new Proxy(o, {
+  deleteProperty: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.deleteProperty(p, 'p1');
+});

--- a/test/built-ins/Reflect/deleteProperty/return-boolean.js
+++ b/test/built-ins/Reflect/deleteProperty/return-boolean.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.4
+description: >
+  Return boolean result.
+info: >
+  26.1.4 Reflect.deleteProperty ( target, propertyKey )
+
+  ...
+  4. Return target.[[Delete]](key).
+---*/
+
+var o = {};
+
+o.p1 = 'foo';
+assert.sameValue(Reflect.deleteProperty(o, 'p1'), true);
+assert.sameValue(o.hasOwnProperty('p1'), false);
+
+o.p2 = 'foo';
+Object.freeze(o);
+assert.sameValue(Reflect.deleteProperty(o, 'p2'), false);
+assert.sameValue(o.hasOwnProperty('p2'), true);

--- a/test/built-ins/Reflect/deleteProperty/target-is-not-object-throws.js
+++ b/test/built-ins/Reflect/deleteProperty/target-is-not-object-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.4
+description: >
+  Throws a TypeError if target is not an Object.
+info: >
+  26.1.4 Reflect.deleteProperty ( target, propertyKey )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.deleteProperty(1, 'p');
+});
+
+assert.throws(TypeError, function() {
+  Reflect.deleteProperty(null, 'p');
+});
+
+assert.throws(TypeError, function() {
+  Reflect.deleteProperty(undefined, 'p');
+});
+
+assert.throws(TypeError, function() {
+  Reflect.deleteProperty('', 'p');
+});

--- a/test/built-ins/Reflect/deleteProperty/target-is-symbol-throws.js
+++ b/test/built-ins/Reflect/deleteProperty/target-is-symbol-throws.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.4
+description: >
+  Throws a TypeError if target is a Symbol
+info: >
+  26.1.4 Reflect.deleteProperty ( target, propertyKey )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.deleteProperty(Symbol(1), 'p');
+});

--- a/test/built-ins/Reflect/enumerate/does-not-iterate-over-symbol-properties.js
+++ b/test/built-ins/Reflect/enumerate/does-not-iterate-over-symbol-properties.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 Leonardo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.5
+description: >
+  Returned iterator does not iterate over symbol properties.
+info: >
+  26.1.5 Reflect.enumerate ( target )
+
+  ...
+  2. Return target.[[Enumerate]]().
+features: [Symbol]
+---*/
+
+var iter, step;
+var s = Symbol('1');
+
+var o = {
+  'a': 1,
+  'b': 1
+};
+
+o[s] = 1;
+
+iter = Reflect.enumerate(o);
+
+step = iter.next();
+assert.sameValue(step.value, 'a');
+assert.sameValue(step.done, false);
+
+step = iter.next();
+assert.sameValue(step.value, 'b');
+assert.sameValue(step.done, false);
+
+step = iter.next();
+assert.sameValue(step.value, undefined);
+assert.sameValue(step.done, true);

--- a/test/built-ins/Reflect/enumerate/enumerate.js
+++ b/test/built-ins/Reflect/enumerate/enumerate.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.5
+description: >
+  Reflect.enumerate is configurable, writable and not enumerable.
+info: >
+  26.1.5 Reflect.enumerate ( target )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Reflect, 'enumerate');
+verifyWritable(Reflect, 'enumerate');
+verifyConfigurable(Reflect, 'enumerate');

--- a/test/built-ins/Reflect/enumerate/length.js
+++ b/test/built-ins/Reflect/enumerate/length.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.5
+description: >
+  Reflect.enumerate.length value and property descriptor
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.enumerate.length, 1,
+  'The value of `Reflect.enumerate.length` is `1`'
+);
+
+verifyNotEnumerable(Reflect.enumerate, 'length');
+verifyNotWritable(Reflect.enumerate, 'length');
+verifyConfigurable(Reflect.enumerate, 'length');

--- a/test/built-ins/Reflect/enumerate/name.js
+++ b/test/built-ins/Reflect/enumerate/name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.5
+description: >
+  Reflect.enumerate.name value and property descriptor
+info: >
+  26.1.5 Reflect.enumerate ( target )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.enumerate.name, 'enumerate',
+  'The value of `Reflect.enumerate.name` is `"enumerate"`'
+);
+
+verifyNotEnumerable(Reflect.enumerate, 'name');
+verifyNotWritable(Reflect.enumerate, 'name');
+verifyConfigurable(Reflect.enumerate, 'name');

--- a/test/built-ins/Reflect/enumerate/return-abrupt-from-result.js
+++ b/test/built-ins/Reflect/enumerate/return-abrupt-from-result.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.5
+description: >
+  Return abrupt result.
+info: >
+  26.1.5 Reflect.enumerate ( target )
+
+  ...
+  2. Return target.[[Enumerate]]().
+features: [Proxy]
+---*/
+
+var o = {};
+var p = new Proxy(o, {
+  enumerate: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.enumerate(p);
+});

--- a/test/built-ins/Reflect/enumerate/return-iterator.js
+++ b/test/built-ins/Reflect/enumerate/return-iterator.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.5
+description: >
+  Return an iterator.
+info: >
+  26.1.5 Reflect.enumerate ( target )
+
+  ...
+  2. Return target.[[Enumerate]]().
+---*/
+
+var iter, step;
+var arr = ['a', 'b', 'c'];
+
+iter = Reflect.enumerate(arr);
+
+step = iter.next();
+assert.sameValue(step.value, '0');
+assert.sameValue(step.done, false);
+
+step = iter.next();
+assert.sameValue(step.value, '1');
+assert.sameValue(step.done, false);
+
+step = iter.next();
+assert.sameValue(step.value, '2');
+assert.sameValue(step.done, false);
+
+step = iter.next();
+assert.sameValue(step.value, undefined);
+assert.sameValue(step.done, true);
+
+var o = {
+  'a': 42,
+  'b': 43,
+  'c': 44
+};
+
+Object.defineProperty(o, 'd', {
+  enumerable: false,
+  value: 45
+});
+
+iter = Reflect.enumerate(o);
+
+step = iter.next();
+assert.sameValue(step.value, 'a');
+assert.sameValue(step.done, false);
+
+step = iter.next();
+assert.sameValue(step.value, 'b');
+assert.sameValue(step.done, false);
+
+step = iter.next();
+assert.sameValue(step.value, 'c');
+assert.sameValue(step.done, false);
+
+step = iter.next();
+assert.sameValue(step.value, undefined);
+assert.sameValue(step.done, true);

--- a/test/built-ins/Reflect/enumerate/target-is-not-object-throws.js
+++ b/test/built-ins/Reflect/enumerate/target-is-not-object-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.5
+description: >
+  Throws a TypeError if target is not an Object.
+info: >
+  26.1.5 Reflect.enumerate ( target )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.enumerate(1);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.enumerate(null);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.enumerate(undefined);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.enumerate('');
+});

--- a/test/built-ins/Reflect/enumerate/target-is-symbol-throws.js
+++ b/test/built-ins/Reflect/enumerate/target-is-symbol-throws.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.5
+description: >
+  Throws a TypeError if target is a Symbol
+info: >
+  26.1.5 Reflect.enumerate ( target )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.enumerate(Symbol(1), 'p');
+});

--- a/test/built-ins/Reflect/get/get.js
+++ b/test/built-ins/Reflect/get/get.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.6
+description: >
+  Reflect.get is configurable, writable and not enumerable.
+info: >
+  26.1.6 Reflect.get ( target, propertyKey [ , receiver ])
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Reflect, 'get');
+verifyWritable(Reflect, 'get');
+verifyConfigurable(Reflect, 'get');

--- a/test/built-ins/Reflect/get/length.js
+++ b/test/built-ins/Reflect/get/length.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.6
+description: >
+  Reflect.get.length value and property descriptor
+info: >
+  26.1.6 Reflect.get ( target, propertyKey [ , receiver ])
+
+  The length property of the get function is 2.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.get.length, 2,
+  'The value of `Reflect.get.length` is `2`'
+);
+
+verifyNotEnumerable(Reflect.get, 'length');
+verifyNotWritable(Reflect.get, 'length');
+verifyConfigurable(Reflect.get, 'length');

--- a/test/built-ins/Reflect/get/name.js
+++ b/test/built-ins/Reflect/get/name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.6
+description: >
+  Reflect.get.name value and property descriptor
+info: >
+  26.1.6 Reflect.get ( target, propertyKey [ , receiver ])
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.get.name, 'get',
+  'The value of `Reflect.get.name` is `"get"`'
+);
+
+verifyNotEnumerable(Reflect.get, 'name');
+verifyNotWritable(Reflect.get, 'name');
+verifyConfigurable(Reflect.get, 'name');

--- a/test/built-ins/Reflect/get/return-abrupt-from-property-key.js
+++ b/test/built-ins/Reflect/get/return-abrupt-from-property-key.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.6
+description: >
+  Return abrupt from ToPropertyKey(propertyKey)
+info: >
+  26.1.6 Reflect.get ( target, propertyKey [ , receiver ])
+
+  ...
+  2. Let key be ToPropertyKey(propertyKey).
+  3. ReturnIfAbrupt(key).
+  ...
+---*/
+
+var p = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  Reflect.get({}, p);
+});

--- a/test/built-ins/Reflect/get/return-abrupt-from-result.js
+++ b/test/built-ins/Reflect/get/return-abrupt-from-result.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.6
+description: >
+  Return abrupt result from get a property value.
+info: >
+  26.1.6 Reflect.get ( target, propertyKey [ , receiver ])
+
+  ...
+  5. Return target.[[Get]](key, receiver).
+---*/
+
+var o1 = {};
+Object.defineProperty(o1, 'p1', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.get(o1, 'p1');
+});
+
+// Abrupt from the prototype property
+var o2 = Object.create(o1);
+assert.throws(Test262Error, function() {
+  Reflect.get(o2, 'p1');
+});

--- a/test/built-ins/Reflect/get/return-value-from-receiver.js
+++ b/test/built-ins/Reflect/get/return-value-from-receiver.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.6
+description: >
+  Return value from a receiver.
+info: >
+  26.1.6 Reflect.get ( target, propertyKey [ , receiver ])
+
+  ...
+  4. If receiver is not present, then
+    a. Let receiver be target.
+  5. Return target.[[Get]](key, receiver).
+
+  9.1.8 [[Get]] (P, Receiver)
+
+  ...
+  2. Let desc be O.[[GetOwnProperty]](P).
+  3. ReturnIfAbrupt(desc).
+  4. If desc is undefined, then
+    a. Let parent be O.[[GetPrototypeOf]]().
+    b. ReturnIfAbrupt(parent).
+    c. If parent is null, return undefined.
+    d. Return parent.[[Get]](P, Receiver).
+  5. If IsDataDescriptor(desc) is true, return desc.[[Value]].
+  6. Otherwise, IsAccessorDescriptor(desc) must be true so, let getter be
+  desc.[[Get]].
+  7. If getter is undefined, return undefined.
+  8. Return Call(getter, Receiver).
+---*/
+
+var o1 = {};
+var receiver = {
+  y: 42
+};
+
+Object.defineProperty(o1, 'x', {
+  get: function() {
+    return this.y;
+  }
+});
+assert.sameValue(
+  Reflect.get(o1, 'x', receiver), 42,
+  'Return own property value using a receiver'
+);
+
+var o2 = Object.create(o1);
+assert.sameValue(
+  Reflect.get(o2, 'x', receiver), 42,
+  'Return prototype property value using a receiver'
+);

--- a/test/built-ins/Reflect/get/return-value-from-symbol-key.js
+++ b/test/built-ins/Reflect/get/return-value-from-symbol-key.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.6
+description: >
+  Return value where property key is a symbol.
+info: >
+  26.1.6 Reflect.get ( target, propertyKey [ , receiver ])
+
+  ...
+  2. Let key be ToPropertyKey(propertyKey).
+  ...
+
+  7.1.14 ToPropertyKey ( argument )
+
+  ...
+  3. If Type(key) is Symbol, then
+    a. Return key.
+  ...
+features: [Symbol]
+---*/
+
+var o = {};
+var s = Symbol('1');
+o[s] = 42;
+
+assert.sameValue(Reflect.get(o, s), 42);

--- a/test/built-ins/Reflect/get/return-value.js
+++ b/test/built-ins/Reflect/get/return-value.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.6
+description: >
+  Return value.
+info: >
+  26.1.6 Reflect.get ( target, propertyKey [ , receiver ])
+
+  ...
+  4. If receiver is not present, then
+    a. Let receiver be target.
+  5. Return target.[[Get]](key, receiver).
+
+  9.1.8 [[Get]] (P, Receiver)
+
+  ...
+  2. Let desc be O.[[GetOwnProperty]](P).
+  3. ReturnIfAbrupt(desc).
+  4. If desc is undefined, then
+    a. Let parent be O.[[GetPrototypeOf]]().
+    b. ReturnIfAbrupt(parent).
+    c. If parent is null, return undefined.
+    d. Return parent.[[Get]](P, Receiver).
+  5. If IsDataDescriptor(desc) is true, return desc.[[Value]].
+  6. Otherwise, IsAccessorDescriptor(desc) must be true so, let getter be
+  desc.[[Get]].
+  7. If getter is undefined, return undefined.
+  8. Return Call(getter, Receiver).
+---*/
+
+var o = {};
+
+o.p1 = 'value 1';
+assert.sameValue(
+  Reflect.get(o, 'p1'), 'value 1',
+  'Return value from data descriptor'
+);
+
+Object.defineProperty(o, 'p2', {
+  get: undefined
+});
+assert.sameValue(
+  Reflect.get(o, 'p2'), undefined,
+  'Return undefined if getter is undefined'
+);
+
+Object.defineProperty(o, 'p3', {
+  get: function() {
+    return 'foo';
+  }
+});
+assert.sameValue(
+  Reflect.get(o, 'p3'), 'foo',
+  'Return Call(getter, Receiver)'
+);
+
+var o2 = Object.create({p: 42});
+assert.sameValue(
+  Reflect.get(o2, 'p'), 42,
+  'Return value from prototype without own property.'
+);
+
+assert.sameValue(
+  Reflect.get(o2, 'u'), undefined,
+  'Return undefined without property on the object and its prototype'
+);

--- a/test/built-ins/Reflect/get/target-is-not-object-throws.js
+++ b/test/built-ins/Reflect/get/target-is-not-object-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.6
+description: >
+  Throws a TypeError if target is not an Object.
+info: >
+  26.1.6 Reflect.get ( target, propertyKey [ , receiver ])
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.get(1, 'p');
+});
+
+assert.throws(TypeError, function() {
+  Reflect.get(null, 'p');
+});
+
+assert.throws(TypeError, function() {
+  Reflect.get(undefined, 'p');
+});
+
+assert.throws(TypeError, function() {
+  Reflect.get('', 'p');
+});

--- a/test/built-ins/Reflect/get/target-is-symbol-throws.js
+++ b/test/built-ins/Reflect/get/target-is-symbol-throws.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.6
+description: >
+  Throws a TypeError if target is a Symbol
+info: >
+  26.1.6 Reflect.get ( target, propertyKey [ , receiver ])
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.get(Symbol(1), 'p');
+});

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/getOwnPropertyDescriptor.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/getOwnPropertyDescriptor.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.7
+description: >
+  Reflect.getOwnPropertyDescriptor is configurable, writable and not enumerable.
+info: >
+  26.1.7 Reflect.getOwnPropertyDescriptor ( target, propertyKey )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Reflect, 'getOwnPropertyDescriptor');
+verifyWritable(Reflect, 'getOwnPropertyDescriptor');
+verifyConfigurable(Reflect, 'getOwnPropertyDescriptor');

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/length.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/length.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.7
+description: >
+  Reflect.getOwnPropertyDescriptor.length value and property descriptor
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.getOwnPropertyDescriptor.length, 2,
+  'The value of `Reflect.getOwnPropertyDescriptor.length` is `2`'
+);
+
+verifyNotEnumerable(Reflect.getOwnPropertyDescriptor, 'length');
+verifyNotWritable(Reflect.getOwnPropertyDescriptor, 'length');
+verifyConfigurable(Reflect.getOwnPropertyDescriptor, 'length');

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/name.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.7
+description: >
+  Reflect.getOwnPropertyDescriptor.name value and property descriptor
+info: >
+  26.1.7 Reflect.getOwnPropertyDescriptor ( target, propertyKey )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.getOwnPropertyDescriptor.name, 'getOwnPropertyDescriptor',
+  'The value of `Reflect.getOwnPropertyDescriptor.name` is `"getOwnPropertyDescriptor"`'
+);
+
+verifyNotEnumerable(Reflect.getOwnPropertyDescriptor, 'name');
+verifyNotWritable(Reflect.getOwnPropertyDescriptor, 'name');
+verifyConfigurable(Reflect.getOwnPropertyDescriptor, 'name');

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/return-abrupt-from-property-key.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/return-abrupt-from-property-key.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.7
+description: >
+  Return abrupt from ToPropertyKey(propertyKey)
+info: >
+  26.1.7 Reflect.getOwnPropertyDescriptor ( target, propertyKey )
+
+  ...
+  2. Let key be ToPropertyKey(propertyKey).
+  3. ReturnIfAbrupt(key).
+  ...
+---*/
+
+var p = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  Reflect.getOwnPropertyDescriptor({}, p);
+});

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/return-abrupt-from-result.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/return-abrupt-from-result.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.7
+description: >
+  Return abrupt result from getting the property descriptor.
+info: >
+  26.1.7 Reflect.getOwnPropertyDescriptor ( target, propertyKey )
+
+  ...
+  4. Let desc be target.[[GetOwnProperty]](key).
+  5. ReturnIfAbrupt(desc).
+  ...
+features: [Proxy]
+---*/
+
+var o1 = {};
+var p = new Proxy(o1, {
+  getOwnPropertyDescriptor: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.getOwnPropertyDescriptor(p, 'p1');
+});

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/return-from-accessor-descriptor.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/return-from-accessor-descriptor.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.7
+description: >
+  Return a property descriptor object as an accessor descriptor.
+info: >
+  26.1.7 Reflect.getOwnPropertyDescriptor ( target, propertyKey )
+
+  ...
+  4. Let desc be target.[[GetOwnProperty]](key).
+  5. ReturnIfAbrupt(desc).
+  6. Return FromPropertyDescriptor(desc).
+
+  6.2.4.4 FromPropertyDescriptor ( Desc )
+
+  ...
+  2. Let obj be ObjectCreate(%ObjectPrototype%).
+  ...
+  4. If Desc has a [[Value]] field, then
+    a. Perform CreateDataProperty(obj, "value", Desc.[[Value]]).
+  5. If Desc has a [[Writable]] field, then
+    a. Perform CreateDataProperty(obj, "writable", Desc.[[Writable]]).
+  6. If Desc has a [[Get]] field, then
+    a. Perform CreateDataProperty(obj, "get", Desc.[[Get]]).
+  7. If Desc has a [[Set]] field, then
+    a. Perform CreateDataProperty(obj, "set", Desc.[[Set]])
+  8. If Desc has an [[Enumerable]] field, then
+    a. Perform CreateDataProperty(obj, "enumerable", Desc.[[Enumerable]]).
+  9. If Desc has a [[Configurable]] field, then
+    a. Perform CreateDataProperty(obj , "configurable", Desc.[[Configurable]]).
+  ...
+  11. Return obj.
+
+includes: [compareArray.js]
+---*/
+
+var o1 = {};
+var fn = function() {};
+Object.defineProperty(o1, 'p', {
+  get: fn,
+  configurable: true
+});
+
+var result = Reflect.getOwnPropertyDescriptor(o1, 'p');
+
+assert(
+  compareArray(
+    Object.keys(result),
+    ['get', 'set', 'enumerable', 'configurable']
+  )
+);
+assert.sameValue(result.enumerable, false);
+assert.sameValue(result.configurable, true);
+assert.sameValue(result.get, fn);
+assert.sameValue(result.set, undefined);

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/return-from-data-descriptor.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/return-from-data-descriptor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.7
+description: >
+  Return a property descriptor object as a data descriptor.
+info: >
+  26.1.7 Reflect.getOwnPropertyDescriptor ( target, propertyKey )
+
+  ...
+  4. Let desc be target.[[GetOwnProperty]](key).
+  5. ReturnIfAbrupt(desc).
+  6. Return FromPropertyDescriptor(desc).
+includes: [compareArray.js]
+---*/
+
+var o1 = {
+  p: 'foo'
+};
+
+var result = Reflect.getOwnPropertyDescriptor(o1, 'p');
+
+assert(
+  compareArray(
+    Object.keys(result),
+    ['value', 'writable', 'enumerable', 'configurable']
+  )
+);
+assert.sameValue(result.value, 'foo');
+assert.sameValue(result.enumerable, true);
+assert.sameValue(result.configurable, true);
+assert.sameValue(result.writable, true);

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/symbol-property.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/symbol-property.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.7
+description: >
+  Use a symbol value on property key.
+info: >
+  26.1.7 Reflect.getOwnPropertyDescriptor ( target, propertyKey )
+
+  ...
+  2. Let key be ToPropertyKey(propertyKey).
+  ...
+
+  7.1.14 ToPropertyKey ( argument )
+
+  ...
+  3. If Type(key) is Symbol, then
+    a. Return key.
+  ...
+includes: [compareArray.js]
+features: [Symbol]
+---*/
+
+var o = {};
+var s = Symbol('42');
+o[s] = 42;
+
+var result = Reflect.getOwnPropertyDescriptor(o, s);
+
+assert(
+  compareArray(
+    Object.keys(result),
+    ['value', 'writable', 'enumerable', 'configurable']
+  )
+);
+assert.sameValue(result.value, 42);
+assert.sameValue(result.enumerable, true);
+assert.sameValue(result.configurable, true);
+assert.sameValue(result.writable, true);

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/target-is-not-object-throws.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/target-is-not-object-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.7
+description: >
+  Throws a TypeError if target is not an Object.
+info: >
+  26.1.7 Reflect.getOwnPropertyDescriptor ( target, propertyKey )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.getOwnPropertyDescriptor(1, 'p');
+});
+
+assert.throws(TypeError, function() {
+  Reflect.getOwnPropertyDescriptor(null, 'p');
+});
+
+assert.throws(TypeError, function() {
+  Reflect.getOwnPropertyDescriptor(undefined, 'p');
+});
+
+assert.throws(TypeError, function() {
+  Reflect.getOwnPropertyDescriptor('', 'p');
+});

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/target-is-symbol-throws.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/target-is-symbol-throws.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.7
+description: >
+  Throws a TypeError if target is a Symbol
+info: >
+  26.1.7 Reflect.getOwnPropertyDescriptor ( target, propertyKey )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.getOwnPropertyDescriptor(Symbol(1), 'p');
+});

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/undefined-own-property.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/undefined-own-property.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 Leonardo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.7
+description: >
+  Return undefined for an non existing own property.
+info: >
+  26.1.7 Reflect.getOwnPropertyDescriptor ( target, propertyKey )
+
+  ...
+  4. Let desc be target.[[GetOwnProperty]](key).
+  5. ReturnIfAbrupt(desc).
+  6. Return FromPropertyDescriptor(desc).
+
+  6.2.4.4 FromPropertyDescriptor ( Desc )
+
+  1. If Desc is undefined, return undefined.
+---*/
+
+var o = Object.create({p: 1});
+
+var result = Reflect.getOwnPropertyDescriptor(o, 'p');
+assert.sameValue(result, undefined);

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/undefined-property.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/undefined-property.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.7
+description: >
+  Return undefined for an undefined property.
+info: >
+  26.1.7 Reflect.getOwnPropertyDescriptor ( target, propertyKey )
+
+  ...
+  4. Let desc be target.[[GetOwnProperty]](key).
+  5. ReturnIfAbrupt(desc).
+  6. Return FromPropertyDescriptor(desc).
+
+  6.2.4.4 FromPropertyDescriptor ( Desc )
+
+  1. If Desc is undefined, return undefined.
+---*/
+
+var result = Reflect.getOwnPropertyDescriptor({}, undefined);
+assert.sameValue(result, undefined);

--- a/test/built-ins/Reflect/getPrototypeOf/getPrototypeOf.js
+++ b/test/built-ins/Reflect/getPrototypeOf/getPrototypeOf.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.8
+description: >
+  Reflect.getPrototypeOf is configurable, writable and not enumerable.
+info: >
+  26.1.8 Reflect.getPrototypeOf ( target )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Reflect, 'getPrototypeOf');
+verifyWritable(Reflect, 'getPrototypeOf');
+verifyConfigurable(Reflect, 'getPrototypeOf');

--- a/test/built-ins/Reflect/getPrototypeOf/length.js
+++ b/test/built-ins/Reflect/getPrototypeOf/length.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.8
+description: >
+  Reflect.getPrototypeOf.length value and property descriptor
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.getPrototypeOf.length, 1,
+  'The value of `Reflect.getPrototypeOf.length` is `1`'
+);
+
+verifyNotEnumerable(Reflect.getPrototypeOf, 'length');
+verifyNotWritable(Reflect.getPrototypeOf, 'length');
+verifyConfigurable(Reflect.getPrototypeOf, 'length');

--- a/test/built-ins/Reflect/getPrototypeOf/name.js
+++ b/test/built-ins/Reflect/getPrototypeOf/name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.8
+description: >
+  Reflect.getPrototypeOf.name value and property descriptor
+info: >
+  26.1.8 Reflect.getPrototypeOf ( target )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.getPrototypeOf.name, 'getPrototypeOf',
+  'The value of `Reflect.getPrototypeOf.name` is `"getPrototypeOf"`'
+);
+
+verifyNotEnumerable(Reflect.getPrototypeOf, 'name');
+verifyNotWritable(Reflect.getPrototypeOf, 'name');
+verifyConfigurable(Reflect.getPrototypeOf, 'name');

--- a/test/built-ins/Reflect/getPrototypeOf/null-prototype.js
+++ b/test/built-ins/Reflect/getPrototypeOf/null-prototype.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.8
+description: >
+  Return null prototype.
+info: >
+  26.1.8 Reflect.getPrototypeOf ( target )
+
+  ...
+  2. Return target.[[GetPrototypeOf]]().
+---*/
+
+var o = Object.create(null);
+assert.sameValue(Reflect.getPrototypeOf(o), null);

--- a/test/built-ins/Reflect/getPrototypeOf/return-abrupt-from-result.js
+++ b/test/built-ins/Reflect/getPrototypeOf/return-abrupt-from-result.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.8
+description: >
+  Return abrupt result from getting the prototype.
+info: >
+  26.1.8 Reflect.getPrototypeOf ( target )
+
+  ...
+  2. Return target.[[GetPrototypeOf]]().
+  ...
+features: [Proxy]
+---*/
+
+var o1 = {};
+var p = new Proxy(o1, {
+  getPrototypeOf: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.getPrototypeOf(p);
+});

--- a/test/built-ins/Reflect/getPrototypeOf/return-prototype.js
+++ b/test/built-ins/Reflect/getPrototypeOf/return-prototype.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.8
+description: >
+  Returns the internal [[Prototype]] object.
+info: >
+  26.1.8 Reflect.getPrototypeOf ( target )
+
+  ...
+  2. Return target.[[GetPrototypeOf]]().
+---*/
+
+var o = {};
+assert.sameValue(
+  Reflect.getPrototypeOf(o), Object.prototype,
+  'return default prototypes'
+);

--- a/test/built-ins/Reflect/getPrototypeOf/skip-own-properties.js
+++ b/test/built-ins/Reflect/getPrototypeOf/skip-own-properties.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.8
+description: >
+  Skip own properties to return the internal [[Prototype]] object.
+info: >
+  26.1.8 Reflect.getPrototypeOf ( target )
+
+  ...
+  2. Return target.[[GetPrototypeOf]]().
+---*/
+
+var valid = {};
+var o = Object.create(valid, {
+  prototype: {value: 'invalid', enumerable: true}
+});
+
+assert.sameValue(
+  Reflect.getPrototypeOf(o), valid,
+  'skip own properties'
+);

--- a/test/built-ins/Reflect/getPrototypeOf/target-is-not-object-throws.js
+++ b/test/built-ins/Reflect/getPrototypeOf/target-is-not-object-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.8
+description: >
+  Throws a TypeError if target is not an Object.
+info: >
+  26.1.8 Reflect.getPrototypeOf ( target )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.getPrototypeOf(1);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.getPrototypeOf(null);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.getPrototypeOf(undefined);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.getPrototypeOf('');
+});

--- a/test/built-ins/Reflect/getPrototypeOf/target-is-symbol-throws.js
+++ b/test/built-ins/Reflect/getPrototypeOf/target-is-symbol-throws.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.8
+description: >
+  Throws a TypeError if target is a Symbol
+info: >
+  26.1.8 Reflect.getPrototypeOf ( target )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.getPrototypeOf(Symbol(1));
+});

--- a/test/built-ins/Reflect/has/has.js
+++ b/test/built-ins/Reflect/has/has.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.9
+description: >
+  Reflect.has is configurable, writable and not enumerable.
+info: >
+  26.1.9 Reflect.has ( target, propertyKey )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Reflect, 'has');
+verifyWritable(Reflect, 'has');
+verifyConfigurable(Reflect, 'has');

--- a/test/built-ins/Reflect/has/length.js
+++ b/test/built-ins/Reflect/has/length.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.9
+description: >
+  Reflect.has.length value and property descriptor
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.has.length, 2,
+  'The value of `Reflect.has.length` is `2`'
+);
+
+verifyNotEnumerable(Reflect.has, 'length');
+verifyNotWritable(Reflect.has, 'length');
+verifyConfigurable(Reflect.has, 'length');

--- a/test/built-ins/Reflect/has/name.js
+++ b/test/built-ins/Reflect/has/name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.9
+description: >
+  Reflect.has.name value and property descriptor
+info: >
+  26.1.9 Reflect.has ( target, propertyKey )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.has.name, 'has',
+  'The value of `Reflect.has.name` is `"has"`'
+);
+
+verifyNotEnumerable(Reflect.has, 'name');
+verifyNotWritable(Reflect.has, 'name');
+verifyConfigurable(Reflect.has, 'name');

--- a/test/built-ins/Reflect/has/return-abrupt-from-property-key.js
+++ b/test/built-ins/Reflect/has/return-abrupt-from-property-key.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.9
+description: >
+  Return abrupt from ToPropertyKey(propertyKey)
+info: >
+  26.1.9 Reflect.has ( target, propertyKey )
+
+  ...
+  2. Let key be ToPropertyKey(propertyKey).
+  3. ReturnIfAbrupt(key).
+  ...
+---*/
+
+var p = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  Reflect.has({}, p);
+});

--- a/test/built-ins/Reflect/has/return-abrupt-from-result.js
+++ b/test/built-ins/Reflect/has/return-abrupt-from-result.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.9
+description: >
+  Return abrupt result.
+info: >
+  26.1.9 Reflect.has ( target, propertyKey )
+
+  ...
+  4. Return target.[[HasProperty]](key).
+features: [Proxy]
+---*/
+
+var o = {};
+var p = new Proxy(o, {
+  has: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.has(p, 'p1');
+});

--- a/test/built-ins/Reflect/has/return-boolean.js
+++ b/test/built-ins/Reflect/has/return-boolean.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.9
+description: >
+  Return boolean value.
+info: >
+  26.1.9 Reflect.has ( target, propertyKey )
+
+  ...
+  4. Return target.[[HasProperty]](key).
+
+
+  9.1.7.1 OrdinaryHasProperty (O, P)
+
+  ...
+  2. Let hasOwn be OrdinaryGetOwnProperty(O, P).
+  3. If hasOwn is not undefined, return true.
+  4. Let parent be O.[[GetPrototypeOf]]().
+  5. ReturnIfAbrupt(parent).
+  6. If parent is not null, then
+    a. Return parent.[[HasProperty]](P).
+  7. Return false.
+---*/
+
+var o1 = {
+  p: 42
+};
+
+assert.sameValue(Reflect.has(o1, 'p'), true, 'true from own property');
+assert.sameValue(
+  Reflect.has(o1, 'z'), false,
+  'false when property is not present'
+);
+
+var o2 = Object.create({p: 42});
+assert.sameValue(Reflect.has(o2, 'p'), true, 'true from a prototype property');

--- a/test/built-ins/Reflect/has/symbol-property.js
+++ b/test/built-ins/Reflect/has/symbol-property.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.9
+description: >
+  Return boolean value from a projectKey as a Symbol
+info: >
+  26.1.9 Reflect.has ( target, propertyKey )
+
+  ...
+  2. Let key be ToPropertyKey(propertyKey).
+  ...
+
+  7.1.14 ToPropertyKey ( argument )
+
+  ...
+  3. If Type(key) is Symbol, then
+    a. Return key.
+  ...
+features: [Symbol]
+---*/
+
+var o = {};
+var s1 = Symbol('1');
+o[s1] = 42;
+
+var s2 = Symbol('1');
+
+
+assert.sameValue(Reflect.has(o, s1), true, 'true from own property');
+assert.sameValue(
+  Reflect.has(o, s2), false,
+  'false when property is not present'
+);

--- a/test/built-ins/Reflect/has/target-is-not-object-throws.js
+++ b/test/built-ins/Reflect/has/target-is-not-object-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.9
+description: >
+  Throws a TypeError if target is not an Object.
+info: >
+  26.1.9 Reflect.has ( target, propertyKey )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.has(1, 'p');
+});
+
+assert.throws(TypeError, function() {
+  Reflect.has(null, 'p');
+});
+
+assert.throws(TypeError, function() {
+  Reflect.has(undefined, 'p');
+});
+
+assert.throws(TypeError, function() {
+  Reflect.has('', 'p');
+});

--- a/test/built-ins/Reflect/has/target-is-symbol-throws.js
+++ b/test/built-ins/Reflect/has/target-is-symbol-throws.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.9
+description: >
+  Throws a TypeError if target is a Symbol
+info: >
+  26.1.9 Reflect.has ( target, propertyKey )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.has(Symbol(1), 'p');
+});

--- a/test/built-ins/Reflect/isExtensible/isExtensible.js
+++ b/test/built-ins/Reflect/isExtensible/isExtensible.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.10
+description: >
+  Reflect.isExtensible is configurable, writable and not enumerable.
+info: >
+  26.1.10 Reflect.isExtensible (target)
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Reflect, 'isExtensible');
+verifyWritable(Reflect, 'isExtensible');
+verifyConfigurable(Reflect, 'isExtensible');

--- a/test/built-ins/Reflect/isExtensible/length.js
+++ b/test/built-ins/Reflect/isExtensible/length.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.10
+description: >
+  Reflect.isExtensible.length value and property descriptor
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.isExtensible.length, 1,
+  'The value of `Reflect.isExtensible.length` is `1`'
+);
+
+verifyNotEnumerable(Reflect.isExtensible, 'length');
+verifyNotWritable(Reflect.isExtensible, 'length');
+verifyConfigurable(Reflect.isExtensible, 'length');

--- a/test/built-ins/Reflect/isExtensible/name.js
+++ b/test/built-ins/Reflect/isExtensible/name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.10
+description: >
+  Reflect.isExtensible.name value and property descriptor
+info: >
+  26.1.10 Reflect.isExtensible (target)
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.isExtensible.name, 'isExtensible',
+  'The value of `Reflect.isExtensible.name` is `"isExtensible"`'
+);
+
+verifyNotEnumerable(Reflect.isExtensible, 'name');
+verifyNotWritable(Reflect.isExtensible, 'name');
+verifyConfigurable(Reflect.isExtensible, 'name');

--- a/test/built-ins/Reflect/isExtensible/return-abrupt-from-result.js
+++ b/test/built-ins/Reflect/isExtensible/return-abrupt-from-result.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.10
+description: >
+  Return abrupt result.
+info: >
+  26.1.10 Reflect.isExtensible (target)
+
+  ...
+  2. Return target.[[IsExtensible]]().
+features: [Proxy]
+---*/
+
+var o1 = {};
+var p = new Proxy(o1, {
+  isExtensible: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.isExtensible(p);
+});

--- a/test/built-ins/Reflect/isExtensible/return-boolean.js
+++ b/test/built-ins/Reflect/isExtensible/return-boolean.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.10
+description: >
+  Returns the boolean result.
+info: >
+  26.1.10 Reflect.isExtensible (target)
+
+  ...
+  2. Return target.[[IsExtensible]]().
+---*/
+
+var o = {};
+assert.sameValue(Reflect.isExtensible(o), true);
+
+Object.preventExtensions(o);
+assert.sameValue(Reflect.isExtensible(o), false);

--- a/test/built-ins/Reflect/isExtensible/target-is-not-object-throws.js
+++ b/test/built-ins/Reflect/isExtensible/target-is-not-object-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.10
+description: >
+  Throws a TypeError if target is not an Object.
+info: >
+  26.1.10 Reflect.isExtensible (target)
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.isExtensible(1);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.isExtensible(null);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.isExtensible(undefined);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.isExtensible('');
+});

--- a/test/built-ins/Reflect/isExtensible/target-is-symbol-throws.js
+++ b/test/built-ins/Reflect/isExtensible/target-is-symbol-throws.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.10
+description: >
+  Throws a TypeError if target is a Symbol
+info: >
+  26.1.10 Reflect.isExtensible (target)
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.isExtensible(Symbol(1));
+});

--- a/test/built-ins/Reflect/object-prototype.js
+++ b/test/built-ins/Reflect/object-prototype.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1
+description: >
+  The value of the [[Prototype]] internal slot of the Reflect object
+  is the intrinsic object %ObjectPrototype% (19.1.3).
+---*/
+
+assert.sameValue(
+  Object.getPrototypeOf(Reflect),
+  Object.prototype,
+  '`Object.getPrototypeOf(Reflect)` returns `Object.prototype`'
+);

--- a/test/built-ins/Reflect/ownKeys/length.js
+++ b/test/built-ins/Reflect/ownKeys/length.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.11
+description: >
+  Reflect.ownKeys.length value and property descriptor
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.ownKeys.length, 1,
+  'The value of `Reflect.ownKeys.length` is `1`'
+);
+
+verifyNotEnumerable(Reflect.ownKeys, 'length');
+verifyNotWritable(Reflect.ownKeys, 'length');
+verifyConfigurable(Reflect.ownKeys, 'length');

--- a/test/built-ins/Reflect/ownKeys/name.js
+++ b/test/built-ins/Reflect/ownKeys/name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.11
+description: >
+  Reflect.ownKeys.name value and property descriptor
+info: >
+  26.1.11 Reflect.ownKeys ( target )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.ownKeys.name, 'ownKeys',
+  'The value of `Reflect.ownKeys.name` is `"ownKeys"`'
+);
+
+verifyNotEnumerable(Reflect.ownKeys, 'name');
+verifyNotWritable(Reflect.ownKeys, 'name');
+verifyConfigurable(Reflect.ownKeys, 'name');

--- a/test/built-ins/Reflect/ownKeys/ownKeys.js
+++ b/test/built-ins/Reflect/ownKeys/ownKeys.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.11
+description: >
+  Reflect.ownKeys is configurable, writable and not enumerable.
+info: >
+  26.1.11 Reflect.ownKeys ( target )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Reflect, 'ownKeys');
+verifyWritable(Reflect, 'ownKeys');
+verifyConfigurable(Reflect, 'ownKeys');

--- a/test/built-ins/Reflect/ownKeys/return-abrupt-from-result.js
+++ b/test/built-ins/Reflect/ownKeys/return-abrupt-from-result.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.11
+description: >
+  Return abrupt result from target.[[OwnPropertyKeys]]()
+info: >
+  26.1.11 Reflect.ownKeys ( target )
+
+  ...
+  2. Let keys be target.[[OwnPropertyKeys]]().
+  3. ReturnIfAbrupt(keys).
+  ...
+features: [Proxy]
+---*/
+
+var o = {};
+var p = new Proxy(o, {
+  ownKeys: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.ownKeys(p);
+});

--- a/test/built-ins/Reflect/ownKeys/return-array-with-own-keys-only.js
+++ b/test/built-ins/Reflect/ownKeys/return-array-with-own-keys-only.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.11
+description: >
+  Returns target's own property keys only, ignore prototype keys.
+info: >
+  26.1.11 Reflect.ownKeys ( target )
+
+  ...
+  2. Let keys be target.[[OwnPropertyKeys]]().
+  3. ReturnIfAbrupt(keys).
+  4. Return CreateArrayFromList(keys).
+includes: [compareArray.js]
+---*/
+
+var proto = {
+  foo: 1
+};
+
+var o = Object.create(proto);
+o.p1 = 42;
+o.p2 = 43;
+o.p3 = 44;
+assert(
+  compareArray(Reflect.ownKeys(o), ['p1', 'p2', 'p3']),
+  'return object own keys'
+);

--- a/test/built-ins/Reflect/ownKeys/return-empty-array.js
+++ b/test/built-ins/Reflect/ownKeys/return-empty-array.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.11
+description: >
+  Returns empty array when target has now own properties.
+info: >
+  26.1.11 Reflect.ownKeys ( target )
+
+  ...
+  2. Let keys be target.[[OwnPropertyKeys]]().
+  3. ReturnIfAbrupt(keys).
+  4. Return CreateArrayFromList(keys).
+includes: [compareArray.js]
+---*/
+
+assert(compareArray(Reflect.ownKeys({}), []));
+
+var o = {d: 42};
+delete o.d;
+assert(compareArray(Reflect.ownKeys(o), []));

--- a/test/built-ins/Reflect/ownKeys/return-non-enumerable-keys.js
+++ b/test/built-ins/Reflect/ownKeys/return-non-enumerable-keys.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.11
+description: >
+  Returns target's own non enumerable property keys.
+info: >
+  26.1.11 Reflect.ownKeys ( target )
+
+  ...
+  2. Let keys be target.[[OwnPropertyKeys]]().
+  3. ReturnIfAbrupt(keys).
+  4. Return CreateArrayFromList(keys).
+includes: [compareArray.js]
+---*/
+
+assert(
+  compareArray(Reflect.ownKeys([]), ['length']),
+  'return non enumerable `length` from empty array'
+);
+
+assert(
+  compareArray(Reflect.ownKeys([,,2]), ['2', 'length']),
+  'return array keys'
+);
+
+var o = {};
+Object.defineProperty(o, 'p1', {
+  value: 42,
+  enumerable: false
+});
+Object.defineProperty(o, 'p2', {
+  get: function() {},
+  enumerable: false
+});
+
+assert(compareArray(Reflect.ownKeys(o), ['p1', 'p2']));

--- a/test/built-ins/Reflect/ownKeys/return-on-corresponding-order.js
+++ b/test/built-ins/Reflect/ownKeys/return-on-corresponding-order.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.11
+description: >
+  Returns keys in their corresponding order.
+info: >
+  26.1.11 Reflect.ownKeys ( target )
+
+  ...
+  2. Let keys be target.[[OwnPropertyKeys]]().
+  3. ReturnIfAbrupt(keys).
+  4. Return CreateArrayFromList(keys).
+
+  9.1.12 [[OwnPropertyKeys]] ( )
+
+  1. Let keys be a new empty List.
+  2. For each own property key P of O that is an integer index, in ascending
+  numeric index order
+    a. Add P as the last element of keys.
+  3. For each own property key P of O that is a String but is not an integer
+  index, in property creation order
+    a. Add P as the last element of keys.
+  4. For each own property key P of O that is a Symbol, in property creation
+  order
+    a. Add P as the last element of keys.
+  5. Return keys.
+features: [Symbol]
+---*/
+
+
+var o = {};
+o.p1 = 42;
+o.p2 = 43;
+
+var s1 = Symbol('1');
+var s2 = Symbol('a');
+o[s1] = 44;
+o[s2] = 45;
+
+o[2] = 46;
+o[0] = 47;
+o[1] = 48;
+
+var result = Reflect.ownKeys(o);
+
+assert.sameValue(result.length, 7);
+assert.sameValue(result[0], '0');
+assert.sameValue(result[1], '1');
+assert.sameValue(result[2], '2');
+assert.sameValue(result[3], 'p1');
+assert.sameValue(result[4], 'p2');
+assert.sameValue(result[5], s1);
+assert.sameValue(result[6], s2);

--- a/test/built-ins/Reflect/ownKeys/target-is-not-object-throws.js
+++ b/test/built-ins/Reflect/ownKeys/target-is-not-object-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.11
+description: >
+  Throws a TypeError if target is not an Object.
+info: >
+  26.1.11 Reflect.ownKeys ( target )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.ownKeys(1);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.ownKeys(null);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.ownKeys(undefined);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.ownKeys('');
+});

--- a/test/built-ins/Reflect/ownKeys/target-is-symbol-throws.js
+++ b/test/built-ins/Reflect/ownKeys/target-is-symbol-throws.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.11
+description: >
+  Throws a TypeError if target is a Symbol
+info: >
+  26.1.11 Reflect.ownKeys ( target )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.ownKeys(Symbol(1));
+});

--- a/test/built-ins/Reflect/preventExtensions/always-return-true-from-ordinary-object.js
+++ b/test/built-ins/Reflect/preventExtensions/always-return-true-from-ordinary-object.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.12
+description: >
+  Always returns true when target is an ordinary object.
+info: >
+  26.1.12 Reflect.preventExtensions ( target )
+
+  ...
+  2. Return target.[[PreventExtensions]]().
+
+  9.1.4 [[PreventExtensions]] ( )
+
+  1. Set the value of the [[Extensible]] internal slot of O to false.
+  2. Return true.
+---*/
+
+var o = {};
+assert.sameValue(
+  Reflect.preventExtensions(o), true,
+  'returns true after preventing extentions on an object'
+);
+assert.sameValue(
+  Reflect.preventExtensions(o), true,
+  'returns true even if the object already prevents extentions'
+);

--- a/test/built-ins/Reflect/preventExtensions/length.js
+++ b/test/built-ins/Reflect/preventExtensions/length.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.12
+description: >
+  Reflect.preventExtensions.length value and property descriptor
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.preventExtensions.length, 1,
+  'The value of `Reflect.preventExtensions.length` is `1`'
+);
+
+verifyNotEnumerable(Reflect.preventExtensions, 'length');
+verifyNotWritable(Reflect.preventExtensions, 'length');
+verifyConfigurable(Reflect.preventExtensions, 'length');

--- a/test/built-ins/Reflect/preventExtensions/name.js
+++ b/test/built-ins/Reflect/preventExtensions/name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.12
+description: >
+  Reflect.preventExtensions.name value and property descriptor
+info: >
+  26.1.12 Reflect.preventExtensions ( target )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.preventExtensions.name, 'preventExtensions',
+  'The value of `Reflect.preventExtensions.name` is `"preventExtensions"`'
+);
+
+verifyNotEnumerable(Reflect.preventExtensions, 'name');
+verifyNotWritable(Reflect.preventExtensions, 'name');
+verifyConfigurable(Reflect.preventExtensions, 'name');

--- a/test/built-ins/Reflect/preventExtensions/prevent-extensions.js
+++ b/test/built-ins/Reflect/preventExtensions/prevent-extensions.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.12
+description: >
+  Prevent extentions on target.
+info: >
+  26.1.12 Reflect.preventExtensions ( target )
+
+  ...
+  2. Return target.[[PreventExtensions]]().
+
+  9.1.4 [[PreventExtensions]] ( )
+
+  1. Set the value of the [[Extensible]] internal slot of O to false.
+  ...
+---*/
+
+var o = {};
+Reflect.preventExtensions(o);
+assert.sameValue(Object.isExtensible(o), false, 'object is not extensible');
+
+assert.throws(TypeError, function() {
+  Object.defineProperty(o, 'y', {});
+});
+assert.throws(TypeError, function() {
+  Object.setPrototypeOf(o, Array.prototype);
+});
+
+Reflect.preventExtensions(o);
+assert.sameValue(
+  Object.isExtensible(o), false,
+  'object is still not extensible on exhausted calls'
+);

--- a/test/built-ins/Reflect/preventExtensions/preventExtensions.js
+++ b/test/built-ins/Reflect/preventExtensions/preventExtensions.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.12
+description: >
+  Reflect.preventExtensions is configurable, writable and not enumerable.
+info: >
+  26.1.12 Reflect.preventExtensions ( target )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Reflect, 'preventExtensions');
+verifyWritable(Reflect, 'preventExtensions');
+verifyConfigurable(Reflect, 'preventExtensions');

--- a/test/built-ins/Reflect/preventExtensions/return-abrupt-from-result.js
+++ b/test/built-ins/Reflect/preventExtensions/return-abrupt-from-result.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.12
+description: >
+  Return abrupt result.
+info: >
+  26.1.12 Reflect.preventExtensions ( target )
+
+  ...
+  2. Return target.[[PreventExtensions]]().
+features: [Proxy]
+---*/
+
+var o1 = {};
+var p = new Proxy(o1, {
+  preventExtensions: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.preventExtensions(p);
+});

--- a/test/built-ins/Reflect/preventExtensions/return-boolean-from-proxy-object.js
+++ b/test/built-ins/Reflect/preventExtensions/return-boolean-from-proxy-object.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.12
+description: >
+  Returns boolean from Proxy object.
+info: >
+  26.1.12 Reflect.preventExtensions ( target )
+
+  ...
+  2. Return target.[[PreventExtensions]]().
+
+  9.5.4 [[PreventExtensions]] ( )
+
+  8. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target»)).
+  9. ReturnIfAbrupt(booleanTrapResult).
+  10. If booleanTrapResult is true, then
+    a. Let targetIsExtensible be target.[[IsExtensible]]().
+    b. ReturnIfAbrupt(targetIsExtensible).
+    c. If targetIsExtensible is true, throw a TypeError exception.
+  11. Return booleanTrapResult.
+features: [Proxy]
+---*/
+
+var p1 = new Proxy({}, {
+  preventExtensions: function() {
+    return false;
+  }
+});
+
+assert.sameValue(
+  Reflect.preventExtensions(p1), false,
+  'returns false from Proxy handler'
+);
+
+var p2 = new Proxy({}, {
+  preventExtensions: function(target) {
+    Object.preventExtensions(target);
+    return true;
+  }
+});
+
+assert.sameValue(
+  Reflect.preventExtensions(p2), true,
+  'returns true from Proxy handler'
+);

--- a/test/built-ins/Reflect/preventExtensions/target-is-not-object-throws.js
+++ b/test/built-ins/Reflect/preventExtensions/target-is-not-object-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.10
+description: >
+  Throws a TypeError if target is not an Object.
+info: >
+  26.1.10 Reflect.isExtensible (target)
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.isExtensible(1);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.isExtensible(null);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.isExtensible(undefined);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.isExtensible('');
+});

--- a/test/built-ins/Reflect/preventExtensions/target-is-symbol-throws.js
+++ b/test/built-ins/Reflect/preventExtensions/target-is-symbol-throws.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.10
+description: >
+  Throws a TypeError if target is a Symbol
+info: >
+  26.1.10 Reflect.isExtensible (target)
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.isExtensible(Symbol(1));
+});

--- a/test/built-ins/Reflect/properties.js
+++ b/test/built-ins/Reflect/properties.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1
+description: >
+  Reflect is configurable, writable and not enumerable.
+info: >
+  17 ECMAScript Standard Built-in Objects
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(this, 'Reflect');
+verifyWritable(this, 'Reflect');
+verifyConfigurable(this, 'Reflect');

--- a/test/built-ins/Reflect/set/call-prototype-property-set.js
+++ b/test/built-ins/Reflect/set/call-prototype-property-set.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Call accessor's set from target's prototype.
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  ...
+  4. If receiver is not present, then
+    a. Let receiver be target.
+  5. Return target.[[Set]](key, V, receiver).
+
+  9.1.9 [[Set]] ( P, V, Receiver)
+
+  ...
+  4. If ownDesc is undefined, then
+    a. Let parent be O.[[GetPrototypeOf]]().
+    b. ReturnIfAbrupt(parent).
+    c. If parent is not null, then
+      i. Return parent.[[Set]](P, V, Receiver).
+  ...
+  11. Return true.
+---*/
+
+var args;
+var count = 0;
+var _this;
+var proto = {};
+Object.defineProperty(proto, 'p', {
+  set: function() {
+    _this = this;
+    args = arguments;
+    count++;
+  }
+});
+
+var target = Object.create(proto);
+var result = Reflect.set(target, 'p', 42);
+assert.sameValue(result, true, 'returns true');
+assert.sameValue(args.length, 1, 'prototype `set` called with 1 argument');
+assert.sameValue(args[0], 42, 'prototype `set` called with 42');
+assert.sameValue(_this, target, 'prototype `set` called with target as `this`');
+assert.sameValue(count, 1, 'prototype `set` called once');

--- a/test/built-ins/Reflect/set/creates-a-data-descriptor.js
+++ b/test/built-ins/Reflect/set/creates-a-data-descriptor.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Creates a property data descriptor.
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  ...
+  4. If receiver is not present, then
+    a. Let receiver be target.
+  5. Return target.[[Set]](key, V, receiver).
+
+  9.1.9 [[Set]] ( P, V, Receiver)
+
+  ...
+  4. If ownDesc is undefined, then
+    a. Let parent be O.[[GetPrototypeOf]]().
+    b. ReturnIfAbrupt(parent).
+    c. If parent is not null, then
+      i. Return parent.[[Set]](P, V, Receiver).
+    d. Else,
+      ii. Let ownDesc be the PropertyDescriptor{[[Value]]: undefined,
+      [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true}.
+  5. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+    b. If Type(Receiver) is not Object, return false.
+    c. Let existingDescriptor be Receiver.[[GetOwnProperty]](P).
+    d. ReturnIfAbrupt(existingDescriptor).
+    e. If existingDescriptor is not undefined, then
+      i. If IsAccessorDescriptor(existingDescriptor) is true, return false.
+      ii. If existingDescriptor.[[Writable]] is false, return false.
+      iii. Let valueDesc be the PropertyDescriptor{[[Value]]: V}.
+      iv. Return Receiver.[[DefineOwnProperty]](P, valueDesc).
+    f. Else Receiver does not currently have a property P,
+      i. Return CreateDataProperty(Receiver, P, V).
+  6. Assert: IsAccessorDescriptor(ownDesc) is true.
+  7. Let setter be ownDesc.[[Set]].
+  8. If setter is undefined, return false.
+  ...
+  11. Return true.
+includes: [propertyHelper.js]
+---*/
+
+var o1 = {};
+var result = Reflect.set(o1, 'p', 42);
+assert.sameValue(result, true, 'returns true on a successful setting');
+var desc = Object.getOwnPropertyDescriptor(o1, 'p');
+assert.sameValue(
+  desc.value, 42,
+  'sets a data descriptor to set a new property'
+);
+verifyWritable(o1, 'p');
+verifyEnumerable(o1, 'p');
+verifyConfigurable(o1, 'p');
+
+var o2 = {};
+var receiver = {};
+result = Reflect.set(o2, 'p', 43, receiver);
+assert.sameValue(
+  result, true,
+  'returns true on a successful setting with a receiver'
+);
+desc = Object.getOwnPropertyDescriptor(o2, 'p');
+assert.sameValue(
+  desc, undefined,
+  'does not set a data descriptor on target if receiver is given'
+);
+desc = Object.getOwnPropertyDescriptor(receiver, 'p');
+assert.sameValue(
+  desc.value, 43,
+  'sets a data descriptor on the receiver object to set a new property'
+);
+verifyWritable(receiver, 'p');
+verifyEnumerable(receiver, 'p');
+verifyConfigurable(receiver, 'p');
+

--- a/test/built-ins/Reflect/set/different-property-descriptors.js
+++ b/test/built-ins/Reflect/set/different-property-descriptors.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Return false if target property turns to a data descriptor and receiver
+  property is an accessor descriptor.
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  ...
+  4. If receiver is not present, then
+    a. Let receiver be target.
+  5. Return target.[[Set]](key, V, receiver).
+
+  9.1.9 [[Set]] ( P, V, Receiver)
+
+  ...
+  4. If ownDesc is undefined, then
+    a. Let parent be O.[[GetPrototypeOf]]().
+    b. ReturnIfAbrupt(parent).
+    c. If parent is not null, then
+      i. Return parent.[[Set]](P, V, Receiver).
+    d. Else,
+      ii. Let ownDesc be the PropertyDescriptor{[[Value]]: undefined,
+      [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true}.
+  5. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+    b. If Type(Receiver) is not Object, return false.
+    c. Let existingDescriptor be Receiver.[[GetOwnProperty]](P).
+    d. ReturnIfAbrupt(existingDescriptor).
+    e. If existingDescriptor is not undefined, then
+      i. If IsAccessorDescriptor(existingDescriptor) is true, return false.
+  ...
+---*/
+
+var receiver = {};
+var fn = function() {};
+Object.defineProperty(receiver, 'p', {
+  set: fn
+});
+
+var o1 = {};
+var result = Reflect.set(o1, 'p', 42, receiver);
+assert.sameValue(
+  result, false,
+  'target has no own `p` and receiver.p has an accessor descriptor'
+);
+assert.sameValue(
+  Object.getOwnPropertyDescriptor(receiver, 'p').set, fn,
+  'receiver.p is not changed'
+);
+assert.sameValue(o1.hasOwnProperty('p'), false, 'target.p is not set');
+
+var o2 = {p: 43};
+result = Reflect.set(o2, 'p', 42, receiver);
+assert.sameValue(
+  result, false,
+  'target.p has a data descriptor and receiver.p has an accessor descriptor'
+);
+assert.sameValue(
+  Object.getOwnPropertyDescriptor(receiver, 'p').set, fn,
+  'receiver.p is not changed'
+);
+assert.sameValue(o2.p, 43, 'target.p is not changed');

--- a/test/built-ins/Reflect/set/length.js
+++ b/test/built-ins/Reflect/set/length.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Reflect.set.length value and property descriptor
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  The length property of the set function is 3.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.set.length, 3,
+  'The value of `Reflect.set.length` is `3`'
+);
+
+verifyNotEnumerable(Reflect.set, 'length');
+verifyNotWritable(Reflect.set, 'length');
+verifyConfigurable(Reflect.set, 'length');

--- a/test/built-ins/Reflect/set/name.js
+++ b/test/built-ins/Reflect/set/name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Reflect.set.name value and property descriptor
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.set.name, 'set',
+  'The value of `Reflect.set.name` is `"set"`'
+);
+
+verifyNotEnumerable(Reflect.set, 'name');
+verifyNotWritable(Reflect.set, 'name');
+verifyConfigurable(Reflect.set, 'name');

--- a/test/built-ins/Reflect/set/receiver-is-not-object.js
+++ b/test/built-ins/Reflect/set/receiver-is-not-object.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Return false if receiver is not an object.
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  ...
+  4. If receiver is not present, then
+    a. Let receiver be target.
+  5. Return target.[[Set]](key, V, receiver).
+
+  9.1.9 [[Set]] ( P, V, Receiver)
+
+  ...
+  4. If ownDesc is undefined, then
+    a. Let parent be O.[[GetPrototypeOf]]().
+    b. ReturnIfAbrupt(parent).
+    c. If parent is not null, then
+      i. Return parent.[[Set]](P, V, Receiver).
+    d. Else,
+      ii. Let ownDesc be the PropertyDescriptor{[[Value]]: undefined,
+      [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true}.
+  5. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+    b. If Type(Receiver) is not Object, return false.
+  ...
+---*/
+
+var o1 = {p: 42};
+var receiver = 'receiver is a string';
+var result = Reflect.set(o1, 'p', 43, receiver);
+
+assert.sameValue(result, false, 'returns false');
+assert.sameValue(o1.p, 42, 'does not set a value');
+assert.sameValue(
+  receiver.hasOwnProperty('p'), false,
+  'does not set a new property on receiver if it is not an object'
+);

--- a/test/built-ins/Reflect/set/return-abrupt-from-property-key.js
+++ b/test/built-ins/Reflect/set/return-abrupt-from-property-key.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Return abrupt from ToPropertyKey(propertyKey)
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  ...
+  2. Let key be ToPropertyKey(propertyKey).
+  3. ReturnIfAbrupt(key).
+  ...
+---*/
+
+var p = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  Reflect.set({}, p);
+});

--- a/test/built-ins/Reflect/set/return-abrupt-from-result.js
+++ b/test/built-ins/Reflect/set/return-abrupt-from-result.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Return abrupt result from get a property value.
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  ...
+  5. Return target.[[Set]](key, V, receiver).
+---*/
+
+var o1 = {};
+Object.defineProperty(o1, 'p1', {
+  set: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.set(o1, 'p1', 42);
+});
+
+// Abrupt from the prototype property
+var o2 = Object.create(o1);
+assert.throws(Test262Error, function() {
+  Reflect.set(o2, 'p1', 42);
+});

--- a/test/built-ins/Reflect/set/return-false-if-receiver-is-not-writable.js
+++ b/test/built-ins/Reflect/set/return-false-if-receiver-is-not-writable.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Return false if receiver is not writable.
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  ...
+  4. If receiver is not present, then
+    a. Let receiver be target.
+  5. Return target.[[Set]](key, V, receiver).
+
+  9.1.9 [[Set]] ( P, V, Receiver)
+
+  ...
+  5. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+  ...
+---*/
+
+var o1 = {};
+
+Object.defineProperty(o1, 'p', {
+  writable: false,
+  value: 42
+});
+var result = Reflect.set(o1, 'p', 43);
+assert.sameValue(result, false, 'returns false');
+assert.sameValue(o1.p, 42, 'does not set a new value');

--- a/test/built-ins/Reflect/set/return-false-if-target-is-not-writable.js
+++ b/test/built-ins/Reflect/set/return-false-if-target-is-not-writable.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Return false if target is not writable.
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  ...
+  4. If receiver is not present, then
+    a. Let receiver be target.
+  5. Return target.[[Set]](key, V, receiver).
+
+  9.1.9 [[Set]] ( P, V, Receiver)
+
+  ...
+  5. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+    b. If Type(Receiver) is not Object, return false.
+    c. Let existingDescriptor be Receiver.[[GetOwnProperty]](P).
+    d. ReturnIfAbrupt(existingDescriptor).
+    e. If existingDescriptor is not undefined, then
+      i. If IsAccessorDescriptor(existingDescriptor) is true, return false.
+      ii. If existingDescriptor.[[Writable]] is false, return false.
+  ...
+---*/
+
+var o1 = {};
+var receiver = {};
+Object.defineProperty(receiver, 'p', {
+  writable: false,
+  value: 42
+});
+var result = Reflect.set(o1, 'p', 43, receiver);
+assert.sameValue(result, false, 'returns false');
+assert.sameValue(receiver.p, 42, 'does not set a new value on receiver');
+assert.sameValue(
+  o1.hasOwnProperty('p'), false,
+  'does not set a new value on target'
+);

--- a/test/built-ins/Reflect/set/set-value-on-accessor-descriptor-with-receiver.js
+++ b/test/built-ins/Reflect/set/set-value-on-accessor-descriptor-with-receiver.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Set value on an accessor descriptor property with receiver as `this`.
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  ...
+  4. If receiver is not present, then
+    a. Let receiver be target.
+  5. Return target.[[Set]](key, V, receiver).
+
+  9.1.9 [[Set]] ( P, V, Receiver)
+
+  ...
+  6. Assert: IsAccessorDescriptor(ownDesc) is true.
+  7. Let setter be ownDesc.[[Set]].
+  8. If setter is undefined, return false.
+  9. Let setterResult be Call(setter, Receiver, «V»).
+  10. ReturnIfAbrupt(setterResult).
+  11. Return true.
+---*/
+
+var args;
+var count = 0
+var o1 = {};
+var receiver = {};
+var _receiver;
+Object.defineProperty(o1, 'p', {
+  set: function(a) {
+    count++;
+    args = arguments;
+    _receiver = this;
+    return false;
+  }
+});
+
+var result = Reflect.set(o1, 'p', 42, receiver);
+assert.sameValue(
+  result, true,
+  'returns true if target.p has an accessor descriptor'
+);
+assert.sameValue(args.length, 1, 'target.p set is called with 1 argument');
+assert.sameValue(args[0], 42, 'target.p set is called with V');
+assert.sameValue(count, 1, 'target.p set is called once');
+assert.sameValue(
+  _receiver, receiver,
+  'target.p set is called with receiver as `this`'
+);

--- a/test/built-ins/Reflect/set/set-value-on-accessor-descriptor.js
+++ b/test/built-ins/Reflect/set/set-value-on-accessor-descriptor.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Set value on an accessor descriptor property.
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  ...
+  4. If receiver is not present, then
+    a. Let receiver be target.
+  5. Return target.[[Set]](key, V, receiver).
+
+  9.1.9 [[Set]] ( P, V, Receiver)
+
+  ...
+  6. Assert: IsAccessorDescriptor(ownDesc) is true.
+  7. Let setter be ownDesc.[[Set]].
+  8. If setter is undefined, return false.
+  9. Let setterResult be Call(setter, Receiver, «V»).
+  10. ReturnIfAbrupt(setterResult).
+  11. Return true.
+---*/
+
+var args;
+var count = 0
+var o1 = {};
+Object.defineProperty(o1, 'p', {
+  set: function(a) {
+    count++;
+    args = arguments;
+    return false;
+  }
+});
+
+var result = Reflect.set(o1, 'p', 42);
+assert.sameValue(
+  result, true,
+  'returns true if target.p has an accessor descriptor'
+);
+assert.sameValue(args.length, 1, 'target.p set is called with 1 argument');
+assert.sameValue(args[0], 42, 'target.p set is called with V');
+assert.sameValue(count, 1, 'target.p set is called once');
+

--- a/test/built-ins/Reflect/set/set-value-on-data-descriptor.js
+++ b/test/built-ins/Reflect/set/set-value-on-data-descriptor.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Sets the new value.
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  ...
+  4. If receiver is not present, then
+    a. Let receiver be target.
+  5. Return target.[[Set]](key, V, receiver).
+
+  9.1.9 [[Set]] ( P, V, Receiver)
+
+  ...
+  5. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+    b. If Type(Receiver) is not Object, return false.
+    c. Let existingDescriptor be Receiver.[[GetOwnProperty]](P).
+    d. ReturnIfAbrupt(existingDescriptor).
+    e. If existingDescriptor is not undefined, then
+      i. If IsAccessorDescriptor(existingDescriptor) is true, return false.
+      ii. If existingDescriptor.[[Writable]] is false, return false.
+      iii. Let valueDesc be the PropertyDescriptor{[[Value]]: V}.
+      iv. Return Receiver.[[DefineOwnProperty]](P, valueDesc).
+    f. Else Receiver does not currently have a property P,
+      i. Return CreateDataProperty(Receiver, P, V).
+  ...
+---*/
+
+var o1 = {p: 43};
+var result = Reflect.set(o1, 'p', 42);
+assert.sameValue(result, true, 'returns true on a successful setting');
+assert.sameValue(
+  o1.p, 42,
+  'sets the new value'
+);
+
+var o2 = {p: 43};
+var receiver = {p: 44};
+var result = Reflect.set(o2, 'p', 42, receiver);
+assert.sameValue(result, true, 'returns true on a successful setting');
+assert.sameValue(o2.p, 43, 'with a receiver, does not set a value on target');
+assert.sameValue(receiver.p, 42, 'sets the new value on the receiver');

--- a/test/built-ins/Reflect/set/set.js
+++ b/test/built-ins/Reflect/set/set.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Reflect.set is configurable, writable and not enumerable.
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Reflect, 'set');
+verifyWritable(Reflect, 'set');
+verifyConfigurable(Reflect, 'set');

--- a/test/built-ins/Reflect/set/symbol-property.js
+++ b/test/built-ins/Reflect/set/symbol-property.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Sets the new value.
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  ...
+  2. Let key be ToPropertyKey(propertyKey).
+  ...
+
+  7.1.14 ToPropertyKey ( argument )
+
+  ...
+  3. If Type(key) is Symbol, then
+    a. Return key.
+  ...
+features: [Symbol]
+---*/
+
+var o1 = {};
+var s = Symbol('1');
+var result = Reflect.set(o1, s, 42);
+assert.sameValue(result, true, 'returns true on a successful setting');
+assert.sameValue(o1[s], 42, 'sets the new value');
+
+var o2 = {};
+o2[s] = 43;
+var receiver = {};
+receiver[s] = 44;
+var result = Reflect.set(o2, s, 42, receiver);
+assert.sameValue(result, true, 'returns true on a successful setting');
+assert.sameValue(o2[s], 43, 'with a receiver, does not set a value on target');
+assert.sameValue(receiver[s], 42, 'sets the new value on the receiver');

--- a/test/built-ins/Reflect/set/target-is-not-object-throws.js
+++ b/test/built-ins/Reflect/set/target-is-not-object-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Throws a TypeError if target is not an Object.
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.set(1, 'p', 42);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.set(null, 'p', 42);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.set(undefined, 'p', 42);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.set('', 'p', 42);
+});

--- a/test/built-ins/Reflect/set/target-is-symbol-throws.js
+++ b/test/built-ins/Reflect/set/target-is-symbol-throws.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.13
+description: >
+  Throws a TypeError if target is a Symbol
+info: >
+  26.1.13 Reflect.set ( target, propertyKey, V [ , receiver ] )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.set(Symbol(1), 'p', 42);
+});

--- a/test/built-ins/Reflect/setPrototypeOf/length.js
+++ b/test/built-ins/Reflect/setPrototypeOf/length.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.14
+description: >
+  Reflect.setPrototypeOf.length value and property descriptor
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.setPrototypeOf.length, 2,
+  'The value of `Reflect.setPrototypeOf.length` is `2`'
+);
+
+verifyNotEnumerable(Reflect.setPrototypeOf, 'length');
+verifyNotWritable(Reflect.setPrototypeOf, 'length');
+verifyConfigurable(Reflect.setPrototypeOf, 'length');

--- a/test/built-ins/Reflect/setPrototypeOf/name.js
+++ b/test/built-ins/Reflect/setPrototypeOf/name.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.14
+description: >
+  Reflect.setPrototypeOf.name value and property descriptor
+info: >
+  26.1.14 Reflect.setPrototypeOf ( target, proto )
+
+  17 ECMAScript Standard Built-in Objects
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  Reflect.setPrototypeOf.name, 'setPrototypeOf',
+  'The value of `Reflect.setPrototypeOf.name` is `"setPrototypeOf"`'
+);
+
+verifyNotEnumerable(Reflect.setPrototypeOf, 'name');
+verifyNotWritable(Reflect.setPrototypeOf, 'name');
+verifyConfigurable(Reflect.setPrototypeOf, 'name');

--- a/test/built-ins/Reflect/setPrototypeOf/proto-is-not-object-and-not-null-throws.js
+++ b/test/built-ins/Reflect/setPrototypeOf/proto-is-not-object-and-not-null-throws.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.14
+description: >
+  Throws a TypeError if proto is not Object or proto is not null.
+info: >
+  26.1.14 Reflect.setPrototypeOf ( target, proto )
+
+  ...
+  2. If Type(proto) is not Object and proto is not null, throw a TypeError
+  exception
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.setPrototypeOf({}, undefined);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.setPrototypeOf({}, 1);
+});
+
+assert.throws(TypeError, function() {
+  Reflect.setPrototypeOf({}, 'string');
+});
+
+assert.throws(TypeError, function() {
+  Reflect.setPrototypeOf({}, true);
+});

--- a/test/built-ins/Reflect/setPrototypeOf/proto-is-symbol-throws.js
+++ b/test/built-ins/Reflect/setPrototypeOf/proto-is-symbol-throws.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.14
+description: >
+  Throws a TypeError if proto is a Symbol
+info: >
+  26.1.14 Reflect.setPrototypeOf ( target, proto )
+
+  ...
+  2. If Type(proto) is not Object and proto is not null, throw a TypeError
+  exception
+  ...
+features: [Symbol]
+---*/
+
+var s = Symbol(1);
+assert.throws(TypeError, function() {
+  Reflect.setPrototypeOf({}, s);
+});

--- a/test/built-ins/Reflect/setPrototypeOf/return-abrupt-from-result.js
+++ b/test/built-ins/Reflect/setPrototypeOf/return-abrupt-from-result.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.14
+description: >
+  Return abrupt result.
+info: >
+  26.1.14 Reflect.setPrototypeOf ( target, proto )
+
+  ...
+  3. Return target.[[SetPrototypeOf]](proto).
+features: [Proxy]
+---*/
+
+var target = {};
+var p = new Proxy(target, {
+  setPrototypeOf: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Reflect.setPrototypeOf(p, {});
+});

--- a/test/built-ins/Reflect/setPrototypeOf/return-false-if-target-and-proto-are-the-same.js
+++ b/test/built-ins/Reflect/setPrototypeOf/return-false-if-target-and-proto-are-the-same.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.14
+description: >
+  Return false if target and proto are the same, without setting a new prototype.
+info: >
+  26.1.14 Reflect.setPrototypeOf ( target, proto )
+
+  ...
+  3. Return target.[[SetPrototypeOf]](proto).
+
+  9.1.2 [[SetPrototypeOf]] (V)
+
+  ...
+  8. Repeat while done is false,
+    a. If p is null, let done be true.
+    b. Else, if SameValue(p, O) is true, return false.
+  ...
+---*/
+
+var o1 = {};
+assert.sameValue(Reflect.setPrototypeOf(o1, o1), false);
+assert.sameValue(Object.getPrototypeOf(o1), Object.prototype);

--- a/test/built-ins/Reflect/setPrototypeOf/return-false-if-target-is-not-extensible.js
+++ b/test/built-ins/Reflect/setPrototypeOf/return-false-if-target-is-not-extensible.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.14
+description: >
+  Return false if target is not extensible, without changing the prototype.
+info: >
+  26.1.14 Reflect.setPrototypeOf ( target, proto )
+
+  ...
+  3. Return target.[[SetPrototypeOf]](proto).
+
+  9.1.2 [[SetPrototypeOf]] (V)
+
+  ...
+  5. If extensible is false, return false.
+  ...
+---*/
+
+var o1 = {};
+Object.preventExtensions(o1);
+assert.sameValue(Reflect.setPrototypeOf(o1, {}), false);
+assert.sameValue(Object.getPrototypeOf(o1), Object.prototype);
+
+var o2 = {};
+Object.preventExtensions(o2);
+assert.sameValue(Reflect.setPrototypeOf(o2, null), false);
+assert.sameValue(Object.getPrototypeOf(o2), Object.prototype);
+
+var o3 = Object.create(null);
+Object.preventExtensions(o3);
+assert.sameValue(Reflect.setPrototypeOf(o3, {}), false);
+assert.sameValue(Object.getPrototypeOf(o3), null);

--- a/test/built-ins/Reflect/setPrototypeOf/return-false-if-target-is-prototype-of-proto.js
+++ b/test/built-ins/Reflect/setPrototypeOf/return-false-if-target-is-prototype-of-proto.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.14
+description: >
+  Return false if target is found as a prototype of proto, without setting.
+info: >
+  26.1.14 Reflect.setPrototypeOf ( target, proto )
+
+  ...
+  3. Return target.[[SetPrototypeOf]](proto).
+
+  9.1.2 [[SetPrototypeOf]] (V)
+
+  ...
+  8. Repeat while done is false,
+    a. If p is null, let done be true.
+    b. Else, if SameValue(p, O) is true, return false.
+    c. Else,
+      i. If the [[GetPrototypeOf]] internal method of p is not the ordinary
+      object internal method defined in 9.1.1, let done be true.
+      ii. Else, let p be the value of p’s [[Prototype]] internal slot.
+  ...
+---*/
+
+var target = {};
+var proto = Object.create(target);
+assert.sameValue(Reflect.setPrototypeOf(target, proto), false);
+assert.sameValue(Object.getPrototypeOf(target), Object.prototype);

--- a/test/built-ins/Reflect/setPrototypeOf/return-true-if-new-prototype-is-set.js
+++ b/test/built-ins/Reflect/setPrototypeOf/return-true-if-new-prototype-is-set.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.14
+description: >
+  Return true if the new prototype is set.
+info: >
+  26.1.14 Reflect.setPrototypeOf ( target, proto )
+
+  ...
+  3. Return target.[[SetPrototypeOf]](proto).
+
+  9.1.2 [[SetPrototypeOf]] (V)
+
+  ...
+  9. Set the value of the [[Prototype]] internal slot of O to V.
+  10. Return true.
+  ...
+---*/
+
+var o1 = {};
+assert.sameValue(Reflect.setPrototypeOf(o1, null), true);
+assert.sameValue(Object.getPrototypeOf(o1), null);
+
+var o2 = Object.create(null);
+assert.sameValue(Reflect.setPrototypeOf(o2, Object.prototype), true);
+assert.sameValue(Object.getPrototypeOf(o2), Object.prototype);
+
+var o3 = {};
+var proto = {};
+assert.sameValue(Reflect.setPrototypeOf(o3, proto), true);
+assert.sameValue(Object.getPrototypeOf(o3), proto);

--- a/test/built-ins/Reflect/setPrototypeOf/return-true-if-proto-is-current.js
+++ b/test/built-ins/Reflect/setPrototypeOf/return-true-if-proto-is-current.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.14
+description: >
+  Return true if proto has the same value as current target's prototype.
+info: >
+  26.1.14 Reflect.setPrototypeOf ( target, proto )
+
+  ...
+  3. Return target.[[SetPrototypeOf]](proto).
+
+  9.1.2 [[SetPrototypeOf]] (V)
+
+  ...
+  4. If SameValue(V, current), return true.
+  ...
+---*/
+
+var o1 = {};
+Object.preventExtensions(o1);
+assert.sameValue(Reflect.setPrototypeOf(o1, Object.prototype), true);
+
+var o2 = Object.create(null);
+Object.preventExtensions(o2);
+assert.sameValue(Reflect.setPrototypeOf(o2, null), true);
+
+var proto = {};
+var o3 = Object.create(proto);
+Object.preventExtensions(o3);
+assert.sameValue(Reflect.setPrototypeOf(o3, proto), true);

--- a/test/built-ins/Reflect/setPrototypeOf/setPrototypeOf.js
+++ b/test/built-ins/Reflect/setPrototypeOf/setPrototypeOf.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.14
+description: >
+  Reflect.setPrototypeOf is configurable, writable and not enumerable.
+info: >
+  26.1.14 Reflect.setPrototypeOf ( target, proto )
+
+  17 ECMAScript Standard Built-in Objects
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Reflect, 'setPrototypeOf');
+verifyWritable(Reflect, 'setPrototypeOf');
+verifyConfigurable(Reflect, 'setPrototypeOf');

--- a/test/built-ins/Reflect/setPrototypeOf/target-is-not-object-throws.js
+++ b/test/built-ins/Reflect/setPrototypeOf/target-is-not-object-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.14
+description: >
+  Throws a TypeError if target is not an Object.
+info: >
+  26.1.14 Reflect.setPrototypeOf ( target, proto )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.setPrototypeOf(1, {});
+});
+
+assert.throws(TypeError, function() {
+  Reflect.setPrototypeOf(null, {});
+});
+
+assert.throws(TypeError, function() {
+  Reflect.setPrototypeOf(undefined, {});
+});
+
+assert.throws(TypeError, function() {
+  Reflect.setPrototypeOf('', {});
+});

--- a/test/built-ins/Reflect/setPrototypeOf/target-is-symbol-throws.js
+++ b/test/built-ins/Reflect/setPrototypeOf/target-is-symbol-throws.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 26.1.14
+description: >
+  Throws a TypeError if target is a Symbol
+info: >
+  26.1.14 Reflect.setPrototypeOf ( target, proto )
+
+  1. If Type(target) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+  Reflect.setPrototypeOf(Symbol(1), {});
+});


### PR DESCRIPTION
This branch will add tests for the entire Reflect object and its static methods.

~~The current commits are ready to review, while I'll still write the tests for [26.1.6](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.get) to [26.1.14](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.setprototypeof) on the following day(s).~~