### PR TITLE
Use guillemets («») to quote string values - fixes #174

### DIFF
--- a/harness/assert.js
+++ b/harness/assert.js
@@ -30,7 +30,7 @@ assert.sameValue = function (actual, expected, message) {
         message += ' ';
     }
 
-    message += 'Expected SameValue(' + String(actual) + ', ' + String(expected) + ') to be true';
+    message += 'Expected SameValue(«' + String(actual) + '», «' + String(expected) + '») to be true';
 
     $ERROR(message);
 };
@@ -46,7 +46,7 @@ assert.notSameValue = function (actual, unexpected, message) {
         message += ' ';
     }
 
-    message += 'Expected SameValue(' + String(actual) + ', ' + String(unexpected) + ') to be false';
+    message += 'Expected SameValue(«' + String(actual) + '», «' + String(unexpected) + '») to be false';
 
     $ERROR(message);
 };


### PR DESCRIPTION
Expected/actual values should be delimited in a way that
isn't confusable with actual string quotes " '