### PR TITLE
String.prototype.to{Lower,Upper} tests for special casing

### DIFF
--- a/test/built-ins/String/prototype/toLocaleLowerCase/special_casing.js
+++ b/test/built-ins/String/prototype/toLocaleLowerCase/special_casing.js
@@ -1,0 +1,136 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Check if String.prototype.toLocaleLowerCase supports mappings defined in SpecialCasings
+info: >
+    The result must be derived according to the locale-insensitive case mappings in the Unicode Character
+    Database (this explicitly includes not only the UnicodeData.txt file, but also all locale-insensitive
+    mappings in the SpecialCasings.txt file that accompanies it).
+es5id: 15.5.4.17
+es6id: 21.1.3.20
+---*/
+
+// SpecialCasing.txt, except for conditional mappings.
+
+assert.sameValue("\u00DF".toLocaleLowerCase(), "\u00DF", "LATIN SMALL LETTER SHARP S");
+
+// Locale-sensitive for Turkish and Azeri.
+// assert.sameValue("\u0130".toLocaleLowerCase(), "\u0069\u0307", "LATIN CAPITAL LETTER I WITH DOT ABOVE");
+
+assert.sameValue("\uFB00".toLocaleLowerCase(), "\uFB00", "LATIN SMALL LIGATURE FF");
+assert.sameValue("\uFB01".toLocaleLowerCase(), "\uFB01", "LATIN SMALL LIGATURE FI");
+assert.sameValue("\uFB02".toLocaleLowerCase(), "\uFB02", "LATIN SMALL LIGATURE FL");
+assert.sameValue("\uFB03".toLocaleLowerCase(), "\uFB03", "LATIN SMALL LIGATURE FFI");
+assert.sameValue("\uFB04".toLocaleLowerCase(), "\uFB04", "LATIN SMALL LIGATURE FFL");
+assert.sameValue("\uFB05".toLocaleLowerCase(), "\uFB05", "LATIN SMALL LIGATURE LONG S T");
+assert.sameValue("\uFB06".toLocaleLowerCase(), "\uFB06", "LATIN SMALL LIGATURE ST");
+
+assert.sameValue("\u0587".toLocaleLowerCase(), "\u0587", "ARMENIAN SMALL LIGATURE ECH YIWN");
+assert.sameValue("\uFB13".toLocaleLowerCase(), "\uFB13", "ARMENIAN SMALL LIGATURE MEN NOW");
+assert.sameValue("\uFB14".toLocaleLowerCase(), "\uFB14", "ARMENIAN SMALL LIGATURE MEN ECH");
+assert.sameValue("\uFB15".toLocaleLowerCase(), "\uFB15", "ARMENIAN SMALL LIGATURE MEN INI");
+assert.sameValue("\uFB16".toLocaleLowerCase(), "\uFB16", "ARMENIAN SMALL LIGATURE VEW NOW");
+assert.sameValue("\uFB17".toLocaleLowerCase(), "\uFB17", "ARMENIAN SMALL LIGATURE MEN XEH");
+
+assert.sameValue("\u0149".toLocaleLowerCase(), "\u0149", "LATIN SMALL LETTER N PRECEDED BY APOSTROPHE");
+
+assert.sameValue("\u0390".toLocaleLowerCase(), "\u0390", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS");
+assert.sameValue("\u03B0".toLocaleLowerCase(), "\u03B0", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS");
+
+assert.sameValue("\u01F0".toLocaleLowerCase(), "\u01F0", "LATIN SMALL LETTER J WITH CARON");
+assert.sameValue("\u1E96".toLocaleLowerCase(), "\u1E96", "LATIN SMALL LETTER H WITH LINE BELOW");
+assert.sameValue("\u1E97".toLocaleLowerCase(), "\u1E97", "LATIN SMALL LETTER T WITH DIAERESIS");
+assert.sameValue("\u1E98".toLocaleLowerCase(), "\u1E98", "LATIN SMALL LETTER W WITH RING ABOVE");
+assert.sameValue("\u1E99".toLocaleLowerCase(), "\u1E99", "LATIN SMALL LETTER Y WITH RING ABOVE");
+assert.sameValue("\u1E9A".toLocaleLowerCase(), "\u1E9A", "LATIN SMALL LETTER A WITH RIGHT HALF RING");
+
+assert.sameValue("\u1F50".toLocaleLowerCase(), "\u1F50", "GREEK SMALL LETTER UPSILON WITH PSILI");
+assert.sameValue("\u1F52".toLocaleLowerCase(), "\u1F52", "GREEK SMALL LETTER UPSILON WITH PSILI AND VARIA");
+assert.sameValue("\u1F54".toLocaleLowerCase(), "\u1F54", "GREEK SMALL LETTER UPSILON WITH PSILI AND OXIA");
+assert.sameValue("\u1F56".toLocaleLowerCase(), "\u1F56", "GREEK SMALL LETTER UPSILON WITH PSILI AND PERISPOMENI");
+assert.sameValue("\u1FB6".toLocaleLowerCase(), "\u1FB6", "GREEK SMALL LETTER ALPHA WITH PERISPOMENI");
+assert.sameValue("\u1FC6".toLocaleLowerCase(), "\u1FC6", "GREEK SMALL LETTER ETA WITH PERISPOMENI");
+assert.sameValue("\u1FD2".toLocaleLowerCase(), "\u1FD2", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND VARIA");
+assert.sameValue("\u1FD3".toLocaleLowerCase(), "\u1FD3", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA");
+assert.sameValue("\u1FD6".toLocaleLowerCase(), "\u1FD6", "GREEK SMALL LETTER IOTA WITH PERISPOMENI");
+assert.sameValue("\u1FD7".toLocaleLowerCase(), "\u1FD7", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND PERISPOMENI");
+assert.sameValue("\u1FE2".toLocaleLowerCase(), "\u1FE2", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND VARIA");
+assert.sameValue("\u1FE3".toLocaleLowerCase(), "\u1FE3", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND OXIA");
+assert.sameValue("\u1FE4".toLocaleLowerCase(), "\u1FE4", "GREEK SMALL LETTER RHO WITH PSILI");
+assert.sameValue("\u1FE6".toLocaleLowerCase(), "\u1FE6", "GREEK SMALL LETTER UPSILON WITH PERISPOMENI");
+assert.sameValue("\u1FE7".toLocaleLowerCase(), "\u1FE7", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND PERISPOMENI");
+assert.sameValue("\u1FF6".toLocaleLowerCase(), "\u1FF6", "GREEK SMALL LETTER OMEGA WITH PERISPOMENI");
+
+assert.sameValue("\u1F80".toLocaleLowerCase(), "\u1F80", "GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F81".toLocaleLowerCase(), "\u1F81", "GREEK SMALL LETTER ALPHA WITH DASIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F82".toLocaleLowerCase(), "\u1F82", "GREEK SMALL LETTER ALPHA WITH PSILI AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F83".toLocaleLowerCase(), "\u1F83", "GREEK SMALL LETTER ALPHA WITH DASIA AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F84".toLocaleLowerCase(), "\u1F84", "GREEK SMALL LETTER ALPHA WITH PSILI AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F85".toLocaleLowerCase(), "\u1F85", "GREEK SMALL LETTER ALPHA WITH DASIA AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F86".toLocaleLowerCase(), "\u1F86", "GREEK SMALL LETTER ALPHA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F87".toLocaleLowerCase(), "\u1F87", "GREEK SMALL LETTER ALPHA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1F88".toLocaleLowerCase(), "\u1F80", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F89".toLocaleLowerCase(), "\u1F81", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8A".toLocaleLowerCase(), "\u1F82", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8B".toLocaleLowerCase(), "\u1F83", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8C".toLocaleLowerCase(), "\u1F84", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8D".toLocaleLowerCase(), "\u1F85", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8E".toLocaleLowerCase(), "\u1F86", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8F".toLocaleLowerCase(), "\u1F87", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI");
+
+assert.sameValue("\u1F90".toLocaleLowerCase(), "\u1F90", "GREEK SMALL LETTER ETA WITH PSILI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F91".toLocaleLowerCase(), "\u1F91", "GREEK SMALL LETTER ETA WITH DASIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F92".toLocaleLowerCase(), "\u1F92", "GREEK SMALL LETTER ETA WITH PSILI AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F93".toLocaleLowerCase(), "\u1F93", "GREEK SMALL LETTER ETA WITH DASIA AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F94".toLocaleLowerCase(), "\u1F94", "GREEK SMALL LETTER ETA WITH PSILI AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F95".toLocaleLowerCase(), "\u1F95", "GREEK SMALL LETTER ETA WITH DASIA AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F96".toLocaleLowerCase(), "\u1F96", "GREEK SMALL LETTER ETA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F97".toLocaleLowerCase(), "\u1F97", "GREEK SMALL LETTER ETA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1F98".toLocaleLowerCase(), "\u1F90", "GREEK CAPITAL LETTER ETA WITH PSILI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F99".toLocaleLowerCase(), "\u1F91", "GREEK CAPITAL LETTER ETA WITH DASIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9A".toLocaleLowerCase(), "\u1F92", "GREEK CAPITAL LETTER ETA WITH PSILI AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9B".toLocaleLowerCase(), "\u1F93", "GREEK CAPITAL LETTER ETA WITH DASIA AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9C".toLocaleLowerCase(), "\u1F94", "GREEK CAPITAL LETTER ETA WITH PSILI AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9D".toLocaleLowerCase(), "\u1F95", "GREEK CAPITAL LETTER ETA WITH DASIA AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9E".toLocaleLowerCase(), "\u1F96", "GREEK CAPITAL LETTER ETA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9F".toLocaleLowerCase(), "\u1F97", "GREEK CAPITAL LETTER ETA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI");
+
+assert.sameValue("\u1FA0".toLocaleLowerCase(), "\u1FA0", "GREEK SMALL LETTER OMEGA WITH PSILI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA1".toLocaleLowerCase(), "\u1FA1", "GREEK SMALL LETTER OMEGA WITH DASIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA2".toLocaleLowerCase(), "\u1FA2", "GREEK SMALL LETTER OMEGA WITH PSILI AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA3".toLocaleLowerCase(), "\u1FA3", "GREEK SMALL LETTER OMEGA WITH DASIA AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA4".toLocaleLowerCase(), "\u1FA4", "GREEK SMALL LETTER OMEGA WITH PSILI AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA5".toLocaleLowerCase(), "\u1FA5", "GREEK SMALL LETTER OMEGA WITH DASIA AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA6".toLocaleLowerCase(), "\u1FA6", "GREEK SMALL LETTER OMEGA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA7".toLocaleLowerCase(), "\u1FA7", "GREEK SMALL LETTER OMEGA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1FA8".toLocaleLowerCase(), "\u1FA0", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND PROSGEGRAMMENI");
+assert.sameValue("\u1FA9".toLocaleLowerCase(), "\u1FA1", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAA".toLocaleLowerCase(), "\u1FA2", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAB".toLocaleLowerCase(), "\u1FA3", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAC".toLocaleLowerCase(), "\u1FA4", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAD".toLocaleLowerCase(), "\u1FA5", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAE".toLocaleLowerCase(), "\u1FA6", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAF".toLocaleLowerCase(), "\u1FA7", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI");
+
+assert.sameValue("\u1FB3".toLocaleLowerCase(), "\u1FB3", "GREEK SMALL LETTER ALPHA WITH YPOGEGRAMMENI");
+assert.sameValue("\u1FBC".toLocaleLowerCase(), "\u1FB3", "GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI");
+assert.sameValue("\u1FC3".toLocaleLowerCase(), "\u1FC3", "GREEK SMALL LETTER ETA WITH YPOGEGRAMMENI");
+assert.sameValue("\u1FCC".toLocaleLowerCase(), "\u1FC3", "GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI");
+assert.sameValue("\u1FF3".toLocaleLowerCase(), "\u1FF3", "GREEK SMALL LETTER OMEGA WITH YPOGEGRAMMENI");
+assert.sameValue("\u1FFC".toLocaleLowerCase(), "\u1FF3", "GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI");
+
+assert.sameValue("\u1FB2".toLocaleLowerCase(), "\u1FB2", "GREEK SMALL LETTER ALPHA WITH VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FB4".toLocaleLowerCase(), "\u1FB4", "GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FC2".toLocaleLowerCase(), "\u1FC2", "GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FC4".toLocaleLowerCase(), "\u1FC4", "GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FF2".toLocaleLowerCase(), "\u1FF2", "GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FF4".toLocaleLowerCase(), "\u1FF4", "GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1FB7".toLocaleLowerCase(), "\u1FB7", "GREEK SMALL LETTER ALPHA WITH PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FC7".toLocaleLowerCase(), "\u1FC7", "GREEK SMALL LETTER ETA WITH PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FF7".toLocaleLowerCase(), "\u1FF7", "GREEK SMALL LETTER OMEGA WITH PERISPOMENI AND YPOGEGRAMMENI");

--- a/test/built-ins/String/prototype/toLocaleLowerCase/special_casing_conditional.js
+++ b/test/built-ins/String/prototype/toLocaleLowerCase/special_casing_conditional.js
@@ -1,0 +1,101 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Check if String.prototype.toLocaleLowerCase supports conditional mappings defined in SpecialCasings
+info: >
+    The result must be derived according to the locale-insensitive case mappings in the Unicode Character
+    Database (this explicitly includes not only the UnicodeData.txt file, but also all locale-insensitive
+    mappings in the SpecialCasings.txt file that accompanies it).
+es5id: 15.5.4.17
+es6id: 21.1.3.20
+---*/
+
+// SpecialCasing.txt, conditional, language-insensitive mappings.
+
+// <code>; <lower>; <title>; <upper>; (<condition_list>;)? # <comment>
+// 03A3; 03C2; 03A3; 03A3; Final_Sigma; # GREEK CAPITAL LETTER SIGMA
+// 03A3; 03C3; 03A3; 03A3; # GREEK CAPITAL LETTER SIGMA
+
+// Final_Sigma is defined in Unicode 5.1, 3.13 Default Case Algorithms.
+
+assert.sameValue(
+  "\u03A3".toLocaleLowerCase(),
+  "\u03C3",
+  "Single GREEK CAPITAL LETTER SIGMA"
+);
+
+// Sigma preceded by Cased and zero or more Case_Ignorable.
+assert.sameValue(
+  "A\u03A3".toLocaleLowerCase(),
+  "a\u03C2",
+  "Sigma preceded by LATIN CAPITAL LETTER A"
+);
+assert.sameValue(
+  "\uD835\uDCA2\u03A3".toLocaleLowerCase(),
+  "\uD835\uDCA2\u03C2",
+  "Sigma preceded by MATHEMATICAL SCRIPT CAPITAL G (D835 DCA2 = 1D4A2)"
+);
+assert.sameValue(
+  "A.\u03A3".toLocaleLowerCase(),
+  "a.\u03C2",
+  "Sigma preceded by FULL STOP"
+);
+assert.sameValue(
+  "A\u00AD\u03A3".toLocaleLowerCase(),
+  "a\u00AD\u03C2",
+  "Sigma preceded by SOFT HYPHEN (00AD)"
+);
+assert.sameValue(
+  "A\uD834\uDE42\u03A3".toLocaleLowerCase(),
+  "a\uD834\uDE42\u03C2",
+  "Sigma preceded by COMBINING GREEK MUSICAL TRISEME (D834 DE42 = 1D242)"
+);
+assert.sameValue(
+  "\u0345\u03A3".toLocaleLowerCase(),
+  "\u0345\u03C3",
+  "Sigma preceded by COMBINING GREEK YPOGEGRAMMENI (0345)"
+);
+assert.sameValue(
+  "\u0391\u0345\u03A3".toLocaleLowerCase(),
+  "\u03B1\u0345\u03C2",
+  "Sigma preceded by GREEK CAPITAL LETTER ALPHA (0391), COMBINING GREEK YPOGEGRAMMENI (0345)"
+);
+
+// Sigma not followed by zero or more Case_Ignorable and then Cased.
+assert.sameValue(
+  "A\u03A3B".toLocaleLowerCase(),
+  "a\u03C3b",
+  "Sigma followed by LATIN CAPITAL LETTER B"
+);
+assert.sameValue(
+  "A\u03A3\uD835\uDCA2".toLocaleLowerCase(),
+  "a\u03C3\uD835\uDCA2",
+  "Sigma followed by MATHEMATICAL SCRIPT CAPITAL G (D835 DCA2 = 1D4A2)"
+);
+assert.sameValue(
+  "A\u03A3.b".toLocaleLowerCase(),
+  "a\u03C3.b",
+  "Sigma followed by FULL STOP"
+);
+assert.sameValue(
+  "A\u03A3\u00ADB".toLocaleLowerCase(),
+  "a\u03C3\u00ADb",
+  "Sigma followed by SOFT HYPHEN (00AD)"
+);
+assert.sameValue(
+  "A\u03A3\uD834\uDE42B".toLocaleLowerCase(),
+  "a\u03C3\uD834\uDE42b",
+  "Sigma followed by COMBINING GREEK MUSICAL TRISEME (D834 DE42 = 1D242)"
+);
+assert.sameValue(
+  "A\u03A3\u0345".toLocaleLowerCase(),
+  "a\u03C2\u0345",
+  "Sigma followed by COMBINING GREEK YPOGEGRAMMENI (0345)"
+);
+assert.sameValue(
+  "A\u03A3\u0345\u0391".toLocaleLowerCase(),
+  "a\u03C3\u0345\u03B1",
+  "Sigma followed by COMBINING GREEK YPOGEGRAMMENI (0345), GREEK CAPITAL LETTER ALPHA (0391)"
+);

--- a/test/built-ins/String/prototype/toLocaleUpperCase/special_casing.js
+++ b/test/built-ins/String/prototype/toLocaleUpperCase/special_casing.js
@@ -1,0 +1,135 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Check if String.prototype.toLocaleUpperCase supports mappings defined in SpecialCasings
+info: >
+    The result must be derived according to the locale-insensitive case mappings in the Unicode Character
+    Database (this explicitly includes not only the UnicodeData.txt file, but also all locale-insensitive
+    mappings in the SpecialCasings.txt file that accompanies it).
+es5id: 15.5.4.19
+es6id: 21.1.3.21
+---*/
+
+// SpecialCasing.txt, except for conditional mappings.
+
+assert.sameValue("\u00DF".toLocaleUpperCase(), "\u0053\u0053", "LATIN SMALL LETTER SHARP S");
+
+assert.sameValue("\u0130".toLocaleUpperCase(), "\u0130", "LATIN CAPITAL LETTER I WITH DOT ABOVE");
+
+assert.sameValue("\uFB00".toLocaleUpperCase(), "\u0046\u0046", "LATIN SMALL LIGATURE FF");
+assert.sameValue("\uFB01".toLocaleUpperCase(), "\u0046\u0049", "LATIN SMALL LIGATURE FI");
+assert.sameValue("\uFB02".toLocaleUpperCase(), "\u0046\u004C", "LATIN SMALL LIGATURE FL");
+assert.sameValue("\uFB03".toLocaleUpperCase(), "\u0046\u0046\u0049", "LATIN SMALL LIGATURE FFI");
+assert.sameValue("\uFB04".toLocaleUpperCase(), "\u0046\u0046\u004C", "LATIN SMALL LIGATURE FFL");
+assert.sameValue("\uFB05".toLocaleUpperCase(), "\u0053\u0054", "LATIN SMALL LIGATURE LONG S T");
+assert.sameValue("\uFB06".toLocaleUpperCase(), "\u0053\u0054", "LATIN SMALL LIGATURE ST");
+
+assert.sameValue("\u0587".toLocaleUpperCase(), "\u0535\u0552", "ARMENIAN SMALL LIGATURE ECH YIWN");
+assert.sameValue("\uFB13".toLocaleUpperCase(), "\u0544\u0546", "ARMENIAN SMALL LIGATURE MEN NOW");
+assert.sameValue("\uFB14".toLocaleUpperCase(), "\u0544\u0535", "ARMENIAN SMALL LIGATURE MEN ECH");
+assert.sameValue("\uFB15".toLocaleUpperCase(), "\u0544\u053B", "ARMENIAN SMALL LIGATURE MEN INI");
+assert.sameValue("\uFB16".toLocaleUpperCase(), "\u054E\u0546", "ARMENIAN SMALL LIGATURE VEW NOW");
+assert.sameValue("\uFB17".toLocaleUpperCase(), "\u0544\u053D", "ARMENIAN SMALL LIGATURE MEN XEH");
+
+assert.sameValue("\u0149".toLocaleUpperCase(), "\u02BC\u004E", "LATIN SMALL LETTER N PRECEDED BY APOSTROPHE");
+
+assert.sameValue("\u0390".toLocaleUpperCase(), "\u0399\u0308\u0301", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS");
+assert.sameValue("\u03B0".toLocaleUpperCase(), "\u03A5\u0308\u0301", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS");
+
+assert.sameValue("\u01F0".toLocaleUpperCase(), "\u004A\u030C", "LATIN SMALL LETTER J WITH CARON");
+assert.sameValue("\u1E96".toLocaleUpperCase(), "\u0048\u0331", "LATIN SMALL LETTER H WITH LINE BELOW");
+assert.sameValue("\u1E97".toLocaleUpperCase(), "\u0054\u0308", "LATIN SMALL LETTER T WITH DIAERESIS");
+assert.sameValue("\u1E98".toLocaleUpperCase(), "\u0057\u030A", "LATIN SMALL LETTER W WITH RING ABOVE");
+assert.sameValue("\u1E99".toLocaleUpperCase(), "\u0059\u030A", "LATIN SMALL LETTER Y WITH RING ABOVE");
+assert.sameValue("\u1E9A".toLocaleUpperCase(), "\u0041\u02BE", "LATIN SMALL LETTER A WITH RIGHT HALF RING");
+
+assert.sameValue("\u1F50".toLocaleUpperCase(), "\u03A5\u0313", "GREEK SMALL LETTER UPSILON WITH PSILI");
+assert.sameValue("\u1F52".toLocaleUpperCase(), "\u03A5\u0313\u0300", "GREEK SMALL LETTER UPSILON WITH PSILI AND VARIA");
+assert.sameValue("\u1F54".toLocaleUpperCase(), "\u03A5\u0313\u0301", "GREEK SMALL LETTER UPSILON WITH PSILI AND OXIA");
+assert.sameValue("\u1F56".toLocaleUpperCase(), "\u03A5\u0313\u0342", "GREEK SMALL LETTER UPSILON WITH PSILI AND PERISPOMENI");
+assert.sameValue("\u1FB6".toLocaleUpperCase(), "\u0391\u0342", "GREEK SMALL LETTER ALPHA WITH PERISPOMENI");
+assert.sameValue("\u1FC6".toLocaleUpperCase(), "\u0397\u0342", "GREEK SMALL LETTER ETA WITH PERISPOMENI");
+assert.sameValue("\u1FD2".toLocaleUpperCase(), "\u0399\u0308\u0300", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND VARIA");
+assert.sameValue("\u1FD3".toLocaleUpperCase(), "\u0399\u0308\u0301", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA");
+assert.sameValue("\u1FD6".toLocaleUpperCase(), "\u0399\u0342", "GREEK SMALL LETTER IOTA WITH PERISPOMENI");
+assert.sameValue("\u1FD7".toLocaleUpperCase(), "\u0399\u0308\u0342", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND PERISPOMENI");
+assert.sameValue("\u1FE2".toLocaleUpperCase(), "\u03A5\u0308\u0300", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND VARIA");
+assert.sameValue("\u1FE3".toLocaleUpperCase(), "\u03A5\u0308\u0301", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND OXIA");
+assert.sameValue("\u1FE4".toLocaleUpperCase(), "\u03A1\u0313", "GREEK SMALL LETTER RHO WITH PSILI");
+assert.sameValue("\u1FE6".toLocaleUpperCase(), "\u03A5\u0342", "GREEK SMALL LETTER UPSILON WITH PERISPOMENI");
+assert.sameValue("\u1FE7".toLocaleUpperCase(), "\u03A5\u0308\u0342", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND PERISPOMENI");
+assert.sameValue("\u1FF6".toLocaleUpperCase(), "\u03A9\u0342", "GREEK SMALL LETTER OMEGA WITH PERISPOMENI");
+
+assert.sameValue("\u1F80".toLocaleUpperCase(), "\u1F08\u0399", "GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F81".toLocaleUpperCase(), "\u1F09\u0399", "GREEK SMALL LETTER ALPHA WITH DASIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F82".toLocaleUpperCase(), "\u1F0A\u0399", "GREEK SMALL LETTER ALPHA WITH PSILI AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F83".toLocaleUpperCase(), "\u1F0B\u0399", "GREEK SMALL LETTER ALPHA WITH DASIA AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F84".toLocaleUpperCase(), "\u1F0C\u0399", "GREEK SMALL LETTER ALPHA WITH PSILI AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F85".toLocaleUpperCase(), "\u1F0D\u0399", "GREEK SMALL LETTER ALPHA WITH DASIA AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F86".toLocaleUpperCase(), "\u1F0E\u0399", "GREEK SMALL LETTER ALPHA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F87".toLocaleUpperCase(), "\u1F0F\u0399", "GREEK SMALL LETTER ALPHA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1F88".toLocaleUpperCase(), "\u1F08\u0399", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F89".toLocaleUpperCase(), "\u1F09\u0399", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8A".toLocaleUpperCase(), "\u1F0A\u0399", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8B".toLocaleUpperCase(), "\u1F0B\u0399", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8C".toLocaleUpperCase(), "\u1F0C\u0399", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8D".toLocaleUpperCase(), "\u1F0D\u0399", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8E".toLocaleUpperCase(), "\u1F0E\u0399", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8F".toLocaleUpperCase(), "\u1F0F\u0399", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI");
+
+assert.sameValue("\u1F90".toLocaleUpperCase(), "\u1F28\u0399", "GREEK SMALL LETTER ETA WITH PSILI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F91".toLocaleUpperCase(), "\u1F29\u0399", "GREEK SMALL LETTER ETA WITH DASIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F92".toLocaleUpperCase(), "\u1F2A\u0399", "GREEK SMALL LETTER ETA WITH PSILI AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F93".toLocaleUpperCase(), "\u1F2B\u0399", "GREEK SMALL LETTER ETA WITH DASIA AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F94".toLocaleUpperCase(), "\u1F2C\u0399", "GREEK SMALL LETTER ETA WITH PSILI AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F95".toLocaleUpperCase(), "\u1F2D\u0399", "GREEK SMALL LETTER ETA WITH DASIA AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F96".toLocaleUpperCase(), "\u1F2E\u0399", "GREEK SMALL LETTER ETA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F97".toLocaleUpperCase(), "\u1F2F\u0399", "GREEK SMALL LETTER ETA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1F98".toLocaleUpperCase(), "\u1F28\u0399", "GREEK CAPITAL LETTER ETA WITH PSILI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F99".toLocaleUpperCase(), "\u1F29\u0399", "GREEK CAPITAL LETTER ETA WITH DASIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9A".toLocaleUpperCase(), "\u1F2A\u0399", "GREEK CAPITAL LETTER ETA WITH PSILI AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9B".toLocaleUpperCase(), "\u1F2B\u0399", "GREEK CAPITAL LETTER ETA WITH DASIA AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9C".toLocaleUpperCase(), "\u1F2C\u0399", "GREEK CAPITAL LETTER ETA WITH PSILI AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9D".toLocaleUpperCase(), "\u1F2D\u0399", "GREEK CAPITAL LETTER ETA WITH DASIA AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9E".toLocaleUpperCase(), "\u1F2E\u0399", "GREEK CAPITAL LETTER ETA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9F".toLocaleUpperCase(), "\u1F2F\u0399", "GREEK CAPITAL LETTER ETA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI");
+
+assert.sameValue("\u1FA0".toLocaleUpperCase(), "\u1F68\u0399", "GREEK SMALL LETTER OMEGA WITH PSILI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA1".toLocaleUpperCase(), "\u1F69\u0399", "GREEK SMALL LETTER OMEGA WITH DASIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA2".toLocaleUpperCase(), "\u1F6A\u0399", "GREEK SMALL LETTER OMEGA WITH PSILI AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA3".toLocaleUpperCase(), "\u1F6B\u0399", "GREEK SMALL LETTER OMEGA WITH DASIA AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA4".toLocaleUpperCase(), "\u1F6C\u0399", "GREEK SMALL LETTER OMEGA WITH PSILI AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA5".toLocaleUpperCase(), "\u1F6D\u0399", "GREEK SMALL LETTER OMEGA WITH DASIA AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA6".toLocaleUpperCase(), "\u1F6E\u0399", "GREEK SMALL LETTER OMEGA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA7".toLocaleUpperCase(), "\u1F6F\u0399", "GREEK SMALL LETTER OMEGA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1FA8".toLocaleUpperCase(), "\u1F68\u0399", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND PROSGEGRAMMENI");
+assert.sameValue("\u1FA9".toLocaleUpperCase(), "\u1F69\u0399", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAA".toLocaleUpperCase(), "\u1F6A\u0399", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAB".toLocaleUpperCase(), "\u1F6B\u0399", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAC".toLocaleUpperCase(), "\u1F6C\u0399", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAD".toLocaleUpperCase(), "\u1F6D\u0399", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAE".toLocaleUpperCase(), "\u1F6E\u0399", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAF".toLocaleUpperCase(), "\u1F6F\u0399", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI");
+
+assert.sameValue("\u1FB3".toLocaleUpperCase(), "\u0391\u0399", "GREEK SMALL LETTER ALPHA WITH YPOGEGRAMMENI");
+assert.sameValue("\u1FBC".toLocaleUpperCase(), "\u0391\u0399", "GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI");
+assert.sameValue("\u1FC3".toLocaleUpperCase(), "\u0397\u0399", "GREEK SMALL LETTER ETA WITH YPOGEGRAMMENI");
+assert.sameValue("\u1FCC".toLocaleUpperCase(), "\u0397\u0399", "GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI");
+assert.sameValue("\u1FF3".toLocaleUpperCase(), "\u03A9\u0399", "GREEK SMALL LETTER OMEGA WITH YPOGEGRAMMENI");
+assert.sameValue("\u1FFC".toLocaleUpperCase(), "\u03A9\u0399", "GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI");
+
+assert.sameValue("\u1FB2".toLocaleUpperCase(), "\u1FBA\u0399", "GREEK SMALL LETTER ALPHA WITH VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FB4".toLocaleUpperCase(), "\u0386\u0399", "GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FC2".toLocaleUpperCase(), "\u1FCA\u0399", "GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FC4".toLocaleUpperCase(), "\u0389\u0399", "GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FF2".toLocaleUpperCase(), "\u1FFA\u0399", "GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FF4".toLocaleUpperCase(), "\u038F\u0399", "GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1FB7".toLocaleUpperCase(), "\u0391\u0342\u0399", "GREEK SMALL LETTER ALPHA WITH PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FC7".toLocaleUpperCase(), "\u0397\u0342\u0399", "GREEK SMALL LETTER ETA WITH PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FF7".toLocaleUpperCase(), "\u03A9\u0342\u0399", "GREEK SMALL LETTER OMEGA WITH PERISPOMENI AND YPOGEGRAMMENI");

--- a/test/built-ins/String/prototype/toLowerCase/special_casing.js
+++ b/test/built-ins/String/prototype/toLowerCase/special_casing.js
@@ -1,0 +1,135 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Check if String.prototype.toLowerCase supports mappings defined in SpecialCasings
+info: >
+    The result must be derived according to the locale-insensitive case mappings in the Unicode Character
+    Database (this explicitly includes not only the UnicodeData.txt file, but also all locale-insensitive
+    mappings in the SpecialCasings.txt file that accompanies it).
+es5id: 15.5.4.16
+es6id: 21.1.3.22
+---*/
+
+// SpecialCasing.txt, except for conditional mappings.
+
+assert.sameValue("\u00DF".toLowerCase(), "\u00DF", "LATIN SMALL LETTER SHARP S");
+
+assert.sameValue("\u0130".toLowerCase(), "\u0069\u0307", "LATIN CAPITAL LETTER I WITH DOT ABOVE");
+
+assert.sameValue("\uFB00".toLowerCase(), "\uFB00", "LATIN SMALL LIGATURE FF");
+assert.sameValue("\uFB01".toLowerCase(), "\uFB01", "LATIN SMALL LIGATURE FI");
+assert.sameValue("\uFB02".toLowerCase(), "\uFB02", "LATIN SMALL LIGATURE FL");
+assert.sameValue("\uFB03".toLowerCase(), "\uFB03", "LATIN SMALL LIGATURE FFI");
+assert.sameValue("\uFB04".toLowerCase(), "\uFB04", "LATIN SMALL LIGATURE FFL");
+assert.sameValue("\uFB05".toLowerCase(), "\uFB05", "LATIN SMALL LIGATURE LONG S T");
+assert.sameValue("\uFB06".toLowerCase(), "\uFB06", "LATIN SMALL LIGATURE ST");
+
+assert.sameValue("\u0587".toLowerCase(), "\u0587", "ARMENIAN SMALL LIGATURE ECH YIWN");
+assert.sameValue("\uFB13".toLowerCase(), "\uFB13", "ARMENIAN SMALL LIGATURE MEN NOW");
+assert.sameValue("\uFB14".toLowerCase(), "\uFB14", "ARMENIAN SMALL LIGATURE MEN ECH");
+assert.sameValue("\uFB15".toLowerCase(), "\uFB15", "ARMENIAN SMALL LIGATURE MEN INI");
+assert.sameValue("\uFB16".toLowerCase(), "\uFB16", "ARMENIAN SMALL LIGATURE VEW NOW");
+assert.sameValue("\uFB17".toLowerCase(), "\uFB17", "ARMENIAN SMALL LIGATURE MEN XEH");
+
+assert.sameValue("\u0149".toLowerCase(), "\u0149", "LATIN SMALL LETTER N PRECEDED BY APOSTROPHE");
+
+assert.sameValue("\u0390".toLowerCase(), "\u0390", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS");
+assert.sameValue("\u03B0".toLowerCase(), "\u03B0", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS");
+
+assert.sameValue("\u01F0".toLowerCase(), "\u01F0", "LATIN SMALL LETTER J WITH CARON");
+assert.sameValue("\u1E96".toLowerCase(), "\u1E96", "LATIN SMALL LETTER H WITH LINE BELOW");
+assert.sameValue("\u1E97".toLowerCase(), "\u1E97", "LATIN SMALL LETTER T WITH DIAERESIS");
+assert.sameValue("\u1E98".toLowerCase(), "\u1E98", "LATIN SMALL LETTER W WITH RING ABOVE");
+assert.sameValue("\u1E99".toLowerCase(), "\u1E99", "LATIN SMALL LETTER Y WITH RING ABOVE");
+assert.sameValue("\u1E9A".toLowerCase(), "\u1E9A", "LATIN SMALL LETTER A WITH RIGHT HALF RING");
+
+assert.sameValue("\u1F50".toLowerCase(), "\u1F50", "GREEK SMALL LETTER UPSILON WITH PSILI");
+assert.sameValue("\u1F52".toLowerCase(), "\u1F52", "GREEK SMALL LETTER UPSILON WITH PSILI AND VARIA");
+assert.sameValue("\u1F54".toLowerCase(), "\u1F54", "GREEK SMALL LETTER UPSILON WITH PSILI AND OXIA");
+assert.sameValue("\u1F56".toLowerCase(), "\u1F56", "GREEK SMALL LETTER UPSILON WITH PSILI AND PERISPOMENI");
+assert.sameValue("\u1FB6".toLowerCase(), "\u1FB6", "GREEK SMALL LETTER ALPHA WITH PERISPOMENI");
+assert.sameValue("\u1FC6".toLowerCase(), "\u1FC6", "GREEK SMALL LETTER ETA WITH PERISPOMENI");
+assert.sameValue("\u1FD2".toLowerCase(), "\u1FD2", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND VARIA");
+assert.sameValue("\u1FD3".toLowerCase(), "\u1FD3", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA");
+assert.sameValue("\u1FD6".toLowerCase(), "\u1FD6", "GREEK SMALL LETTER IOTA WITH PERISPOMENI");
+assert.sameValue("\u1FD7".toLowerCase(), "\u1FD7", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND PERISPOMENI");
+assert.sameValue("\u1FE2".toLowerCase(), "\u1FE2", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND VARIA");
+assert.sameValue("\u1FE3".toLowerCase(), "\u1FE3", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND OXIA");
+assert.sameValue("\u1FE4".toLowerCase(), "\u1FE4", "GREEK SMALL LETTER RHO WITH PSILI");
+assert.sameValue("\u1FE6".toLowerCase(), "\u1FE6", "GREEK SMALL LETTER UPSILON WITH PERISPOMENI");
+assert.sameValue("\u1FE7".toLowerCase(), "\u1FE7", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND PERISPOMENI");
+assert.sameValue("\u1FF6".toLowerCase(), "\u1FF6", "GREEK SMALL LETTER OMEGA WITH PERISPOMENI");
+
+assert.sameValue("\u1F80".toLowerCase(), "\u1F80", "GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F81".toLowerCase(), "\u1F81", "GREEK SMALL LETTER ALPHA WITH DASIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F82".toLowerCase(), "\u1F82", "GREEK SMALL LETTER ALPHA WITH PSILI AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F83".toLowerCase(), "\u1F83", "GREEK SMALL LETTER ALPHA WITH DASIA AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F84".toLowerCase(), "\u1F84", "GREEK SMALL LETTER ALPHA WITH PSILI AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F85".toLowerCase(), "\u1F85", "GREEK SMALL LETTER ALPHA WITH DASIA AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F86".toLowerCase(), "\u1F86", "GREEK SMALL LETTER ALPHA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F87".toLowerCase(), "\u1F87", "GREEK SMALL LETTER ALPHA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1F88".toLowerCase(), "\u1F80", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F89".toLowerCase(), "\u1F81", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8A".toLowerCase(), "\u1F82", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8B".toLowerCase(), "\u1F83", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8C".toLowerCase(), "\u1F84", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8D".toLowerCase(), "\u1F85", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8E".toLowerCase(), "\u1F86", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8F".toLowerCase(), "\u1F87", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI");
+
+assert.sameValue("\u1F90".toLowerCase(), "\u1F90", "GREEK SMALL LETTER ETA WITH PSILI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F91".toLowerCase(), "\u1F91", "GREEK SMALL LETTER ETA WITH DASIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F92".toLowerCase(), "\u1F92", "GREEK SMALL LETTER ETA WITH PSILI AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F93".toLowerCase(), "\u1F93", "GREEK SMALL LETTER ETA WITH DASIA AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F94".toLowerCase(), "\u1F94", "GREEK SMALL LETTER ETA WITH PSILI AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F95".toLowerCase(), "\u1F95", "GREEK SMALL LETTER ETA WITH DASIA AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F96".toLowerCase(), "\u1F96", "GREEK SMALL LETTER ETA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F97".toLowerCase(), "\u1F97", "GREEK SMALL LETTER ETA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1F98".toLowerCase(), "\u1F90", "GREEK CAPITAL LETTER ETA WITH PSILI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F99".toLowerCase(), "\u1F91", "GREEK CAPITAL LETTER ETA WITH DASIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9A".toLowerCase(), "\u1F92", "GREEK CAPITAL LETTER ETA WITH PSILI AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9B".toLowerCase(), "\u1F93", "GREEK CAPITAL LETTER ETA WITH DASIA AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9C".toLowerCase(), "\u1F94", "GREEK CAPITAL LETTER ETA WITH PSILI AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9D".toLowerCase(), "\u1F95", "GREEK CAPITAL LETTER ETA WITH DASIA AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9E".toLowerCase(), "\u1F96", "GREEK CAPITAL LETTER ETA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9F".toLowerCase(), "\u1F97", "GREEK CAPITAL LETTER ETA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI");
+
+assert.sameValue("\u1FA0".toLowerCase(), "\u1FA0", "GREEK SMALL LETTER OMEGA WITH PSILI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA1".toLowerCase(), "\u1FA1", "GREEK SMALL LETTER OMEGA WITH DASIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA2".toLowerCase(), "\u1FA2", "GREEK SMALL LETTER OMEGA WITH PSILI AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA3".toLowerCase(), "\u1FA3", "GREEK SMALL LETTER OMEGA WITH DASIA AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA4".toLowerCase(), "\u1FA4", "GREEK SMALL LETTER OMEGA WITH PSILI AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA5".toLowerCase(), "\u1FA5", "GREEK SMALL LETTER OMEGA WITH DASIA AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA6".toLowerCase(), "\u1FA6", "GREEK SMALL LETTER OMEGA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA7".toLowerCase(), "\u1FA7", "GREEK SMALL LETTER OMEGA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1FA8".toLowerCase(), "\u1FA0", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND PROSGEGRAMMENI");
+assert.sameValue("\u1FA9".toLowerCase(), "\u1FA1", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAA".toLowerCase(), "\u1FA2", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAB".toLowerCase(), "\u1FA3", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAC".toLowerCase(), "\u1FA4", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAD".toLowerCase(), "\u1FA5", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAE".toLowerCase(), "\u1FA6", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAF".toLowerCase(), "\u1FA7", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI");
+
+assert.sameValue("\u1FB3".toLowerCase(), "\u1FB3", "GREEK SMALL LETTER ALPHA WITH YPOGEGRAMMENI");
+assert.sameValue("\u1FBC".toLowerCase(), "\u1FB3", "GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI");
+assert.sameValue("\u1FC3".toLowerCase(), "\u1FC3", "GREEK SMALL LETTER ETA WITH YPOGEGRAMMENI");
+assert.sameValue("\u1FCC".toLowerCase(), "\u1FC3", "GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI");
+assert.sameValue("\u1FF3".toLowerCase(), "\u1FF3", "GREEK SMALL LETTER OMEGA WITH YPOGEGRAMMENI");
+assert.sameValue("\u1FFC".toLowerCase(), "\u1FF3", "GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI");
+
+assert.sameValue("\u1FB2".toLowerCase(), "\u1FB2", "GREEK SMALL LETTER ALPHA WITH VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FB4".toLowerCase(), "\u1FB4", "GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FC2".toLowerCase(), "\u1FC2", "GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FC4".toLowerCase(), "\u1FC4", "GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FF2".toLowerCase(), "\u1FF2", "GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FF4".toLowerCase(), "\u1FF4", "GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1FB7".toLowerCase(), "\u1FB7", "GREEK SMALL LETTER ALPHA WITH PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FC7".toLowerCase(), "\u1FC7", "GREEK SMALL LETTER ETA WITH PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FF7".toLowerCase(), "\u1FF7", "GREEK SMALL LETTER OMEGA WITH PERISPOMENI AND YPOGEGRAMMENI");

--- a/test/built-ins/String/prototype/toLowerCase/special_casing_conditional.js
+++ b/test/built-ins/String/prototype/toLowerCase/special_casing_conditional.js
@@ -1,0 +1,101 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Check if String.prototype.toLowerCase supports conditional mappings defined in SpecialCasings
+info: >
+    The result must be derived according to the locale-insensitive case mappings in the Unicode Character
+    Database (this explicitly includes not only the UnicodeData.txt file, but also all locale-insensitive
+    mappings in the SpecialCasings.txt file that accompanies it).
+es5id: 15.5.4.16
+es6id: 21.1.3.22
+---*/
+
+// SpecialCasing.txt, conditional, language-insensitive mappings.
+
+// <code>; <lower>; <title>; <upper>; (<condition_list>;)? # <comment>
+// 03A3; 03C2; 03A3; 03A3; Final_Sigma; # GREEK CAPITAL LETTER SIGMA
+// 03A3; 03C3; 03A3; 03A3; # GREEK CAPITAL LETTER SIGMA
+
+// Final_Sigma is defined in Unicode 5.1, 3.13 Default Case Algorithms.
+
+assert.sameValue(
+  "\u03A3".toLowerCase(),
+  "\u03C3",
+  "Single GREEK CAPITAL LETTER SIGMA"
+);
+
+// Sigma preceded by Cased and zero or more Case_Ignorable.
+assert.sameValue(
+  "A\u03A3".toLowerCase(),
+  "a\u03C2",
+  "Sigma preceded by LATIN CAPITAL LETTER A"
+);
+assert.sameValue(
+  "\uD835\uDCA2\u03A3".toLowerCase(),
+  "\uD835\uDCA2\u03C2",
+  "Sigma preceded by MATHEMATICAL SCRIPT CAPITAL G (D835 DCA2 = 1D4A2)"
+);
+assert.sameValue(
+  "A.\u03A3".toLowerCase(),
+  "a.\u03C2",
+  "Sigma preceded by FULL STOP"
+);
+assert.sameValue(
+  "A\u00AD\u03A3".toLowerCase(),
+  "a\u00AD\u03C2",
+  "Sigma preceded by SOFT HYPHEN (00AD)"
+);
+assert.sameValue(
+  "A\uD834\uDE42\u03A3".toLowerCase(),
+  "a\uD834\uDE42\u03C2",
+  "Sigma preceded by COMBINING GREEK MUSICAL TRISEME (D834 DE42 = 1D242)"
+);
+assert.sameValue(
+  "\u0345\u03A3".toLowerCase(),
+  "\u0345\u03C3",
+  "Sigma preceded by COMBINING GREEK YPOGEGRAMMENI (0345)"
+);
+assert.sameValue(
+  "\u0391\u0345\u03A3".toLowerCase(),
+  "\u03B1\u0345\u03C2",
+  "Sigma preceded by GREEK CAPITAL LETTER ALPHA (0391), COMBINING GREEK YPOGEGRAMMENI (0345)"
+);
+
+// Sigma not followed by zero or more Case_Ignorable and then Cased.
+assert.sameValue(
+  "A\u03A3B".toLowerCase(),
+  "a\u03C3b",
+  "Sigma followed by LATIN CAPITAL LETTER B"
+);
+assert.sameValue(
+  "A\u03A3\uD835\uDCA2".toLowerCase(),
+  "a\u03C3\uD835\uDCA2",
+  "Sigma followed by MATHEMATICAL SCRIPT CAPITAL G (D835 DCA2 = 1D4A2)"
+);
+assert.sameValue(
+  "A\u03A3.b".toLowerCase(),
+  "a\u03C3.b",
+  "Sigma followed by FULL STOP"
+);
+assert.sameValue(
+  "A\u03A3\u00ADB".toLowerCase(),
+  "a\u03C3\u00ADb",
+  "Sigma followed by SOFT HYPHEN (00AD)"
+);
+assert.sameValue(
+  "A\u03A3\uD834\uDE42B".toLowerCase(),
+  "a\u03C3\uD834\uDE42b",
+  "Sigma followed by COMBINING GREEK MUSICAL TRISEME (D834 DE42 = 1D242)"
+);
+assert.sameValue(
+  "A\u03A3\u0345".toLowerCase(),
+  "a\u03C2\u0345",
+  "Sigma followed by COMBINING GREEK YPOGEGRAMMENI (0345)"
+);
+assert.sameValue(
+  "A\u03A3\u0345\u0391".toLowerCase(),
+  "a\u03C3\u0345\u03B1",
+  "Sigma followed by COMBINING GREEK YPOGEGRAMMENI (0345), GREEK CAPITAL LETTER ALPHA (0391)"
+);

--- a/test/built-ins/String/prototype/toUpperCase/special_casing.js
+++ b/test/built-ins/String/prototype/toUpperCase/special_casing.js
@@ -1,0 +1,135 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Check if String.prototype.toUpperCase supports mappings defined in SpecialCasings
+info: >
+    The result must be derived according to the locale-insensitive case mappings in the Unicode Character
+    Database (this explicitly includes not only the UnicodeData.txt file, but also all locale-insensitive
+    mappings in the SpecialCasings.txt file that accompanies it).
+es5id: 15.5.4.18
+es6id: 21.1.3.24
+---*/
+
+// SpecialCasing.txt, except for conditional mappings.
+
+assert.sameValue("\u00DF".toUpperCase(), "\u0053\u0053", "LATIN SMALL LETTER SHARP S");
+
+assert.sameValue("\u0130".toUpperCase(), "\u0130", "LATIN CAPITAL LETTER I WITH DOT ABOVE");
+
+assert.sameValue("\uFB00".toUpperCase(), "\u0046\u0046", "LATIN SMALL LIGATURE FF");
+assert.sameValue("\uFB01".toUpperCase(), "\u0046\u0049", "LATIN SMALL LIGATURE FI");
+assert.sameValue("\uFB02".toUpperCase(), "\u0046\u004C", "LATIN SMALL LIGATURE FL");
+assert.sameValue("\uFB03".toUpperCase(), "\u0046\u0046\u0049", "LATIN SMALL LIGATURE FFI");
+assert.sameValue("\uFB04".toUpperCase(), "\u0046\u0046\u004C", "LATIN SMALL LIGATURE FFL");
+assert.sameValue("\uFB05".toUpperCase(), "\u0053\u0054", "LATIN SMALL LIGATURE LONG S T");
+assert.sameValue("\uFB06".toUpperCase(), "\u0053\u0054", "LATIN SMALL LIGATURE ST");
+
+assert.sameValue("\u0587".toUpperCase(), "\u0535\u0552", "ARMENIAN SMALL LIGATURE ECH YIWN");
+assert.sameValue("\uFB13".toUpperCase(), "\u0544\u0546", "ARMENIAN SMALL LIGATURE MEN NOW");
+assert.sameValue("\uFB14".toUpperCase(), "\u0544\u0535", "ARMENIAN SMALL LIGATURE MEN ECH");
+assert.sameValue("\uFB15".toUpperCase(), "\u0544\u053B", "ARMENIAN SMALL LIGATURE MEN INI");
+assert.sameValue("\uFB16".toUpperCase(), "\u054E\u0546", "ARMENIAN SMALL LIGATURE VEW NOW");
+assert.sameValue("\uFB17".toUpperCase(), "\u0544\u053D", "ARMENIAN SMALL LIGATURE MEN XEH");
+
+assert.sameValue("\u0149".toUpperCase(), "\u02BC\u004E", "LATIN SMALL LETTER N PRECEDED BY APOSTROPHE");
+
+assert.sameValue("\u0390".toUpperCase(), "\u0399\u0308\u0301", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS");
+assert.sameValue("\u03B0".toUpperCase(), "\u03A5\u0308\u0301", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS");
+
+assert.sameValue("\u01F0".toUpperCase(), "\u004A\u030C", "LATIN SMALL LETTER J WITH CARON");
+assert.sameValue("\u1E96".toUpperCase(), "\u0048\u0331", "LATIN SMALL LETTER H WITH LINE BELOW");
+assert.sameValue("\u1E97".toUpperCase(), "\u0054\u0308", "LATIN SMALL LETTER T WITH DIAERESIS");
+assert.sameValue("\u1E98".toUpperCase(), "\u0057\u030A", "LATIN SMALL LETTER W WITH RING ABOVE");
+assert.sameValue("\u1E99".toUpperCase(), "\u0059\u030A", "LATIN SMALL LETTER Y WITH RING ABOVE");
+assert.sameValue("\u1E9A".toUpperCase(), "\u0041\u02BE", "LATIN SMALL LETTER A WITH RIGHT HALF RING");
+
+assert.sameValue("\u1F50".toUpperCase(), "\u03A5\u0313", "GREEK SMALL LETTER UPSILON WITH PSILI");
+assert.sameValue("\u1F52".toUpperCase(), "\u03A5\u0313\u0300", "GREEK SMALL LETTER UPSILON WITH PSILI AND VARIA");
+assert.sameValue("\u1F54".toUpperCase(), "\u03A5\u0313\u0301", "GREEK SMALL LETTER UPSILON WITH PSILI AND OXIA");
+assert.sameValue("\u1F56".toUpperCase(), "\u03A5\u0313\u0342", "GREEK SMALL LETTER UPSILON WITH PSILI AND PERISPOMENI");
+assert.sameValue("\u1FB6".toUpperCase(), "\u0391\u0342", "GREEK SMALL LETTER ALPHA WITH PERISPOMENI");
+assert.sameValue("\u1FC6".toUpperCase(), "\u0397\u0342", "GREEK SMALL LETTER ETA WITH PERISPOMENI");
+assert.sameValue("\u1FD2".toUpperCase(), "\u0399\u0308\u0300", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND VARIA");
+assert.sameValue("\u1FD3".toUpperCase(), "\u0399\u0308\u0301", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA");
+assert.sameValue("\u1FD6".toUpperCase(), "\u0399\u0342", "GREEK SMALL LETTER IOTA WITH PERISPOMENI");
+assert.sameValue("\u1FD7".toUpperCase(), "\u0399\u0308\u0342", "GREEK SMALL LETTER IOTA WITH DIALYTIKA AND PERISPOMENI");
+assert.sameValue("\u1FE2".toUpperCase(), "\u03A5\u0308\u0300", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND VARIA");
+assert.sameValue("\u1FE3".toUpperCase(), "\u03A5\u0308\u0301", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND OXIA");
+assert.sameValue("\u1FE4".toUpperCase(), "\u03A1\u0313", "GREEK SMALL LETTER RHO WITH PSILI");
+assert.sameValue("\u1FE6".toUpperCase(), "\u03A5\u0342", "GREEK SMALL LETTER UPSILON WITH PERISPOMENI");
+assert.sameValue("\u1FE7".toUpperCase(), "\u03A5\u0308\u0342", "GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND PERISPOMENI");
+assert.sameValue("\u1FF6".toUpperCase(), "\u03A9\u0342", "GREEK SMALL LETTER OMEGA WITH PERISPOMENI");
+
+assert.sameValue("\u1F80".toUpperCase(), "\u1F08\u0399", "GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F81".toUpperCase(), "\u1F09\u0399", "GREEK SMALL LETTER ALPHA WITH DASIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F82".toUpperCase(), "\u1F0A\u0399", "GREEK SMALL LETTER ALPHA WITH PSILI AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F83".toUpperCase(), "\u1F0B\u0399", "GREEK SMALL LETTER ALPHA WITH DASIA AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F84".toUpperCase(), "\u1F0C\u0399", "GREEK SMALL LETTER ALPHA WITH PSILI AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F85".toUpperCase(), "\u1F0D\u0399", "GREEK SMALL LETTER ALPHA WITH DASIA AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F86".toUpperCase(), "\u1F0E\u0399", "GREEK SMALL LETTER ALPHA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F87".toUpperCase(), "\u1F0F\u0399", "GREEK SMALL LETTER ALPHA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1F88".toUpperCase(), "\u1F08\u0399", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F89".toUpperCase(), "\u1F09\u0399", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8A".toUpperCase(), "\u1F0A\u0399", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8B".toUpperCase(), "\u1F0B\u0399", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8C".toUpperCase(), "\u1F0C\u0399", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8D".toUpperCase(), "\u1F0D\u0399", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8E".toUpperCase(), "\u1F0E\u0399", "GREEK CAPITAL LETTER ALPHA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F8F".toUpperCase(), "\u1F0F\u0399", "GREEK CAPITAL LETTER ALPHA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI");
+
+assert.sameValue("\u1F90".toUpperCase(), "\u1F28\u0399", "GREEK SMALL LETTER ETA WITH PSILI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F91".toUpperCase(), "\u1F29\u0399", "GREEK SMALL LETTER ETA WITH DASIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F92".toUpperCase(), "\u1F2A\u0399", "GREEK SMALL LETTER ETA WITH PSILI AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F93".toUpperCase(), "\u1F2B\u0399", "GREEK SMALL LETTER ETA WITH DASIA AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F94".toUpperCase(), "\u1F2C\u0399", "GREEK SMALL LETTER ETA WITH PSILI AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F95".toUpperCase(), "\u1F2D\u0399", "GREEK SMALL LETTER ETA WITH DASIA AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1F96".toUpperCase(), "\u1F2E\u0399", "GREEK SMALL LETTER ETA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1F97".toUpperCase(), "\u1F2F\u0399", "GREEK SMALL LETTER ETA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1F98".toUpperCase(), "\u1F28\u0399", "GREEK CAPITAL LETTER ETA WITH PSILI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F99".toUpperCase(), "\u1F29\u0399", "GREEK CAPITAL LETTER ETA WITH DASIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9A".toUpperCase(), "\u1F2A\u0399", "GREEK CAPITAL LETTER ETA WITH PSILI AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9B".toUpperCase(), "\u1F2B\u0399", "GREEK CAPITAL LETTER ETA WITH DASIA AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9C".toUpperCase(), "\u1F2C\u0399", "GREEK CAPITAL LETTER ETA WITH PSILI AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9D".toUpperCase(), "\u1F2D\u0399", "GREEK CAPITAL LETTER ETA WITH DASIA AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9E".toUpperCase(), "\u1F2E\u0399", "GREEK CAPITAL LETTER ETA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI");
+assert.sameValue("\u1F9F".toUpperCase(), "\u1F2F\u0399", "GREEK CAPITAL LETTER ETA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI");
+
+assert.sameValue("\u1FA0".toUpperCase(), "\u1F68\u0399", "GREEK SMALL LETTER OMEGA WITH PSILI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA1".toUpperCase(), "\u1F69\u0399", "GREEK SMALL LETTER OMEGA WITH DASIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA2".toUpperCase(), "\u1F6A\u0399", "GREEK SMALL LETTER OMEGA WITH PSILI AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA3".toUpperCase(), "\u1F6B\u0399", "GREEK SMALL LETTER OMEGA WITH DASIA AND VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA4".toUpperCase(), "\u1F6C\u0399", "GREEK SMALL LETTER OMEGA WITH PSILI AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA5".toUpperCase(), "\u1F6D\u0399", "GREEK SMALL LETTER OMEGA WITH DASIA AND OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA6".toUpperCase(), "\u1F6E\u0399", "GREEK SMALL LETTER OMEGA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FA7".toUpperCase(), "\u1F6F\u0399", "GREEK SMALL LETTER OMEGA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1FA8".toUpperCase(), "\u1F68\u0399", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND PROSGEGRAMMENI");
+assert.sameValue("\u1FA9".toUpperCase(), "\u1F69\u0399", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAA".toUpperCase(), "\u1F6A\u0399", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAB".toUpperCase(), "\u1F6B\u0399", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND VARIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAC".toUpperCase(), "\u1F6C\u0399", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAD".toUpperCase(), "\u1F6D\u0399", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND OXIA AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAE".toUpperCase(), "\u1F6E\u0399", "GREEK CAPITAL LETTER OMEGA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI");
+assert.sameValue("\u1FAF".toUpperCase(), "\u1F6F\u0399", "GREEK CAPITAL LETTER OMEGA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI");
+
+assert.sameValue("\u1FB3".toUpperCase(), "\u0391\u0399", "GREEK SMALL LETTER ALPHA WITH YPOGEGRAMMENI");
+assert.sameValue("\u1FBC".toUpperCase(), "\u0391\u0399", "GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI");
+assert.sameValue("\u1FC3".toUpperCase(), "\u0397\u0399", "GREEK SMALL LETTER ETA WITH YPOGEGRAMMENI");
+assert.sameValue("\u1FCC".toUpperCase(), "\u0397\u0399", "GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI");
+assert.sameValue("\u1FF3".toUpperCase(), "\u03A9\u0399", "GREEK SMALL LETTER OMEGA WITH YPOGEGRAMMENI");
+assert.sameValue("\u1FFC".toUpperCase(), "\u03A9\u0399", "GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI");
+
+assert.sameValue("\u1FB2".toUpperCase(), "\u1FBA\u0399", "GREEK SMALL LETTER ALPHA WITH VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FB4".toUpperCase(), "\u0386\u0399", "GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FC2".toUpperCase(), "\u1FCA\u0399", "GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FC4".toUpperCase(), "\u0389\u0399", "GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FF2".toUpperCase(), "\u1FFA\u0399", "GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI");
+assert.sameValue("\u1FF4".toUpperCase(), "\u038F\u0399", "GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI");
+
+assert.sameValue("\u1FB7".toUpperCase(), "\u0391\u0342\u0399", "GREEK SMALL LETTER ALPHA WITH PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FC7".toUpperCase(), "\u0397\u0342\u0399", "GREEK SMALL LETTER ETA WITH PERISPOMENI AND YPOGEGRAMMENI");
+assert.sameValue("\u1FF7".toUpperCase(), "\u03A9\u0342\u0399", "GREEK SMALL LETTER OMEGA WITH PERISPOMENI AND YPOGEGRAMMENI");

--- a/test/intl402/String/prototype/toLocaleLowerCase/capital_I_with_dot.js
+++ b/test/intl402/String/prototype/toLocaleLowerCase/capital_I_with_dot.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Check if String.prototype.toLocaleLowerCase supports mappings defined in SpecialCasings
+info: >
+    The result must be derived according to the case mappings in the Unicode character database (this explicitly
+    includes not only the UnicodeData.txt file, but also the SpecialCasings.txt file that accompanies it).
+es5id: 15.5.4.16
+es6id: 21.1.3.20
+---*/
+
+// Locale-sensitive for Turkish and Azeri.
+assert.sameValue("\u0130".toLocaleLowerCase("und"), "\u0069\u0307", "LATIN CAPITAL LETTER I WITH DOT ABOVE");

--- a/test/intl402/String/prototype/toLocaleLowerCase/special_casing_Azeri.js
+++ b/test/intl402/String/prototype/toLocaleLowerCase/special_casing_Azeri.js
@@ -1,0 +1,85 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Check if String.prototype.toLocaleLowerCase supports language-sensitive mappings defined in SpecialCasings (Azeri)
+info: >
+    The result must be derived according to the case mappings in the Unicode character database (this explicitly
+    includes not only the UnicodeData.txt file, but also the SpecialCasings.txt file that accompanies it).
+es5id: 15.5.4.16
+es6id: 21.1.3.20
+---*/
+
+// SpecialCasing.txt, conditional, language-sensitive mappings (Azeri).
+
+// LATIN CAPITAL LETTER I WITH DOT ABOVE (U+0130) changed to LATIN SMALL LETTER I when lowercasing.
+assert.sameValue(
+  "\u0130".toLocaleLowerCase("az"),
+  "i",
+  "LATIN CAPITAL LETTER I WITH DOT ABOVE"
+);
+
+
+// COMBINING DOT ABOVE (U+0307) removed after LATIN CAPITAL LETTER I when lowercasing.
+// - COMBINING DOT BELOW (U+0323), combining class 220 (Below)
+// - PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE (U+101FD = D800 DDFD), combining class 220 (Below)
+assert.sameValue(
+  "I\u0307".toLocaleLowerCase("az"),
+  "i",
+  "LATIN CAPITAL LETTER I followed by COMBINING DOT ABOVE"
+);
+assert.sameValue(
+  "I\u0323\u0307".toLocaleLowerCase("az"),
+  "i\u0323",
+  "LATIN CAPITAL LETTER I followed by COMBINING DOT BELOW, COMBINING DOT ABOVE"
+);
+assert.sameValue(
+  "I\uD800\uDDFD\u0307".toLocaleLowerCase("az"),
+  "i\uD800\uDDFD",
+  "LATIN CAPITAL LETTER I followed by PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE, COMBINING DOT ABOVE"
+);
+
+
+// COMBINING DOT ABOVE (U+0307) not removed when character is preceded by a character of combining class 0.
+assert.sameValue(
+  "IA\u0307".toLocaleLowerCase("az"),
+  "\u0131a\u0307",
+  "LATIN CAPITAL LETTER I followed by LATIN CAPITAL LETTER A, COMBINING DOT ABOVE"
+);
+
+
+// COMBINING DOT ABOVE (U+0307) not removed when character is preceded by a character of combining class 230.
+// - COMBINING GRAVE ACCENT (U+0300), combining class 230 (Above)
+// - MUSICAL SYMBOL COMBINING DOIT (U+1D185, D834 DD85), combining class 230 (Above)
+assert.sameValue(
+  "I\u0300\u0307".toLocaleLowerCase("az"),
+  "\u0131\u0300\u0307",
+  "LATIN CAPITAL LETTER I followed by COMBINING GRAVE ACCENT, COMBINING DOT ABOVE"
+);
+assert.sameValue(
+  "I\uD834\uDD85\u0307".toLocaleLowerCase("az"),
+  "\u0131\uD834\uDD85\u0307",
+  "LATIN CAPITAL LETTER I followed by MUSICAL SYMBOL COMBINING DOIT, COMBINING DOT ABOVE"
+);
+
+
+// LATIN CAPITAL LETTER I changed to LATIN SMALL LETTER DOTLESS I (U+0131) when lowercasing.
+assert.sameValue(
+  "I".toLocaleLowerCase("az"),
+  "\u0131",
+  "LATIN CAPITAL LETTER I"
+);
+
+
+// No changes when lowercasing LATIN SMALL LETTER I and LATIN SMALL LETTER DOTLESS I (U+0131).
+assert.sameValue(
+  "i".toLocaleLowerCase("az"),
+  "i",
+  "LATIN SMALL LETTER I"
+);
+assert.sameValue(
+  "\u0131".toLocaleLowerCase("az"),
+  "\u0131",
+  "LATIN SMALL LETTER DOTLESS I"
+);

--- a/test/intl402/String/prototype/toLocaleLowerCase/special_casing_Lithuanian.js
+++ b/test/intl402/String/prototype/toLocaleLowerCase/special_casing_Lithuanian.js
@@ -1,0 +1,193 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Check if String.prototype.toLocaleLowerCase supports language-sensitive mappings defined in SpecialCasings (Lithuanian)
+info: >
+    The result must be derived according to the case mappings in the Unicode character database (this explicitly
+    includes not only the UnicodeData.txt file, but also the SpecialCasings.txt file that accompanies it).
+es5id: 15.5.4.16
+es6id: 21.1.3.20
+---*/
+
+// SpecialCasing.txt, conditional, language-sensitive mappings (Lithuanian).
+
+// COMBINING DOT ABOVE added when lowercasing capital I, J and I WITH OGONEK (U+012E).
+// Character directly followed by character of combining class 230 (Above).
+// - COMBINING GRAVE ACCENT (U+0300), combining class 230 (Above)
+assert.sameValue(
+  "I\u0300".toLocaleLowerCase("lt"),
+  "i\u0307\u0300",
+  "LATIN CAPITAL LETTER I followed by COMBINING GRAVE ACCENT"
+);
+assert.sameValue(
+  "J\u0300".toLocaleLowerCase("lt"),
+  "j\u0307\u0300",
+  "LATIN CAPITAL LETTER J followed by COMBINING GRAVE ACCENT"
+);
+assert.sameValue(
+  "\u012E\u0300".toLocaleLowerCase("lt"),
+  "\u012F\u0307\u0300",
+  "LATIN CAPITAL LETTER I WITH OGONEK followed by COMBINING GRAVE ACCENT"
+);
+
+
+// COMBINING DOT ABOVE added when lowercasing capital I, J and I WITH OGONEK (U+012E).
+// Character directly followed by character of combining class 230 (Above).
+// - MUSICAL SYMBOL COMBINING DOIT (U+1D185, D834 DD85), combining class 230 (Above)
+assert.sameValue(
+  "I\uD834\uDD85".toLocaleLowerCase("lt"),
+  "i\u0307\uD834\uDD85",
+  "LATIN CAPITAL LETTER I followed by MUSICAL SYMBOL COMBINING DOIT"
+);
+assert.sameValue(
+  "J\uD834\uDD85".toLocaleLowerCase("lt"),
+  "j\u0307\uD834\uDD85",
+  "LATIN CAPITAL LETTER J followed by MUSICAL SYMBOL COMBINING DOIT"
+);
+assert.sameValue(
+  "\u012E\uD834\uDD85".toLocaleLowerCase("lt"),
+  "\u012F\u0307\uD834\uDD85",
+  "LATIN CAPITAL LETTER I WITH OGONEK followed by MUSICAL SYMBOL COMBINING DOIT"
+);
+
+
+// COMBINING DOT ABOVE added when lowercasing capital I, J and I WITH OGONEK (U+012E).
+// Character not directly followed by character of combining class 230 (Above).
+// - COMBINING RING BELOW (U+0325), combining class 220 (Below)
+// - COMBINING GRAVE ACCENT (U+0300), combining class 230 (Above)
+assert.sameValue(
+  "I\u0325\u0300".toLocaleLowerCase("lt"),
+  "i\u0307\u0325\u0300",
+  "LATIN CAPITAL LETTER I followed by COMBINING RING BELOW, COMBINING GRAVE ACCENT"
+);
+assert.sameValue(
+  "J\u0325\u0300".toLocaleLowerCase("lt"),
+  "j\u0307\u0325\u0300",
+  "LATIN CAPITAL LETTER J followed by COMBINING RING BELOW, COMBINING GRAVE ACCENT"
+);
+assert.sameValue(
+  "\u012E\u0325\u0300".toLocaleLowerCase("lt"),
+  "\u012F\u0307\u0325\u0300",
+  "LATIN CAPITAL LETTER I WITH OGONEK followed by COMBINING RING BELOW, COMBINING GRAVE ACCENT"
+);
+
+
+// COMBINING DOT ABOVE added when lowercasing capital I, J and I WITH OGONEK (U+012E).
+// Character not directly followed by character of combining class 230 (Above).
+// - PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE (U+101FD, D800 DDFD), combining class 220 (Below)
+// - COMBINING GRAVE ACCENT (U+0300), combining class 230 (Above)
+assert.sameValue(
+  "I\uD800\uDDFD\u0300".toLocaleLowerCase("lt"),
+  "i\u0307\uD800\uDDFD\u0300",
+  "LATIN CAPITAL LETTER I followed by PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE, COMBINING GRAVE ACCENT"
+);
+assert.sameValue(
+  "J\uD800\uDDFD\u0300".toLocaleLowerCase("lt"),
+  "j\u0307\uD800\uDDFD\u0300",
+  "LATIN CAPITAL LETTER J followed by PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE, COMBINING GRAVE ACCENT"
+);
+assert.sameValue(
+  "\u012E\uD800\uDDFD\u0300".toLocaleLowerCase("lt"),
+  "\u012F\u0307\uD800\uDDFD\u0300",
+  "LATIN CAPITAL LETTER I WITH OGONEK followed by PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE, COMBINING GRAVE ACCENT"
+);
+
+
+// COMBINING DOT ABOVE added when lowercasing capital I, J and I WITH OGONEK (U+012E).
+// Character not directly followed by character of combining class 230 (Above).
+// - COMBINING RING BELOW (U+0325), combining class 220 (Below)
+// - MUSICAL SYMBOL COMBINING DOIT (U+1D185, D834 DD85), combining class 230 (Above)
+assert.sameValue(
+  "I\u0325\uD834\uDD85".toLocaleLowerCase("lt"),
+  "i\u0307\u0325\uD834\uDD85",
+  "LATIN CAPITAL LETTER I followed by COMBINING RING BELOW, MUSICAL SYMBOL COMBINING DOIT"
+);
+assert.sameValue(
+  "J\u0325\uD834\uDD85".toLocaleLowerCase("lt"),
+  "j\u0307\u0325\uD834\uDD85",
+  "LATIN CAPITAL LETTER J followed by COMBINING RING BELOW, MUSICAL SYMBOL COMBINING DOIT"
+);
+assert.sameValue(
+  "\u012E\u0325\uD834\uDD85".toLocaleLowerCase("lt"),
+  "\u012F\u0307\u0325\uD834\uDD85",
+  "LATIN CAPITAL LETTER I WITH OGONEK followed by COMBINING RING BELOW, MUSICAL SYMBOL COMBINING DOIT"
+);
+
+
+// COMBINING DOT ABOVE added when lowercasing capital I, J and I WITH OGONEK (U+012E).
+// Character not directly followed by character of combining class 230 (Above).
+// - PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE (U+101FD, D800 DDFD), combining class 220 (Below)
+// - MUSICAL SYMBOL COMBINING DOIT (U+1D185, D834 DD85), combining class 230 (Above)
+assert.sameValue(
+  "I\uD800\uDDFD\uD834\uDD85".toLocaleLowerCase("lt"),
+  "i\u0307\uD800\uDDFD\uD834\uDD85",
+  "LATIN CAPITAL LETTER I followed by PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE, MUSICAL SYMBOL COMBINING DOIT"
+);
+assert.sameValue(
+  "J\uD800\uDDFD\uD834\uDD85".toLocaleLowerCase("lt"),
+  "j\u0307\uD800\uDDFD\uD834\uDD85",
+  "LATIN CAPITAL LETTER J followed by PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE, MUSICAL SYMBOL COMBINING DOIT"
+);
+assert.sameValue(
+  "\u012E\uD800\uDDFD\uD834\uDD85".toLocaleLowerCase("lt"),
+  "\u012F\u0307\uD800\uDDFD\uD834\uDD85",
+  "LATIN CAPITAL LETTER I WITH OGONEK followed by PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE, MUSICAL SYMBOL COMBINING DOIT"
+);
+
+
+// COMBINING DOT ABOVE not added when character is followed by a character of combining class 0.
+// - COMBINING GRAVE ACCENT (U+0300), combining class 230 (Above)
+assert.sameValue(
+  "IA\u0300".toLocaleLowerCase("lt"),
+  "ia\u0300",
+  "LATIN CAPITAL LETTER I followed by LATIN CAPITAL LETTER A, COMBINING GRAVE ACCENT"
+);
+assert.sameValue(
+  "JA\u0300".toLocaleLowerCase("lt"),
+  "ja\u0300",
+  "LATIN CAPITAL LETTER J followed by LATIN CAPITAL LETTER A, COMBINING GRAVE ACCENT"
+);
+assert.sameValue(
+  "\u012EA\u0300".toLocaleLowerCase("lt"),
+  "\u012Fa\u0300",
+  "LATIN CAPITAL LETTER I WITH OGONEK followed by LATIN CAPITAL LETTER A, COMBINING GRAVE ACCENT"
+);
+
+
+// COMBINING DOT ABOVE not added when character is followed by a character of combining class 0.
+// - MUSICAL SYMBOL COMBINING DOIT (U+1D185, D834 DD85), combining class 230 (Above)
+assert.sameValue(
+  "IA\uD834\uDD85".toLocaleLowerCase("lt"),
+  "ia\uD834\uDD85",
+  "LATIN CAPITAL LETTER I followed by LATIN CAPITAL LETTER A, MUSICAL SYMBOL COMBINING DOIT"
+);
+assert.sameValue(
+  "JA\uD834\uDD85".toLocaleLowerCase("lt"),
+  "ja\uD834\uDD85",
+  "LATIN CAPITAL LETTER J followed by LATIN CAPITAL LETTER A, MUSICAL SYMBOL COMBINING DOIT"
+);
+assert.sameValue(
+  "\u012EA\uD834\uDD85".toLocaleLowerCase("lt"),
+  "\u012Fa\uD834\uDD85",
+  "LATIN CAPITAL LETTER I WITH OGONEK (U+012E) followed by LATIN CAPITAL LETTER A, MUSICAL SYMBOL COMBINING DOIT"
+);
+
+
+// Precomposed characters with accents above.
+assert.sameValue(
+  "\u00CC".toLocaleLowerCase("lt"),
+  "\u0069\u0307\u0300",
+  "LATIN CAPITAL LETTER I WITH GRAVE"
+);
+assert.sameValue(
+  "\u00CD".toLocaleLowerCase("lt"),
+  "\u0069\u0307\u0301",
+  "LATIN CAPITAL LETTER I WITH ACUTE"
+);
+assert.sameValue(
+  "\u0128".toLocaleLowerCase("lt"),
+  "\u0069\u0307\u0303",
+  "LATIN CAPITAL LETTER I WITH TILDE"
+);

--- a/test/intl402/String/prototype/toLocaleLowerCase/special_casing_Turkish.js
+++ b/test/intl402/String/prototype/toLocaleLowerCase/special_casing_Turkish.js
@@ -1,0 +1,85 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Check if String.prototype.toLocaleLowerCase supports language-sensitive mappings defined in SpecialCasings (Turkish)
+info: >
+    The result must be derived according to the case mappings in the Unicode character database (this explicitly
+    includes not only the UnicodeData.txt file, but also the SpecialCasings.txt file that accompanies it).
+es5id: 15.5.4.16
+es6id: 21.1.3.20
+---*/
+
+// SpecialCasing.txt, conditional, language-sensitive mappings (Turkish).
+
+// LATIN CAPITAL LETTER I WITH DOT ABOVE (U+0130) changed to LATIN SMALL LETTER I when lowercasing.
+assert.sameValue(
+  "\u0130".toLocaleLowerCase("tr"),
+  "i",
+  "LATIN CAPITAL LETTER I WITH DOT ABOVE"
+);
+
+
+// COMBINING DOT ABOVE (U+0307) removed after LATIN CAPITAL LETTER I when lowercasing.
+// - COMBINING DOT BELOW (U+0323), combining class 220 (Below)
+// - PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE (U+101FD = D800 DDFD), combining class 220 (Below)
+assert.sameValue(
+  "I\u0307".toLocaleLowerCase("tr"),
+  "i",
+  "LATIN CAPITAL LETTER I followed by COMBINING DOT ABOVE"
+);
+assert.sameValue(
+  "I\u0323\u0307".toLocaleLowerCase("tr"),
+  "i\u0323",
+  "LATIN CAPITAL LETTER I followed by COMBINING DOT BELOW, COMBINING DOT ABOVE"
+);
+assert.sameValue(
+  "I\uD800\uDDFD\u0307".toLocaleLowerCase("tr"),
+  "i\uD800\uDDFD",
+  "LATIN CAPITAL LETTER I followed by PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE, COMBINING DOT ABOVE"
+);
+
+
+// COMBINING DOT ABOVE (U+0307) not removed when character is preceded by a character of combining class 0.
+assert.sameValue(
+  "IA\u0307".toLocaleLowerCase("tr"),
+  "\u0131a\u0307",
+  "LATIN CAPITAL LETTER I followed by LATIN CAPITAL LETTER A, COMBINING DOT ABOVE"
+);
+
+
+// COMBINING DOT ABOVE (U+0307) not removed when character is preceded by a character of combining class 230.
+// - COMBINING GRAVE ACCENT (U+0300), combining class 230 (Above)
+// - MUSICAL SYMBOL COMBINING DOIT (U+1D185, D834 DD85), combining class 230 (Above)
+assert.sameValue(
+  "I\u0300\u0307".toLocaleLowerCase("tr"),
+  "\u0131\u0300\u0307",
+  "LATIN CAPITAL LETTER I followed by COMBINING GRAVE ACCENT, COMBINING DOT ABOVE"
+);
+assert.sameValue(
+  "I\uD834\uDD85\u0307".toLocaleLowerCase("tr"),
+  "\u0131\uD834\uDD85\u0307",
+  "LATIN CAPITAL LETTER I followed by MUSICAL SYMBOL COMBINING DOIT, COMBINING DOT ABOVE"
+);
+
+
+// LATIN CAPITAL LETTER I changed to LATIN SMALL LETTER DOTLESS I (U+0131) when lowercasing.
+assert.sameValue(
+  "I".toLocaleLowerCase("tr"),
+  "\u0131",
+  "LATIN CAPITAL LETTER I"
+);
+
+
+// No changes when lowercasing LATIN SMALL LETTER I and LATIN SMALL LETTER DOTLESS I (U+0131).
+assert.sameValue(
+  "i".toLocaleLowerCase("tr"),
+  "i",
+  "LATIN SMALL LETTER I"
+);
+assert.sameValue(
+  "\u0131".toLocaleLowerCase("tr"),
+  "\u0131",
+  "LATIN SMALL LETTER DOTLESS I"
+);

--- a/test/intl402/String/prototype/toLocaleUpperCase/special_casing_Azeri.js
+++ b/test/intl402/String/prototype/toLocaleUpperCase/special_casing_Azeri.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Check if String.prototype.toLocaleUpperCase supports language-sensitive mappings defined in SpecialCasings (Azeri)
+info: >
+    The result must be derived according to the case mappings in the Unicode character database (this explicitly
+    includes not only the UnicodeData.txt file, but also the SpecialCasings.txt file that accompanies it).
+es5id: 15.5.4.16
+es6id: 21.1.3.21
+---*/
+
+// SpecialCasing.txt, conditional, language-sensitive mappings (Azeri).
+
+// LATIN CAPITAL LETTER I WITH DOT ABOVE (U+0130) not changed when uppercasing.
+assert.sameValue(
+  "\u0130".toLocaleUpperCase("az"),
+  "\u0130",
+  "LATIN CAPITAL LETTER I WITH DOT ABOVE"
+);
+
+
+// LATIN CAPITAL LETTER I not changed when uppercasing.
+assert.sameValue(
+  "I".toLocaleUpperCase("az"),
+  "I",
+  "LATIN CAPITAL LETTER I"
+);
+
+
+// LATIN SMALL LETTER I changed to LATIN CAPITAL LETTER I WITH DOT ABOVE (U+0130) when uppercasing.
+assert.sameValue(
+  "i".toLocaleUpperCase("az"),
+  "\u0130",
+  "LATIN SMALL LETTER I"
+);
+
+
+// LATIN SMALL LETTER DOTLESS I (U+0131) changed to LATIN CAPITAL LETTER I when uppercasing.
+assert.sameValue(
+  "\u0131".toLocaleUpperCase("az"),
+  "I",
+  "LATIN SMALL LETTER DOTLESS I"
+);

--- a/test/intl402/String/prototype/toLocaleUpperCase/special_casing_Lithuanian.js
+++ b/test/intl402/String/prototype/toLocaleUpperCase/special_casing_Lithuanian.js
@@ -1,0 +1,113 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Check if String.prototype.toLocaleUpperCase supports language-sensitive mappings defined in SpecialCasings (Lithuanian)
+info: >
+    The result must be derived according to the case mappings in the Unicode character database (this explicitly
+    includes not only the UnicodeData.txt file, but also the SpecialCasings.txt file that accompanies it).
+es5id: 15.5.4.16
+es6id: 21.1.3.21
+---*/
+
+// SpecialCasing.txt, conditional, language-sensitive mappings (Lithuanian).
+
+// COMBINING DOT ABOVE (U+0307) not removed when uppercasing capital I and J.
+assert.sameValue(
+  "I\u0307".toLocaleUpperCase("lt"),
+  "I\u0307",
+  "COMBINING DOT ABOVE preceded by LATIN CAPITAL LETTER I"
+);
+assert.sameValue(
+  "J\u0307".toLocaleUpperCase("lt"),
+  "J\u0307",
+  "COMBINING DOT ABOVE preceded by LATIN CAPITAL LETTER J"
+);
+
+
+// Code points with Soft_Dotted property (Unicode 5.1, PropList.txt)
+var softDotted = [
+  "\u0069", "\u006A",   // LATIN SMALL LETTER I..LATIN SMALL LETTER J
+  "\u012F",             // LATIN SMALL LETTER I WITH OGONEK
+  "\u0249",             // LATIN SMALL LETTER J WITH STROKE
+  "\u0268",             // LATIN SMALL LETTER I WITH STROKE
+  "\u029D",             // LATIN SMALL LETTER J WITH CROSSED-TAIL
+  "\u02B2",             // MODIFIER LETTER SMALL J
+  "\u03F3",             // GREEK LETTER YOT
+  "\u0456",             // CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+  "\u0458",             // CYRILLIC SMALL LETTER JE
+  "\u1D62",             // LATIN SUBSCRIPT SMALL LETTER I
+  "\u1D96",             // LATIN SMALL LETTER I WITH RETROFLEX HOOK
+  "\u1DA4",             // MODIFIER LETTER SMALL I WITH STROKE
+  "\u1DA8",             // MODIFIER LETTER SMALL J WITH CROSSED-TAIL
+  "\u1E2D",             // LATIN SMALL LETTER I WITH TILDE BELOW
+  "\u1ECB",             // LATIN SMALL LETTER I WITH DOT BELOW
+  "\u2071",             // SUPERSCRIPT LATIN SMALL LETTER I
+  "\u2148", "\u2149",   // DOUBLE-STRUCK ITALIC SMALL I..DOUBLE-STRUCK ITALIC SMALL J
+  "\u2C7C",             // LATIN SUBSCRIPT SMALL LETTER J
+  "\uD835\uDC22", "\uD835\uDC23",   // MATHEMATICAL BOLD SMALL I..MATHEMATICAL BOLD SMALL J
+  "\uD835\uDC56", "\uD835\uDC57",   // MATHEMATICAL ITALIC SMALL I..MATHEMATICAL ITALIC SMALL J
+  "\uD835\uDC8A", "\uD835\uDC8B",   // MATHEMATICAL BOLD ITALIC SMALL I..MATHEMATICAL BOLD ITALIC SMALL J
+  "\uD835\uDCBE", "\uD835\uDCBF",   // MATHEMATICAL SCRIPT SMALL I..MATHEMATICAL SCRIPT SMALL J
+  "\uD835\uDCF2", "\uD835\uDCF3",   // MATHEMATICAL BOLD SCRIPT SMALL I..MATHEMATICAL BOLD SCRIPT SMALL J
+  "\uD835\uDD26", "\uD835\uDD27",   // MATHEMATICAL FRAKTUR SMALL I..MATHEMATICAL FRAKTUR SMALL J
+  "\uD835\uDD5A", "\uD835\uDD5B",   // MATHEMATICAL DOUBLE-STRUCK SMALL I..MATHEMATICAL DOUBLE-STRUCK SMALL J
+  "\uD835\uDD8E", "\uD835\uDD8F",   // MATHEMATICAL BOLD FRAKTUR SMALL I..MATHEMATICAL BOLD FRAKTUR SMALL J
+  "\uD835\uDDC2", "\uD835\uDDC3",   // MATHEMATICAL SANS-SERIF SMALL I..MATHEMATICAL SANS-SERIF SMALL J
+  "\uD835\uDDF6", "\uD835\uDDF7",   // MATHEMATICAL SANS-SERIF BOLD SMALL I..MATHEMATICAL SANS-SERIF BOLD SMALL J
+  "\uD835\uDE2A", "\uD835\uDE2B",   // MATHEMATICAL SANS-SERIF ITALIC SMALL I..MATHEMATICAL SANS-SERIF ITALIC SMALL J
+  "\uD835\uDE5E", "\uD835\uDE5F",   // MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL I..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL J
+  "\uD835\uDE92", "\uD835\uDE93",   // MATHEMATICAL MONOSPACE SMALL I..MATHEMATICAL MONOSPACE SMALL J
+];
+assert.sameValue(softDotted.length, 46, "Total code points with Soft_Dotted property");
+
+function charInfo(ch) {
+  function hexString(n) {
+    var s = n.toString(16).toUpperCase();
+    return "0000".slice(s.length) + s;
+  }
+
+  if (ch.length === 1) {
+    return "U+" + hexString(ch.charCodeAt(0));
+  }
+  var high = ch.charCodeAt(0);
+  var low = ch.charCodeAt(1);
+  var codePoint = ((high << 10) + low) + (0x10000 - (0xD800 << 10) - 0xDC00);
+  return "U+" + hexString(codePoint) + " = " + hexString(high) + " " + hexString(low);
+}
+
+
+// COMBINING DOT ABOVE (U+0307) removed when preceded by Soft_Dotted.
+// Character directly preceded by Soft_Dotted.
+for (var i = 0; i < softDotted.length; ++i) {
+  assert.sameValue(
+    (softDotted[i] + "\u0307").toLocaleUpperCase("lt"),
+    softDotted[i].toLocaleUpperCase("und"),
+    "COMBINING DOT ABOVE preceded by Soft_Dotted (" + charInfo(softDotted[i]) + ")"
+  );
+}
+
+
+// COMBINING DOT ABOVE (U+0307) removed if preceded by Soft_Dotted.
+// Character not directly preceded by Soft_Dotted.
+// - COMBINING DOT BELOW (U+0323), combining class 220 (Below)
+for (var i = 0; i < softDotted.length; ++i) {
+  assert.sameValue(
+    (softDotted[i] + "\u0323\u0307").toLocaleUpperCase("lt"),
+    softDotted[i].toLocaleUpperCase("und") + "\u0323",
+    "COMBINING DOT ABOVE preceded by Soft_Dotted (" + charInfo(softDotted[i]) + "), COMBINING DOT BELOW"
+  );
+}
+
+
+// COMBINING DOT ABOVE removed if preceded by Soft_Dotted.
+// Character not directly preceded by Soft_Dotted.
+// - PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE (U+101FD = D800 DDFD), combining class 220 (Below)
+for (var i = 0; i < softDotted.length; ++i) {
+  assert.sameValue(
+    (softDotted[i] + "\uD800\uDDFD\u0307").toLocaleUpperCase("lt"),
+    softDotted[i].toLocaleUpperCase("und") + "\uD800\uDDFD",
+    "COMBINING DOT ABOVE preceded by Soft_Dotted (" + charInfo(softDotted[i]) + "), PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE"
+  );
+}

--- a/test/intl402/String/prototype/toLocaleUpperCase/special_casing_Turkish.js
+++ b/test/intl402/String/prototype/toLocaleUpperCase/special_casing_Turkish.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Check if String.prototype.toLocaleUpperCase supports language-sensitive mappings defined in SpecialCasings (Turkish)
+info: >
+    The result must be derived according to the case mappings in the Unicode character database (this explicitly
+    includes not only the UnicodeData.txt file, but also the SpecialCasings.txt file that accompanies it).
+es5id: 15.5.4.16
+es6id: 21.1.3.21
+---*/
+
+// SpecialCasing.txt, conditional, language-sensitive mappings (Turkish).
+
+// LATIN CAPITAL LETTER I WITH DOT ABOVE (U+0130) not changed when uppercasing.
+assert.sameValue(
+  "\u0130".toLocaleUpperCase("tr"),
+  "\u0130",
+  "LATIN CAPITAL LETTER I WITH DOT ABOVE"
+);
+
+
+// LATIN CAPITAL LETTER I not changed when uppercasing.
+assert.sameValue(
+  "I".toLocaleUpperCase("tr"),
+  "I",
+  "LATIN CAPITAL LETTER I"
+);
+
+
+// LATIN SMALL LETTER I changed to LATIN CAPITAL LETTER I WITH DOT ABOVE (U+0130) when uppercasing.
+assert.sameValue(
+  "i".toLocaleUpperCase("tr"),
+  "\u0130",
+  "LATIN SMALL LETTER I"
+);
+
+
+// LATIN SMALL LETTER DOTLESS I (U+0131) changed to LATIN CAPITAL LETTER I when uppercasing.
+assert.sameValue(
+  "\u0131".toLocaleUpperCase("tr"),
+  "I",
+  "LATIN SMALL LETTER DOTLESS I"
+);


### PR DESCRIPTION
Changes in "test/built-ins/String/prototype":
- String.prototype.to{LowerCase, UpperCase, LocaleLowerCase, LocaleUpperCase} are specified to implement the locale-insensitive case mappings defined in SpecialCasings.txt, add new tests for this requirement.
- The tests for toLowerCase and toLocaleLowerCase resp. toUpperCase and toLocaleUpperCase are the same. This is intentional, the methods need to implement the same functionality. 

Changes in "test/intl402/String/prototype":
- String.prototype.to{LocaleLowerCase, LocaleUpperCase} are additionally specified to implement the locale-sensitive case mappings defined in SpecialCasings.txt, add new tests for this requirement.


Notes:
  1. ~~This PR currently depends on #397~~ (No longer applies, re-based and force pushed.)
  1. The test cases also include the new ES2015 (and ECMA-402, v2) requirement to iterate over string code points instead of code units in String.prototype.to{LowerCase, UpperCase, LocaleLowerCase, LocaleUpperCase}.