### PR TITLE
Add tests for well-known Symbol: @@split

### DIFF
--- a/test/built-ins/RegExp/prototype/Symbol.split/coerce-flags-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/coerce-flags-err.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Behavior when error thrown while coercing `flags` property
+info: >
+    [...]
+    7. Let flags be ToString(Get(rx, "flags")).
+    8. ReturnIfAbrupt(flags).
+features: [Symbol.split]
+---*/
+
+var uncoercibleFlags = {
+  flags: {
+    toString: function() {
+      throw new Test262Error();
+    }
+  }
+};
+
+assert.throws(Test262Error, function() {
+  RegExp.prototype[Symbol.split].call(uncoercibleFlags);
+});
+
+uncoercibleFlags = {
+  flags: Symbol.split
+};
+
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call(uncoercibleFlags);
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/coerce-flags.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/coerce-flags.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: String coercion of `flags` property
+info: >
+    [...]
+    7. Let flags be ToString(Get(rx, "flags")).
+    [...]
+    13. Let splitter be Construct(C, «rx, newFlags»).
+    [...]
+features: [Symbol.split, Symbol.species]
+---*/
+
+var obj = {
+  constructor: function() {},
+  flags: {
+    toString: function() {
+      return 'toString valuey';
+    }
+  }
+};
+var flagsArg;
+
+obj.constructor = function() {};
+obj.constructor[Symbol.species] = function(_, flags) {
+  flagsArg = flags;
+  return /./y;
+};
+
+RegExp.prototype[Symbol.split].call(obj);
+
+assert.sameValue(flagsArg, 'toString valuey');

--- a/test/built-ins/RegExp/prototype/Symbol.split/coerce-limit-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/coerce-limit-err.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Behavior when error thrown while coercing `limit` argument
+info: >
+    [...]
+    17. If limit is undefined, let lim be 253–1; else let lim be
+        ToLength(limit).
+    18. ReturnIfAbrupt(lim).
+features: [Symbol.split]
+---*/
+
+var uncoercibleObj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(TypeError, function() {
+  /./[Symbol.split]('', Symbol.split);
+});
+
+assert.throws(Test262Error, function() {
+  /./[Symbol.split]('', uncoercibleObj);
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/coerce-limit.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/coerce-limit.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Length coercion of `limit` argument
+info: >
+    [...]
+    17. If limit is undefined, let lim be 253–1; else let lim be
+        ToLength(limit).
+    [...]
+features: [Symbol.split]
+---*/
+
+var result;
+
+result = /./[Symbol.split]('abc', -23);
+assert(Array.isArray(result));
+assert.sameValue(result.length, 0);
+
+result = /./[Symbol.split]('abc', 1.9);
+assert(Array.isArray(result));
+assert.sameValue(result.length, 1);
+assert.sameValue(result[0], '');
+
+result = /./[Symbol.split]('abc', NaN);
+assert(Array.isArray(result));
+assert.sameValue(result.length, 0);

--- a/test/built-ins/RegExp/prototype/Symbol.split/coerce-string-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/coerce-string-err.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Behavior when error thrown while coercing `string` argument
+info: >
+    [...]
+    3. Let S be ToString(string).
+    4. ReturnIfAbrupt(S).
+features: [Symbol.split]
+---*/
+
+var uncoercibleObj = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  /./[Symbol.split](uncoercibleObj);
+});
+
+assert.throws(TypeError, function() {
+  /./[Symbol.split](Symbol.split);
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/coerce-string.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/coerce-string.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: String coercion of `string` argument
+info: >
+    [...]
+    3. Let S be ToString(string).
+    [...]
+features: [Symbol.split]
+---*/
+
+var obj = {
+  toString: function() {
+    return 'toString value';
+  }
+};
+var result;
+
+result = / /[Symbol.split](obj);
+
+assert(Array.isArray(result));
+assert.sameValue(result.length, 2);
+assert.sameValue(result[0], 'toString');
+assert.sameValue(result[1], 'value');

--- a/test/built-ins/RegExp/prototype/Symbol.split/get-flags-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/get-flags-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Behavior when error thrown while accessing `flags` property
+info: >
+    [...]
+    7. Let flags be ToString(Get(rx, "flags")).
+    8. ReturnIfAbrupt(flags).
+features: [Symbol.split]
+---*/
+
+var poisonedFlags = {
+  get flags() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  RegExp.prototype[Symbol.split].call(poisonedFlags);
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/length.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/length.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 21.2.5.11
+description: RegExp.prototype[Symbol.split] `length` property
+info: >
+    The length property of the @@split method is 2.
+
+    ES6 Section 17:
+
+    [...]
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(RegExp.prototype[Symbol.split].length, 2);
+
+verifyNotEnumerable(RegExp.prototype[Symbol.split], 'length');
+verifyNotWritable(RegExp.prototype[Symbol.split], 'length');
+verifyConfigurable(RegExp.prototype[Symbol.split], 'length');

--- a/test/built-ins/RegExp/prototype/Symbol.split/limit-0-bail.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/limit-0-bail.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: No matching attempt is made when `limit` argument is `0`
+info: >
+    [...]
+    21. If lim = 0, return A.
+features: [Symbol.split, Symbol.species]
+---*/
+
+var result;
+var obj = {
+  constructor: function() {}
+};
+obj.constructor[Symbol.species] = function() {
+  return {
+    exec: function() {
+      $ERROR('No match should be attempted when `limit` is `0`.');
+    }
+  };
+};
+
+result = RegExp.prototype[Symbol.split].call(obj, '', 0);
+
+assert(Array.isArray(result));
+assert.sameValue(result.length, 0);

--- a/test/built-ins/RegExp/prototype/Symbol.split/name.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/name.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 21.2.5.11
+description: RegExp.prototype[Symbol.split] `name` property
+info: >
+    The value of the name property of this function is "[Symbol.split]".
+
+    ES6 Section 17:
+
+    [...]
+
+    Unless otherwise specified, the name property of a built-in Function
+    object, if it exists, has the attributes { [[Writable]]: false,
+    [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(RegExp.prototype[Symbol.split].name, '[Symbol.split]');
+
+verifyNotEnumerable(RegExp.prototype[Symbol.split], 'name');
+verifyNotWritable(RegExp.prototype[Symbol.split], 'name');
+verifyConfigurable(RegExp.prototype[Symbol.split], 'name');

--- a/test/built-ins/RegExp/prototype/Symbol.split/prop-desc.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/prop-desc.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: RegExp.prototype[Symbol.split] property descriptor
+info: >
+    ES6 Section 17
+
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [Symbol.split]
+---*/
+
+verifyNotEnumerable(RegExp.prototype, Symbol.split);
+verifyWritable(RegExp.prototype, Symbol.split);
+verifyConfigurable(RegExp.prototype, Symbol.split);

--- a/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-ctor-get-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-ctor-get-err.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Behavior when error thrown while accessing `constructor` property
+info: >
+    [...]
+    5. Let C be SpeciesConstructor(rx, %RegExp%).
+    6. ReturnIfAbrupt(C).
+
+    ES6 Section 7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+    1. Assert: Type(O) is Object.
+    2. Let C be Get(O, "constructor").
+    3. ReturnIfAbrupt(C).
+features: [Symbol.split]
+---*/
+
+var poisonedCtor = {
+  get constructor() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  RegExp.prototype[Symbol.split].call(poisonedCtor);
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-ctor-non-obj.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-ctor-non-obj.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: TypeError when `constructor` property is defined but not an object
+info: >
+    [...]
+    5. Let C be SpeciesConstructor(rx, %RegExp%).
+    6. ReturnIfAbrupt(C).
+
+    ES6 Section 7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+    1. Assert: Type(O) is Object.
+    2. Let C be Get(O, "constructor").
+    3. ReturnIfAbrupt(C).
+    4. If C is undefined, return defaultConstructor.
+    5. If Type(C) is not Object, throw a TypeError exception.
+features: [Symbol.split]
+---*/
+
+var obj = { flags: '' };
+
+// Avoid false positives from unrelated TypeErrors
+RegExp.prototype[Symbol.split].call(obj);
+
+obj.constructor = false;
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call(obj);
+});
+
+obj.constructor = 'string';
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call(obj);
+});
+
+obj.constructor = Symbol.split;
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call(obj);
+});
+
+obj.constructor = 86;
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call(obj);
+});
+
+obj.constructor = null;
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call(obj);
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-ctor-undef.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-ctor-undef.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: RegExp used when `this` value does not define a constructor
+info: >
+    [...]
+    5. Let C be SpeciesConstructor(rx, %RegExp%).
+    [...]
+
+    ES6 Section 7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+    1. Assert: Type(O) is Object.
+    2. Let C be Get(O, "constructor").
+    3. ReturnIfAbrupt(C).
+    4. If C is undefined, return defaultConstructor.
+features: [Symbol.split]
+---*/
+
+var re = /[db]/;
+var result;
+re.constructor = undefined;
+
+result = re[Symbol.split]('abcde');
+
+assert(Array.isArray(result));
+assert.sameValue(result.length, 3);
+assert.sameValue(result[0], 'a');
+assert.sameValue(result[1], 'c');
+assert.sameValue(result[2], 'e');

--- a/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-err.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Behavior when error thrown by custom species constructor
+info: >
+    [...]
+    5. Let C be SpeciesConstructor(rx, %RegExp%).
+    [...]
+    13. Let splitter be Construct(C, «rx, newFlags»).
+    14. ReturnIfAbrupt(splitter).
+
+    ES6 Section 7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+    1. Assert: Type(O) is Object.
+    2. Let C be Get(O, "constructor").
+    3. ReturnIfAbrupt(C).
+    4. If C is undefined, return defaultConstructor.
+    5. If Type(C) is not Object, throw a TypeError exception.
+    6. Let S be Get(C, @@species).
+    7. ReturnIfAbrupt(S).
+    8. If S is either undefined or null, return defaultConstructor.
+    9. If IsConstructor(S) is true, return S.
+features: [Symbol.split, Symbol.species]
+---*/
+
+var re = /x/;
+re.constructor = function() {};
+re.constructor[Symbol.species] = function() {
+  throw new Test262Error();
+};
+
+assert.throws(Test262Error, function() {
+  re[Symbol.split]();
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-species-get-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-species-get-err.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: >
+    Behavior when error thrown while accessing `Symbol.species` property of
+    constructor
+info: >
+    [...]
+    5. Let C be SpeciesConstructor(rx, %RegExp%).
+    6. ReturnIfAbrupt(C).
+
+    ES6 Section 7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+    1. Assert: Type(O) is Object.
+    2. Let C be Get(O, "constructor").
+    3. ReturnIfAbrupt(C).
+    4. If C is undefined, return defaultConstructor.
+    5. If Type(C) is not Object, throw a TypeError exception.
+    6. Let S be Get(C, @@species).
+    7. ReturnIfAbrupt(S).
+features: [Symbol.split, Symbol.species]
+---*/
+
+var poisonedSpecies = function() {};
+Object.defineProperty(poisonedSpecies, Symbol.species, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  RegExp.prototype[Symbol.split].call({ constructor: poisonedSpecies });
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-species-non-ctor.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-species-non-ctor.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: >
+    TypeError thrown when `Symbol.species` property value is not a constructor
+info: >
+    [...]
+    5. Let C be SpeciesConstructor(rx, %RegExp%).
+    6. ReturnIfAbrupt(C).
+
+    ES6 Section 7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+    1. Assert: Type(O) is Object.
+    2. Let C be Get(O, "constructor").
+    3. ReturnIfAbrupt(C).
+    4. If C is undefined, return defaultConstructor.
+    5. If Type(C) is not Object, throw a TypeError exception.
+    6. Let S be Get(C, @@species).
+    7. ReturnIfAbrupt(S).
+    8. If S is either undefined or null, return defaultConstructor.
+    9. If IsConstructor(S) is true, return S.
+    10. Throw a TypeError exception.
+features: [Symbol.split, Symbol.species]
+---*/
+
+var re = /./;
+re.constructor = function() {};
+
+// Avoid false positives from unrelated TypeErrors
+re[Symbol.split]();
+
+re.constructor[Symbol.species] = {};
+assert.throws(TypeError, function() {
+  re[Symbol.split]();
+});
+
+re.constructor[Symbol.species] = 0;
+assert.throws(TypeError, function() {
+  re[Symbol.split]();
+});
+
+re.constructor[Symbol.species] = '';
+assert.throws(TypeError, function() {
+  re[Symbol.split]();
+});
+
+re.constructor[Symbol.species] = Symbol.split;
+assert.throws(TypeError, function() {
+  re[Symbol.split]();
+});
+
+re.constructor[Symbol.species] = Date.now;
+assert.throws(TypeError, function() {
+  re[Symbol.split]();
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-species-undef.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-species-undef.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: >
+    RegExp used when the `Symbol.species` property of the `this` value's
+    constructor is `undefined` or `null`
+info: >
+    [...]
+    5. Let C be SpeciesConstructor(rx, %RegExp%).
+    [...]
+
+    ES6 Section 7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+    1. Assert: Type(O) is Object.
+    2. Let C be Get(O, "constructor").
+    3. ReturnIfAbrupt(C).
+    4. If C is undefined, return defaultConstructor.
+    5. If Type(C) is not Object, throw a TypeError exception.
+    6. Let S be Get(C, @@species).
+    7. ReturnIfAbrupt(S).
+    8. If S is either undefined or null, return defaultConstructor.
+features: [Symbol.split, Symbol.species]
+---*/
+
+var noSpecies = function() {};
+var re = /[db]/;
+var result;
+re.constructor = noSpecies;
+
+noSpecies[Symbol.species] = undefined;
+result = re[Symbol.split]('abcde');
+
+assert(Array.isArray(result));
+assert.sameValue(result.length, 3);
+assert.sameValue(result[0], 'a');
+assert.sameValue(result[1], 'c');
+assert.sameValue(result[2], 'e');
+
+noSpecies[Symbol.species] = null;
+result = re[Symbol.split]('abcde');
+
+assert(Array.isArray(result));
+assert.sameValue(result.length, 3);
+assert.sameValue(result[0], 'a');
+assert.sameValue(result[1], 'c');
+assert.sameValue(result[2], 'e');

--- a/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-y.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/species-ctor-y.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: The `y` flag is always used in constructing the "splitter" object
+info: >
+    [...]
+    5. Let C be SpeciesConstructor(rx, %RegExp%).
+    [...]
+    11. If flags contains "y", let newFlags be flags.
+    12. Else, let newFlags be the string that is the concatenation of flags and
+        "y".
+    13. Let splitter be Construct(C, «rx, newFlags»).
+    [...]
+features: [Symbol.split, Symbol.species]
+---*/
+
+var flagsArg;
+var re = {};
+re.constructor = function() {};
+re.constructor[Symbol.species] = function(_, flags) {
+  flagsArg = flags;
+  return /./y;
+};
+
+re.flags = '';
+RegExp.prototype[Symbol.split].call(re, '');
+assert.sameValue(flagsArg, 'y');
+
+re.flags = 'abcd';
+RegExp.prototype[Symbol.split].call(re, '');
+assert.sameValue(flagsArg, 'abcdy');
+
+re.flags = 'Y';
+RegExp.prototype[Symbol.split].call(re, '');
+assert.sameValue(flagsArg, 'Yy');
+
+re.flags = 'y';
+RegExp.prototype[Symbol.split].call(re, '');
+assert.sameValue(flagsArg, 'y');
+
+re.flags = 'abycd';
+RegExp.prototype[Symbol.split].call(re, '');
+assert.sameValue(flagsArg, 'abycd');

--- a/test/built-ins/RegExp/prototype/Symbol.split/species-ctor.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/species-ctor.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Invocation of custom species constructor
+info: >
+    [...]
+    5. Let C be SpeciesConstructor(rx, %RegExp%).
+    [...]
+    13. Let splitter be Construct(C, «rx, newFlags»).
+    [...]
+
+    ES6 Section 7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+    1. Assert: Type(O) is Object.
+    2. Let C be Get(O, "constructor").
+    3. ReturnIfAbrupt(C).
+    4. If C is undefined, return defaultConstructor.
+    5. If Type(C) is not Object, throw a TypeError exception.
+    6. Let S be Get(C, @@species).
+    7. ReturnIfAbrupt(S).
+    8. If S is either undefined or null, return defaultConstructor.
+    9. If IsConstructor(S) is true, return S.
+features: [Symbol.split, Symbol.species]
+---*/
+
+var thisVal, args, result;
+var re = /x/iy;
+re.constructor = function() {};
+re.constructor[Symbol.species] = function() {
+  thisVal = this;
+  args = arguments;
+  return /[db]/y;
+};
+
+result = RegExp.prototype[Symbol.split].call(re, 'abcde');
+
+assert(Array.isArray(result));
+assert.sameValue(result.length, 3);
+assert.sameValue(result[0], 'a');
+assert.sameValue(result[1], 'c');
+assert.sameValue(result[2], 'e');
+
+assert(thisVal instanceof re.constructor[Symbol.species]);
+assert.sameValue(args.length, 2);
+assert.sameValue(args[0], re);
+assert.sameValue(args[1], 'iy');

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-adv-thru-empty-match.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-adv-thru-empty-match.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description:
+    lastIndex is explicitly advanced following an empty match
+es6id: 21.2.5.11
+info: >
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        b. ReturnIfAbrupt(setStatus).
+        c. Let z be RegExpExec(splitter, S).
+        d. ReturnIfAbrupt(z).
+        e. If z is null, let q be AdvanceStringIndex(S, q, unicodeMatching).
+        f. Else z is not null,
+           i. Let e be ToLength(Get(splitter, "lastIndex")).
+           ii. ReturnIfAbrupt(e).
+           iii. If e = p, let q be AdvanceStringIndex(S, q, unicodeMatching).
+features: [Symbol.split]
+---*/
+
+var result = /(?:)/[Symbol.split]('abc');
+
+assert(Array.isArray(result));
+assert.sameValue(result.length, 3);
+assert.sameValue(result[0], 'a');
+assert.sameValue(result[1], 'b');
+assert.sameValue(result[2], 'c');

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-coerce-lastindex-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-coerce-lastindex-err.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: >
+    Behavior when error thrown while coercing `lastIndex` property of splitter
+    after a match
+info: >
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        [...]
+        c. Let z be RegExpExec(splitter, S).
+        [...]
+        f. Else z is not null,
+           i. Let e be ToLength(Get(splitter, "lastIndex")).
+           ii. ReturnIfAbrupt(e).
+features: [Symbol.split, Symbol.species]
+---*/
+
+var badLastIndex;
+var obj = {
+  constructor: function() {}
+};
+var fakeRe = {
+  set lastIndex(_) {},
+  get lastIndex() {
+    return badLastIndex;
+  },
+  exec: function() {
+    return [];
+  }
+};
+obj.constructor[Symbol.species] = function() {
+  return fakeRe;
+};
+
+badLastIndex = Symbol.split;
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call(obj, 'abcd');
+});
+
+badLastIndex = {
+  valueOf: function() { throw new Test262Error(); }
+};
+assert.throws(Test262Error, function() {
+  RegExp.prototype[Symbol.split].call(obj, 'abcd');
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-coerce-lastindex.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-coerce-lastindex.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Length coercion of `lastIndex` property of splitter after a match
+info: >
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        [...]
+        c. Let z be RegExpExec(splitter, S).
+        [...]
+        f. Else z is not null,
+           i. Let e be ToLength(Get(splitter, "lastIndex")).
+           [...]
+features: [Symbol.split, Symbol.species]
+---*/
+
+var result;
+var obj = {
+  constructor: function() {}
+};
+var fakeRe = {
+  set lastIndex(_) {},
+  get lastIndex() {
+    return {
+      valueOf: function() {
+        return 2.9;
+      }
+    };
+  },
+  exec: function() {
+    return [];
+  }
+};
+obj.constructor[Symbol.species] = function() {
+  return fakeRe;
+};
+
+result = RegExp.prototype[Symbol.split].call(obj, 'abcd');
+
+assert(Array.isArray(result));
+assert.sameValue(result.length, 2);
+assert.sameValue(result[0], '');
+assert.sameValue(result[1], 'cd');

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-empty-match-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-empty-match-err.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Behavior when error thrown while executing match for empty string
+info: >
+    [...]
+    22. If size = 0, then
+        a. Let z be RegExpExec(splitter, S).
+        b. ReturnIfAbrupt(z).
+features: [Symbol.split, Symbol.species]
+---*/
+
+var obj = {
+  constructor: function() {}
+};
+obj.constructor[Symbol.species] = function() {
+  return {
+    exec: function() {
+      throw new Test262Error();
+    }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  RegExp.prototype[Symbol.split].call(obj, '');
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-empty-match.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-empty-match.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Successful match of empty string
+info: >
+    [...]
+    22. If size = 0, then
+        a. Let z be RegExpExec(splitter, S).
+        b. ReturnIfAbrupt(z).
+        c. If z is not null, return A.
+features: [Symbol.split]
+---*/
+
+var result = /(?:)/[Symbol.split]('');
+
+assert(Array.isArray(result));
+assert.sameValue(result.length, 0);

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-empty-no-match.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-empty-no-match.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Unsuccessful match of empty string
+info: >
+    [...]
+    22. If size = 0, then
+        a. Let z be RegExpExec(splitter, S).
+        b. ReturnIfAbrupt(z).
+        c. If z is not null, return A.
+        d. Assert: The following call will never result in an abrupt
+           completion.
+        e. Perform CreateDataProperty(A, "0", S).
+        f. Return A.
+features: [Symbol.split]
+---*/
+
+var result = /./[Symbol.split]('');
+
+assert(Array.isArray(result));
+assert.sameValue(result.length, 1);
+assert.sameValue(result[0], '');

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-get-lastindex-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-get-lastindex-err.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: >
+    Behavior when error thrown while accessing `lastIndex` property of splitter
+    after a match
+info: >
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        [...]
+        c. Let z be RegExpExec(splitter, S).
+        [...]
+        f. Else z is not null,
+           i. Let e be ToLength(Get(splitter, "lastIndex")).
+           ii. ReturnIfAbrupt(e).
+features: [Symbol.split, Symbol.species]
+---*/
+
+var obj = {
+  constructor: function() {}
+};
+var callCount = 0;
+var fakeRe = {
+  set lastIndex(_) {},
+  get lastIndex() {
+    throw new Test262Error();
+  },
+  exec: function() {
+    callCount += 1;
+    return [];
+  }
+};
+obj.constructor[Symbol.species] = function() {
+  return fakeRe;
+};
+
+assert.throws(Test262Error, function() {
+  RegExp.prototype[Symbol.split].call(obj, 'abcd');
+});
+
+assert.sameValue(callCount, 1);

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-limit-capturing.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-limit-capturing.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: The `limit` argument is applied to capturing groups
+info: >
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        [...]
+        c. Let z be RegExpExec(splitter, S).
+        [...]
+        f. Else z is not null,
+           [...]
+           iv. Else e ≠ p,
+               [...]
+               11. Repeat, while i ≤ numberOfCaptures.
+                   [...]
+                   f. If lengthA = lim, return A.
+features: [Symbol.split]
+---*/
+
+var result = /c(d)(e)/[Symbol.split]('abcdefg', 2);
+
+assert(Array.isArray(result));
+assert.sameValue(result.length, 2);
+assert.sameValue(result[0], 'ab');
+assert.sameValue(result[1], 'd');

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-limit.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-limit.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Results limited to number specified as second argument
+info: >
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        [...]
+        c. Let z be RegExpExec(splitter, S).
+        [...]
+        f. Else z is not null,
+           [...]
+           iv. Else e ≠ p,
+               [...]
+               3. Perform CreateDataProperty(A, ToString(lengthA), T).
+               4. Let lengthA be lengthA +1.
+               5. If lengthA = lim, return A.
+features: [Symbol.split]
+---*/
+
+var result = /x/[Symbol.split]('axbxcxdxe', 3);
+
+assert(Array.isArray(result));
+assert.sameValue(result.length, 3);
+assert.sameValue(result[0], 'a');
+assert.sameValue(result[1], 'b');
+assert.sameValue(result[2], 'c');

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-match-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-match-err.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: >
+    Behavior when error thrown while executing match for non-empty string
+info: >
+    [...]
+    24. Repeat, while q < size
+        [...]
+        c. Let z be RegExpExec(splitter, S).
+        d. ReturnIfAbrupt(z).
+features: [Symbol.split, Symbol.species]
+---*/
+
+var obj = {
+  constructor: function() {}
+};
+obj.constructor[Symbol.species] = function() {
+  return {
+    exec: function() {
+      throw new Test262Error();
+    }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  RegExp.prototype[Symbol.split].call(obj, 'a');
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-result-coerce-length-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-result-coerce-length-err.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: >
+    Behavior when error thrown while coercing `length` property of match result
+info: >
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        [...]
+        c. Let z be RegExpExec(splitter, S).
+        [...]
+        f. Else z is not null,
+           iv. Else e ≠ p,
+               [...]
+               7. Let numberOfCaptures be ToLength(Get(z, "length")).
+               8. ReturnIfAbrupt(numberOfCaptures).
+features: [Symbol.split, Symbol.species]
+---*/
+
+var obj = {
+  constructor: function() {}
+};
+var uncoercibleLength;
+var fakeRe = {
+  exec: function() {
+    return {
+      length: uncoercibleLength
+    };
+  }
+};
+obj.constructor[Symbol.species] = function() {
+  return fakeRe;
+};
+
+uncoercibleLength = Symbol.split;
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call(obj, 'abcd');
+});
+
+uncoercibleLength = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+assert.throws(Test262Error, function() {
+  RegExp.prototype[Symbol.split].call(obj, 'abcd');
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-result-coerce-length.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-result-coerce-length.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: >
+    Length coercion of `length` property of match result
+info: >
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        [...]
+        c. Let z be RegExpExec(splitter, S).
+        [...]
+        f. Else z is not null,
+           iv. Else e ≠ p,
+               [...]
+               7. Let numberOfCaptures be ToLength(Get(z, "length")).
+               [...]
+features: [Symbol.split, Symbol.species]
+---*/
+
+var result;
+var obj = {
+  constructor: function() {}
+};
+var fakeRe = {
+  exec: function() {
+    fakeRe.lastIndex = 1;
+    return {
+      length: {
+        valueOf: function() {
+          return 2.9;
+        }
+      },
+      0: 'foo',
+      1: 'bar',
+      2: 'baz'
+    };
+  }
+};
+obj.constructor[Symbol.species] = function() {
+  return fakeRe;
+};
+
+result = RegExp.prototype[Symbol.split].call(obj, 'a');
+
+assert(Array.isArray(result));
+assert.sameValue(result.length, 3);
+assert.sameValue(result[0], '');
+assert.sameValue(result[1], 'bar');
+assert.sameValue(result[2], '');

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-result-get-capture-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-result-get-capture-err.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: >
+    Behavior when error thrown while accessing capturing group match
+info: >
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        [...]
+        c. Let z be RegExpExec(splitter, S).
+        [...]
+        f. Else z is not null,
+           iv. Else e ≠ p,
+               [...]
+               11. Repeat, while i ≤ numberOfCaptures.
+                   [...]
+                   a. Let nextCapture be Get(z, ToString(i)).
+                   b. ReturnIfAbrupt(nextCapture).
+features: [Symbol.split, Symbol.species]
+---*/
+
+var result;
+var obj = {
+  constructor: function() {}
+};
+var poisonedCapture = {
+  length: 3,
+  0: 'a',
+  1: 'b',
+  get 2() {
+    throw new Test262Error();
+  }
+};
+var fakeRe = {
+  exec: function() {
+    fakeRe.lastIndex = 1;
+    return poisonedCapture;
+  }
+};
+obj.constructor[Symbol.species] = function() {
+  return fakeRe;
+};
+
+assert.throws(Test262Error, function() {
+  RegExp.prototype[Symbol.split].call(obj, 'a');
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-result-get-length-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-result-get-length-err.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: >
+    Behavior when error thrown while accessing `length` property of match
+    result
+info: >
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        [...]
+        c. Let z be RegExpExec(splitter, S).
+        [...]
+        f. Else z is not null,
+           iv. Else e ≠ p,
+               [...]
+               7. Let numberOfCaptures be ToLength(Get(z, "length")).
+               8. ReturnIfAbrupt(numberOfCaptures).
+features: [Symbol.split, Symbol.species]
+---*/
+
+var obj = {
+  constructor: function() {}
+};
+var poisonedLength = {
+  get length() {
+    throw new Test262Error();
+  }
+};
+var fakeRe = {
+  exec: function() {
+    return poisonedLength;
+  }
+};
+obj.constructor[Symbol.species] = function() {
+  return fakeRe;
+};
+
+assert.throws(Test262Error, function() {
+  RegExp.prototype[Symbol.split].call(obj, 'abcd');
+});

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-set-lastindex-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-set-lastindex-err.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: >
+    Behavior when error thrown while setting `lastIndex` property of splitter
+info: >
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        b. ReturnIfAbrupt(setStatus).
+features: [Symbol.split, Symbol.species]
+---*/
+
+var callCount = 0;
+var obj = {
+  constructor: function() {}
+};
+obj.constructor[Symbol.species] = function() {
+  return {
+    set lastIndex(_) {
+      throw new Test262Error();
+    },
+    exec: function() {
+      callCount += 1;
+    }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  RegExp.prototype[Symbol.split].call(obj, 'a');
+});
+
+assert.sameValue(callCount, 0);

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-set-lastindex-match.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-set-lastindex-match.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Setting `lastIndex` property of splitter after a match
+info: >
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        [...]
+        c. Let z be RegExpExec(splitter, S).
+        [...]
+        f. Else z is not null,
+           i. Let e be ToLength(Get(splitter, "lastIndex")).
+           [...]
+           iv. Else e ≠ p,
+                [...]
+                6. Let p be e.
+                [...]
+                12. Let q be p.
+features: [Symbol.split, Symbol.species]
+---*/
+
+var obj = {
+  constructor: function() {}
+};
+var lastIndex = 0;
+var indices = '';
+var fakeRe = {
+  set lastIndex(val) {
+    lastIndex = val;
+    indices += val + ',';
+  },
+  get lastIndex() {
+    return lastIndex;
+  },
+  exec: function() {
+    lastIndex += 1;
+    return ['a'];
+  }
+};
+obj.constructor[Symbol.species] = function() {
+  return fakeRe;
+};
+
+RegExp.prototype[Symbol.split].call(obj, 'abcd');
+
+assert.sameValue(indices, '0,1,2,3,');

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-set-lastindex-no-match.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-set-lastindex-no-match.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Setting `lastIndex` property of splitter after a failed match
+info: >
+    [...]
+    24. Repeat, while q < size
+        a. Let setStatus be Set(splitter, "lastIndex", q, true).
+        [...]
+        e. If z is null, let q be AdvanceStringIndex(S, q, unicodeMatching).
+        [...]
+features: [Symbol.split, Symbol.species]
+---*/
+
+var obj = {
+  constructor: function() {}
+};
+var indices = '';
+var fakeRe = {
+  set lastIndex(val) {
+    indices += val + ',';
+  },
+  exec: function() {
+    return null;
+  }
+};
+obj.constructor[Symbol.species] = function() {
+  return fakeRe;
+};
+
+RegExp.prototype[Symbol.split].call(obj, 'abcd');
+
+assert.sameValue(indices, '0,1,2,3,');

--- a/test/built-ins/RegExp/prototype/Symbol.split/str-trailing-chars.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-trailing-chars.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.2.5.11
+description: Characters after the final match are appended to the result
+info: >
+    [...]
+    25. Let T be a String value equal to the substring of S consisting of the
+        elements at indices p (inclusive) through size (exclusive).
+    26. Assert: The following call will never result in an abrupt completion.
+    27. Perform CreateDataProperty(A, ToString(lengthA), T ).
+    28. Return A.
+features: [Symbol.split]
+---*/
+
+var result = /d/[Symbol.split]('abcdefg');
+
+assert(Array.isArray(result));
+assert.sameValue(result.length, 2);
+assert.sameValue(result[0], 'abc');
+assert.sameValue(result[1], 'efg');

--- a/test/built-ins/RegExp/prototype/Symbol.split/this-val-non-obj.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/this-val-non-obj.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: The `this` value must be an object
+es6id: 21.2.5.11
+info: >
+    1. Let rx be the this value.
+    2. If Type(rx) is not Object, throw a TypeError exception.
+features: [Symbol.split]
+---*/
+
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call();
+});
+
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call(undefined);
+});
+
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call(null);
+});
+
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call(true);
+});
+
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call('string');
+});
+
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call(Symbol.split);
+});
+
+assert.throws(TypeError, function() {
+  RegExp.prototype[Symbol.split].call(86);
+});

--- a/test/built-ins/String/prototype/split/cstm-split-get-err.js
+++ b/test/built-ins/String/prototype/split/cstm-split-get-err.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Behavior when error is thrown accessing @@split property
+es6id: 21.1.3.17
+info: >
+    [...]
+    3. If separator is neither undefined nor null, then
+       a. Let splitter be GetMethod(separator, @@split).
+       b. ReturnIfAbrupt(splitter).
+features: [Symbol.split]
+---*/
+
+var poisonedSplit = {};
+Object.defineProperty(poisonedSplit, Symbol.split, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  ''.split(poisonedSplit);
+});

--- a/test/built-ins/String/prototype/split/cstm-split-invocation.js
+++ b/test/built-ins/String/prototype/split/cstm-split-invocation.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Invocation of @@split property of user-supplied objects
+es6id: 21.1.3.17
+info: >
+    [...]
+    3. If separator is neither undefined nor null, then
+       a. Let splitter be GetMethod(separator, @@split).
+       b. ReturnIfAbrupt(splitter).
+       c. If splitter is not undefined, then
+          i. Return Call(splitter, separator, «O, limit»).
+features: [Symbol.split]
+---*/
+
+var separator = {};
+var returnVal = {};
+var callCount = 0;
+var thisVal, args;
+
+separator[Symbol.split] = function() {
+  callCount += 1;
+  thisVal = this;
+  args = arguments;
+  return returnVal;
+};
+
+assert.sameValue(''.split(separator, 'limit'), returnVal);
+assert.sameValue(thisVal, separator);
+assert.notSameValue(args, undefined);
+assert.sameValue(args.length, 2);
+assert.sameValue(args[0], '');
+assert.sameValue(args[1], 'limit');

--- a/test/built-ins/Symbol/split/prop-desc.js
+++ b/test/built-ins/Symbol/split/prop-desc.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 19.4.2.11
+description: >
+    `Symbol.split` property descriptor
+info: >
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+features: [Symbol.split]
+---*/
+
+assert.sameValue(typeof Symbol.split, 'symbol');
+verifyNotEnumerable(Symbol, 'split');
+verifyNotWritable(Symbol, 'split');
+verifyNotConfigurable(Symbol, 'split');


### PR DESCRIPTION
Some of these tests are pretty complicated, so I'm especially interested in
ideas for simplification. Unfortunately, many concern semantics that only seem
to be verifiable using odd RegExp-like objects; this is why there is such heavy
usage of `Symbol.species`.