### PR TITLE
Tests for changes introduced in ES2015 (Annex E)

### DIFF
--- a/test/built-ins/Array/prototype/reverse/get_if_present_with_delete.js
+++ b/test/built-ins/Array/prototype/reverse/get_if_present_with_delete.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Array.prototype.reverse only gets present properties - delete property with getter
+info: >
+  22.1.3.20 Array.prototype.reverse ( )
+
+  ...
+  7.
+    d. Let lowerExists be HasProperty(O, lowerP).
+    e. ReturnIfAbrupt(lowerExists).
+    f. If lowerExists is true, then
+      i.  Let lowerValue be Get(O, lowerP).
+      ii. ReturnIfAbrupt(lowerValue).
+    g. Let upperExists be HasProperty(O, upperP).
+    h. ReturnIfAbrupt(upperExists).
+    i. If upperExists is true, then
+      i.  Let upperValue be Get(O, upperP).
+      ii. ReturnIfAbrupt(upperValue).
+es6id: 22.1.3.20
+---*/
+
+var array = ["first", "second"];
+
+Object.defineProperty(array, 0, {
+  get: function() {
+    array.length = 0;
+    return "first";
+  }
+});
+
+array.reverse();
+
+assert.sameValue((0 in array), false, "Indexed property '0' not present");
+assert.sameValue((1 in array), true, "Indexed property '1' present");
+assert.sameValue(array[1], "first", "Indexed property '1' value correct");

--- a/test/built-ins/Array/prototype/splice/called_with_one_argument.js
+++ b/test/built-ins/Array/prototype/splice/called_with_one_argument.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Array.prototype.splice deletes length-start elements when called with one argument
+info: >
+  22.1.3.25 Array.prototype.splice (start, deleteCount , ...items )
+
+  ...
+  9. Else if the number of actual arguments is 1, then
+    a. Let insertCount be 0.
+    b. Let actualDeleteCount be len – actualStart.
+es6id: 22.1.3.25
+---*/
+
+var array = ["first", "second", "third"];
+
+var result = array.splice(1);
+
+assert.sameValue(array.length, 1, "array length updated");
+assert.sameValue(array[0], "first", "array[0] unchanged");
+
+assert.sameValue(result.length, 2, "result array length correct");
+assert.sameValue(result[0], "second", "result[0] correct");
+assert.sameValue(result[1], "third", "result[1] correct");

--- a/test/built-ins/Array/prototype/splice/set_length_no_args.js
+++ b/test/built-ins/Array/prototype/splice/set_length_no_args.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Array.prototype.splice sets length when called with no arguments
+info: >
+  22.1.3.25 Array.prototype.splice (start, deleteCount , ...items )
+
+  ...
+  24. Let setStatus be Set(O, "length", len – actualDeleteCount + itemCount, true).
+  25. ReturnIfAbrupt(setStatus).
+es5id: 15.4.4.12
+es6id: 22.1.3.25
+---*/
+
+var getCallCount = 0, setCallCount = 0;
+var lengthValue;
+
+var obj = {
+  get length() {
+    getCallCount += 1;
+    return "0";
+  },
+  set length(v) {
+    setCallCount += 1;
+    lengthValue = v;
+  }
+};
+
+Array.prototype.splice.call(obj);
+
+assert.sameValue(getCallCount, 1, "Get('length') called exactly once");
+assert.sameValue(setCallCount, 1, "Set('length') called exactly once");
+assert.sameValue(lengthValue, 0, "Set('length') called with ToLength('0')");

--- a/test/built-ins/Array/prototype/toLocaleString/primitive_this_value.js
+++ b/test/built-ins/Array/prototype/toLocaleString/primitive_this_value.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Array.prototype.toLocaleString called with primitive element
+info: >
+  22.1.3.26 Array.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] )
+
+  ...
+  10. Else
+    a. Let R be ToString(Invoke(firstElement, "toLocaleString")).
+    b. ReturnIfAbrupt(R).
+  ...
+  12.
+    ...
+    e. Else
+      i.  Let R be ToString(Invoke(nextElement, "toLocaleString")).
+      ii. ReturnIfAbrupt(R).
+es6id: 22.1.3.26
+flags: [onlyStrict]
+---*/
+
+var listSeparator = ["", ""].toLocaleString();
+
+Boolean.prototype.toString = function() {
+  return typeof this;
+};
+
+assert.sameValue([true, false].toLocaleString(), ("boolean" + listSeparator + "boolean"));

--- a/test/built-ins/Array/prototype/toLocaleString/primitive_this_value_getter.js
+++ b/test/built-ins/Array/prototype/toLocaleString/primitive_this_value_getter.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Array.prototype.toLocaleString called with primitive element in getter
+info: >
+  22.1.3.26 Array.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] )
+
+  ...
+  10. Else
+    a. Let R be ToString(Invoke(firstElement, "toLocaleString")).
+    b. ReturnIfAbrupt(R).
+  ...
+  12.
+    ...
+    e. Else
+      i.  Let R be ToString(Invoke(nextElement, "toLocaleString")).
+      ii. ReturnIfAbrupt(R).
+es6id: 22.1.3.26
+flags: [onlyStrict]
+---*/
+
+var listSeparator = ["", ""].toLocaleString();
+
+Object.defineProperty(Boolean.prototype, "toString", {
+  get: function() {
+    var v = typeof this;
+    return function() {
+      return v;
+    };
+  }
+});
+
+assert.sameValue([true, false].toLocaleString(), ("boolean" + listSeparator + "boolean"));

--- a/test/built-ins/Date/TimeClip_negative_zero.js
+++ b/test/built-ins/Date/TimeClip_negative_zero.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: TimeClip converts negative zero to positive zero
+info: >
+  20.3.1.15 TimeClip (time)
+
+  ...
+  3. Return ToInteger(time) + (+0). (Adding a positive zero converts -0 to +0.)
+es6id: 20.3.1.15
+---*/
+
+var date = new Date(-0);
+
+assert.sameValue(date.getTime(), +0, "TimeClip does not return negative zero");

--- a/test/built-ins/Date/construct_with_date.js
+++ b/test/built-ins/Date/construct_with_date.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Date constructor called with Date object
+info: >
+  20.3.2.2 Date ( value )
+
+  ...
+  3. If NewTarget is not undefined, then
+    a. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+      i. Let tv be thisTimeValue(value).
+es6id: 20.3.2.2
+---*/
+
+var dateValue = 1438560000000;
+
+var oldDate = new Date(dateValue);
+oldDate.toString = function() {
+  $ERROR("toString() method called");
+};
+oldDate.valueOf = function() {
+  $ERROR("valueOf() method called");
+};
+
+var newDate = new Date(oldDate);
+
+assert.sameValue(newDate.getTime(), dateValue, "Same date value");

--- a/test/built-ins/Error/message_property.js
+++ b/test/built-ins/Error/message_property.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Error constructor creates own message property
+info: >
+  19.5.1.1 Error ( message )
+
+  ...
+  4.
+    ...
+    c. Let msgDesc be the PropertyDescriptor{[[Value]]: msg, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true}.
+    d. Let status be DefinePropertyOrThrow(O, "message", msgDesc).
+es6id: 19.5.1.1
+includes: [propertyHelper.js]
+---*/
+
+var message = "my-message";
+var error = new Error(message);
+
+verifyEqualTo(error, "message", message);
+verifyNotEnumerable(error, "message");
+verifyWritable(error, "message");
+verifyConfigurable(error, "message");

--- a/test/built-ins/Error/message_property_native_error.js
+++ b/test/built-ins/Error/message_property_native_error.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: NativeError constructor creates own message property
+info: >
+  19.5.6.1.1 NativeError ( message )
+
+  ...
+  4.
+    ...
+    c. Let msgDesc be the PropertyDescriptor{[[Value]]: msg, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true}.
+    d. Let status be DefinePropertyOrThrow(O, "message", msgDesc).
+es6id: 19.5.6.1.1
+includes: [propertyHelper.js]
+---*/
+
+var nativeErrors = [
+  EvalError, RangeError, ReferenceError, SyntaxError, TypeError, URIError
+];
+
+for (var i = 0; i < nativeErrors.length; ++i) {
+  var nativeError = nativeErrors[i];
+
+  var message = "my-message";
+  var error = new nativeError(message);
+
+  verifyEqualTo(error, "message", message);
+  verifyNotEnumerable(error, "message");
+  verifyWritable(error, "message");
+  verifyConfigurable(error, "message");
+}

--- a/test/built-ins/Object/prototype/hasOwnProperty/symbol_own_property.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/symbol_own_property.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Object.prototype.hasOwnProperty called with symbol property key
+info: >
+  19.1.3.2 Object.prototype.hasOwnProperty ( V )
+
+  1. Let P be ToPropertyKey(V).
+  2. ReturnIfAbrupt(P).
+  ...
+es6id: 19.1.3.2
+---*/
+
+var obj = {};
+var sym = Symbol();
+
+assert.sameValue(
+  obj.hasOwnProperty(sym),
+  false,
+  "Returns false if symbol own property not found"
+);
+
+obj[sym] = 0;
+
+assert.sameValue(
+  obj.hasOwnProperty(sym),
+  true,
+  "Returns true if symbol own property found"
+);

--- a/test/built-ins/Object/prototype/hasOwnProperty/symbol_property_toPrimitive.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/symbol_property_toPrimitive.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Object.prototype.hasOwnProperty with symbol and @@toPrimitive conversion
+info: >
+  19.1.3.2 Object.prototype.hasOwnProperty ( V )
+
+  1. Let P be ToPropertyKey(V).
+  2. ReturnIfAbrupt(P).
+  ...
+es6id: 19.1.3.2
+features: [Symbol.toPrimitive]
+---*/
+
+var obj = {};
+var sym = Symbol();
+
+var callCount = 0;
+var wrapper = {};
+wrapper[Symbol.toPrimitive] = function() {
+  callCount += 1;
+  return sym;
+};
+
+obj[sym] = 0;
+
+assert.sameValue(
+  obj.hasOwnProperty(wrapper),
+  true,
+  "Returns true if symbol own property found"
+);
+
+assert.sameValue(callCount, 1, "toPrimitive method called exactly once");

--- a/test/built-ins/Object/prototype/hasOwnProperty/symbol_property_toString.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/symbol_property_toString.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Object.prototype.hasOwnProperty with symbol and toString conversion
+info: >
+  19.1.3.2 Object.prototype.hasOwnProperty ( V )
+
+  1. Let P be ToPropertyKey(V).
+  2. ReturnIfAbrupt(P).
+  ...
+es6id: 19.1.3.2
+---*/
+
+var obj = {};
+var sym = Symbol();
+
+var callCount = 0;
+var wrapper = {
+  toString: function() {
+    callCount += 1;
+    return sym;
+  },
+  valueOf: function() {
+    $ERROR("valueOf() called");
+  }
+};
+
+obj[sym] = 0;
+
+assert.sameValue(
+  obj.hasOwnProperty(wrapper),
+  true,
+  "Returns true if symbol own property found"
+);
+
+assert.sameValue(callCount, 1, "toString method called exactly once");

--- a/test/built-ins/Object/prototype/hasOwnProperty/symbol_property_valueOf.js
+++ b/test/built-ins/Object/prototype/hasOwnProperty/symbol_property_valueOf.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Object.prototype.hasOwnProperty with symbol and valueOf conversion
+info: >
+  19.1.3.2 Object.prototype.hasOwnProperty ( V )
+
+  1. Let P be ToPropertyKey(V).
+  2. ReturnIfAbrupt(P).
+  ...
+es6id: 19.1.3.2
+---*/
+
+var obj = {};
+var sym = Symbol();
+
+var callCount = 0;
+var wrapper = {
+  valueOf: function() {
+    callCount += 1;
+    return sym;
+  },
+  toString: null
+};
+
+obj[sym] = 0;
+
+assert.sameValue(
+  obj.hasOwnProperty(wrapper),
+  true,
+  "Returns true if symbol own property found"
+);
+
+assert.sameValue(callCount, 1, "valueOf method called exactly once");

--- a/test/built-ins/Object/prototype/propertyIsEnumerable/symbol_own_property.js
+++ b/test/built-ins/Object/prototype/propertyIsEnumerable/symbol_own_property.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Object.prototype.propertyIsEnumerable called with symbol property key
+info: >
+  19.1.3.4 Object.prototype.propertyIsEnumerable ( V )
+
+  1. Let P be ToPropertyKey(V).
+  2. ReturnIfAbrupt(P).
+  ...
+es6id: 19.1.3.4
+---*/
+
+var obj = {};
+var sym = Symbol();
+
+assert.sameValue(
+  obj.propertyIsEnumerable(sym),
+  false,
+  "Returns false if symbol own property not found"
+);
+
+obj[sym] = 0;
+
+assert.sameValue(
+  obj.propertyIsEnumerable(sym),
+  true,
+  "Returns true if symbol own enumerable property found"
+);

--- a/test/built-ins/Object/prototype/propertyIsEnumerable/symbol_property_toPrimitive.js
+++ b/test/built-ins/Object/prototype/propertyIsEnumerable/symbol_property_toPrimitive.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Object.prototype.propertyIsEnumerable with symbol and @@toPrimitive conversion
+info: >
+  19.1.3.4 Object.prototype.propertyIsEnumerable ( V )
+
+  1. Let P be ToPropertyKey(V).
+  2. ReturnIfAbrupt(P).
+  ...
+es6id: 19.1.3.4
+features: [Symbol.toPrimitive]
+---*/
+
+var obj = {};
+var sym = Symbol();
+
+var callCount = 0;
+var wrapper = {};
+wrapper[Symbol.toPrimitive] = function() {
+  callCount += 1;
+  return sym;
+};
+
+obj[sym] = 0;
+
+assert.sameValue(
+  obj.propertyIsEnumerable(wrapper),
+  true,
+  "Returns true if symbol own enumerable property found"
+);
+
+assert.sameValue(callCount, 1, "toPrimitive method called exactly once");

--- a/test/built-ins/Object/prototype/propertyIsEnumerable/symbol_property_toString.js
+++ b/test/built-ins/Object/prototype/propertyIsEnumerable/symbol_property_toString.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Object.prototype.propertyIsEnumerable with symbol and toString conversion
+info: >
+  19.1.3.4 Object.prototype.propertyIsEnumerable ( V )
+
+  1. Let P be ToPropertyKey(V).
+  2. ReturnIfAbrupt(P).
+  ...
+es6id: 19.1.3.4
+---*/
+
+var obj = {};
+var sym = Symbol();
+
+var callCount = 0;
+var wrapper = {
+  toString: function() {
+    callCount += 1;
+    return sym;
+  },
+  valueOf: function() {
+    $ERROR("valueOf() called");
+  }
+};
+
+obj[sym] = 0;
+
+assert.sameValue(
+  obj.propertyIsEnumerable(wrapper),
+  true,
+  "Returns true if symbol own enumerable property found"
+);
+
+assert.sameValue(callCount, 1, "toString method called exactly once");

--- a/test/built-ins/Object/prototype/propertyIsEnumerable/symbol_property_valueOf.js
+++ b/test/built-ins/Object/prototype/propertyIsEnumerable/symbol_property_valueOf.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Object.prototype.propertyIsEnumerable with symbol and valueOf conversion
+info: >
+  19.1.3.4 Object.prototype.propertyIsEnumerable ( V )
+
+  1. Let P be ToPropertyKey(V).
+  2. ReturnIfAbrupt(P).
+  ...
+es6id: 19.1.3.4
+---*/
+
+var obj = {};
+var sym = Symbol();
+
+var callCount = 0;
+var wrapper = {
+  valueOf: function() {
+    callCount += 1;
+    return sym;
+  },
+  toString: null
+};
+
+obj[sym] = 0;
+
+assert.sameValue(
+  obj.propertyIsEnumerable(wrapper),
+  true,
+  "Returns true if symbol own enumerable property found"
+);
+
+assert.sameValue(callCount, 1, "valueOf method called exactly once");

--- a/test/built-ins/Object/prototype/toLocaleString/primitive_this_value.js
+++ b/test/built-ins/Object/prototype/toLocaleString/primitive_this_value.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Object.prototype.toLocaleString called with primitive thisValue
+info: >
+  19.1.3.5 Object.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] )
+
+  ...
+  2. Return Invoke(O, "toString").
+es6id: 19.1.3.5
+flags: [onlyStrict]
+---*/
+
+Boolean.prototype.toString = function() {
+  return typeof this;
+};
+
+assert.sameValue(true.toLocaleString(), "boolean");

--- a/test/built-ins/Object/prototype/toLocaleString/primitive_this_value_getter.js
+++ b/test/built-ins/Object/prototype/toLocaleString/primitive_this_value_getter.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Object.prototype.toLocaleString called with primitive thisValue in getter
+info: >
+  19.1.3.5 Object.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] )
+
+  ...
+  2. Return Invoke(O, "toString").
+es6id: 19.1.3.5
+flags: [onlyStrict]
+---*/
+
+Object.defineProperty(Boolean.prototype, "toString", {
+  get: function() {
+    var v = typeof this;
+    return function() {
+      return v;
+    };
+  }
+});
+
+assert.sameValue(true.toLocaleString(), "boolean");

--- a/test/built-ins/RegExp/call_with_non_regexp_same_constructor.js
+++ b/test/built-ins/RegExp/call_with_non_regexp_same_constructor.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: RegExp returns its input argument if constructor is same-value
+info: >
+  21.2.3.1 RegExp ( pattern, flags )
+
+  ...
+  4. Else,
+    a. Let newTarget be the active function object.
+    b. If patternIsRegExp is true and flags is undefined, then
+      i.   Let patternConstructor be Get(pattern, "constructor").
+      ii.  ReturnIfAbrupt(patternConstructor).
+      iii. If SameValue(newTarget, patternConstructor) is true, return pattern.
+es6id: 21.2.3.1
+features: [Symbol.match]
+---*/
+
+var obj = {
+  constructor: RegExp
+};
+obj[Symbol.match] = true;
+
+assert.sameValue(RegExp(obj), obj, "RegExp returns its input argument");

--- a/test/built-ins/RegExp/call_with_regexp_match_falsy.js
+++ b/test/built-ins/RegExp/call_with_regexp_match_falsy.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: RegExp returns a new object if constructor is not same-value
+info: >
+  21.2.3.1 RegExp ( pattern, flags )
+
+  ...
+  4. Else,
+    a. Let newTarget be the active function object.
+    b. If patternIsRegExp is true and flags is undefined, then
+      i.   Let patternConstructor be Get(pattern, "constructor").
+      ii.  ReturnIfAbrupt(patternConstructor).
+      iii. If SameValue(newTarget, patternConstructor) is true, return pattern.
+es6id: 21.2.3.1
+features: [Symbol.match]
+---*/
+
+var regExpObj = /(?:)/;
+regExpObj[Symbol.match] = false;
+
+assert.notSameValue(RegExp(regExpObj), regExpObj, "RegExp returns new object");

--- a/test/built-ins/RegExp/call_with_regexp_not_same_constructor.js
+++ b/test/built-ins/RegExp/call_with_regexp_not_same_constructor.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: RegExp returns a new object if constructor is not same-value
+info: >
+  21.2.3.1 RegExp ( pattern, flags )
+
+  ...
+  4. Else,
+    a. Let newTarget be the active function object.
+    b. If patternIsRegExp is true and flags is undefined, then
+      i.   Let patternConstructor be Get(pattern, "constructor").
+      ii.  ReturnIfAbrupt(patternConstructor).
+      iii. If SameValue(newTarget, patternConstructor) is true, return pattern.
+es6id: 21.2.3.1
+---*/
+
+var regExpObj = /(?:)/;
+regExpObj.constructor = null;
+
+assert.notSameValue(RegExp(regExpObj), regExpObj, "RegExp returns new object");

--- a/test/built-ins/String/prototype/toLocaleLowerCase/supplementary_plane.js
+++ b/test/built-ins/String/prototype/toLocaleLowerCase/supplementary_plane.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: String.prototype.toLocaleLowerCase() iterates over code points
+info: >
+    21.1.3.20 String.prototype.toLocaleLowerCase()
+    ...
+    This function interprets a String value as a sequence of UTF-16 encoded
+    code points, as described in 6.1.4.
+
+    This function works exactly the same as toLowerCase [...].
+
+    21.1.3.20 String.prototype.toLowerCase ( )
+
+    ...
+    4. Let cpList be a List containing in order the code points as defined in
+       6.1.4 of S, starting at the first element of S.
+    5. For each code point c in cpList, if the Unicode Character Database
+       provides a language insensitive lower case equivalent of c then replace
+       c in cpList with that equivalent code point(s).
+es6id: 21.1.3.20
+---*/
+
+assert.sameValue("\uD801\uDC00".toLocaleLowerCase(), "\uD801\uDC28", "DESERET CAPITAL LETTER LONG I");
+assert.sameValue("\uD801\uDC01".toLocaleLowerCase(), "\uD801\uDC29", "DESERET CAPITAL LETTER LONG E");
+assert.sameValue("\uD801\uDC02".toLocaleLowerCase(), "\uD801\uDC2A", "DESERET CAPITAL LETTER LONG A");
+assert.sameValue("\uD801\uDC03".toLocaleLowerCase(), "\uD801\uDC2B", "DESERET CAPITAL LETTER LONG AH");
+assert.sameValue("\uD801\uDC04".toLocaleLowerCase(), "\uD801\uDC2C", "DESERET CAPITAL LETTER LONG O");
+assert.sameValue("\uD801\uDC05".toLocaleLowerCase(), "\uD801\uDC2D", "DESERET CAPITAL LETTER LONG OO");
+assert.sameValue("\uD801\uDC06".toLocaleLowerCase(), "\uD801\uDC2E", "DESERET CAPITAL LETTER SHORT I");
+assert.sameValue("\uD801\uDC07".toLocaleLowerCase(), "\uD801\uDC2F", "DESERET CAPITAL LETTER SHORT E");
+assert.sameValue("\uD801\uDC08".toLocaleLowerCase(), "\uD801\uDC30", "DESERET CAPITAL LETTER SHORT A");
+assert.sameValue("\uD801\uDC09".toLocaleLowerCase(), "\uD801\uDC31", "DESERET CAPITAL LETTER SHORT AH");
+assert.sameValue("\uD801\uDC0A".toLocaleLowerCase(), "\uD801\uDC32", "DESERET CAPITAL LETTER SHORT O");
+assert.sameValue("\uD801\uDC0B".toLocaleLowerCase(), "\uD801\uDC33", "DESERET CAPITAL LETTER SHORT OO");
+assert.sameValue("\uD801\uDC0C".toLocaleLowerCase(), "\uD801\uDC34", "DESERET CAPITAL LETTER AY");
+assert.sameValue("\uD801\uDC0D".toLocaleLowerCase(), "\uD801\uDC35", "DESERET CAPITAL LETTER OW");
+assert.sameValue("\uD801\uDC0E".toLocaleLowerCase(), "\uD801\uDC36", "DESERET CAPITAL LETTER WU");
+assert.sameValue("\uD801\uDC0F".toLocaleLowerCase(), "\uD801\uDC37", "DESERET CAPITAL LETTER YEE");
+assert.sameValue("\uD801\uDC10".toLocaleLowerCase(), "\uD801\uDC38", "DESERET CAPITAL LETTER H");
+assert.sameValue("\uD801\uDC11".toLocaleLowerCase(), "\uD801\uDC39", "DESERET CAPITAL LETTER PEE");
+assert.sameValue("\uD801\uDC12".toLocaleLowerCase(), "\uD801\uDC3A", "DESERET CAPITAL LETTER BEE");
+assert.sameValue("\uD801\uDC13".toLocaleLowerCase(), "\uD801\uDC3B", "DESERET CAPITAL LETTER TEE");
+assert.sameValue("\uD801\uDC14".toLocaleLowerCase(), "\uD801\uDC3C", "DESERET CAPITAL LETTER DEE");
+assert.sameValue("\uD801\uDC15".toLocaleLowerCase(), "\uD801\uDC3D", "DESERET CAPITAL LETTER CHEE");
+assert.sameValue("\uD801\uDC16".toLocaleLowerCase(), "\uD801\uDC3E", "DESERET CAPITAL LETTER JEE");
+assert.sameValue("\uD801\uDC17".toLocaleLowerCase(), "\uD801\uDC3F", "DESERET CAPITAL LETTER KAY");
+assert.sameValue("\uD801\uDC18".toLocaleLowerCase(), "\uD801\uDC40", "DESERET CAPITAL LETTER GAY");
+assert.sameValue("\uD801\uDC19".toLocaleLowerCase(), "\uD801\uDC41", "DESERET CAPITAL LETTER EF");
+assert.sameValue("\uD801\uDC1A".toLocaleLowerCase(), "\uD801\uDC42", "DESERET CAPITAL LETTER VEE");
+assert.sameValue("\uD801\uDC1B".toLocaleLowerCase(), "\uD801\uDC43", "DESERET CAPITAL LETTER ETH");
+assert.sameValue("\uD801\uDC1C".toLocaleLowerCase(), "\uD801\uDC44", "DESERET CAPITAL LETTER THEE");
+assert.sameValue("\uD801\uDC1D".toLocaleLowerCase(), "\uD801\uDC45", "DESERET CAPITAL LETTER ES");
+assert.sameValue("\uD801\uDC1E".toLocaleLowerCase(), "\uD801\uDC46", "DESERET CAPITAL LETTER ZEE");
+assert.sameValue("\uD801\uDC1F".toLocaleLowerCase(), "\uD801\uDC47", "DESERET CAPITAL LETTER ESH");
+assert.sameValue("\uD801\uDC20".toLocaleLowerCase(), "\uD801\uDC48", "DESERET CAPITAL LETTER ZHEE");
+assert.sameValue("\uD801\uDC21".toLocaleLowerCase(), "\uD801\uDC49", "DESERET CAPITAL LETTER ER");
+assert.sameValue("\uD801\uDC22".toLocaleLowerCase(), "\uD801\uDC4A", "DESERET CAPITAL LETTER EL");
+assert.sameValue("\uD801\uDC23".toLocaleLowerCase(), "\uD801\uDC4B", "DESERET CAPITAL LETTER EM");
+assert.sameValue("\uD801\uDC24".toLocaleLowerCase(), "\uD801\uDC4C", "DESERET CAPITAL LETTER EN");
+assert.sameValue("\uD801\uDC25".toLocaleLowerCase(), "\uD801\uDC4D", "DESERET CAPITAL LETTER ENG");
+assert.sameValue("\uD801\uDC26".toLocaleLowerCase(), "\uD801\uDC4E", "DESERET CAPITAL LETTER OI");
+assert.sameValue("\uD801\uDC27".toLocaleLowerCase(), "\uD801\uDC4F", "DESERET CAPITAL LETTER EW");

--- a/test/built-ins/String/prototype/toLocaleUpperCase/supplementary_plane.js
+++ b/test/built-ins/String/prototype/toLocaleUpperCase/supplementary_plane.js
@@ -1,0 +1,70 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: String.prototype.toLocaleUpperCase() iterates over code points
+info: >
+    21.1.3.21 String.prototype.toLocaleUpperCase()
+    ...
+    This function interprets a String value as a sequence of UTF-16 encoded
+    code points, as described in 6.1.4.
+
+    This function works exactly the same as toUpperCase [...].
+
+    21.1.3.24 String.prototype.toUpperCase ( )
+
+    This function behaves in exactly the same way as String.prototype.toLowerCase,
+    except that code points are mapped to their uppercase equivalents as specified
+    in the Unicode Character Database.
+
+    21.1.3.22 String.prototype.toLowerCase ( )
+
+    ...
+    4. Let cpList be a List containing in order the code points as defined in
+       6.1.4 of S, starting at the first element of S.
+    5. For each code point c in cpList, if the Unicode Character Database
+       provides a language insensitive lower case equivalent of c then replace
+       c in cpList with that equivalent code point(s).
+es6id: 21.1.3.21
+---*/
+
+assert.sameValue("\uD801\uDC28".toLocaleUpperCase(), "\uD801\uDC00", "DESERET SMALL LETTER LONG I");
+assert.sameValue("\uD801\uDC29".toLocaleUpperCase(), "\uD801\uDC01", "DESERET SMALL LETTER LONG E");
+assert.sameValue("\uD801\uDC2A".toLocaleUpperCase(), "\uD801\uDC02", "DESERET SMALL LETTER LONG A");
+assert.sameValue("\uD801\uDC2B".toLocaleUpperCase(), "\uD801\uDC03", "DESERET SMALL LETTER LONG AH");
+assert.sameValue("\uD801\uDC2C".toLocaleUpperCase(), "\uD801\uDC04", "DESERET SMALL LETTER LONG O");
+assert.sameValue("\uD801\uDC2D".toLocaleUpperCase(), "\uD801\uDC05", "DESERET SMALL LETTER LONG OO");
+assert.sameValue("\uD801\uDC2E".toLocaleUpperCase(), "\uD801\uDC06", "DESERET SMALL LETTER SHORT I");
+assert.sameValue("\uD801\uDC2F".toLocaleUpperCase(), "\uD801\uDC07", "DESERET SMALL LETTER SHORT E");
+assert.sameValue("\uD801\uDC30".toLocaleUpperCase(), "\uD801\uDC08", "DESERET SMALL LETTER SHORT A");
+assert.sameValue("\uD801\uDC31".toLocaleUpperCase(), "\uD801\uDC09", "DESERET SMALL LETTER SHORT AH");
+assert.sameValue("\uD801\uDC32".toLocaleUpperCase(), "\uD801\uDC0A", "DESERET SMALL LETTER SHORT O");
+assert.sameValue("\uD801\uDC33".toLocaleUpperCase(), "\uD801\uDC0B", "DESERET SMALL LETTER SHORT OO");
+assert.sameValue("\uD801\uDC34".toLocaleUpperCase(), "\uD801\uDC0C", "DESERET SMALL LETTER AY");
+assert.sameValue("\uD801\uDC35".toLocaleUpperCase(), "\uD801\uDC0D", "DESERET SMALL LETTER OW");
+assert.sameValue("\uD801\uDC36".toLocaleUpperCase(), "\uD801\uDC0E", "DESERET SMALL LETTER WU");
+assert.sameValue("\uD801\uDC37".toLocaleUpperCase(), "\uD801\uDC0F", "DESERET SMALL LETTER YEE");
+assert.sameValue("\uD801\uDC38".toLocaleUpperCase(), "\uD801\uDC10", "DESERET SMALL LETTER H");
+assert.sameValue("\uD801\uDC39".toLocaleUpperCase(), "\uD801\uDC11", "DESERET SMALL LETTER PEE");
+assert.sameValue("\uD801\uDC3A".toLocaleUpperCase(), "\uD801\uDC12", "DESERET SMALL LETTER BEE");
+assert.sameValue("\uD801\uDC3B".toLocaleUpperCase(), "\uD801\uDC13", "DESERET SMALL LETTER TEE");
+assert.sameValue("\uD801\uDC3C".toLocaleUpperCase(), "\uD801\uDC14", "DESERET SMALL LETTER DEE");
+assert.sameValue("\uD801\uDC3D".toLocaleUpperCase(), "\uD801\uDC15", "DESERET SMALL LETTER CHEE");
+assert.sameValue("\uD801\uDC3E".toLocaleUpperCase(), "\uD801\uDC16", "DESERET SMALL LETTER JEE");
+assert.sameValue("\uD801\uDC3F".toLocaleUpperCase(), "\uD801\uDC17", "DESERET SMALL LETTER KAY");
+assert.sameValue("\uD801\uDC40".toLocaleUpperCase(), "\uD801\uDC18", "DESERET SMALL LETTER GAY");
+assert.sameValue("\uD801\uDC41".toLocaleUpperCase(), "\uD801\uDC19", "DESERET SMALL LETTER EF");
+assert.sameValue("\uD801\uDC42".toLocaleUpperCase(), "\uD801\uDC1A", "DESERET SMALL LETTER VEE");
+assert.sameValue("\uD801\uDC43".toLocaleUpperCase(), "\uD801\uDC1B", "DESERET SMALL LETTER ETH");
+assert.sameValue("\uD801\uDC44".toLocaleUpperCase(), "\uD801\uDC1C", "DESERET SMALL LETTER THEE");
+assert.sameValue("\uD801\uDC45".toLocaleUpperCase(), "\uD801\uDC1D", "DESERET SMALL LETTER ES");
+assert.sameValue("\uD801\uDC46".toLocaleUpperCase(), "\uD801\uDC1E", "DESERET SMALL LETTER ZEE");
+assert.sameValue("\uD801\uDC47".toLocaleUpperCase(), "\uD801\uDC1F", "DESERET SMALL LETTER ESH");
+assert.sameValue("\uD801\uDC48".toLocaleUpperCase(), "\uD801\uDC20", "DESERET SMALL LETTER ZHEE");
+assert.sameValue("\uD801\uDC49".toLocaleUpperCase(), "\uD801\uDC21", "DESERET SMALL LETTER ER");
+assert.sameValue("\uD801\uDC4A".toLocaleUpperCase(), "\uD801\uDC22", "DESERET SMALL LETTER EL");
+assert.sameValue("\uD801\uDC4B".toLocaleUpperCase(), "\uD801\uDC23", "DESERET SMALL LETTER EM");
+assert.sameValue("\uD801\uDC4C".toLocaleUpperCase(), "\uD801\uDC24", "DESERET SMALL LETTER EN");
+assert.sameValue("\uD801\uDC4D".toLocaleUpperCase(), "\uD801\uDC25", "DESERET SMALL LETTER ENG");
+assert.sameValue("\uD801\uDC4E".toLocaleUpperCase(), "\uD801\uDC26", "DESERET SMALL LETTER OI");
+assert.sameValue("\uD801\uDC4F".toLocaleUpperCase(), "\uD801\uDC27", "DESERET SMALL LETTER EW");

--- a/test/built-ins/String/prototype/toLowerCase/supplementary_plane.js
+++ b/test/built-ins/String/prototype/toLowerCase/supplementary_plane.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: String.prototype.toLowerCase() iterates over code points
+info: >
+    21.1.3.22 String.prototype.toLowerCase ( )
+
+    ...
+    4. Let cpList be a List containing in order the code points as defined in
+       6.1.4 of S, starting at the first element of S.
+    5. For each code point c in cpList, if the Unicode Character Database
+       provides a language insensitive lower case equivalent of c then replace
+       c in cpList with that equivalent code point(s).
+es6id: 21.1.3.22
+---*/
+
+assert.sameValue("\uD801\uDC00".toLowerCase(), "\uD801\uDC28", "DESERET CAPITAL LETTER LONG I");
+assert.sameValue("\uD801\uDC01".toLowerCase(), "\uD801\uDC29", "DESERET CAPITAL LETTER LONG E");
+assert.sameValue("\uD801\uDC02".toLowerCase(), "\uD801\uDC2A", "DESERET CAPITAL LETTER LONG A");
+assert.sameValue("\uD801\uDC03".toLowerCase(), "\uD801\uDC2B", "DESERET CAPITAL LETTER LONG AH");
+assert.sameValue("\uD801\uDC04".toLowerCase(), "\uD801\uDC2C", "DESERET CAPITAL LETTER LONG O");
+assert.sameValue("\uD801\uDC05".toLowerCase(), "\uD801\uDC2D", "DESERET CAPITAL LETTER LONG OO");
+assert.sameValue("\uD801\uDC06".toLowerCase(), "\uD801\uDC2E", "DESERET CAPITAL LETTER SHORT I");
+assert.sameValue("\uD801\uDC07".toLowerCase(), "\uD801\uDC2F", "DESERET CAPITAL LETTER SHORT E");
+assert.sameValue("\uD801\uDC08".toLowerCase(), "\uD801\uDC30", "DESERET CAPITAL LETTER SHORT A");
+assert.sameValue("\uD801\uDC09".toLowerCase(), "\uD801\uDC31", "DESERET CAPITAL LETTER SHORT AH");
+assert.sameValue("\uD801\uDC0A".toLowerCase(), "\uD801\uDC32", "DESERET CAPITAL LETTER SHORT O");
+assert.sameValue("\uD801\uDC0B".toLowerCase(), "\uD801\uDC33", "DESERET CAPITAL LETTER SHORT OO");
+assert.sameValue("\uD801\uDC0C".toLowerCase(), "\uD801\uDC34", "DESERET CAPITAL LETTER AY");
+assert.sameValue("\uD801\uDC0D".toLowerCase(), "\uD801\uDC35", "DESERET CAPITAL LETTER OW");
+assert.sameValue("\uD801\uDC0E".toLowerCase(), "\uD801\uDC36", "DESERET CAPITAL LETTER WU");
+assert.sameValue("\uD801\uDC0F".toLowerCase(), "\uD801\uDC37", "DESERET CAPITAL LETTER YEE");
+assert.sameValue("\uD801\uDC10".toLowerCase(), "\uD801\uDC38", "DESERET CAPITAL LETTER H");
+assert.sameValue("\uD801\uDC11".toLowerCase(), "\uD801\uDC39", "DESERET CAPITAL LETTER PEE");
+assert.sameValue("\uD801\uDC12".toLowerCase(), "\uD801\uDC3A", "DESERET CAPITAL LETTER BEE");
+assert.sameValue("\uD801\uDC13".toLowerCase(), "\uD801\uDC3B", "DESERET CAPITAL LETTER TEE");
+assert.sameValue("\uD801\uDC14".toLowerCase(), "\uD801\uDC3C", "DESERET CAPITAL LETTER DEE");
+assert.sameValue("\uD801\uDC15".toLowerCase(), "\uD801\uDC3D", "DESERET CAPITAL LETTER CHEE");
+assert.sameValue("\uD801\uDC16".toLowerCase(), "\uD801\uDC3E", "DESERET CAPITAL LETTER JEE");
+assert.sameValue("\uD801\uDC17".toLowerCase(), "\uD801\uDC3F", "DESERET CAPITAL LETTER KAY");
+assert.sameValue("\uD801\uDC18".toLowerCase(), "\uD801\uDC40", "DESERET CAPITAL LETTER GAY");
+assert.sameValue("\uD801\uDC19".toLowerCase(), "\uD801\uDC41", "DESERET CAPITAL LETTER EF");
+assert.sameValue("\uD801\uDC1A".toLowerCase(), "\uD801\uDC42", "DESERET CAPITAL LETTER VEE");
+assert.sameValue("\uD801\uDC1B".toLowerCase(), "\uD801\uDC43", "DESERET CAPITAL LETTER ETH");
+assert.sameValue("\uD801\uDC1C".toLowerCase(), "\uD801\uDC44", "DESERET CAPITAL LETTER THEE");
+assert.sameValue("\uD801\uDC1D".toLowerCase(), "\uD801\uDC45", "DESERET CAPITAL LETTER ES");
+assert.sameValue("\uD801\uDC1E".toLowerCase(), "\uD801\uDC46", "DESERET CAPITAL LETTER ZEE");
+assert.sameValue("\uD801\uDC1F".toLowerCase(), "\uD801\uDC47", "DESERET CAPITAL LETTER ESH");
+assert.sameValue("\uD801\uDC20".toLowerCase(), "\uD801\uDC48", "DESERET CAPITAL LETTER ZHEE");
+assert.sameValue("\uD801\uDC21".toLowerCase(), "\uD801\uDC49", "DESERET CAPITAL LETTER ER");
+assert.sameValue("\uD801\uDC22".toLowerCase(), "\uD801\uDC4A", "DESERET CAPITAL LETTER EL");
+assert.sameValue("\uD801\uDC23".toLowerCase(), "\uD801\uDC4B", "DESERET CAPITAL LETTER EM");
+assert.sameValue("\uD801\uDC24".toLowerCase(), "\uD801\uDC4C", "DESERET CAPITAL LETTER EN");
+assert.sameValue("\uD801\uDC25".toLowerCase(), "\uD801\uDC4D", "DESERET CAPITAL LETTER ENG");
+assert.sameValue("\uD801\uDC26".toLowerCase(), "\uD801\uDC4E", "DESERET CAPITAL LETTER OI");
+assert.sameValue("\uD801\uDC27".toLowerCase(), "\uD801\uDC4F", "DESERET CAPITAL LETTER EW");

--- a/test/built-ins/String/prototype/toUpperCase/supplementary_plane.js
+++ b/test/built-ins/String/prototype/toUpperCase/supplementary_plane.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: String.prototype.toUpperCase() iterates over code points
+info: >
+    21.1.3.24 String.prototype.toUpperCase ( )
+
+    This function behaves in exactly the same way as String.prototype.toLowerCase,
+    except that code points are mapped to their uppercase equivalents as specified
+    in the Unicode Character Database.
+
+    21.1.3.22 String.prototype.toLowerCase ( )
+
+    ...
+    4. Let cpList be a List containing in order the code points as defined in
+       6.1.4 of S, starting at the first element of S.
+    5. For each code point c in cpList, if the Unicode Character Database
+       provides a language insensitive lower case equivalent of c then replace
+       c in cpList with that equivalent code point(s).
+es6id: 21.1.3.24
+---*/
+
+assert.sameValue("\uD801\uDC28".toUpperCase(), "\uD801\uDC00", "DESERET SMALL LETTER LONG I");
+assert.sameValue("\uD801\uDC29".toUpperCase(), "\uD801\uDC01", "DESERET SMALL LETTER LONG E");
+assert.sameValue("\uD801\uDC2A".toUpperCase(), "\uD801\uDC02", "DESERET SMALL LETTER LONG A");
+assert.sameValue("\uD801\uDC2B".toUpperCase(), "\uD801\uDC03", "DESERET SMALL LETTER LONG AH");
+assert.sameValue("\uD801\uDC2C".toUpperCase(), "\uD801\uDC04", "DESERET SMALL LETTER LONG O");
+assert.sameValue("\uD801\uDC2D".toUpperCase(), "\uD801\uDC05", "DESERET SMALL LETTER LONG OO");
+assert.sameValue("\uD801\uDC2E".toUpperCase(), "\uD801\uDC06", "DESERET SMALL LETTER SHORT I");
+assert.sameValue("\uD801\uDC2F".toUpperCase(), "\uD801\uDC07", "DESERET SMALL LETTER SHORT E");
+assert.sameValue("\uD801\uDC30".toUpperCase(), "\uD801\uDC08", "DESERET SMALL LETTER SHORT A");
+assert.sameValue("\uD801\uDC31".toUpperCase(), "\uD801\uDC09", "DESERET SMALL LETTER SHORT AH");
+assert.sameValue("\uD801\uDC32".toUpperCase(), "\uD801\uDC0A", "DESERET SMALL LETTER SHORT O");
+assert.sameValue("\uD801\uDC33".toUpperCase(), "\uD801\uDC0B", "DESERET SMALL LETTER SHORT OO");
+assert.sameValue("\uD801\uDC34".toUpperCase(), "\uD801\uDC0C", "DESERET SMALL LETTER AY");
+assert.sameValue("\uD801\uDC35".toUpperCase(), "\uD801\uDC0D", "DESERET SMALL LETTER OW");
+assert.sameValue("\uD801\uDC36".toUpperCase(), "\uD801\uDC0E", "DESERET SMALL LETTER WU");
+assert.sameValue("\uD801\uDC37".toUpperCase(), "\uD801\uDC0F", "DESERET SMALL LETTER YEE");
+assert.sameValue("\uD801\uDC38".toUpperCase(), "\uD801\uDC10", "DESERET SMALL LETTER H");
+assert.sameValue("\uD801\uDC39".toUpperCase(), "\uD801\uDC11", "DESERET SMALL LETTER PEE");
+assert.sameValue("\uD801\uDC3A".toUpperCase(), "\uD801\uDC12", "DESERET SMALL LETTER BEE");
+assert.sameValue("\uD801\uDC3B".toUpperCase(), "\uD801\uDC13", "DESERET SMALL LETTER TEE");
+assert.sameValue("\uD801\uDC3C".toUpperCase(), "\uD801\uDC14", "DESERET SMALL LETTER DEE");
+assert.sameValue("\uD801\uDC3D".toUpperCase(), "\uD801\uDC15", "DESERET SMALL LETTER CHEE");
+assert.sameValue("\uD801\uDC3E".toUpperCase(), "\uD801\uDC16", "DESERET SMALL LETTER JEE");
+assert.sameValue("\uD801\uDC3F".toUpperCase(), "\uD801\uDC17", "DESERET SMALL LETTER KAY");
+assert.sameValue("\uD801\uDC40".toUpperCase(), "\uD801\uDC18", "DESERET SMALL LETTER GAY");
+assert.sameValue("\uD801\uDC41".toUpperCase(), "\uD801\uDC19", "DESERET SMALL LETTER EF");
+assert.sameValue("\uD801\uDC42".toUpperCase(), "\uD801\uDC1A", "DESERET SMALL LETTER VEE");
+assert.sameValue("\uD801\uDC43".toUpperCase(), "\uD801\uDC1B", "DESERET SMALL LETTER ETH");
+assert.sameValue("\uD801\uDC44".toUpperCase(), "\uD801\uDC1C", "DESERET SMALL LETTER THEE");
+assert.sameValue("\uD801\uDC45".toUpperCase(), "\uD801\uDC1D", "DESERET SMALL LETTER ES");
+assert.sameValue("\uD801\uDC46".toUpperCase(), "\uD801\uDC1E", "DESERET SMALL LETTER ZEE");
+assert.sameValue("\uD801\uDC47".toUpperCase(), "\uD801\uDC1F", "DESERET SMALL LETTER ESH");
+assert.sameValue("\uD801\uDC48".toUpperCase(), "\uD801\uDC20", "DESERET SMALL LETTER ZHEE");
+assert.sameValue("\uD801\uDC49".toUpperCase(), "\uD801\uDC21", "DESERET SMALL LETTER ER");
+assert.sameValue("\uD801\uDC4A".toUpperCase(), "\uD801\uDC22", "DESERET SMALL LETTER EL");
+assert.sameValue("\uD801\uDC4B".toUpperCase(), "\uD801\uDC23", "DESERET SMALL LETTER EM");
+assert.sameValue("\uD801\uDC4C".toUpperCase(), "\uD801\uDC24", "DESERET SMALL LETTER EN");
+assert.sameValue("\uD801\uDC4D".toUpperCase(), "\uD801\uDC25", "DESERET SMALL LETTER ENG");
+assert.sameValue("\uD801\uDC4E".toUpperCase(), "\uD801\uDC26", "DESERET SMALL LETTER OI");
+assert.sameValue("\uD801\uDC4F".toUpperCase(), "\uD801\uDC27", "DESERET SMALL LETTER EW");


### PR DESCRIPTION
- String case functions iterate over code points
- Has called before Get in Array.p.reverse
- Add test for web-compat Array.p.splice behaviour; Plus missing test for no arguments case
- ToObject no longer applied to this-value in Array.p.toLocaleString
- ToObject no longer applied to this-value in Object.p.toLocaleString
- Add tests for Object.p.propertyIsEnumerable and symbol property keys
- Add tests for Object.p.hasOwnProperty and symbol property keys
- Test property descriptor attributes of message property
- Tests for RegExp constructor checks
- Date constructor when called with date object
- TimeClip never returns negative zero