### PR TITLE
Replace runTestCase in test/language (part 2)

### DIFF
--- a/test/language/arguments-object/10.6-12-1.js
+++ b/test/language/arguments-object/10.6-12-1.js
@@ -5,16 +5,9 @@
 es5id: 10.6-12-1
 description: Accessing callee property of Arguments object is allowed
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  try 
-  {
     arguments.callee;
-    return true;
-  }
-  catch (e) {
-  }
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/arguments-object/10.6-12-2.js
+++ b/test/language/arguments-object/10.6-12-2.js
@@ -5,17 +5,15 @@
 es5id: 10.6-12-2
 description: arguments.callee has correct attributes
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  
   var desc = Object.getOwnPropertyDescriptor(arguments,"callee");
-  if(desc.configurable === true &&
-     desc.enumerable === false &&
-     desc.writable === true &&
-     desc.hasOwnProperty('get') == false &&
-     desc.hasOwnProperty('put') == false)
-    return true;   
+
+  assert.sameValue(desc.configurable, true, 'desc.configurable');
+  assert.sameValue(desc.enumerable, false, 'desc.enumerable');
+  assert.sameValue(desc.writable, true, 'desc.writable');
+  assert.sameValue(desc.hasOwnProperty('get'), false, 'desc.hasOwnProperty("get")');
+  assert.sameValue(desc.hasOwnProperty('set'), false, 'desc.hasOwnProperty("set")');
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/arguments-object/10.6-13-1.js
+++ b/test/language/arguments-object/10.6-13-1.js
@@ -5,16 +5,9 @@
 es5id: 10.6-13-1
 description: Accessing caller property of Arguments object is allowed
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  try 
-  {
     arguments.caller;
-    return true;
-  }
-  catch (e) {
-  }
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/arguments-object/10.6-13-b-2-s.js
+++ b/test/language/arguments-object/10.6-13-b-2-s.js
@@ -5,11 +5,10 @@
 es5id: 10.6-13-b-2-s
 description: arguments.caller exists in strict mode
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
   var desc = Object.getOwnPropertyDescriptor(arguments,"caller");
-  return desc!== undefined;
+  assert.notSameValue(desc, undefined);
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/arguments-object/10.6-13-b-3-s.js
+++ b/test/language/arguments-object/10.6-13-b-3-s.js
@@ -5,18 +5,16 @@
 es5id: 10.6-13-b-3-s
 description: arguments.caller is non-configurable in strict mode
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
   var desc = Object.getOwnPropertyDescriptor(arguments,"caller");
-  
-  return (desc.configurable === false && 
-     desc.enumerable === false && 
-     desc.hasOwnProperty('value') == false  && 
-     desc.hasOwnProperty('writable') == false &&
-     desc.hasOwnProperty('get') == true && 
-     desc.hasOwnProperty('set') == true);                                     
-    
+
+  assert.sameValue(desc.configurable, false, 'desc.configurable');
+  assert.sameValue(desc.enumerable, false, 'desc.enumerable');
+  assert.sameValue(desc.hasOwnProperty('value'), false, 'desc.hasOwnProperty("value")');
+  assert.sameValue(desc.hasOwnProperty('writable'), false, 'desc.hasOwnProperty("writable")');
+  assert.sameValue(desc.hasOwnProperty('get'), true, 'desc.hasOwnProperty("get")');
+  assert.sameValue(desc.hasOwnProperty('set'), true, 'desc.hasOwnProperty("set")');
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/arguments-object/10.6-13-c-2-s.js
+++ b/test/language/arguments-object/10.6-13-c-2-s.js
@@ -4,11 +4,10 @@
 /*---
 es5id: 10.6-13-c-2-s
 description: arguments.callee is exists
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
   var desc = Object.getOwnPropertyDescriptor(arguments,"callee");
-  return desc !== undefined;
+  assert.notSameValue(desc, undefined);
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/arguments-object/10.6-13-c-3-s.js
+++ b/test/language/arguments-object/10.6-13-c-3-s.js
@@ -5,16 +5,16 @@
 es5id: 10.6-13-c-3-s
 description: arguments.callee is non-configurable in strict mode
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
   var desc = Object.getOwnPropertyDescriptor(arguments,"callee");
-  return (desc.configurable === false &&
-     desc.enumerable === false &&
-     desc.hasOwnProperty('value') == false &&
-     desc.hasOwnProperty('writable') == false &&
-     desc.hasOwnProperty('get') == true &&
-     desc.hasOwnProperty('set') == true);
+
+  assert.sameValue(desc.configurable, false, 'desc.configurable');
+  assert.sameValue(desc.enumerable, false, 'desc.enumerable');
+  assert.sameValue(desc.hasOwnProperty('value'), false, 'desc.hasOwnProperty("value")');
+  assert.sameValue(desc.hasOwnProperty('writable'), false, 'desc.hasOwnProperty("writable")');
+  assert.sameValue(desc.hasOwnProperty('get'), true, 'desc.hasOwnProperty("get")');
+  assert.sameValue(desc.hasOwnProperty('set'), true, 'desc.hasOwnProperty("set")');
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/arguments-object/10.6-5-1.js
+++ b/test/language/arguments-object/10.6-5-1.js
@@ -6,11 +6,9 @@ es5id: 10.6-5-1
 description: >
     [[Prototype]] property of Arguments is set to Object prototype
     object
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  if(Object.getPrototypeOf(arguments) === Object.getPrototypeOf({}))
-    return true;
+  assert.sameValue(Object.getPrototypeOf(arguments), Object.getPrototypeOf({}));
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/arguments-object/10.6-6-1.js
+++ b/test/language/arguments-object/10.6-6-1.js
@@ -4,12 +4,11 @@
 /*---
 es5id: 10.6-6-1
 description: "'length property of arguments object exists"
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
   
   var desc = Object.getOwnPropertyDescriptor(arguments,"length");
-  return desc !== undefined
+  assert.notSameValue(desc, undefined);
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/arguments-object/10.6-6-2.js
+++ b/test/language/arguments-object/10.6-6-2.js
@@ -4,15 +4,13 @@
 /*---
 es5id: 10.6-6-2
 description: "'length' property of arguments object has correct attributes"
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-  
   var desc = Object.getOwnPropertyDescriptor(arguments,"length");
-  if(desc.configurable === true &&
-     desc.enumerable === false &&
-     desc.writable === true )
-    return true;
+
+  assert.sameValue(desc.configurable, true, 'desc.configurable');
+  assert.sameValue(desc.enumerable, false, 'desc.enumerable');
+  assert.sameValue(desc.writable, true, 'desc.writable');
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/arguments-object/10.6-6-3-s.js
+++ b/test/language/arguments-object/10.6-6-3-s.js
@@ -6,10 +6,9 @@ es5id: 10.6-6-3
 description: >
     'length' property of arguments object for 0 argument function
     exists
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-	return (function () {return arguments.length !== undefined})();
+  assert.sameValue(arguments.length, 0);
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/arguments-object/10.6-6-3.js
+++ b/test/language/arguments-object/10.6-6-3.js
@@ -7,11 +7,10 @@ description: >
     'length' property of arguments object for 0 argument function
     exists
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
       var arguments= undefined;
-	return (function () {return arguments.length !== undefined})();
+	(function () { assert.sameValue(arguments.length, 0); })();
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/arguments-object/10.6-6-4-s.js
+++ b/test/language/arguments-object/10.6-6-4-s.js
@@ -6,10 +6,9 @@ es5id: 10.6-6-4
 description: >
     'length' property of arguments object for 0 argument function call
     is 0 even with formal parameters
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-	return (function (a,b,c) {return arguments.length === 0})();
+function testcase(a,b,c) {
+	assert.sameValue(arguments.length, 0);
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/arguments-object/10.6-6-4.js
+++ b/test/language/arguments-object/10.6-6-4.js
@@ -7,11 +7,10 @@ description: >
     'length' property of arguments object for 0 argument function call
     is 0 even with formal parameters
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
       var arguments= undefined;
-	return (function (a,b,c) {return arguments.length === 0})();
+	(function (a,b,c) { assert.sameValue(arguments.length, 0); })();
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/directive-prologue/10.1.1-1-s.js
+++ b/test/language/directive-prologue/10.1.1-1-s.js
@@ -7,12 +7,12 @@ description: >
     Strict Mode - Use Strict Directive Prologue is 'use  strict';
     which contains two space between 'use' and 'strict'
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         "use  strict";
         var public = 1;
-        return public === 1;
+
+        assert.sameValue(public, 1);
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/directive-prologue/10.1.1-10-s.js
+++ b/test/language/directive-prologue/10.1.1-10-s.js
@@ -7,12 +7,12 @@ description: >
     Strict Mode - Use Strict Directive Prologue is ''USE STRICT';' in
     which all characters are uppercase
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         "USE STRICT";
         var public = 1;
-        return public === 1;
+
+        assert.sameValue(public, 1);
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/directive-prologue/10.1.1-11-s.js
+++ b/test/language/directive-prologue/10.1.1-11-s.js
@@ -7,17 +7,16 @@ description: >
     Strict Mode - Eval code is strict code with a Use Strict Directive
     at the beginning of the block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
+var err = null;
+
         try {
             eval("'use strict'; var public = 1; var anotherVariableNotReserveWord = 2;");
-
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && typeof public === "undefined" &&
-                typeof anotherVariableNotReserveWord === "undefined";
+            err = e;
         }
-    }
-runTestCase(testcase);
+
+assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+assert.sameValue(typeof public, "undefined", 'typeof public');
+assert.sameValue(typeof anotherVariableNotReserveWord, "undefined", 'typeof anotherVariableNotReserveWord');

--- a/test/language/directive-prologue/10.1.1-12-s.js
+++ b/test/language/directive-prologue/10.1.1-12-s.js
@@ -7,11 +7,9 @@ description: >
     Strict Mode - Eval code is strict eval code with a Use Strict
     Directive in the middle of the block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         eval("var public = 1; 'use strict'; var anotherVariableNotReserveWord = 2;");
-        return public === 1 && anotherVariableNotReserveWord === 2;
-    }
-runTestCase(testcase);
+
+assert.sameValue(public, 1, 'public');
+assert.sameValue(anotherVariableNotReserveWord, 2, 'anotherVariableNotReserveWord');

--- a/test/language/directive-prologue/10.1.1-13-s.js
+++ b/test/language/directive-prologue/10.1.1-13-s.js
@@ -7,11 +7,9 @@ description: >
     Strict Mode - Eval code is strict eval code with a Use Strict
     Directive at the end of the block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         eval("var public = 1; var anotherVariableNotReserveWord = 2; 'use strict';");
-        return public === 1 && anotherVariableNotReserveWord === 2;
-    }
-runTestCase(testcase);
+
+assert.sameValue(public, 1, 'public');
+assert.sameValue(anotherVariableNotReserveWord, 2, 'anotherVariableNotReserveWord');

--- a/test/language/directive-prologue/10.1.1-14-s.js
+++ b/test/language/directive-prologue/10.1.1-14-s.js
@@ -7,16 +7,10 @@ description: >
     Strict Mode - The call to eval function is contained in a Strict
     Mode block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
+assert.throws(SyntaxError, function() {
         'use strict';
-        try {
+
             eval("var public = 1;");
-            return false;
-        } catch (e) {
-            return true;
-        }
-    }
-runTestCase(testcase);
+});

--- a/test/language/directive-prologue/10.1.1-15-s.js
+++ b/test/language/directive-prologue/10.1.1-15-s.js
@@ -8,20 +8,16 @@ description: >
     is strict function code if FunctionDeclaration is contained in use
     strict
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         "use strict";
         function fun() {
-            try {
-                eval("var public = 1;");
-                return false;
-            } catch (e) {
-                return e instanceof SyntaxError;
-            }
+            eval("var public = 1;");
         }
 
-        return fun();
+        assert.throws(SyntaxError, function() {
+            fun();
+        });
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/directive-prologue/10.1.1-16-s.js
+++ b/test/language/directive-prologue/10.1.1-16-s.js
@@ -8,18 +8,13 @@ description: >
     is strict function code if FunctionExpression is contained in use
     strict
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         "use strict";
-        return function () {
-            try {
+
+        assert.throws(SyntaxError, function() {
                 eval("var public = 1;");
-                return false;
-            } catch (e) {
-                return e instanceof SyntaxError;
-            }
-        } ();
+        });
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/directive-prologue/10.1.1-17-s.js
+++ b/test/language/directive-prologue/10.1.1-17-s.js
@@ -8,12 +8,10 @@ description: >
     PropertyAssignment is in Strict Mode if Accessor
     PropertyAssignment is contained in use strict(getter)
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
+assert.throws(SyntaxError, function() {
         "use strict";
-        try {
             var obj = {};
             Object.defineProperty(obj, "accProperty", {
                 get: function () {
@@ -23,9 +21,4 @@ function testcase() {
             });
 
             var temp = obj.accProperty === 11;
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError;
-        }
-    }
-runTestCase(testcase);
+});

--- a/test/language/directive-prologue/10.1.1-18-s.js
+++ b/test/language/directive-prologue/10.1.1-18-s.js
@@ -8,14 +8,14 @@ description: >
     PropertyAssignment is in Strict Mode if Accessor
     PropertyAssignment is contained in use strict(setter)
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
+var data = "data";
+
+assert.throws(SyntaxError, function() {
         "use strict";
-        try {
+
             var obj = {};
-            var data = "data";
             Object.defineProperty(obj, "accProperty", {
                 set: function (value) {
                     eval("var public = 1;");
@@ -24,9 +24,6 @@ function testcase() {
             });
 
             obj.accProperty = "overrideData";
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError && data === "data";
-        }
-    }
-runTestCase(testcase);
+});
+
+assert.sameValue(data, "data", 'data unchanged');

--- a/test/language/directive-prologue/10.1.1-19-s.js
+++ b/test/language/directive-prologue/10.1.1-19-s.js
@@ -7,19 +7,14 @@ description: >
     Strict Mode - Function code of a FunctionDeclaration contains Use
     Strict Directive which appears at the start of the block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         function fun() {
             "use strict";
-            try {
+
                 eval("var public = 1;");
-                return false;
-            } catch (e) {
-                return e instanceof SyntaxError;
-            }
         }
-        return fun();
-    }
-runTestCase(testcase);
+
+assert.throws(SyntaxError, function() {
+    fun();
+});

--- a/test/language/directive-prologue/10.1.1-2-s.js
+++ b/test/language/directive-prologue/10.1.1-2-s.js
@@ -7,17 +7,10 @@ description: >
     Strict Mode - Use Strict Directive Prologue is ''use strict''
     which lost the last character ';'
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
+assert.throws(SyntaxError, function() {
         "use strict"
-        try {
-            eval("var public = 1;");
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError;
-        }
 
-    }
-runTestCase(testcase);
+            eval("var public = 1;");
+});

--- a/test/language/directive-prologue/10.1.1-20-s.js
+++ b/test/language/directive-prologue/10.1.1-20-s.js
@@ -7,15 +7,11 @@ description: >
     Strict Mode - Function code of a FunctionDeclaration contains Use
     Strict Directive which appears in the middle of the block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         function fun() {
             eval("var public = 1;");
             "use strict";
-            return public === 1;
+            assert.sameValue(public, 1);
         }
-        return fun();
-    }
-runTestCase(testcase);
+        fun();

--- a/test/language/directive-prologue/10.1.1-21-s.js
+++ b/test/language/directive-prologue/10.1.1-21-s.js
@@ -7,15 +7,10 @@ description: >
     Strict Mode - Function code of a FunctionDeclaration contains Use
     Strict Directive which appears at the end of the block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
         function fun() {
             eval("var public = 1;");
-            return public === 1;
+            assert.sameValue(public, 1);
             "use strict";
         }
-        return fun();
-    }
-runTestCase(testcase);
+        fun();

--- a/test/language/directive-prologue/10.1.1-22-s.js
+++ b/test/language/directive-prologue/10.1.1-22-s.js
@@ -7,18 +7,10 @@ description: >
     Strict Mode - Function code of a FunctionExpression contains Use
     Strict Directive which appears at the start of the block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-        return function () {
+assert.throws(SyntaxError, function () {
             "use strict";
-            try {
+
                 eval("var public = 1;");
-                return false;
-            } catch (e) {
-                return e instanceof SyntaxError;
-            }
-        } ();
-    }
-runTestCase(testcase);
+});

--- a/test/language/directive-prologue/10.1.1-23-s.js
+++ b/test/language/directive-prologue/10.1.1-23-s.js
@@ -7,14 +7,10 @@ description: >
     Strict Mode - Function code of a FunctionExpression contains Use
     Strict Directive which appears in the middle of the block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-        return function () {
+        (function () {
             eval("var public = 1;");
-            return public === 1;
+            assert.sameValue(public, 1);
             "use strict";
-        } ();
-    }
-runTestCase(testcase);
+        }) ();

--- a/test/language/directive-prologue/10.1.1-24-s.js
+++ b/test/language/directive-prologue/10.1.1-24-s.js
@@ -7,14 +7,11 @@ description: >
     Strict Mode - Function code of a FunctionExpression contains Use
     Strict Directive which appears at the end of the block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-        return function () {
+        (function () {
             eval("var public = 1;");
             "use strict";
-            return public === 1;
-        } ();
-    }
-runTestCase(testcase);
+
+            assert.sameValue(public, 1);
+        }) ();

--- a/test/language/directive-prologue/10.1.1-26-s.js
+++ b/test/language/directive-prologue/10.1.1-26-s.js
@@ -8,13 +8,12 @@ description: >
     contains Use Strict Directive which appears at the start of the
     block(setter)
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-        try {
+var data = "data";
+
+assert.throws(SyntaxError, function() {
             var obj = {};
-            var data = "data";
             Object.defineProperty(obj, "accProperty", {
                 set: function (value) {
                     "use strict";
@@ -24,10 +23,6 @@ function testcase() {
             });
 
             obj.accProperty = "overrideData";
+});
 
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError && data === "data";
-        }
-    }
-runTestCase(testcase);
+assert.sameValue(data, "data", 'data unchanged');

--- a/test/language/directive-prologue/10.1.1-27-s.js
+++ b/test/language/directive-prologue/10.1.1-27-s.js
@@ -8,10 +8,8 @@ description: >
     contains Use Strict Directive which appears in the middle of the
     block(getter)
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var obj = {};
         Object.defineProperty(obj, "accProperty", {
             get: function () {
@@ -20,6 +18,6 @@ function testcase() {
                 return 11;
             }
         });
-        return obj.accProperty === 11 && public === 1;
-    }
-runTestCase(testcase);
+
+assert.sameValue(obj.accProperty, 11, 'obj.accProperty');
+assert.sameValue(public, 1, 'public');

--- a/test/language/directive-prologue/10.1.1-28-s.js
+++ b/test/language/directive-prologue/10.1.1-28-s.js
@@ -8,10 +8,8 @@ description: >
     contains Use Strict Directive which appears at the end of the
     block(setter)
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var obj = {};
         var data;
 
@@ -23,6 +21,5 @@ function testcase() {
             }
         });
         obj.accProperty = "overrideData";
-        return data==="overrideData";
-    }
-runTestCase(testcase);
+
+assert.sameValue(data, "overrideData", 'data');

--- a/test/language/directive-prologue/10.1.1-29-s.js
+++ b/test/language/directive-prologue/10.1.1-29-s.js
@@ -7,13 +7,11 @@ description: >
     Strict Mode - The built-in Function constructor is contained in
     use strict code
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         "use strict";
         var funObj = new Function("a", "eval('public = 1;');");
         funObj();
-        return true;
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/directive-prologue/10.1.1-3-s.js
+++ b/test/language/directive-prologue/10.1.1-3-s.js
@@ -7,13 +7,12 @@ description: >
     Strict Mode - Use Strict Directive Prologue is '' use strict';'
     which the first character is space
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         " use strict";
         var public = 1;
 
-        return public === 1;
+        assert.sameValue(public, 1);
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/directive-prologue/10.1.1-31-s.js
+++ b/test/language/directive-prologue/10.1.1-31-s.js
@@ -8,12 +8,11 @@ description: >
     contains Use Strict Directive which appears in the middle of the
     block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
+
         var funObj = new Function("a", "eval('public = 1;'); 'use strict'; anotherVariable = 2;");
         funObj();
-        return public === 1 && anotherVariable === 2;
-    }
-runTestCase(testcase);
+
+assert.sameValue(public, 1, 'public');
+assert.sameValue(anotherVariable, 2, 'anotherVariable');

--- a/test/language/directive-prologue/10.1.1-32-s.js
+++ b/test/language/directive-prologue/10.1.1-32-s.js
@@ -7,12 +7,11 @@ description: >
     Strict Mode - Function code of built-in Function constructor
     contains Use Strict Directive which appears at the end of the block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
+
         var funObj = new Function("a", "eval('public = 1;'); anotherVariable = 2; 'use strict';");
         funObj();
-        return public === 1 && anotherVariable === 2;
-    }
-runTestCase(testcase);
+
+assert.sameValue(public, 1, 'public');
+assert.sameValue(anotherVariable, 2, 'anotherVariable');

--- a/test/language/directive-prologue/10.1.1-4-s.js
+++ b/test/language/directive-prologue/10.1.1-4-s.js
@@ -7,12 +7,12 @@ description: >
     Strict Mode - Use Strict Directive Prologue is ''use strict ';'
     which the last character is space
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         "use strict ";
         var public = 1;
-        return public === 1;
+
+        assert.sameValue(public, 1);
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/directive-prologue/10.1.1-5-s.js
+++ b/test/language/directive-prologue/10.1.1-5-s.js
@@ -7,17 +7,10 @@ description: >
     Strict Mode - Use Strict Directive Prologue is ''use strict';'
     which appears at the beginning of the block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
+assert.throws(SyntaxError, function() {
         "use strict";
-        try {
-            eval("var public = 1;");
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError;
-        }
 
-    }
-runTestCase(testcase);
+            eval("var public = 1;");
+});

--- a/test/language/directive-prologue/10.1.1-6-s.js
+++ b/test/language/directive-prologue/10.1.1-6-s.js
@@ -7,13 +7,14 @@ description: >
     Strict Mode - Use Strict Directive Prologue is ''use strict';'
     which appears in the middle of the block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         var interface = 2;
         "use strict";
         var public = 1;
-        return public === 1 && interface === 2;
+
+        assert.sameValue(public, 1, 'public');
+        assert.sameValue(interface, 2, 'interface');
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/directive-prologue/10.1.1-7-s.js
+++ b/test/language/directive-prologue/10.1.1-7-s.js
@@ -7,12 +7,11 @@ description: >
     Strict Mode - Use Strict Directive Prologue is ''use strict';'
     which appears at the end of the block
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         var public = 1;
-        return public === 1;
+        assert.sameValue(public, 1);
         "use strict";
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/directive-prologue/10.1.1-8-s.js
+++ b/test/language/directive-prologue/10.1.1-8-s.js
@@ -7,17 +7,11 @@ description: >
     Strict Mode - Use Strict Directive Prologue is ''use strict';'
     which appears twice in the directive prologue
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
+assert.throws(SyntaxError, function() {
         "use strict";
         "use strict";
-        try {
+
             eval("var public = 1;");
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError;
-        }
-    }
-runTestCase(testcase);
+});

--- a/test/language/directive-prologue/10.1.1-9-s.js
+++ b/test/language/directive-prologue/10.1.1-9-s.js
@@ -7,12 +7,11 @@ description: >
     Strict Mode - Use Strict Directive Prologue is ''Use strict';' in
     which the first character is uppercase
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         "Use strict";
         var public = 1;
-        return public === 1;
+        assert.sameValue(public, 1);
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/directive-prologue/14.1-1-s.js
+++ b/test/language/directive-prologue/14.1-1-s.js
@@ -5,10 +5,7 @@
 es5id: 14.1-1-s
 description: "'use strict' directive - correct usage"
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -16,6 +13,4 @@ function testcase() {
      return(this === undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-10-s.js
+++ b/test/language/directive-prologue/14.1-10-s.js
@@ -5,10 +5,7 @@
 es5id: 14.1-10-s
 description: other directives - may follow 'use strict' directive
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -17,6 +14,4 @@ function testcase() {
      return (this === undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-11-s.js
+++ b/test/language/directive-prologue/14.1-11-s.js
@@ -5,10 +5,7 @@
 es5id: 14.1-11-s
 description: comments may preceed 'use strict' directive
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -19,6 +16,4 @@ function testcase() {
 
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-12-s.js
+++ b/test/language/directive-prologue/14.1-12-s.js
@@ -5,10 +5,7 @@
 es5id: 14.1-12-s
 description: comments may follow 'use strict' directive
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -17,6 +14,4 @@ function testcase() {
      return (this === undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-13-s.js
+++ b/test/language/directive-prologue/14.1-13-s.js
@@ -5,10 +5,7 @@
 es5id: 14.1-13-s
 description: semicolon insertion works for'use strict' directive
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -16,6 +13,4 @@ function testcase() {
      return (this === undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-14-s.js
+++ b/test/language/directive-prologue/14.1-14-s.js
@@ -5,10 +5,7 @@
 es5id: 14.1-14-s
 description: semicolon insertion may come before 'use strict' directive
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -17,6 +14,4 @@ function testcase() {
     return (this === undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-15-s.js
+++ b/test/language/directive-prologue/14.1-15-s.js
@@ -5,10 +5,7 @@
 es5id: 14.1-15-s
 description: blank lines may come before 'use strict' directive
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -22,6 +19,4 @@ function testcase() {
     return (this === undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-16-s.js
+++ b/test/language/directive-prologue/14.1-16-s.js
@@ -7,10 +7,7 @@ description: >
     'use strict' directive - not recognized if it follow an empty
     statement
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -18,6 +15,4 @@ function testcase() {
      return (this !== undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-17-s.js
+++ b/test/language/directive-prologue/14.1-17-s.js
@@ -7,10 +7,7 @@ description: >
     'use strict' directive - not recognized if it follow some other
     statment empty statement
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -19,6 +16,4 @@ function testcase() {
     return (this !== undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-2-s.js
+++ b/test/language/directive-prologue/14.1-2-s.js
@@ -5,10 +5,7 @@
 es5id: 14.1-2-s
 description: "\"use strict\" directive - correct usage double quotes"
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -16,6 +13,4 @@ function testcase() {
      return (this === undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-3-s.js
+++ b/test/language/directive-prologue/14.1-3-s.js
@@ -7,10 +7,7 @@ description: >
     'use strict' directive - not recognized if it contains extra
     whitespace
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -18,6 +15,4 @@ function testcase() {
      return (this !== undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-4-s.js
+++ b/test/language/directive-prologue/14.1-4-s.js
@@ -7,10 +7,7 @@ description: >
     'use strict' directive - not recognized if contains Line
     Continuation
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -19,6 +16,4 @@ ict';
      return (this !== undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-5-s.js
+++ b/test/language/directive-prologue/14.1-5-s.js
@@ -7,10 +7,7 @@ description: >
     'use strict' directive - not recognized if contains a
     EscapeSequence
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -18,6 +15,4 @@ function testcase() {
      return(this !== undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-6-s.js
+++ b/test/language/directive-prologue/14.1-6-s.js
@@ -7,10 +7,7 @@ description: >
     'use strict' directive - not recognized if contains a <TAB>
     instead of a space
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -18,6 +15,4 @@ function testcase() {
      return (this !== undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-7-s.js
+++ b/test/language/directive-prologue/14.1-7-s.js
@@ -5,10 +5,7 @@
 es5id: 14.1-7-s
 description: "'use strict' directive - not recognized if upper case"
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -16,6 +13,4 @@ function testcase() {
      return (this !== undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-8-s.js
+++ b/test/language/directive-prologue/14.1-8-s.js
@@ -5,10 +5,7 @@
 es5id: 14.1-8-s
 description: "'use strict' directive - may follow other directives"
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -17,6 +14,4 @@ function testcase() {
      return (this === undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/directive-prologue/14.1-9-s.js
+++ b/test/language/directive-prologue/14.1-9-s.js
@@ -5,10 +5,7 @@
 es5id: 14.1-9-s
 description: "'use strict' directive - may occur multiple times"
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
-
-function testcase() {
 
   function foo()
   {
@@ -17,6 +14,4 @@ function testcase() {
      return (this === undefined);
   }
 
-  return foo.call(undefined);
- }
-runTestCase(testcase);
+assert(foo.call(undefined));

--- a/test/language/eval-code/10.4.2-1-1.js
+++ b/test/language/eval-code/10.4.2-1-1.js
@@ -4,17 +4,13 @@
 /*---
 es5id: 10.4.2-1-1
 description: Indirect call to eval has context set to global context
-includes: [runTestCase.js]
 ---*/
 
 var __10_4_2_1_1_1 = "str";
 function testcase() {
     var _eval = eval;
     var __10_4_2_1_1_1 = "str1";
-    if(_eval("\'str\' === __10_4_2_1_1_1") === true &&  // indirect eval
-       eval("\'str1\' === __10_4_2_1_1_1") === true) {   // direct eval
-       return true;
-    }
-    return false;
+    assert(_eval("\'str\' === __10_4_2_1_1_1"), 'indirect eval');
+    assert(eval("\'str1\' === __10_4_2_1_1_1"), 'direct eval');
 }
-runTestCase(testcase);
+testcase();

--- a/test/language/eval-code/10.4.2-1-2.js
+++ b/test/language/eval-code/10.4.2-1-2.js
@@ -6,7 +6,6 @@ es5id: 10.4.2-1-2
 description: >
     Indirect call to eval has context set to global context (nested
     function)
-includes: [runTestCase.js]
 ---*/
 
 var __10_4_2_1_2 = "str";
@@ -15,13 +14,9 @@ function testcase() {
             var __10_4_2_1_2 = "str1";
             function foo() {
                 var __10_4_2_1_2 = "str2";
-                if(_eval("\'str\' === __10_4_2_1_2") === true &&  // indirect eval
-                    eval("\'str2\' === __10_4_2_1_2") === true) {   // direct eval
-                    return true;
-                } else {
-                    return false;
-                }
+                assert(_eval("\'str\' === __10_4_2_1_2"), 'indirect eval');
+                assert(eval("\'str2\' === __10_4_2_1_2"), 'direct eval');
             }
-            return foo();
+            foo();
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/eval-code/10.4.2-1-3.js
+++ b/test/language/eval-code/10.4.2-1-3.js
@@ -6,7 +6,6 @@ es5id: 10.4.2-1-3
 description: >
     Indirect call to eval has context set to global context (catch
     block)
-includes: [runTestCase.js]
 ---*/
 
 var __10_4_2_1_3 = "str";
@@ -18,12 +17,8 @@ function testcase() {
             }
             catch (e) {
                 var __10_4_2_1_3 = "str2";
-                if (_eval("\'str\' === __10_4_2_1_3") === true &&  // indirect eval
-                    eval("\'str2\' === __10_4_2_1_3") === true) {  // direct eval
-                    return true;
-                } else {
-                    return false;
-                }
+                assert(_eval("\'str\' === __10_4_2_1_3"), 'indirect eval');
+                assert(eval("\'str2\' === __10_4_2_1_3"), 'direct eval');
             }
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/eval-code/10.4.2-1-4.js
+++ b/test/language/eval-code/10.4.2-1-4.js
@@ -7,7 +7,6 @@ description: >
     Indirect call to eval has context set to global context (with
     block)
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 var __10_4_2_1_4 = "str";
@@ -17,11 +16,8 @@ function testcase() {
             var _eval = eval;
             var __10_4_2_1_4 = "str1";
             with (o) {
-                if (_eval("\'str\' === __10_4_2_1_4") === true &&  // indirect eval
-                    eval("\'str2\' === __10_4_2_1_4") === true) {  // direct eval
-                    return true;
-                }
+                assert(_eval("\'str\' === __10_4_2_1_4"), 'indirect eval');
+                assert(eval("\'str2\' === __10_4_2_1_4"), 'direct eval');
             }
-            return false;
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/eval-code/10.4.2-1-5.js
+++ b/test/language/eval-code/10.4.2-1-5.js
@@ -6,7 +6,6 @@ es5id: 10.4.2-1-5
 description: >
     Indirect call to eval has context set to global context (inside
     another eval)
-includes: [runTestCase.js]
 ---*/
 
 var __10_4_2_1_5 = "str";
@@ -18,6 +17,6 @@ function testcase() {
                           _eval(\"\'str\' === __10_4_2_1_5 \") && \
                           eval(\"\'str2\' === __10_4_2_1_5\")\
                         ");
-            return r;
+            assert(r);
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/eval-code/10.4.2-2-c-1.js
+++ b/test/language/eval-code/10.4.2-2-c-1.js
@@ -7,15 +7,14 @@ description: >
     Direct val code in non-strict mode - can instantiate variable in
     calling context
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
   var x = 0;
-  return function inner() {
+  function inner() {
      eval("var x = 1");
-     if (x === 1)
-        return true;
-     } ();
-   }
-runTestCase(testcase);
+     assert.sameValue(x, 1, "x");
+  }
+  inner();
+}
+testcase();

--- a/test/language/eval-code/10.4.2-2-s.js
+++ b/test/language/eval-code/10.4.2-2-s.js
@@ -7,11 +7,10 @@ description: >
     Strict Mode - Strict mode eval code cannot instantiate functions
     in the variable environment of the caller to eval
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         eval("function fun(x){ return x }");
-        return typeof (fun) === "undefined";
+        assert.sameValue(typeof (fun), "undefined");
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/eval-code/10.4.2-3-c-1-s.js
+++ b/test/language/eval-code/10.4.2-3-c-1-s.js
@@ -6,15 +6,14 @@ es5id: 10.4.2-3-c-1-s
 description: >
     Direct eval code in strict mode - cannot instantiate variable in
     the variable environment of the calling context
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
   var _10_4_2_3_c_1_s = 0;
   function _10_4_2_3_c_1_sFunc() {
      eval("'use strict';var _10_4_2_3_c_1_s = 1");
-     return _10_4_2_3_c_1_s===0;
+     assert.sameValue(_10_4_2_3_c_1_s, 0);
   } 
-  return _10_4_2_3_c_1_sFunc();
+  _10_4_2_3_c_1_sFunc();
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/eval-code/10.4.2-3-c-2-s.js
+++ b/test/language/eval-code/10.4.2-3-c-2-s.js
@@ -7,15 +7,14 @@ description: >
     Calling code in strict mode - eval cannot instantiate variable in
     the variable environment of the calling context
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
   var _10_4_2_3_c_2_s = 0;
   function _10_4_2_3_c_2_sFunc() {
      eval("var _10_4_2_3_c_2_s = 1");
-     return _10_4_2_3_c_2_s===0;
+     assert.sameValue(_10_4_2_3_c_2_s, 0);
   }
-  return _10_4_2_3_c_2_sFunc();
+  _10_4_2_3_c_2_sFunc();
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/eval-code/10.4.2-3-c-3-s.js
+++ b/test/language/eval-code/10.4.2-3-c-3-s.js
@@ -7,15 +7,11 @@ description: >
     Calling code in strict mode - eval cannot instantiate variable in
     the global context
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 var _10_4_2_3_c_3_s = 0;
 function testcase() {
-  function _10_4_2_3_c_3_sFunc() {
-     eval("var _10_4_2_3_c_3_s = 1");
-     return _10_4_2_3_c_3_s===0;
-  }
-  return _10_4_2_3_c_3_sFunc();
+  eval("var _10_4_2_3_c_3_s = 1");
+  assert.sameValue(_10_4_2_3_c_3_s, 0);
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/eval-code/10.4.2.1-2-s.js
+++ b/test/language/eval-code/10.4.2.1-2-s.js
@@ -7,11 +7,10 @@ description: >
     Strict Mode - Strict mode eval code cannot instantiate functions
     in the variable environment of the caller to eval
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         eval("function _10_4_2_1_2_fun(){}");
-        return typeof _10_4_2_1_2_fun === "undefined";
+        assert.sameValue(typeof _10_4_2_1_2_fun, "undefined");
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/eval-code/10.4.2.1-4-s.js
+++ b/test/language/eval-code/10.4.2.1-4-s.js
@@ -6,11 +6,10 @@ es5id: 10.4.2.1-4-s
 description: >
     Strict Mode - Strict mode eval code cannot instantiate functions
     in the variable environment of the caller to eval.
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         eval("'use strict'; function _10_4_2_1_4_fun(){}");
-        return typeof _10_4_2_1_4_fun === "undefined";
+        assert.sameValue(typeof _10_4_2_1_4_fun, "undefined");
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/assignment/11.13.1-4-1.js
+++ b/test/language/expressions/assignment/11.13.1-4-1.js
@@ -8,24 +8,17 @@ description: >
     simple assignment creates property on the global object if
     LeftHandSide is an unresolvable reference
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
   function foo() {
     __ES3_1_test_suite_test_11_13_1_unique_id_3__ = 42;
   }
   foo();
 
   var desc = Object.getOwnPropertyDescriptor(fnGlobalObject(), '__ES3_1_test_suite_test_11_13_1_unique_id_3__');
-  if (desc.value === 42 &&
-      desc.writable === true &&
-      desc.enumerable === true &&
-      desc.configurable === true) {
-    delete __ES3_1_test_suite_test_11_13_1_unique_id_3__;
-    return true;
-  }  
- }
-runTestCase(testcase);
+
+assert.sameValue(desc.value, 42, 'desc.value');
+assert.sameValue(desc.writable, true, 'desc.writable');
+assert.sameValue(desc.enumerable, true, 'desc.enumerable');
+assert.sameValue(desc.configurable, true, 'desc.configurable');

--- a/test/language/expressions/assignment/11.13.1-4-27-s.js
+++ b/test/language/expressions/assignment/11.13.1-4-27-s.js
@@ -6,20 +6,10 @@ es5id: 11.13.1-4-27-s
 description: >
     simple assignment throws TypeError if LeftHandSide is a readonly
     property in strict mode (Global.undefined)
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+flags: [onlyStrict]
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
-    'use strict';
-
-    try {
+assert.throws(TypeError, function() {
       fnGlobalObject().undefined = 42;
-      return false;
-    }
-    catch (e) {
-      return (e instanceof TypeError);
-    }
- }
-runTestCase(testcase);
+});

--- a/test/language/expressions/assignment/11.13.1-4-28-s.js
+++ b/test/language/expressions/assignment/11.13.1-4-28-s.js
@@ -8,16 +8,17 @@ description: >
     appears as the LeftHandSideExpression of simple assignment(=)
     under strict mode
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
+        var err = null;
         var blah = eval;
         try {
             eval("var eval = 20;");
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && blah === eval;
+            err = e;
         }
+        assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+        assert.sameValue(blah, eval, 'blah');
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/assignment/11.13.1-4-29-s.js
+++ b/test/language/expressions/assignment/11.13.1-4-29-s.js
@@ -8,16 +8,17 @@ description: >
     appears as the LeftHandSideExpression of simple assignment(=)
     under strict mode
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
+        var err = null;
         var blah = arguments;
         try {
             eval("var arguments = 20;");
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
+            err = e;
         }
+        assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+        assert.sameValue(blah, arguments, 'blah');
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/assignment/11.13.1-4-31-s.js
+++ b/test/language/expressions/assignment/11.13.1-4-31-s.js
@@ -8,16 +8,17 @@ description: >
     appears as the LeftHandSideExpression (PrimaryExpression) of
     simple assignment(=) under strict mode
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
+        var err = null;
         var blah = arguments;
         try {
             eval("(arguments) = 20;");
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
+            err = e;
         }
+        assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+        assert.sameValue(blah, arguments, 'blah');
 }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/assignment/8.12.5-3-b_1.js
+++ b/test/language/expressions/assignment/8.12.5-3-b_1.js
@@ -6,15 +6,11 @@ es5id: 8.12.5-3-b_1
 description: >
     Changing the value of a data property should not affect it's
     non-value property descriptor attributes.
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-    var origReduce = Array.prototype.reduce;
     var origDesc = Object.getOwnPropertyDescriptor(Array.prototype, "reduce");
     var newDesc;
-    
-    try {
+
         Array.prototype.reduce = function () {;};
         newDesc = Object.getOwnPropertyDescriptor(Array.prototype, "reduce");
         var descArray = [origDesc, newDesc];
@@ -22,19 +18,10 @@ function testcase() {
         for (var j in descArray) {  //Ensure no attributes are magically added to newDesc
             for (var i in descArray[j]) {
                 if (i==="value") {
-                    if (origDesc[i]===newDesc[i]) {
-                        return false;
-                    }
+                    assert.notSameValue(origDesc[i], newDesc[i], 'origDesc[i]');
                 }
-                else if (origDesc[i]!==newDesc[i]) {
-                    return false;
+                else {
+                    assert.sameValue(origDesc[i], newDesc[i], 'origDesc[i]');
                 }
             }
         }
-        return true;        
-    
-    } finally {
-        Array.prototype.reduce = origReduce;
-    }
-}
-runTestCase(testcase);

--- a/test/language/expressions/assignment/8.12.5-3-b_2.js
+++ b/test/language/expressions/assignment/8.12.5-3-b_2.js
@@ -6,19 +6,15 @@ es5id: 8.12.5-3-b_2
 description: >
     Changing the value of a data property should not affect it's
     non-value property descriptor attributes.
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
     var tempObj = {};
     
     Object.defineProperty(tempObj, "reduce", { value:456, enumerable:false, writable:true});
-    var origReduce = tempObj.reduce;
     var origDesc = Object.getOwnPropertyDescriptor(tempObj, "reduce");
 
     var newDesc;
-    
-    try {
+
         tempObj.reduce = 123;
         newDesc = Object.getOwnPropertyDescriptor(tempObj, "reduce");
         var descArray = [origDesc, newDesc];
@@ -26,19 +22,10 @@ function testcase() {
         for (var j in descArray) {
             for (var i in descArray[j]) {
                 if (i==="value") {
-                    if (origDesc[i]===newDesc[i]) {
-                        return false;
-                    }
+                    assert.notSameValue(origDesc[i], newDesc[i], 'origDesc[i]');
                 }
-                else if (origDesc[i]!==newDesc[i]) {
-                    return false;
+                else {
+                    assert.sameValue(origDesc[i], newDesc[i], 'origDesc[i]');
                 }
             }
         }
-        return true;
-    
-    } finally {
-        tempObj.reduce = origReduce;
-    }
-}
-runTestCase(testcase);

--- a/test/language/expressions/assignment/8.12.5-5-b_1.js
+++ b/test/language/expressions/assignment/8.12.5-5-b_1.js
@@ -6,34 +6,23 @@ es5id: 8.12.5-5-b_1
 description: >
     Changing the value of an accessor property should not affect it's
     property descriptor attributes.
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
     var tempObj = {};
     
     Object.defineProperty(tempObj, "reduce", { get: function() {return 456;}, enumerable:false, set: function() {;}});
-    var origReduce = tempObj.reduce;
     var origDesc = Object.getOwnPropertyDescriptor(tempObj, "reduce");
 
     var newDesc;
-    
-    try {
+
         tempObj.reduce = 123;
         newDesc = Object.getOwnPropertyDescriptor(tempObj, "reduce");
         var descArray = [origDesc, newDesc];
         
         for (var j in descArray) {
             for (var i in descArray[j]) {
-                if (origDesc[i]!==newDesc[i]) {
-                    return false;
-                }
+                assert.sameValue(origDesc[i], newDesc[i], 'origDesc[i]');
             }
         }
-        return tempObj.reduce===456;        
-    
-    } finally {
-        tempObj.reduce = origReduce;
-    }
-}
-runTestCase(testcase);
+
+assert.sameValue(tempObj.reduce, 456, 'tempObj.reduce');

--- a/test/language/expressions/compound-assignment/11.13.2-6-12-s.js
+++ b/test/language/expressions/compound-assignment/11.13.2-6-12-s.js
@@ -8,16 +8,17 @@ description: >
     appear as the LeftHandSideExpression of a Compound Assignment
     operator(*=)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
+        var err = null;
         var blah = arguments;
         try {
             eval("arguments *= 20;");
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
+            err = e;
         }
-    }
-runTestCase(testcase);
+        assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+        assert.sameValue(blah, arguments, 'blah');
+}
+testcase();

--- a/test/language/expressions/compound-assignment/11.13.2-6-13-s.js
+++ b/test/language/expressions/compound-assignment/11.13.2-6-13-s.js
@@ -8,16 +8,17 @@ description: >
     appear as the LeftHandSideExpression of a Compound Assignment
     operator(/=)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
+        var err = null;
         var blah = arguments;
         try {
             eval("arguments /= 20;");
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
+            err = e;
         }
-    }
-runTestCase(testcase);
+        assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+        assert.sameValue(blah, arguments, 'blah');
+}
+testcase();

--- a/test/language/expressions/compound-assignment/11.13.2-6-14-s.js
+++ b/test/language/expressions/compound-assignment/11.13.2-6-14-s.js
@@ -8,16 +8,17 @@ description: >
     appear as the LeftHandSideExpression of a Compound Assignment
     operator(%=)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
+        var err = null;
         var blah = arguments;
         try {
             eval("arguments %= 20;");
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
+            err = e;
         }
-    }
-runTestCase(testcase);
+        assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+        assert.sameValue(blah, arguments, 'blah');
+}
+testcase();

--- a/test/language/expressions/compound-assignment/11.13.2-6-15-s.js
+++ b/test/language/expressions/compound-assignment/11.13.2-6-15-s.js
@@ -8,16 +8,17 @@ description: >
     appear as the LeftHandSideExpression of a Compound Assignment
     operator(+=)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
+        var err = null;
         var blah = arguments;
         try {
             eval("arguments += 20;");
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
+            err = e;
         }
-    }
-runTestCase(testcase);
+        assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+        assert.sameValue(blah, arguments, 'blah');
+}
+testcase();

--- a/test/language/expressions/compound-assignment/11.13.2-6-16-s.js
+++ b/test/language/expressions/compound-assignment/11.13.2-6-16-s.js
@@ -8,16 +8,17 @@ description: >
     appear as the LeftHandSideExpression of a Compound Assignment
     operator(-=)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
+        var err = null;
         var blah = arguments;
         try {
             eval("arguments -= 20;");
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
+            err = e;
         }
-    }
-runTestCase(testcase);
+        assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+        assert.sameValue(blah, arguments, 'blah');
+}
+testcase();

--- a/test/language/expressions/compound-assignment/11.13.2-6-17-s.js
+++ b/test/language/expressions/compound-assignment/11.13.2-6-17-s.js
@@ -8,16 +8,17 @@ description: >
     appear as the LeftHandSideExpression of a Compound Assignment
     operator(<<=)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
+        var err = null;
         var blah = arguments;
         try {
             eval("arguments <<= 20;");
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
+            err = e;
         }
-    }
-runTestCase(testcase);
+        assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+        assert.sameValue(blah, arguments, 'blah');
+}
+testcase();

--- a/test/language/expressions/compound-assignment/11.13.2-6-18-s.js
+++ b/test/language/expressions/compound-assignment/11.13.2-6-18-s.js
@@ -8,16 +8,17 @@ description: >
     appear as the LeftHandSideExpression of a Compound Assignment
     operator(>>=)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
+        var err = null;
         var blah = arguments;
         try {
             eval("arguments >>= 20;");
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
+            err = e;
         }
-    }
-runTestCase(testcase);
+        assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+        assert.sameValue(blah, arguments, 'blah');
+}
+testcase();

--- a/test/language/expressions/compound-assignment/11.13.2-6-19-s.js
+++ b/test/language/expressions/compound-assignment/11.13.2-6-19-s.js
@@ -8,16 +8,17 @@ description: >
     appear as the LeftHandSideExpression of a Compound Assignment
     operator(>>>=)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
+        var err = null;
         var blah = arguments;
         try {
             eval("arguments >>>= 20;");
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
+            err = e;
         }
-    }
-runTestCase(testcase);
+        assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+        assert.sameValue(blah, arguments, 'blah');
+}
+testcase();

--- a/test/language/expressions/compound-assignment/11.13.2-6-20-s.js
+++ b/test/language/expressions/compound-assignment/11.13.2-6-20-s.js
@@ -8,16 +8,17 @@ description: >
     appear as the LeftHandSideExpression of a Compound Assignment
     operator(&=)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
+        var err = null;
         var blah = arguments;
         try {
             eval("arguments &= 20;");
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
+            err = e;
         }
-    }
-runTestCase(testcase);
+        assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+        assert.sameValue(blah, arguments, 'blah');
+}
+testcase();

--- a/test/language/expressions/compound-assignment/11.13.2-6-21-s.js
+++ b/test/language/expressions/compound-assignment/11.13.2-6-21-s.js
@@ -8,16 +8,17 @@ description: >
     appear as the LeftHandSideExpression of a Compound Assignment
     operator(^=)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
+        var err = null;
         var blah = arguments;
         try {
             eval("arguments ^= 20;");
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
+            err = e;
         }
-    }
-runTestCase(testcase);
+        assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+        assert.sameValue(blah, arguments, 'blah');
+}
+testcase();

--- a/test/language/expressions/compound-assignment/11.13.2-6-22-s.js
+++ b/test/language/expressions/compound-assignment/11.13.2-6-22-s.js
@@ -8,16 +8,17 @@ description: >
     appear as the LeftHandSideExpression of a Compound Assignment
     operator(|=)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
+        var err = null;
         var blah = arguments;
         try {
             eval("arguments |= 20;");
-            return false;
         } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
+            err = e;
         }
-    }
-runTestCase(testcase);
+        assert(err instanceof SyntaxError, 'err instanceof SyntaxError');
+        assert.sameValue(blah, arguments, 'blah');
+}
+testcase();

--- a/test/language/expressions/delete/11.4.1-0-1.js
+++ b/test/language/expressions/delete/11.4.1-0-1.js
@@ -8,18 +8,14 @@ info: >
 es5id: 11.4.1-0-1
 description: delete operator as UnaryExpression
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
   var x = 1;
   var y = 2;
   var z = 3;
-  
-  if( (!delete x || delete y) &&
-      delete delete z)
-  {
-    return true;
-  }  
+
+  assert((!delete x || delete y), '(!delete x || delete y)');
+  assert(delete delete z, 'delete delete z');
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/delete/11.4.1-2-1.js
+++ b/test/language/expressions/delete/11.4.1-2-1.js
@@ -4,13 +4,8 @@
 /*---
 es5id: 11.4.1-2-1
 description: delete operator returns true when deleting a non-reference (number)
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   var d = delete 42;
-  if (d === true) {
-    return true;
-  }
- }
-runTestCase(testcase);
+
+assert.sameValue(d, true, 'd');

--- a/test/language/expressions/delete/11.4.1-4.a-11.js
+++ b/test/language/expressions/delete/11.4.1-4.a-11.js
@@ -10,7 +10,6 @@ description: >
     delete operator returns true on deleting arguments
     propterties(arguments.callee)
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
@@ -19,7 +18,8 @@ function testcase() {
     return (delete arguments.callee); 
   }
   var d = delete arguments.callee;
-  if(d === true && arguments.callee === undefined)
-    return true;
+
+  assert.sameValue(d, true, 'd');
+  assert.sameValue(arguments.callee, undefined, 'arguments.callee');
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/delete/11.4.1-4.a-13.js
+++ b/test/language/expressions/delete/11.4.1-4.a-13.js
@@ -8,7 +8,6 @@ info: >
 es5id: 11.4.1-4.a-13
 description: delete operator returns false when deleting Array object
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
@@ -18,7 +17,7 @@ function testcase() {
 
   var d = delete a 
 
-  if(d === false && Array.isArray(a) === true)
-    return true;
+  assert.sameValue(d, false, 'd');
+  assert.sameValue(Array.isArray(a), true, 'Array.isArray(a)');
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/delete/11.4.1-4.a-16.js
+++ b/test/language/expressions/delete/11.4.1-4.a-16.js
@@ -8,12 +8,10 @@ info: >
 es5id: 11.4.1-4.a-16
 description: delete operator returns false on deleting arguments object
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
-
-  if(delete arguments === false && arguments !== undefined)
-    return true;
+  assert.sameValue(delete arguments, false, 'delete arguments');
+  assert.notSameValue(arguments, undefined, 'arguments');
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/delete/11.4.1-4.a-17.js
+++ b/test/language/expressions/delete/11.4.1-4.a-17.js
@@ -7,17 +7,12 @@ info: >
     language provides no way to directly exercise [[Delete]], the tests are placed here.
 es5id: 11.4.1-4.a-17
 description: delete operator returns true on deleting a arguments element
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   function foo(a,b)
   {
     var d = delete arguments[0];
     return (d === true && arguments[0] === undefined);  
   }
 
-  if(foo(1,2) === true)
-    return true;
- }
-runTestCase(testcase);
+assert.sameValue(foo(1,2), true, 'foo(1,2)');

--- a/test/language/expressions/delete/11.4.1-4.a-5.js
+++ b/test/language/expressions/delete/11.4.1-4.a-5.js
@@ -10,7 +10,6 @@ description: >
     delete operator returns false when deleting the declaration of the environment object
     inside 'with'
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
@@ -21,9 +20,9 @@ function testcase() {
   {
     d = delete o;
   }
-  if (d === false && typeof(o) === 'object' && o.x === 1) {
-    return true;
-  }
-  return false;
+
+  assert.sameValue(d, false, 'd');
+  assert.sameValue(typeof(o), 'object', 'typeof(o)');
+  assert.sameValue(o.x, 1, 'o.x');
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/delete/11.4.1-4.a-7.js
+++ b/test/language/expressions/delete/11.4.1-4.a-7.js
@@ -8,15 +8,13 @@ info: >
 es5id: 11.4.1-4.a-7
 description: delete operator inside 'eval'
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
   var x = 1;
   var d = eval("delete x");
-  if (d === false && x === 1) {
-    return true;
-  }
-  return false;
+
+  assert.sameValue(d, false, 'd');
+  assert.sameValue(x, 1, 'x');
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/delete/11.4.1-5-1.js
+++ b/test/language/expressions/delete/11.4.1-5-1.js
@@ -7,7 +7,6 @@ description: >
     delete operator returns false when deleting a direct reference to
     a var
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
@@ -15,7 +14,8 @@ function testcase() {
 
   // Now, deleting 'x' directly should fail;
   var d = delete x;
-  if(d === false && x === 1)
-    return true;
+
+  assert.sameValue(d, false, 'd');
+  assert.sameValue(x, 1, 'x');
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/delete/11.4.1-5-3.js
+++ b/test/language/expressions/delete/11.4.1-5-3.js
@@ -7,8 +7,6 @@ description: >
     delete operator returns false when deleting a direct reference to
     a function name
 flags: [noStrict]
-includes:
-    - runTestCase.js
 ---*/
 
 function testcase() {
@@ -16,7 +14,8 @@ function testcase() {
 
   // Now, deleting 'foo' directly should fail;
   var d = delete foo;
-  if(d === false && typeof foo === 'function')
-    return true;
+
+  assert.sameValue(d, false, 'd');
+  assert.sameValue(typeof foo, 'function', 'typeof foo');
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/object/11.1.5-0-1.js
+++ b/test/language/expressions/object/11.1.5-0-1.js
@@ -7,20 +7,16 @@ info: >
     probably be replaced by some more targeted tests.  AllenWB
 es5id: 11.1.5-0-1
 description: Object literal - get set property
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   var s1 = "In getter";
   var s2 = "In setter";
   var s3 = "Modified by setter";
   var o;
   eval("o = {get foo(){ return s1;},set foo(arg){return s2 = s3}};");
-  if(o.foo !== s1) 
-    return false;
+
+assert.sameValue(o.foo, s1, 'o.foo');
+
   o.foo=10;
-  if(s2 !== s3) 
-    return false;
-  return true;
- }
-runTestCase(testcase);
+
+assert.sameValue(s2, s3, 's2');

--- a/test/language/expressions/object/11.1.5-0-2.js
+++ b/test/language/expressions/object/11.1.5-0-2.js
@@ -7,25 +7,21 @@ info: >
     probably be replaced by some more targeted tests.  AllenWB
 es5id: 11.1.5-0-2
 description: Object literal - multiple get set properties
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   var s1 = "First getter";
   var s2 = "First setter";
   var s3 = "Second getter";
   var o;
   eval("o = {get foo(){ return s1;},set foo(arg){return s2 = s3}, get bar(){ return s3}, set bar(arg){ s3 = arg;}};");
-  if(o.foo !== s1) 
-    return false;
+
+assert.sameValue(o.foo, s1, 'o.foo');
+
   o.foo = 10;
-  if(s2 !== s3) 
-    return false;
-  if(o.bar !== s3)
-    return false;
+
+assert.sameValue(s2, s3, 's2');
+assert.sameValue(o.bar, s3, 'o.bar');
+
   o.bar = "Second setter";
-  if(o.bar !== "Second setter")
-    return false;
-  return true;
- }
-runTestCase(testcase);
+
+assert.sameValue(o.bar, "Second setter", 'o.bar');

--- a/test/language/expressions/postfix-decrement/11.3.2-2-1-s.js
+++ b/test/language/expressions/postfix-decrement/11.3.2-2-1-s.js
@@ -7,16 +7,13 @@ description: >
     Strict Mode - SyntaxError is thrown if the identifier 'arguments'
     appear as a PostfixExpression(arguments--)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         var blah = arguments;
-        try {
+        assert.throws(SyntaxError, function() {
             eval("arguments--;");
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
-        }
+        });
+        assert.sameValue(blah, arguments, 'blah');
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/postfix-decrement/11.3.2-2-3-s.js
+++ b/test/language/expressions/postfix-decrement/11.3.2-2-3-s.js
@@ -6,12 +6,11 @@ es5id: 11.3.2-2-3-s
 description: >
     SyntaxError is not thrown if the identifier 'arguments[...]' appears as a
     PostfixExpression(arguments--)
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         arguments[1] = 7;
         arguments[1]--;
-        return arguments[1]===6;
+        assert.sameValue(arguments[1], 6, 'arguments[1]');
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/postfix-increment/11.3.1-2-1-s.js
+++ b/test/language/expressions/postfix-increment/11.3.1-2-1-s.js
@@ -7,16 +7,13 @@ description: >
     Strict Mode - SyntaxError is thrown if the identifier 'arguments'
     appear as a PostfixExpression(arguments++)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         var blah = arguments;
-        try {
+        assert.throws(SyntaxError, function() {
             eval("arguments++;");
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
-        }
+        });
+        assert.sameValue(blah, arguments, 'blah');
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/postfix-increment/11.3.1-2-3-s.js
+++ b/test/language/expressions/postfix-increment/11.3.1-2-3-s.js
@@ -7,12 +7,11 @@ description: >
     Strict Mode - SyntaxError is not thrown if the identifier
     'arguments[...]' appears as a PostfixExpression(arguments++)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         arguments[1] = 7;
         arguments[1]++;
-        return arguments[1]===8;
+        assert.sameValue(arguments[1], 8, 'arguments[1]');
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/prefix-decrement/11.4.5-2-2-s.js
+++ b/test/language/expressions/prefix-decrement/11.4.5-2-2-s.js
@@ -5,16 +5,13 @@
 es5id: 11.4.5-2-2-s
 description: Strict Mode - SyntaxError is thrown for --arguments
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         var blah = arguments;
-        try {
+        assert.throws(SyntaxError, function() {
             eval("--arguments;");
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
-        }
+        });
+        assert.sameValue(blah, arguments, 'blah');
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/prefix-decrement/11.4.5-2-3-s.js
+++ b/test/language/expressions/prefix-decrement/11.4.5-2-3-s.js
@@ -4,12 +4,11 @@
 /*---
 es5id: 11.4.5-2-3-s
 description: SyntaxError is not thrown for --arguments[...]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         arguments[1] = 7;
         --arguments[1];
-        return arguments[1]===6;
+        assert.sameValue(arguments[1], 6, 'arguments[1]');
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/prefix-increment/11.4.4-2-2-s.js
+++ b/test/language/expressions/prefix-increment/11.4.4-2-2-s.js
@@ -5,16 +5,13 @@
 es5id: 11.4.4-2-2-s
 description: Strict Mode - SyntaxError is thrown for ++arguments
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         var blah = arguments;
-        try {
+        assert.throws(SyntaxError, function() {
             eval("++arguments;");
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError && blah === arguments;
-        }
+        });
+        assert.sameValue(blah, arguments, 'blah');
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/prefix-increment/11.4.4-2-3-s.js
+++ b/test/language/expressions/prefix-increment/11.4.4-2-3-s.js
@@ -4,12 +4,11 @@
 /*---
 es5id: 11.4.4-2-3-s
 description: SyntaxError is not thrown for ++arguments[...]
-includes: [runTestCase.js]
 ---*/
 
 function testcase() {
         arguments[1] = 7;
         ++arguments[1];
-        return arguments[1]===8;
+        assert.sameValue(arguments[1], 8, 'arguments[1]');
     }
-runTestCase(testcase);
+testcase();

--- a/test/language/expressions/unary-minus/11.4.7-4-1.js
+++ b/test/language/expressions/unary-minus/11.4.7-4-1.js
@@ -4,10 +4,6 @@
 /*---
 es5id: 11.4.7-4-1
 description: -"" should be zero
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-  return -"" === 0;
- }
-runTestCase(testcase);
+assert.sameValue(-"", -0, '-""');

--- a/test/language/expressions/unary-plus/11.4.6-2-1.js
+++ b/test/language/expressions/unary-plus/11.4.6-2-1.js
@@ -4,10 +4,6 @@
 /*---
 es5id: 11.4.6-2-1
 description: +"" should be zero
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-  return +"" === 0;
- }
-runTestCase(testcase);
+assert.sameValue(+"", 0, '+""');

--- a/test/language/function-code/10.4.3-1-101-s.js
+++ b/test/language/function-code/10.4.3-1-101-s.js
@@ -7,12 +7,9 @@ description: >
     Strict Mode - checking 'this' (non-strict function passed as arg
     to String.prototype.replace from strict context)
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 var x = 3;
 
 function f() {
@@ -20,6 +17,5 @@ function f() {
     return "a";
 }
 
-return (function() {"use strict"; return "ab".replace("b", f)==="aa";}()) && (x===fnGlobalObject());
-}
-runTestCase(testcase);
+assert.sameValue(function() {"use strict"; return "ab".replace("b", f);}(), "aa");
+assert.sameValue(x, fnGlobalObject(), 'x');

--- a/test/language/function-code/10.4.3-1-102-s.js
+++ b/test/language/function-code/10.4.3-1-102-s.js
@@ -6,18 +6,15 @@ es5id: 10.4.3-1-102-s
 description: >
     Strict Mode - checking 'this' (strict anonymous function passed as
     arg to String.prototype.replace)
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
 var x = 3;
 
-return ("ab".replace("b", (function () { 
+assert.sameValue("ab".replace("b", (function () {
                                 "use strict";
                                 return function () {
                                     x = this;
                                     return "a";
                                 }
-                           })())==="aa") && (x===undefined);
-}
-runTestCase(testcase);
+                           })()), "aa");
+assert.sameValue(x, undefined, 'x');

--- a/test/language/function-code/10.4.3-1-103.js
+++ b/test/language/function-code/10.4.3-1-103.js
@@ -6,14 +6,9 @@ es5id: 10.4.3-1-103
 description: >
     Non strict mode should ToObject thisArg if not an object.
     Abstract equality operator should succeed.
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){
   Object.defineProperty(Object.prototype, "x", { get: function () { return this; } }); 
-  if((5).x == 0) return false;
-  if(!((5).x == 5)) return false;
-  return true;
-}
 
-runTestCase(testcase);
+assert.sameValue((5).x == 0, false, '(5).x == 0');
+assert((5).x == 5, '(5).x == 5');

--- a/test/language/function-code/10.4.3-1-104.js
+++ b/test/language/function-code/10.4.3-1-104.js
@@ -7,13 +7,8 @@ description: >
     Strict mode should not ToObject thisArg if not an object.  Strict
     equality operator should succeed.
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){
   Object.defineProperty(Object.prototype, "x", { get: function () { return this; } }); 
-  if(!((5).x === 5)) return false;
-  return true;
-}
 
-runTestCase(testcase);
+assert((5).x === 5, '(5).x === 5');

--- a/test/language/function-code/10.4.3-1-105.js
+++ b/test/language/function-code/10.4.3-1-105.js
@@ -10,14 +10,9 @@ description: >
     Non strict mode should ToObject thisArg if not an object.  Return
     type should be object and strict equality should fail.
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){
   Object.defineProperty(Object.prototype, "x", { get: function () { return this; } }); 
-  if((5).x === 5) return false;
-  if(!(typeof (5).x === "object")) return false;
-  return true;
-}
 
-runTestCase(testcase);
+assert.sameValue((5).x === 5, false, '(5).x === 5');
+assert.sameValue(typeof (5).x, "object", 'typeof (5).x');

--- a/test/language/function-code/10.4.3-1-106.js
+++ b/test/language/function-code/10.4.3-1-106.js
@@ -10,13 +10,8 @@ description: >
     Strict mode should not ToObject thisArg if not an object.  Return
     type should be 'number'.
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){
   Object.defineProperty(Object.prototype, "x", { get: function () { return this; } }); 
-  if(!(typeof (5).x === "number")) return false;
-  return true;
-}
 
-runTestCase(testcase);
+assert.sameValue(typeof (5).x, "number", 'typeof (5).x');

--- a/test/language/function-code/10.4.3-1-11-s.js
+++ b/test/language/function-code/10.4.3-1-11-s.js
@@ -7,12 +7,8 @@ description: >
     Strict Mode - checking 'this' (Anonymous FunctionExpression
     defined within strict mode)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-return (function () {
+assert.sameValue((function () {
     return typeof this;
-})() === "undefined";
-}
-runTestCase(testcase);
+})(), "undefined");

--- a/test/language/function-code/10.4.3-1-12-s.js
+++ b/test/language/function-code/10.4.3-1-12-s.js
@@ -7,13 +7,9 @@ description: >
     Strict Mode - checking 'this' (Anonymous FunctionExpression
     includes strict directive prologue)
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-return (function () {
+assert.sameValue((function () {
     "use strict";
     return typeof this;
-})() === "undefined";
-}
-runTestCase(testcase);
+})(), "undefined");

--- a/test/language/function-code/10.4.3-1-17-s.js
+++ b/test/language/function-code/10.4.3-1-17-s.js
@@ -5,12 +5,11 @@
 es5id: 10.4.3-1-17-s
 description: Strict Mode - checking 'this' (eval used within strict mode)
 flags: [onlyStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
 function testcase() {
-return (eval("typeof this") === "undefined") && (eval("this") !== fnGlobalObject());
+  assert.sameValue(eval("typeof this"), "undefined", 'eval("typeof this")');
+  assert.notSameValue(eval("this"), fnGlobalObject(), 'eval("this")');
 }
-runTestCase(testcase);
+testcase();

--- a/test/language/function-code/10.4.3-1-19-s.js
+++ b/test/language/function-code/10.4.3-1-19-s.js
@@ -7,13 +7,11 @@ description: >
     Strict Mode - checking 'this' (indirect eval used within strict
     mode)
 flags: [onlyStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
 function testcase() {
 var my_eval = eval;
-return my_eval("this") === fnGlobalObject();
+assert.sameValue(my_eval("this"), fnGlobalObject(), 'my_eval("this")');
 }
-runTestCase(testcase);
+testcase();

--- a/test/language/function-code/10.4.3-1-20-s.js
+++ b/test/language/function-code/10.4.3-1-20-s.js
@@ -7,13 +7,11 @@ description: >
     Strict Mode - checking 'this' (indirect eval includes strict
     directive prologue)
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
 function testcase() {
 var my_eval = eval;
-return my_eval("\"use strict\";\nthis") === fnGlobalObject();
+assert.sameValue(my_eval("\"use strict\";\nthis"), fnGlobalObject());
 }
-runTestCase(testcase);
+testcase();

--- a/test/language/function-code/10.4.3-1-33-s.js
+++ b/test/language/function-code/10.4.3-1-33-s.js
@@ -7,15 +7,12 @@ description: >
     Strict Mode - checking 'this' (FunctionDeclaration defined within
     an Anonymous FunctionExpression inside strict mode)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-return (function () {
+(function () {
     function f() {
         return typeof this;
     }
-    return (f()==="undefined") && ((typeof this)==="undefined");
+    assert.sameValue(f(), "undefined", 'f()');
+    assert.sameValue(typeof this, "undefined", 'typeof this');
 })();
-}
-runTestCase(testcase);

--- a/test/language/function-code/10.4.3-1-34-s.js
+++ b/test/language/function-code/10.4.3-1-34-s.js
@@ -7,15 +7,12 @@ description: >
     Strict Mode - checking 'this' (FunctionExpression defined within
     an Anonymous FunctionExpression inside strict mode)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-return (function () {
+(function () {
     var f = function () {
         return typeof this;
     }
-    return (f()==="undefined") && ((typeof this)==="undefined");
+    assert.sameValue(f(), "undefined", 'f()');
+    assert.sameValue(typeof this, "undefined", 'typeof this');
 })();
-}
-runTestCase(testcase);

--- a/test/language/function-code/10.4.3-1-35-s.js
+++ b/test/language/function-code/10.4.3-1-35-s.js
@@ -7,14 +7,11 @@ description: >
     Strict Mode - checking 'this' (Anonymous FunctionExpression
     defined within an Anonymous FunctionExpression inside strict mode)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-return (function () {
-    return ((function () {
+(function () {
+    assert.sameValue((function () {
         return typeof this;
-    })()==="undefined") && ((typeof this)==="undefined");
+    })(), "undefined");
+    assert.sameValue(typeof this, "undefined", 'typeof this');
 })();
-}
-runTestCase(testcase);

--- a/test/language/function-code/10.4.3-1-42-s.js
+++ b/test/language/function-code/10.4.3-1-42-s.js
@@ -7,16 +7,13 @@ description: >
     Strict Mode - checking 'this' (FunctionDeclaration defined within
     an Anonymous FunctionExpression with a strict directive prologue)
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-return (function () {
+(function () {
     "use strict";
     function f() {
         return typeof this;
     }
-    return (f()==="undefined") && ((typeof this)==="undefined");
+    assert.sameValue(f(), "undefined", 'f()');
+    assert.sameValue(typeof this, "undefined", 'typeof this');
 })();
-}
-runTestCase(testcase);

--- a/test/language/function-code/10.4.3-1-43-s.js
+++ b/test/language/function-code/10.4.3-1-43-s.js
@@ -7,16 +7,13 @@ description: >
     Strict Mode - checking 'this' (FunctionExpression defined within
     an Anonymous FunctionExpression with a strict directive prologue)
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-return (function () {
+(function () {
     "use strict";
     var f = function () {
         return typeof this;
     }
-    return (f()==="undefined") && ((typeof this)==="undefined");
+    assert.sameValue(f(), "undefined", 'f()');
+    assert.sameValue(typeof this, "undefined", 'typeof this');
 })();
-}
-runTestCase(testcase);

--- a/test/language/function-code/10.4.3-1-44-s.js
+++ b/test/language/function-code/10.4.3-1-44-s.js
@@ -8,15 +8,12 @@ description: >
     defined within an Anonymous FunctionExpression with a strict
     directive prologue)
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-return (function () {
+(function () {
     "use strict";
-    return ((function () {
+    assert.sameValue((function () {
         return typeof this;
-    })()==="undefined") && ((typeof this)==="undefined");
+    })(), "undefined");
+    assert.sameValue(typeof this, "undefined", 'typeof this');
 })();
-}
-runTestCase(testcase);

--- a/test/language/function-code/10.4.3-1-51-s.js
+++ b/test/language/function-code/10.4.3-1-51-s.js
@@ -7,18 +7,14 @@ description: >
     Strict Mode - checking 'this' (FunctionDeclaration with a strict
     directive prologue defined within an Anonymous FunctionExpression)
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
-return (function () {
+(function () {
     function f() {
         "use strict";
         return typeof this;
     }
-    return (f()==="undefined") && (this===fnGlobalObject());
+    assert.sameValue(f(), "undefined", 'f()');
+    assert.sameValue(this, fnGlobalObject(), 'this');
 })();
-}
-runTestCase(testcase);

--- a/test/language/function-code/10.4.3-1-52-s.js
+++ b/test/language/function-code/10.4.3-1-52-s.js
@@ -7,18 +7,14 @@ description: >
     Strict Mode - checking 'this' (FunctionExpression with a strict
     directive prologue defined within an Anonymous FunctionExpression)
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
-return (function () {
+(function () {
     var f = function () {
         "use strict";
         return typeof this;
     }
-    return (f()==="undefined") && (this===fnGlobalObject());
+    assert.sameValue(f(), "undefined", 'f()');
+    assert.sameValue(this, fnGlobalObject(), 'this');
 })();
-}
-runTestCase(testcase);

--- a/test/language/function-code/10.4.3-1-53-s.js
+++ b/test/language/function-code/10.4.3-1-53-s.js
@@ -8,17 +8,13 @@ description: >
     strict directive prologue defined within an Anonymous
     FunctionExpression)
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
-return (function () {
-    return ((function () {
+(function () {
+    assert.sameValue((function () {
         "use strict";
         return typeof this;
-    })()==="undefined") && (this===fnGlobalObject());
+    })(), "undefined");
+    assert.sameValue(this, fnGlobalObject(), 'this');
 })();
-}
-runTestCase(testcase);

--- a/test/language/function-code/10.4.3-1-63-s.js
+++ b/test/language/function-code/10.4.3-1-63-s.js
@@ -5,11 +5,7 @@
 es5id: 10.4.3-1-63-s
 description: >
     checking 'this' (strict function declaration called by non-strict eval)
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
 function f() { "use strict"; return this===undefined;};
-return eval("f();");
-}
-runTestCase(testcase);
+assert(eval("f();"));

--- a/test/language/function-code/10.4.3-1-64-s.js
+++ b/test/language/function-code/10.4.3-1-64-s.js
@@ -6,13 +6,8 @@ es5id: 10.4.3-1-64-s
 description: >
     checking 'this' (strict function declaration called by non-strict Function
     constructor)
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 fnGlobalObject().f = function() { "use strict"; return this===undefined;};
-return Function("return f();")();
-}
-runTestCase(testcase);
+assert(Function("return f();")());

--- a/test/language/function-code/10.4.3-1-65-s.js
+++ b/test/language/function-code/10.4.3-1-65-s.js
@@ -6,13 +6,8 @@ es5id: 10.4.3-1-65-s
 description: >
     checking 'this' (strict function declaration called by non-strict new'ed
     Function constructor)
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 fnGlobalObject().f = function()  { "use strict"; return this===undefined;};
-return (new Function("return f();"))();
-}
-runTestCase(testcase);
+assert((new Function("return f();"))());

--- a/test/language/function-code/10.4.3-1-82-s.js
+++ b/test/language/function-code/10.4.3-1-82-s.js
@@ -7,11 +7,7 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict eval)
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
 function f() { return this!==undefined;};
-return (function () {"use strict"; return eval("f();");})();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return eval("f();");})());

--- a/test/language/function-code/10.4.3-1-83-s.js
+++ b/test/language/function-code/10.4.3-1-83-s.js
@@ -7,13 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function constructor)
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 fnGlobalObject().f = function() {return this!==undefined;};
-return (function () {return Function("\"use strict\";return f();")();})();
-}
-runTestCase(testcase);
+assert((function () {return Function("\"use strict\";return f();")();})());

--- a/test/language/function-code/10.4.3-1-84-s.js
+++ b/test/language/function-code/10.4.3-1-84-s.js
@@ -7,13 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict new'ed Function constructor)
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 fnGlobalObject().f = function()  { return this!==undefined;};
-return (function () {return new Function("\"use strict\";return f();")();})();
-}
-runTestCase(testcase);
+assert((function () {return new Function("\"use strict\";return f();")();})());

--- a/test/language/function-code/10.4.3-1-85-s.js
+++ b/test/language/function-code/10.4.3-1-85-s.js
@@ -7,11 +7,7 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.apply())
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
 function f() { return this!==undefined;};
-return (function () {"use strict"; return f.apply();})();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return f.apply();})());

--- a/test/language/function-code/10.4.3-1-86-s.js
+++ b/test/language/function-code/10.4.3-1-86-s.js
@@ -7,13 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.apply(null))
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 function f() { return this===fnGlobalObject();};
-return (function () {"use strict"; return f.apply(null);})();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return f.apply(null);})());

--- a/test/language/function-code/10.4.3-1-87-s.js
+++ b/test/language/function-code/10.4.3-1-87-s.js
@@ -7,13 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.apply(undefined))
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 function f() { return this===fnGlobalObject()};
-return (function () {"use strict"; return f.apply(undefined);})();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return f.apply(undefined);})());

--- a/test/language/function-code/10.4.3-1-88-s.js
+++ b/test/language/function-code/10.4.3-1-88-s.js
@@ -7,12 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.apply(someObject))
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
 var o = {};
 function f() { return this===o;};
-return (function () {"use strict"; return f.apply(o);})();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return f.apply(o);})());

--- a/test/language/function-code/10.4.3-1-89-s.js
+++ b/test/language/function-code/10.4.3-1-89-s.js
@@ -7,13 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.apply(globalObject))
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 function f() { return this;};
-return (function () {"use strict"; return f.apply(fnGlobalObject()); })() === fnGlobalObject();
-}
-runTestCase(testcase);
+assert.sameValue((function () {"use strict"; return f.apply(fnGlobalObject()); })(), fnGlobalObject());

--- a/test/language/function-code/10.4.3-1-90-s.js
+++ b/test/language/function-code/10.4.3-1-90-s.js
@@ -7,13 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.call())
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 function f() { return this===fnGlobalObject();};
-return (function () {"use strict"; return f.call(); })();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return f.call(); })());

--- a/test/language/function-code/10.4.3-1-91-s.js
+++ b/test/language/function-code/10.4.3-1-91-s.js
@@ -7,13 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.call(null))
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 function f() { return this===fnGlobalObject();};
-return (function () {"use strict"; return f.call(null); })();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return f.call(null); })());

--- a/test/language/function-code/10.4.3-1-92-s.js
+++ b/test/language/function-code/10.4.3-1-92-s.js
@@ -7,13 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.call(undefined))
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 function f() { return this===fnGlobalObject();};
-return (function () {"use strict"; return f.call(undefined);})();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return f.call(undefined);})());

--- a/test/language/function-code/10.4.3-1-93-s.js
+++ b/test/language/function-code/10.4.3-1-93-s.js
@@ -7,12 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.call(someObject))
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
 var o = {};
 function f() { return this===o;};
-return (function () {"use strict"; return f.call(o); })();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return f.call(o); })());

--- a/test/language/function-code/10.4.3-1-94-s.js
+++ b/test/language/function-code/10.4.3-1-94-s.js
@@ -7,13 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.call(globalObject))
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 function f() { return this===fnGlobalObject();};
-return (function () {"use strict"; return f.call(fnGlobalObject());})();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return f.call(fnGlobalObject());})());

--- a/test/language/function-code/10.4.3-1-95-s.js
+++ b/test/language/function-code/10.4.3-1-95-s.js
@@ -7,13 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.bind()())
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 function f() { return this===fnGlobalObject();};
-return (function () {"use strict"; return f.bind()(); })();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return f.bind()(); })());

--- a/test/language/function-code/10.4.3-1-96-s.js
+++ b/test/language/function-code/10.4.3-1-96-s.js
@@ -7,13 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.bind(null)())
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 function f() { return this===fnGlobalObject();};
-return (function () {"use strict"; return f.bind(null)(); })();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return f.bind(null)(); })());

--- a/test/language/function-code/10.4.3-1-97-s.js
+++ b/test/language/function-code/10.4.3-1-97-s.js
@@ -7,13 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.bind(undefined)())
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 function f() { return this===fnGlobalObject();};
-return (function () {"use strict"; return f.bind(undefined)();})();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return f.bind(undefined)();})());

--- a/test/language/function-code/10.4.3-1-98-s.js
+++ b/test/language/function-code/10.4.3-1-98-s.js
@@ -7,12 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.bind(someObject)())
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
 var o = {};
 function f() { return this===o;};
-return (function () {"use strict"; return f.bind(o)();})();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return f.bind(o)();})());

--- a/test/language/function-code/10.4.3-1-99-s.js
+++ b/test/language/function-code/10.4.3-1-99-s.js
@@ -7,13 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.bind(globalObject)())
 flags: [noStrict]
-includes:
-    - runTestCase.js
-    - fnGlobalObject.js
+includes: [fnGlobalObject.js]
 ---*/
 
-function testcase() {
 function f() { return this===fnGlobalObject();};
-return (function () {"use strict"; return f.bind(fnGlobalObject())();})();
-}
-runTestCase(testcase);
+assert((function () {"use strict"; return f.bind(fnGlobalObject())();})());

--- a/test/language/literals/numeric/7.8.3-1-s.js
+++ b/test/language/literals/numeric/7.8.3-1-s.js
@@ -5,15 +5,15 @@
 es5id: 7.8.3-1-s
 description: Strict Mode - octal extension (010) is forbidden in strict mode
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-        try {           
-            eval("var _7_8_3_1 = 010;");
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError && typeof _7_8_3_1 === "undefined";
-        }
-    }
-runTestCase(testcase);
+var err = null;
+
+try {
+  eval("var _7_8_3_1 = 010;");
+} catch (e) {
+  err = e;
+}
+
+assert(err instanceof SyntaxError);
+assert.sameValue(typeof _7_8_3_1, "undefined");

--- a/test/language/literals/numeric/7.8.3-2-s.js
+++ b/test/language/literals/numeric/7.8.3-2-s.js
@@ -5,15 +5,15 @@
 es5id: 7.8.3-2-s
 description: Strict Mode - octal extension (00) is forbidden in strict mode
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-        try {
-            eval("var _7_8_3_2 = 00;");
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError && typeof _7_8_3_2 === "undefined";
-        }
-    }
-runTestCase(testcase);
+var err = null;
+
+try {
+  eval("var _7_8_3_2 = 00;");
+} catch (e) {
+  err = e;
+}
+
+assert(err instanceof SyntaxError);
+assert.sameValue(typeof _7_8_3_2, "undefined");

--- a/test/language/literals/numeric/7.8.3-3-s.js
+++ b/test/language/literals/numeric/7.8.3-3-s.js
@@ -5,15 +5,15 @@
 es5id: 7.8.3-3-s
 description: Strict Mode - octal extension (01) is forbidden in strict mode
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-        try {
-            eval("var _7_8_3_3 = 01;");
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError && typeof _7_8_3_3 === "undefined";
-        }
-    }
-runTestCase(testcase);
+var err = null;
+
+try {
+  eval("var _7_8_3_3 = 01;");
+} catch (e) {
+  err = e;
+}
+
+assert(err instanceof SyntaxError);
+assert.sameValue(typeof _7_8_3_3, "undefined");

--- a/test/language/literals/numeric/7.8.3-4-s.js
+++ b/test/language/literals/numeric/7.8.3-4-s.js
@@ -5,15 +5,15 @@
 es5id: 7.8.3-4-s
 description: Strict Mode - octal extension (06) is forbidden in strict mode
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-        try {
-            eval("var _7_8_3_4 = 06;");
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError && typeof _7_8_3_4 === "undefined";
-        }
-    }
-runTestCase(testcase);
+var err = null;
+
+try {
+  eval("var _7_8_3_4 = 06;");
+} catch (e) {
+  err = e;
+}
+
+assert(err instanceof SyntaxError);
+assert.sameValue(typeof _7_8_3_4, "undefined");

--- a/test/language/literals/numeric/7.8.3-5-s.js
+++ b/test/language/literals/numeric/7.8.3-5-s.js
@@ -5,15 +5,15 @@
 es5id: 7.8.3-5-s
 description: Strict Mode - octal extension (07) is forbidden in strict mode
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-        try {
-            eval("var _7_8_3_5 = 07;");
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError && typeof _7_8_3_5 === "undefined";
-        }
-    }
-runTestCase(testcase);
+var err = null;
+
+try {
+  eval("var _7_8_3_5 = 07;");
+} catch (e) {
+  err = e;
+}
+
+assert(err instanceof SyntaxError);
+assert.sameValue(typeof _7_8_3_5, "undefined");

--- a/test/language/literals/numeric/7.8.3-6-s.js
+++ b/test/language/literals/numeric/7.8.3-6-s.js
@@ -5,15 +5,15 @@
 es5id: 7.8.3-6-s
 description: Strict Mode - octal extension (000) is forbidden in strict mode
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-        try {
-            eval("var _7_8_3_6 = 000;");
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError && typeof _7_8_3_6 === "undefined";
-        }
-    }
-runTestCase(testcase);
+var err = null;
+
+try {
+  eval("var _7_8_3_6 = 000;");
+} catch (e) {
+  err = e;
+}
+
+assert(err instanceof SyntaxError);
+assert.sameValue(typeof _7_8_3_6, "undefined");

--- a/test/language/literals/numeric/7.8.3-7-s.js
+++ b/test/language/literals/numeric/7.8.3-7-s.js
@@ -5,15 +5,15 @@
 es5id: 7.8.3-7-s
 description: Strict Mode - octal extension (005) is forbidden in strict mode
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-        try {
-            eval("var _7_8_3_7 = 005;");
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError && typeof _7_8_3_7 === "undefined";
-        }
-    }
-runTestCase(testcase);
+var err = null;
+
+try {
+  eval("var _7_8_3_7 = 005;");
+} catch (e) {
+  err = e;
+}
+
+assert(err instanceof SyntaxError);
+assert.sameValue(typeof _7_8_3_7, "undefined");

--- a/test/language/reserved-words/7.6.1-1-1.js
+++ b/test/language/reserved-words/7.6.1-1-1.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-1
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: null, true, false
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             null: 0,
             true: 1,
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-10.js
+++ b/test/language/reserved-words/7.6.1-1-10.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-10
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: in, try, class
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             in: 0, 
             try: 1,
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-11.js
+++ b/test/language/reserved-words/7.6.1-1-11.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-11
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: enum, extends, super
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             enum: 0,
             extends: 1,
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-12.js
+++ b/test/language/reserved-words/7.6.1-1-12.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-12
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: const, export, import
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             const: 0,
             export: 1,
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-13.js
+++ b/test/language/reserved-words/7.6.1-1-13.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-13
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: implements, let, private
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             implements: 0,
             let: 1,
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-14.js
+++ b/test/language/reserved-words/7.6.1-1-14.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-14
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: public, yield, interface
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             public: 0,
             yield: 1,
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-15.js
+++ b/test/language/reserved-words/7.6.1-1-15.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-15
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: package, protected, static
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             package: 0,
             protected: 1,
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-16.js
+++ b/test/language/reserved-words/7.6.1-1-16.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-16
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: undeefined, NaN, Infinity
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             undefined: 0,
             NaN: 1,
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-2.js
+++ b/test/language/reserved-words/7.6.1-1-2.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-2
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: break, case, do
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             break: 0,
             case: 1,
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-3.js
+++ b/test/language/reserved-words/7.6.1-1-3.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-3
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: instanceof, typeof, else
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             instanceof: 0,
             typeof: 1,
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-4.js
+++ b/test/language/reserved-words/7.6.1-1-4.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-4
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: new, var, catch
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             new: 0,
             var: 1,
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-5.js
+++ b/test/language/reserved-words/7.6.1-1-5.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-5
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: finally, return, void
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             finally: 0,
             return: 1,
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-6.js
+++ b/test/language/reserved-words/7.6.1-1-6.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-6
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: continue, for, switch
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             continue: 0, 
             for: 1, 
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-7.js
+++ b/test/language/reserved-words/7.6.1-1-7.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-7
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: while, debugger, function
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             while: 0, 
             debugger: 1, 
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-8.js
+++ b/test/language/reserved-words/7.6.1-1-8.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-8
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: this, with, default
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){
         var tokenCodes  = {       
             this: 0,  
             with: 1, 
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-1-9.js
+++ b/test/language/reserved-words/7.6.1-1-9.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-1-9
 description: >
     Allow reserved words as property names at object initialization,
     verified with hasOwnProperty: if, throw, delete
-includes: [runTestCase.js]
 ---*/
 
-function testcase(){      
         var tokenCodes  = { 
             if: 0, 
             throw: 1, 
@@ -23,12 +21,7 @@ function testcase(){
         for(var p in tokenCodes) {
             for(var p1 in arr) {
                 if(arr[p1] === p) {                     
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-1.js
+++ b/test/language/reserved-words/7.6.1-2-1.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-1
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: null, true, false
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.null = 0;
 	    tokenCodes.true = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-10.js
+++ b/test/language/reserved-words/7.6.1-2-10.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-10
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: in, try, class
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes.in = 0;
         tokenCodes.try = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-11.js
+++ b/test/language/reserved-words/7.6.1-2-11.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-11
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: enum, extends, super
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes.enum = 0;
         tokenCodes.extends = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-12.js
+++ b/test/language/reserved-words/7.6.1-2-12.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-12
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: const, export, import
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.const = 0;
         tokenCodes.export = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-13.js
+++ b/test/language/reserved-words/7.6.1-2-13.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-13
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: implements, let, private
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.implements = 0;
         tokenCodes.let = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-14.js
+++ b/test/language/reserved-words/7.6.1-2-14.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-14
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: public, yield, interface
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.public = 0;
         tokenCodes.yield = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-15.js
+++ b/test/language/reserved-words/7.6.1-2-15.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-15
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: package, protected, static
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.package = 0;
         tokenCodes.protected = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-16.js
+++ b/test/language/reserved-words/7.6.1-2-16.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-16
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: undefined, NaN, Infinity
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes.undefined = 0;
         tokenCodes.NaN = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-2.js
+++ b/test/language/reserved-words/7.6.1-2-2.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-2
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: break, case, do
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.break = 0;  	
         tokenCodes.case = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-3.js
+++ b/test/language/reserved-words/7.6.1-2-3.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-3
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: instanceof, typeof, else
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.instanceof = 0;
         tokenCodes.typeof = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-4.js
+++ b/test/language/reserved-words/7.6.1-2-4.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-4
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: new, var, catch
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes.new = 0;
         tokenCodes.var = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-5.js
+++ b/test/language/reserved-words/7.6.1-2-5.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-5
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: finally, return, void
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes.finally = 0;
         tokenCodes.return = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-6.js
+++ b/test/language/reserved-words/7.6.1-2-6.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-6
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: continue, for, switch
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.continue = 0;
         tokenCodes.for = 1; 
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-7.js
+++ b/test/language/reserved-words/7.6.1-2-7.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-7
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: while, debugger, function
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.while = 0; 
         tokenCodes.debugger = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-8.js
+++ b/test/language/reserved-words/7.6.1-2-8.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-8
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: this, with, default
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes.this = 0; 
         tokenCodes.with = 1; 
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-2-9.js
+++ b/test/language/reserved-words/7.6.1-2-9.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-2-9
 description: >
     Allow reserved words as property names by dot operator assignment,
     verified with hasOwnProperty: if, throw, delete
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes.if = 0;
         tokenCodes.throw = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-1.js
+++ b/test/language/reserved-words/7.6.1-3-1.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-1
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: null, true, false
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['null'] = 0;
 	    tokenCodes['true'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-10.js
+++ b/test/language/reserved-words/7.6.1-3-10.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-10
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: in, try, class
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['in'] = 0;
         tokenCodes['try'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-11.js
+++ b/test/language/reserved-words/7.6.1-3-11.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-11
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: enum, extends, super
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['enum'] = 0;
         tokenCodes['extends'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-12.js
+++ b/test/language/reserved-words/7.6.1-3-12.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-12
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: const, export, import
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['const'] = 0;
         tokenCodes['export'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-13.js
+++ b/test/language/reserved-words/7.6.1-3-13.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-13
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: implements, let, private
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['implements'] = 0;
         tokenCodes['let'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-14.js
+++ b/test/language/reserved-words/7.6.1-3-14.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-14
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: public, yield, interface
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['public'] = 0;
         tokenCodes['yield'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-15.js
+++ b/test/language/reserved-words/7.6.1-3-15.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-15
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: package, protected, static
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['package'] = 0;
         tokenCodes['protected'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-16.js
+++ b/test/language/reserved-words/7.6.1-3-16.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-16
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: undefined, NaN, Infinity
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['undefined'] = 0;
         tokenCodes['NaN'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-2.js
+++ b/test/language/reserved-words/7.6.1-3-2.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-2
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: break, case, do
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['break'] = 0;
         tokenCodes['case'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-3.js
+++ b/test/language/reserved-words/7.6.1-3-3.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-3
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: instanceof, typeof, else
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['instanceof'] = 0;
         tokenCodes['typeof'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-4.js
+++ b/test/language/reserved-words/7.6.1-3-4.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-4
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: new, var, catch
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['new'] = 0;
         tokenCodes['var'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-5.js
+++ b/test/language/reserved-words/7.6.1-3-5.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-5
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: finally, return, void
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['finally'] = 0;
         tokenCodes['return'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-6.js
+++ b/test/language/reserved-words/7.6.1-3-6.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-6
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: continue, for, switch
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['continue'] = 0;
         tokenCodes['for'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-7.js
+++ b/test/language/reserved-words/7.6.1-3-7.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-7
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: while, debugger, function
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['while'] = 0;
         tokenCodes['debugger'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-8.js
+++ b/test/language/reserved-words/7.6.1-3-8.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-8
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: this, with, default
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['this'] = 0;
         tokenCodes['with'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-3-9.js
+++ b/test/language/reserved-words/7.6.1-3-9.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-3-9
 description: >
     Allow reserved words as property names by index
     assignment,verified with hasOwnProperty: if, throw, delete
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes['if'] = 0;
         tokenCodes['throw'] = 1;
@@ -22,12 +20,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-1.js
+++ b/test/language/reserved-words/7.6.1-4-1.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-1
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: null, true, false
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set null(value) {
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-10.js
+++ b/test/language/reserved-words/7.6.1-4-10.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-10
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: in, try, class
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set in(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-11.js
+++ b/test/language/reserved-words/7.6.1-4-11.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-11
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: enum, extends, super
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set enum(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-12.js
+++ b/test/language/reserved-words/7.6.1-4-12.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-12
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: const, export, import
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set const(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-13.js
+++ b/test/language/reserved-words/7.6.1-4-13.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-13
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: implements, let, private
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set implements(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-14.js
+++ b/test/language/reserved-words/7.6.1-4-14.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-14
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: public, yield, interface
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set public(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-15.js
+++ b/test/language/reserved-words/7.6.1-4-15.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-15
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: package, protected, static
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set package(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-16.js
+++ b/test/language/reserved-words/7.6.1-4-16.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-16
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: undefined, NaN, Infinity
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set undefined(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-2.js
+++ b/test/language/reserved-words/7.6.1-4-2.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-2
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: break, case, do
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set break(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-3.js
+++ b/test/language/reserved-words/7.6.1-4-3.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-3
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: instanceof, typeof, else
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set instanceof(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-4.js
+++ b/test/language/reserved-words/7.6.1-4-4.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-4
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: new, var, catch
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set new(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-5.js
+++ b/test/language/reserved-words/7.6.1-4-5.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-5
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: finally, return, void
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set finally(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-6.js
+++ b/test/language/reserved-words/7.6.1-4-6.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-6
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: continue, for, switch
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set continue(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-7.js
+++ b/test/language/reserved-words/7.6.1-4-7.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-7
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: while, debugger, function
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set while(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-8.js
+++ b/test/language/reserved-words/7.6.1-4-8.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-8
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: this, with, default
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set this(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-4-9.js
+++ b/test/language/reserved-words/7.6.1-4-9.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-4-9
 description: >
     Allow reserved words as property names by set function within an
     object, verified with hasOwnProperty: if, throw, delete
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set if(value){
@@ -39,12 +37,7 @@ function testcase() {
         for(var p in tokenCodes) {       
             for(var p1 in arr) {                
                 if(arr[p1] === p) {
-                    if(!tokenCodes.hasOwnProperty(arr[p1])) {
-                        return false;
-                    };
+                    assert(tokenCodes.hasOwnProperty(arr[p1]), 'tokenCodes.hasOwnProperty(arr[p1]) !== true');
                 }
             }
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-1.js
+++ b/test/language/reserved-words/7.6.1-5-1.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-1
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: null, true, false
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = { 
             null: 0,
             true: 1,
@@ -21,10 +19,5 @@ function testcase() {
             'false'
         ];  
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-10.js
+++ b/test/language/reserved-words/7.6.1-5-10.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-10
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: in, try, class
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = { 
             in: 0, 
             try: 1,
@@ -21,10 +19,5 @@ function testcase() {
             'class'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-11.js
+++ b/test/language/reserved-words/7.6.1-5-11.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-11
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: enum, extends, super
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {
             enum: 0,
             extends: 1,
@@ -21,10 +19,5 @@ function testcase() {
             'super'
         ];  
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-12.js
+++ b/test/language/reserved-words/7.6.1-5-12.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-12
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: const, export, import
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {
             const : 0,
             export: 1,
@@ -21,10 +19,5 @@ function testcase() {
             'import'
         ]; 
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-13.js
+++ b/test/language/reserved-words/7.6.1-5-13.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-13
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: implements, let, private
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {
             implements: 0,
             let: 1,
@@ -21,10 +19,5 @@ function testcase() {
             'private'
         ];   
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-14.js
+++ b/test/language/reserved-words/7.6.1-5-14.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-14
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: public, yield, interface
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {
             public: 0,
             yield: 1,
@@ -21,10 +19,5 @@ function testcase() {
             'interface'
         ]; 
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-15.js
+++ b/test/language/reserved-words/7.6.1-5-15.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-15
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: package, protected, static
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {
             package: 0,
             protected: 1,
@@ -21,10 +19,5 @@ function testcase() {
             'static'
         ];  
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-16.js
+++ b/test/language/reserved-words/7.6.1-5-16.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-16
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: undefined, NaN, Infinity
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {
             undefined: 0,
             NaN: 1,
@@ -21,10 +19,5 @@ function testcase() {
             'Infinity'
         ]; 
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-2.js
+++ b/test/language/reserved-words/7.6.1-5-2.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-2
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: break, case, do
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = { 
             break: 0,
             case: 1,
@@ -21,10 +19,5 @@ function testcase() {
             'do'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-3.js
+++ b/test/language/reserved-words/7.6.1-5-3.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-3
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: instanceof, typeof, else
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = { 
             instanceof: 0,
             typeof: 1,
@@ -21,10 +19,5 @@ function testcase() {
             'else'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-4.js
+++ b/test/language/reserved-words/7.6.1-5-4.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-4
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: new, var, catch
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = { 
             new: 0,
             var: 1,
@@ -21,10 +19,5 @@ function testcase() {
             'catch'
         ]; 
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-5.js
+++ b/test/language/reserved-words/7.6.1-5-5.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-5
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: finally, return, void
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = { 
             finally: 0,
             return: 1,
@@ -21,10 +19,5 @@ function testcase() {
             'void'
         ];  
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-6.js
+++ b/test/language/reserved-words/7.6.1-5-6.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-6
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: continue, for, switch
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = { 
             continue: 0, 
             for: 1, 
@@ -21,10 +19,5 @@ function testcase() {
             'switch'
         ];  
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-7.js
+++ b/test/language/reserved-words/7.6.1-5-7.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-7
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: while, debugger, function
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = { 
             while: 0, 
             debugger: 1, 
@@ -21,10 +19,5 @@ function testcase() {
             'function'
         ];    
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-8.js
+++ b/test/language/reserved-words/7.6.1-5-8.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-8
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: this, with, default
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {       
             this: 0,  
             with: 1, 
@@ -21,10 +19,5 @@ function testcase() {
             'default'
         ]; 
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-5-9.js
+++ b/test/language/reserved-words/7.6.1-5-9.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-5-9
 description: >
     Allow reserved words as property names at object initialization,
     accessed via indexing: if, throw, delete
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = { 
             if: 0, 
             throw: 1, 
@@ -21,10 +19,5 @@ function testcase() {
             'delete'
         ];   
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-1.js
+++ b/test/language/reserved-words/7.6.1-6-1.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-1
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: null, true, false
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.null = 0;
 	    tokenCodes.true = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'false'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-10.js
+++ b/test/language/reserved-words/7.6.1-6-10.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-10
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: in, try, class
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.in = 0;
         tokenCodes.try = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'class'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-11.js
+++ b/test/language/reserved-words/7.6.1-6-11.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-11
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: enum, extends, super
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.enum = 0;
         tokenCodes.extends = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'super'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-12.js
+++ b/test/language/reserved-words/7.6.1-6-12.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-12
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: const, export, import
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.const = 0;
         tokenCodes.export = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'import'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-13.js
+++ b/test/language/reserved-words/7.6.1-6-13.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-13
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: implements, let, private
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.implements = 0;
         tokenCodes.let = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'private'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-14.js
+++ b/test/language/reserved-words/7.6.1-6-14.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-14
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: public, yield, interface
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.public = 0;
         tokenCodes.yield = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'interface'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-15.js
+++ b/test/language/reserved-words/7.6.1-6-15.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-15
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: package, protected, static
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.package = 0;
         tokenCodes.protected = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'static' 
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-16.js
+++ b/test/language/reserved-words/7.6.1-6-16.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-16
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: undefined, NaN, Infinity
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.undefined = 0;
         tokenCodes.NaN = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'Infinity'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-2.js
+++ b/test/language/reserved-words/7.6.1-6-2.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-2
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: break, case, do
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes.break = 0;  	
         tokenCodes.case = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'do'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-3.js
+++ b/test/language/reserved-words/7.6.1-6-3.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-3
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: instanceof, typeof, else
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.instanceof = 0;
         tokenCodes.typeof = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'else'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-4.js
+++ b/test/language/reserved-words/7.6.1-6-4.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-4
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: new, var, catch
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.new = 0;
         tokenCodes.var = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'catch'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-5.js
+++ b/test/language/reserved-words/7.6.1-6-5.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-5
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: finally, return, void
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.finally = 0;
         tokenCodes.return = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'void'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-6.js
+++ b/test/language/reserved-words/7.6.1-6-6.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-6
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: continue, for, switch
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.continue = 0;
         tokenCodes.for = 1; 
@@ -20,10 +18,5 @@ function testcase() {
             'switch'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-7.js
+++ b/test/language/reserved-words/7.6.1-6-7.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-7
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: while, debugger, function
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.while = 0; 
         tokenCodes.debugger = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'function'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-8.js
+++ b/test/language/reserved-words/7.6.1-6-8.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-8
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: this, with, default
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.this = 0; 
         tokenCodes.with = 1; 
@@ -20,10 +18,5 @@ function testcase() {
             'default'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-6-9.js
+++ b/test/language/reserved-words/7.6.1-6-9.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-6-9
 description: >
     Allow reserved words as property names by dot operator assignment,
     accessed via indexing: if, throw, delete
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes  = {};
         tokenCodes.if = 0;
         tokenCodes.throw = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'delete'
          ];
          for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-1.js
+++ b/test/language/reserved-words/7.6.1-7-1.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-1
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: null, true, false
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['null'] = 0;
         tokenCodes['true'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'false'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-10.js
+++ b/test/language/reserved-words/7.6.1-7-10.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-10
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: in, try, class
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['in'] = 0;
         tokenCodes['try'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'class'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-11.js
+++ b/test/language/reserved-words/7.6.1-7-11.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-11
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: enum, extends, super
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['enum'] = 0;
         tokenCodes['extends'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'super'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-12.js
+++ b/test/language/reserved-words/7.6.1-7-12.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-12
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: const, export, import
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['const'] = 0;
         tokenCodes['export'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'import'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-13.js
+++ b/test/language/reserved-words/7.6.1-7-13.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-13
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: implements, let, private
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['implements'] = 0;
         tokenCodes['let'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'private'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-14.js
+++ b/test/language/reserved-words/7.6.1-7-14.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-14
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: public, yield, interface
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['public'] = 0;
         tokenCodes['yield'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'interface'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-15.js
+++ b/test/language/reserved-words/7.6.1-7-15.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-15
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: package, protected, static
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['package'] = 0;
         tokenCodes['protected'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'static' 
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-16.js
+++ b/test/language/reserved-words/7.6.1-7-16.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-16
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: undefined, NaN, Infinity
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['undefined'] = 0;
         tokenCodes['NaN'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'Infinity'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-2.js
+++ b/test/language/reserved-words/7.6.1-7-2.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-2
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: break, case, do
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['break'] = 0;
         tokenCodes['case'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'do'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-3.js
+++ b/test/language/reserved-words/7.6.1-7-3.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-3
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: instanceof, typeof, else
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['instanceof'] = 0;
         tokenCodes['typeof'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'else'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-4.js
+++ b/test/language/reserved-words/7.6.1-7-4.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-4
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: new, var, catch
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['new'] = 0;
         tokenCodes['var'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'catch'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-5.js
+++ b/test/language/reserved-words/7.6.1-7-5.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-5
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: finally, return, void
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['finally'] = 0;
         tokenCodes['return'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'void'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-6.js
+++ b/test/language/reserved-words/7.6.1-7-6.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-6
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: continue, for, switch
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['continue'] = 0;
         tokenCodes['for'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'switch'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-7.js
+++ b/test/language/reserved-words/7.6.1-7-7.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-7
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: while, debugger, function
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['while'] = 0;
         tokenCodes['debugger'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'function'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-8.js
+++ b/test/language/reserved-words/7.6.1-7-8.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-8
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: this, with, default
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['this'] = 0;
         tokenCodes['with'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'default'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-7-9.js
+++ b/test/language/reserved-words/7.6.1-7-9.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-7-9
 description: >
     Allow reserved words as property names by index assignment,
     accessed via indexing: if, throw, delete
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var tokenCodes = {};
         tokenCodes['if'] = 0;
         tokenCodes['throw'] = 1;
@@ -20,10 +18,5 @@ function testcase() {
             'delete'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-1.js
+++ b/test/language/reserved-words/7.6.1-8-1.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-1
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: null, true, false
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set null(value) {
@@ -37,10 +35,5 @@ function testcase() {
             'false'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-10.js
+++ b/test/language/reserved-words/7.6.1-8-10.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-10
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: in, try, class
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set in(value){
@@ -37,10 +35,5 @@ function testcase() {
             'class'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-11.js
+++ b/test/language/reserved-words/7.6.1-8-11.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-11
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: enum, extends, super
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set enum(value){
@@ -37,10 +35,5 @@ function testcase() {
             'super'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-12.js
+++ b/test/language/reserved-words/7.6.1-8-12.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-12
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: const, export, import
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set const(value){
@@ -37,10 +35,5 @@ function testcase() {
             'import'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-13.js
+++ b/test/language/reserved-words/7.6.1-8-13.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-13
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: implements, let, private
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set implements(value){
@@ -37,10 +35,5 @@ function testcase() {
             'private'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-14.js
+++ b/test/language/reserved-words/7.6.1-8-14.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-14
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: public, yield, interface
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set public(value){
@@ -37,10 +35,5 @@ function testcase() {
             'interface'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-15.js
+++ b/test/language/reserved-words/7.6.1-8-15.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-15
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: package, protected, static
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set package(value){
@@ -37,10 +35,5 @@ function testcase() {
             'static'  
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-16.js
+++ b/test/language/reserved-words/7.6.1-8-16.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-16
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: undefined, NaN, Infinity
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set undefined(value){
@@ -37,10 +35,5 @@ function testcase() {
             'Infinity'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-2.js
+++ b/test/language/reserved-words/7.6.1-8-2.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-2
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: break, case, do
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set break(value){
@@ -37,10 +35,5 @@ function testcase() {
             'do'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-3.js
+++ b/test/language/reserved-words/7.6.1-8-3.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-3
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: instanceof, typeof, else
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set instanceof(value){
@@ -37,10 +35,5 @@ function testcase() {
             'else'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-4.js
+++ b/test/language/reserved-words/7.6.1-8-4.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-4
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: new, var, catch
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set new(value){
@@ -37,10 +35,5 @@ function testcase() {
             'catch'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-5.js
+++ b/test/language/reserved-words/7.6.1-8-5.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-5
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: finally, return, void
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set finally(value){
@@ -37,10 +35,5 @@ function testcase() {
             'void'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-6.js
+++ b/test/language/reserved-words/7.6.1-8-6.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-6
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: continue, for, switch
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set continue(value){
@@ -37,10 +35,5 @@ function testcase() {
             'switch'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-7.js
+++ b/test/language/reserved-words/7.6.1-8-7.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-7
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: while, debugger, function
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set while(value){
@@ -37,10 +35,5 @@ function testcase() {
             'function'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-8.js
+++ b/test/language/reserved-words/7.6.1-8-8.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-8
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: this, with, default
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set this(value){
@@ -37,10 +35,5 @@ function testcase() {
             'default'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/reserved-words/7.6.1-8-9.js
+++ b/test/language/reserved-words/7.6.1-8-9.js
@@ -6,10 +6,8 @@ es5id: 7.6.1-8-9
 description: >
     Allow reserved words as property names by set function within an
     object, accessed via indexing: if, throw, delete
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var test0 = 0, test1 = 1, test2 = 2;
         var tokenCodes  = {
             set if(value){
@@ -37,10 +35,5 @@ function testcase() {
             'delete'
         ];
         for (var i = 0; i < arr.length; i++) {
-            if (tokenCodes[arr[i]] !== i) {
-                return false;
-            };
+            assert.sameValue(tokenCodes[arr[i]], i, 'tokenCodes[arr[i]]');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/statements/function/13.0-17-s.js
+++ b/test/language/statements/function/13.0-17-s.js
@@ -11,12 +11,6 @@ description: >
     when a Function constructor is contained in strict mode code
     within eval code
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-
         eval("'use strict'; var _13_0_17_fun = new Function('eval = 42;'); _13_0_17_fun();");
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/statements/function/13.0-8-s.js
+++ b/test/language/statements/function/13.0-8-s.js
@@ -10,19 +10,10 @@ description: >
     Strict Mode - SourceElements is evaluated as strict mode code when
     the code of this FunctionExpression is contained in non-strict
     mode but the call to eval is a direct call in strict mode code
-flags: [noStrict]
-includes: [runTestCase.js]
+flags: [onlyStrict]
 ---*/
 
-function testcase() {
-        "use strict";
-
-        try {
+assert.throws(SyntaxError, function() {
             eval("var _13_0_8_fun = function () {eval = 42;};");
             _13_0_8_fun();
-            return false;
-        } catch (e) {
-            return e instanceof SyntaxError;
-        }
-    }
-runTestCase(testcase);
+});

--- a/test/language/statements/function/13.1-1-1.js
+++ b/test/language/statements/function/13.1-1-1.js
@@ -6,17 +6,7 @@ es5id: 13.1-1-1
 description: >
     Duplicate identifier allowed in non-strict function declaration
     parameter list
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase()
-{
-  try 
-  {
     eval('function foo(a,a){}');
-    return true;
-  }
-  catch (e) { return false }
-  }
-runTestCase(testcase);

--- a/test/language/statements/function/13.1-1-2.js
+++ b/test/language/statements/function/13.1-1-2.js
@@ -6,17 +6,7 @@ es5id: 13.1-1-2
 description: >
     Duplicate identifier allowed in non-strict function expression
     parameter list
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase()
-{
-  try 
-  {
     eval('(function foo(a,a){})');
-    return true;
-  }
-  catch (e) { return false }
-  }
-runTestCase(testcase);

--- a/test/language/statements/function/13.1-2-1.js
+++ b/test/language/statements/function/13.1-2-1.js
@@ -6,17 +6,7 @@ es5id: 13.1-2-1
 description: >
     eval allowed as formal parameter name of a non-strict function
     declaration
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase()
-{
-  try 
-  {
     eval("function foo(eval){};");
-    return true;
-  }
-  catch (e) {  }
- }
-runTestCase(testcase);

--- a/test/language/statements/function/13.1-2-5.js
+++ b/test/language/statements/function/13.1-2-5.js
@@ -6,17 +6,7 @@ es5id: 13.1-2-5
 description: >
     arguments allowed as formal parameter name of a non-strict
     function declaration
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase()
-{
-  try 
-  {
     eval("function foo(arguments){};");
-    return true;
-  }
-  catch (e) {  }
- }
-runTestCase(testcase);

--- a/test/language/statements/function/13.1-2-6.js
+++ b/test/language/statements/function/13.1-2-6.js
@@ -6,13 +6,7 @@ es5id: 13.1-2-6
 description: >
     arguments allowed as formal parameter name of a non-strict
     function expression
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase()
-{
     eval("(function foo(arguments){});");
-    return true;
- }
-runTestCase(testcase);

--- a/test/language/statements/function/13.1-3-1.js
+++ b/test/language/statements/function/13.1-3-1.js
@@ -6,17 +6,7 @@ es5id: 13.1-3-1
 description: >
     eval allowed as function identifier in non-strict function
     declaration
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase()
-{
-  try 
-  {
     eval("function eval(){};");
-    return true;
-  }
-  catch (e) {  }  
- }
-runTestCase(testcase);

--- a/test/language/statements/function/13.1-3-2.js
+++ b/test/language/statements/function/13.1-3-2.js
@@ -6,17 +6,7 @@ es5id: 13.1-3-2
 description: >
     eval allowed as function identifier in non-strict function
     expression
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase()
-{
-  try 
-  {
     eval("(function eval(){});");
-    return true;
-  }
-  catch (e) {  }  
- }
-runTestCase(testcase);

--- a/test/language/statements/function/13.1-3-7.js
+++ b/test/language/statements/function/13.1-3-7.js
@@ -6,17 +6,7 @@ es5id: 13.1-3-7
 description: >
     arguments allowed as function identifier in non-strict function
     declaration
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase()
-{
-  try 
-  {
     eval("function arguments (){};");
-    return true;
-  }
-  catch (e) {  }  
- }
-runTestCase(testcase);

--- a/test/language/statements/function/13.1-3-8.js
+++ b/test/language/statements/function/13.1-3-8.js
@@ -6,17 +6,7 @@ es5id: 13.1-3-8
 description: >
     arguments allowed as function identifier in non-strict function
     expression
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase()
-{
-  try 
-  {
     eval("(function arguments (){});");
-    return true;
-  }
-  catch (e) {  }  
- }
-runTestCase(testcase);

--- a/test/language/statements/function/13.2-11-s.js
+++ b/test/language/statements/function/13.2-11-s.js
@@ -6,17 +6,10 @@ es5id: 13.2-11-s
 description: >
     StrictMode - enumerating over a function object looking for
     'caller' fails outside of the function
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var foo = Function("'use strict';");
         
         for (var tempIndex in foo) {
-            if (tempIndex === "caller") {
-                return false;
-            }
+            assert.notSameValue(tempIndex, "caller", 'tempIndex');
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/statements/function/13.2-12-s.js
+++ b/test/language/statements/function/13.2-12-s.js
@@ -6,11 +6,7 @@ es5id: 13.2-12-s
 description: >
     StrictMode - enumerating over a function object looking for
     'caller' fails inside the function
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-            var foo = Function("'use strict'; for (var tempIndex in this) {if (tempIndex===\"caller\") {return false;}}; return true;");
-            return foo.call(foo);
-}
-runTestCase(testcase);
+            var foo = Function("'use strict'; for (var tempIndex in this) {assert.notSameValue(tempIndex, 'caller', 'tempIndex');}");
+            foo.call(foo);

--- a/test/language/statements/function/13.2-15-s.js
+++ b/test/language/statements/function/13.2-15-s.js
@@ -6,17 +6,10 @@ es5id: 13.2-15-s
 description: >
     StrictMode - enumerating over a function object looking for
     'arguments' fails outside of the function
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var foo = new Function("'use strict';");
         
         for (var tempIndex in foo) {
-            if (tempIndex === "arguments") {
-                return false;
-            }
+            assert.notSameValue(tempIndex, "arguments", 'tempIndex');
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/statements/function/13.2-16-s.js
+++ b/test/language/statements/function/13.2-16-s.js
@@ -6,11 +6,7 @@ es5id: 13.2-16-s
 description: >
     StrictMode - enumerating over a function object looking for
     'arguments' fails inside the function
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-            var foo = new Function("'use strict'; for (var tempIndex in this) {if (tempIndex===\"arguments\") {return false;}}; return true;");
-            return foo.call(foo);
-}
-runTestCase(testcase);
+            var foo = new Function("'use strict'; for (var tempIndex in this) {assert.notSameValue(tempIndex, 'arguments', 'tempIndex');}");
+            foo.call(foo);

--- a/test/language/statements/function/13.2-19-s.js
+++ b/test/language/statements/function/13.2-19-s.js
@@ -6,17 +6,10 @@ es5id: 13.2-19-s
 description: >
     StrictMode - enumerating over a function object looking for
     'arguments' fails outside of the function
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var foo = Function("'use strict';");
         
         for (var tempIndex in foo) {
-            if (tempIndex === "arguments") {
-                return false;
-            }
+            assert.notSameValue(tempIndex, "arguments", 'tempIndex');
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/statements/function/13.2-20-s.js
+++ b/test/language/statements/function/13.2-20-s.js
@@ -7,11 +7,7 @@ description: >
     StrictMode - enumerating over a function object looking for
     'arguments' fails inside the function
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-            var foo = Function("'use strict'; for (var tempIndex in this) {if (tempIndex===\"arguments\") {return false;}}; return true;");
-            return foo.call(foo);
-}
-runTestCase(testcase);
+            var foo = Function("'use strict'; for (var tempIndex in this) {assert.notSameValue(tempIndex, 'arguments', 'tempIndex');}");
+            foo.call(foo);

--- a/test/language/statements/function/13.2-23-s.js
+++ b/test/language/statements/function/13.2-23-s.js
@@ -7,16 +7,9 @@ description: >
     StrictMode - enumerating over a function object looking for
     'caller' fails outside of the function
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         function foo () {"use strict";}
         for (var tempIndex in foo) {
-            if (tempIndex === "caller") {
-                return false;
-            }
+            assert.notSameValue(tempIndex, "caller", 'tempIndex');
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/statements/function/13.2-24-s.js
+++ b/test/language/statements/function/13.2-24-s.js
@@ -7,19 +7,13 @@ description: >
     StrictMode - enumerating over a function object looking for
     'caller' fails inside the function
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
             function foo () {
                 "use strict"; 
                 for (var tempIndex in this) {
-                    if (tempIndex==="caller") {
-                        return false;
-                    }
+                    assert.notSameValue(tempIndex, "caller", 'tempIndex');
                 } 
-                return true;
             }
-            return foo.call(foo);
-}
-runTestCase(testcase);
+
+foo.call(foo);

--- a/test/language/statements/function/13.2-27-s.js
+++ b/test/language/statements/function/13.2-27-s.js
@@ -7,17 +7,10 @@ description: >
     StrictMode - enumerating over a function object looking for
     'arguments' fails outside of the function
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         function foo () {"use strict";}
         
         for (var tempIndex in foo) {
-            if (tempIndex === "arguments") {
-                return false;
-            }
+            assert.notSameValue(tempIndex, "arguments", 'tempIndex');
         }
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/statements/function/13.2-28-s.js
+++ b/test/language/statements/function/13.2-28-s.js
@@ -7,19 +7,12 @@ description: >
     StrictMode - enumerating over a function object looking for
     'arguments' fails inside the function
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
             function foo() {
                 "use strict"; 
                 for (var tempIndex in this) {
-                    if (tempIndex==="arguments") {
-                        return false;
-                    }
+                    assert.notSameValue(tempIndex, "arguments", 'tempIndex');
                 } 
-                return true;
             }
-            return foo.call(foo);
-}
-runTestCase(testcase);
+            foo.call(foo);

--- a/test/language/statements/function/13.2-3-s.js
+++ b/test/language/statements/function/13.2-3-s.js
@@ -6,14 +6,11 @@ es5id: 13.2-3-s
 description: >
     StrictMode - Writing or reading from a property named 'arguments'
     of function objects is allowed under both strict and normal modes.
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var foo = function () {
             this.arguments = 12;
         } 
         var obj = new foo();
-        return obj.arguments === 12;
-    }
-runTestCase(testcase);
+
+assert.sameValue(obj.arguments, 12, 'obj.arguments');

--- a/test/language/statements/function/13.2-7-s.js
+++ b/test/language/statements/function/13.2-7-s.js
@@ -7,17 +7,10 @@ description: >
     StrictMode - enumerating over a function object looking for
     'caller' fails outside of the function
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         var foo = new Function("'use strict';");
         
         for (var tempIndex in foo) {
-            if (tempIndex === "caller") {
-                return false;
-            }
+            assert.notSameValue(tempIndex, "caller", 'tempIndex');
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/statements/function/13.2-8-s.js
+++ b/test/language/statements/function/13.2-8-s.js
@@ -7,11 +7,7 @@ description: >
     StrictMode - enumerating over a function object looking for
     'caller' fails inside the function
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-            var foo = new Function("'use strict'; for (var tempIndex in this) {if (tempIndex===\"caller\") {return false;}}; return true;");
-            return foo.call(foo);
-    }
-runTestCase(testcase);
+            var foo = new Function("'use strict'; for (var tempIndex in this) {assert.notSameValue(tempIndex, 'caller', 'tempIndex');}");
+            foo.call(foo);

--- a/test/language/statements/try/12.14-1.js
+++ b/test/language/statements/try/12.14-1.js
@@ -7,10 +7,8 @@ description: >
     catch doesn't change declaration scope - var initializer in catch
     with same name as catch parameter changes parameter
 features: [AnnexB]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   foo = "prior to throw";
   try {
     throw new Error();
@@ -18,7 +16,5 @@ function testcase() {
   catch (foo) {
     var foo = "initializer in catch";
   }
- return foo === "prior to throw";
-  
- }
-runTestCase(testcase);
+
+assert.sameValue(foo, "prior to throw");

--- a/test/language/statements/try/12.14-10.js
+++ b/test/language/statements/try/12.14-10.js
@@ -4,10 +4,8 @@
 /*---
 es5id: 12.14-10
 description: catch introduces scope - name lookup finds function parameter
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   function f(o) {
 
     function innerf(o, x) {
@@ -21,9 +19,5 @@ function testcase() {
 
     return innerf(o, 42);
   }
-  
-  if (f({}) === 42) {
-    return true;
-  }
- }
-runTestCase(testcase);
+
+assert.sameValue(f({}), 42);

--- a/test/language/statements/try/12.14-11.js
+++ b/test/language/statements/try/12.14-11.js
@@ -4,10 +4,8 @@
 /*---
 es5id: 12.14-11
 description: catch introduces scope - name lookup finds inner variable
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   function f(o) {
 
     function innerf(o) {
@@ -23,9 +21,5 @@ function testcase() {
 
     return innerf(o);
   }
-  
-  if (f({}) === 42) {
-    return true;
-  }
- }
-runTestCase(testcase);
+
+assert.sameValue(f({}), 42);

--- a/test/language/statements/try/12.14-12.js
+++ b/test/language/statements/try/12.14-12.js
@@ -4,10 +4,8 @@
 /*---
 es5id: 12.14-12
 description: catch introduces scope - name lookup finds property
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   function f(o) {
 
     function innerf(o) {
@@ -21,9 +19,5 @@ function testcase() {
 
     return innerf(o);
   }
-  
-  if (f({x:42}) === 42) {
-    return true;
-  }
- }
-runTestCase(testcase);
+
+assert.sameValue(f({x:42}), 42);

--- a/test/language/statements/try/12.14-2.js
+++ b/test/language/statements/try/12.14-2.js
@@ -7,10 +7,8 @@ description: >
     catch doesn't change declaration scope - var initializer in catch
     with same name as catch parameter changes parameter
 features: [AnnexB]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   function capturedFoo() {return foo};
   foo = "prior to throw";
   try {
@@ -18,8 +16,6 @@ function testcase() {
   }
   catch (foo) {
     var foo = "initializer in catch";
-    return capturedFoo() !== "initializer in catch";
   }
-  
- }
-runTestCase(testcase);
+
+assert.sameValue(capturedFoo(), "prior to throw");

--- a/test/language/statements/try/12.14-3.js
+++ b/test/language/statements/try/12.14-3.js
@@ -14,17 +14,13 @@ es5id: 12.14-3
 description: >
     catch doesn't change declaration scope - var declaration are
     visible outside when name different from catch parameter
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   try {
     throw new Error();
   }
   catch (e) {
     var foo = "declaration in catch";
   }
-  
-  return foo === "declaration in catch";
- }
-runTestCase(testcase);
+
+assert.sameValue(foo, "declaration in catch");

--- a/test/language/statements/try/12.14-4.js
+++ b/test/language/statements/try/12.14-4.js
@@ -12,10 +12,8 @@ info: >
     eval should use the appended object to the scope chain
 es5id: 12.14-4
 description: catch introduces scope - block-local vars must shadow outer vars
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   var o = { foo : 42};
 
   try {
@@ -23,10 +21,6 @@ function testcase() {
   }
   catch (e) {
     var foo;
-
-    if (foo === undefined) {
-      return true;
-    }
   }
- }
-runTestCase(testcase);
+
+assert.sameValue(foo, undefined);

--- a/test/language/statements/try/12.14-6.js
+++ b/test/language/statements/try/12.14-6.js
@@ -14,10 +14,8 @@ es5id: 12.14-6
 description: >
     catch introduces scope - block-local function expression must
     shadow outer function expression
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   var o = {foo : function () { return 42;}};
 
   try {
@@ -25,9 +23,6 @@ function testcase() {
   }
   catch (e) {
     var foo = function () {};
-    if (foo() === undefined) {
-      return true;
-    }
   }
- }
-runTestCase(testcase);
+
+assert.sameValue(foo(), undefined);

--- a/test/language/statements/try/12.14-7.js
+++ b/test/language/statements/try/12.14-7.js
@@ -12,10 +12,8 @@ info: >
     eval should use the appended object to the scope chain
 es5id: 12.14-7
 description: catch introduces scope - scope removed when exiting catch block
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
       var o = {foo: 1};
       var catchAccessed = false;
       
@@ -25,13 +23,14 @@ function testcase() {
       catch (expObj) {
         catchAccessed = (expObj.foo == 1);
       }
+      assert(catchAccessed, '(expObj.foo == 1)');
 
+
+      catchAccessed = false;
       try {
         expObj;
       }
       catch (e) {
-        return catchAccessed && e instanceof ReferenceError
+        catchAccessed = e instanceof ReferenceError
       }
-      return false;
-    }
-runTestCase(testcase);
+      assert(catchAccessed, 'e instanceof ReferenceError');

--- a/test/language/statements/try/12.14-8.js
+++ b/test/language/statements/try/12.14-8.js
@@ -14,10 +14,8 @@ es5id: 12.14-8
 description: >
     catch introduces scope - scope removed when exiting catch block
     (properties)
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   var o = {foo: 42};
 
   try {
@@ -27,8 +25,4 @@ function testcase() {
     var foo = 1;
   }
 
-  if (o.foo === 42) {
-    return true;
-  }
- }
-runTestCase(testcase);
+assert.sameValue(o.foo, 42);

--- a/test/language/statements/try/12.14-9.js
+++ b/test/language/statements/try/12.14-9.js
@@ -4,10 +4,8 @@
 /*---
 es5id: 12.14-9
 description: catch introduces scope - name lookup finds outer variable
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   function f(o) {
     var x = 42;
 
@@ -22,9 +20,5 @@ function testcase() {
 
     return innerf(o);
   }
-  
-  if (f({}) === 42) {
-    return true;
-  }
- }
-runTestCase(testcase);
+
+assert.sameValue(f({}), 42);

--- a/test/language/statements/try/12.14.1-4-s.js
+++ b/test/language/statements/try/12.14.1-4-s.js
@@ -7,15 +7,14 @@ description: >
     Strict Mode - SyntaxError isn't thrown if a TryStatement with a
     Catch occurs within strict code and the Identifier of the Catch
     production is EVAL
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
+var isInstance = false;
+
         try {
             throw new Error("...");
-            return false;
         } catch (EVAL) {
-            return EVAL instanceof Error;
+            isInstance = EVAL instanceof Error;
         }
-    }
-runTestCase(testcase);
+
+assert(isInstance);

--- a/test/language/statements/try/12.14.1-5-s.js
+++ b/test/language/statements/try/12.14.1-5-s.js
@@ -7,15 +7,14 @@ description: >
     Strict Mode - SyntaxError isn't thrown if a TryStatement with a
     Catch occurs within strict code and the Identifier of the Catch
     production is Arguments
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
+var isInstance = false;
+
         try {
             throw new Error("...");
-            return false;
         } catch (Arguments) {
-            return Arguments instanceof Error;
+            isInstance = Arguments instanceof Error;
         }
-    }
-runTestCase(testcase);
+
+assert(isInstance);

--- a/test/language/statements/try/12.14.1-6-s.js
+++ b/test/language/statements/try/12.14.1-6-s.js
@@ -7,15 +7,14 @@ description: >
     Strict Mode - SyntaxError isn't thrown if a TryStatement with a
     Catch occurs within strict code and the Identifier of the Catch
     production is ARGUMENTS
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
+var isInstance = false;
+
         try {
             throw new Error("...");
-            return false;
         } catch (ARGUMENTS) {
-            return ARGUMENTS instanceof Error;
+            isInstance = ARGUMENTS instanceof Error;
         }
-    }
-runTestCase(testcase);
+
+assert(isInstance);

--- a/test/language/statements/variable/12.2.1-11.js
+++ b/test/language/statements/variable/12.2.1-11.js
@@ -4,12 +4,10 @@
 /*---
 es5id: 12.2.1-11
 description: arguments as var identifier in eval code is allowed
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
 function testcase() {
     eval("var arguments;");
-    return true;
  }
-runTestCase(testcase);
+testcase();

--- a/test/language/statements/variable/12.2.1-12.js
+++ b/test/language/statements/variable/12.2.1-12.js
@@ -4,12 +4,7 @@
 /*---
 es5id: 12.2.1-12
 description: arguments as local var identifier is allowed
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase() {
     eval("(function (){var arguments;})");
-    return true;
- }
-runTestCase(testcase);

--- a/test/language/statements/variable/12.2.1-16-s.js
+++ b/test/language/statements/variable/12.2.1-16-s.js
@@ -6,11 +6,6 @@ es5id: 12.2.1-16-s
 description: >
     A Function constructor (called as a function) declaring a var
     named 'arguments' does not throw a SyntaxError
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         Function('var arguments;');
-        return true;
-}
-runTestCase(testcase);

--- a/test/language/statements/variable/12.2.1-17-s.js
+++ b/test/language/statements/variable/12.2.1-17-s.js
@@ -8,12 +8,7 @@ description: >
     'arguments' will not throw any error if contained within strict
     mode and its body does not start with strict mode
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
     var f = Function('arguments = 42;');
     f();
-    return true;
-}
-runTestCase(testcase);

--- a/test/language/statements/variable/12.2.1-20-s.js
+++ b/test/language/statements/variable/12.2.1-20-s.js
@@ -6,12 +6,7 @@ es5id: 12.2.1-20-s
 description: >
     Strict Mode: an indirect eval declaring a var named 'arguments'
     does not throw
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   var s = eval;
   s('var arguments;');
-  return true;
-}
-runTestCase(testcase);

--- a/test/language/statements/variable/12.2.1-21-s.js
+++ b/test/language/statements/variable/12.2.1-21-s.js
@@ -6,12 +6,7 @@ es5id: 12.2.1-21-s
 description: >
     Strict Mode: an indirect eval assigning into 'arguments' does not
     throw
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   var s = eval;
   s('arguments = 42;');
-  return true;
-}
-runTestCase(testcase);

--- a/test/language/statements/variable/12.2.1-9-s.js
+++ b/test/language/statements/variable/12.2.1-9-s.js
@@ -5,12 +5,7 @@
 es5id: 12.2.1-9-s
 description: >
     an indirect eval declaring a var named 'eval' does not throw
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
   var s = eval;
   s('var eval;');
-  return true;
- }
-runTestCase(testcase);

--- a/test/language/statements/with/12.10-0-10.js
+++ b/test/language/statements/with/12.10-0-10.js
@@ -4,11 +4,9 @@
 /*---
 es5id: 12.10-0-10
 description: with introduces scope - name lookup finds function parameter
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase() {
   function f(o) {
 
     function innerf(o, x) {
@@ -19,9 +17,5 @@ function testcase() {
 
     return innerf(o, 42);
   }
-  
-  if (f({}) === 42) {
-    return true;
-  }
- }
-runTestCase(testcase);
+
+assert.sameValue(f({}), 42);

--- a/test/language/statements/with/12.10-0-11.js
+++ b/test/language/statements/with/12.10-0-11.js
@@ -4,11 +4,9 @@
 /*---
 es5id: 12.10-0-11
 description: with introduces scope - name lookup finds inner variable
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase() {
   function f(o) {
 
     function innerf(o) {
@@ -21,9 +19,5 @@ function testcase() {
 
     return innerf(o);
   }
-  
-  if (f({}) === 42) {
-    return true;
-  }
- }
-runTestCase(testcase);
+
+assert.sameValue(f({}), 42);

--- a/test/language/statements/with/12.10-0-12.js
+++ b/test/language/statements/with/12.10-0-12.js
@@ -4,11 +4,9 @@
 /*---
 es5id: 12.10-0-12
 description: with introduces scope - name lookup finds property
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase() {
   function f(o) {
 
     function innerf(o) {
@@ -19,9 +17,5 @@ function testcase() {
 
     return innerf(o);
   }
-  
-  if (f({x:42}) === 42) {
-    return true;
-  }
- }
-runTestCase(testcase);
+
+assert.sameValue(f({x:42}), 42);

--- a/test/language/statements/with/12.10-0-7.js
+++ b/test/language/statements/with/12.10-0-7.js
@@ -4,11 +4,9 @@
 /*---
 es5id: 12.10-0-7
 description: with introduces scope - scope removed when exiting with statement
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase() {
   var o = {foo: 1};
 
   with (o) {
@@ -17,9 +15,8 @@ function testcase() {
 
   try {
     foo;
+    throw new Error();
   }
   catch (e) {
-     return true;
+    assert(e instanceof ReferenceError);
   }
- }
-runTestCase(testcase);

--- a/test/language/statements/with/12.10-0-9.js
+++ b/test/language/statements/with/12.10-0-9.js
@@ -4,11 +4,9 @@
 /*---
 es5id: 12.10-0-9
 description: with introduces scope - name lookup finds outer variable
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase() {
   function f(o) {
     var x = 42;
 
@@ -20,9 +18,5 @@ function testcase() {
 
     return innerf(o);
   }
-  
-  if (f({}) === 42) {
-    return true;
-  }
- }
-runTestCase(testcase);
+
+assert.sameValue(f({}), 42);

--- a/test/language/statements/with/12.10-2-1.js
+++ b/test/language/statements/with/12.10-2-1.js
@@ -4,23 +4,13 @@
 /*---
 es5id: 12.10-2-1
 description: with - expression being Number
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase() {
   var o = 2;
   var foo = 1;
-  try
-  {
     with (o) {
       foo = 42;
     }
-  }
-  catch(e)
-  {
-  }
-  return true;
-  
- }
-runTestCase(testcase);
+
+assert.sameValue(foo, 42);

--- a/test/language/statements/with/12.10-2-2.js
+++ b/test/language/statements/with/12.10-2-2.js
@@ -4,23 +4,13 @@
 /*---
 es5id: 12.10-2-2
 description: with - expression being Boolean
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase() {
   var o = true;
   var foo = 1;
-  try
-  {
     with (o) {
       foo = 42;
     }
-  }
-  catch(e)
-  {
-  }
-  return true;
-  
- }
-runTestCase(testcase);
+
+assert.sameValue(foo, 42);

--- a/test/language/statements/with/12.10-2-3.js
+++ b/test/language/statements/with/12.10-2-3.js
@@ -4,23 +4,13 @@
 /*---
 es5id: 12.10-2-3
 description: with - expression being string
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase() {
   var o = "str";
   var foo = 1;
-  try
-  {
     with (o) {
       foo = 42;
     }
-  }
-  catch(e)
-  {
-  }
-  return true;
-  
- }
-runTestCase(testcase);
+
+assert.sameValue(foo, 42);

--- a/test/language/statements/with/12.10-7-1.js
+++ b/test/language/statements/with/12.10-7-1.js
@@ -4,28 +4,21 @@
 /*---
 es5id: 12.10-7-1
 description: with introduces scope - restores the earlier environment on exit
-includes: [runTestCase.js]
 flags: [noStrict]
 ---*/
 
-function testcase() {
   var a = 1;
 
   var o = {a : 2};
-  try
-  {
+  try {
     with (o) {
       a = 3;
       throw 1;
       a = 4;
     }
-  }
-  catch(e)
-  {}
-
-  if (a === 1 && o.a === 3) {
-      return true;
+  } catch (e) {
+    // intentionally ignored
   }
 
- }
-runTestCase(testcase);
+assert.sameValue(a, 1, 'a');
+assert.sameValue(o.a, 3, 'o.a');

--- a/test/language/statements/with/12.10.1-13-s.js
+++ b/test/language/statements/with/12.10.1-13-s.js
@@ -7,13 +7,8 @@ description: >
     Strict Mode - SyntaxError isn't thrown when WithStatement body is
     in strict mode code
 flags: [noStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
         with ({}) {
             "use strict";
         }
-        return true;
-    }
-runTestCase(testcase);

--- a/test/language/statements/with/12.10.1-5-s.js
+++ b/test/language/statements/with/12.10.1-5-s.js
@@ -7,13 +7,6 @@ description: >
     with statement allowed in nested Function even if its container
     Function is strict)
 flags: [onlyStrict]
-includes: [runTestCase.js]
 ---*/
 
-function testcase() {
-  
     Function("\'use strict\'; var f1 = Function( \"var o = {}; with (o) {};\")");
-    return true;
-  
- }
-runTestCase(testcase);


### PR DESCRIPTION
This PR removes all other uses of `runTestCase` in the "test/language" directory.