### PR TITLE
add 'onlyStrict' flags to frontmatter of strict-mode tests for classes

### DIFF
--- a/test/language/statements/class/strict-mode/arguments-caller.js
+++ b/test/language/statements/class/strict-mode/arguments-caller.js
@@ -4,7 +4,9 @@
 es6id: 14.5
 description: >
     class strict mode
+flags: [onlyStrict]
 ---*/
+
 var D = class extends function() {
   arguments.caller;
 } {};

--- a/test/language/statements/class/strict-mode/with.js
+++ b/test/language/statements/class/strict-mode/with.js
@@ -4,6 +4,7 @@
 es6id: 14.5
 description: >
     class strict mode: `with` disallowed
+flags: [onlyStrict]
 negative: SyntaxError
 ---*/
 


### PR DESCRIPTION
add 'onlyStrict' flags to frontmatter of strict-mode tests for classes