### PR TITLE
Fix Array.from_arity test

### DIFF
--- a/test/built-ins/Array/from/Array.from_arity.js
+++ b/test/built-ins/Array/from/Array.from_arity.js
@@ -7,7 +7,6 @@ description: >
     The length property of the Array.from method is 1.
 
 info: >
-
     ES6 Section 17:
 
     Unless otherwise specified, the length property of a built-in Function


### PR DESCRIPTION
An extra newline in a comment prevented the import from being parsed properly.