### PR TITLE
Fix #429: writing to const variables is only an error in strict mode.

### DIFF
--- a/test/language/statements/const/syntax/const-invalid-assignment-next-expression-for-non-strict.js
+++ b/test/language/statements/const/syntax/const-invalid-assignment-next-expression-for-non-strict.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2015 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.6.3.7_S5.a.i
+description: >
+    const: invalid assignment in next expression silently fails in non-strict mode
+flags: [noStrict]
+---*/
+
+let hasRun = false;
+let savedValue;
+for (const i = 0; i < 1; i++) {
+  savedValue = i;
+  if (hasRun) {
+    break;
+  }
+  hasRun = true;
+}
+
+assert.sameValue(savedValue, 0);

--- a/test/language/statements/const/syntax/const-invalid-assignment-next-expression-for-strict.js
+++ b/test/language/statements/const/syntax/const-invalid-assignment-next-expression-for-strict.js
@@ -3,9 +3,16 @@
 /*---
 es6id: 13.6.3.7_S5.a.i
 description: >
-    const: invalid assignment in next expression
+    const: invalid assignment in next expression throws TypeError in strict mode
+flags: [onlyStrict]
 ---*/
 
 assert.throws(TypeError, function() {
-  for (const i = 0; i < 1; i++) {}
+  let hasRun = false;
+  for (const i = 0; i < 1; i++) {
+    if (hasRun) {
+      break;
+    }
+    hasRun = true;
+  }
 });

--- a/test/language/statements/const/syntax/const-invalid-assignment-statement-body-for-in-non-strict.js
+++ b/test/language/statements/const/syntax/const-invalid-assignment-statement-body-for-in-non-strict.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.6.4.10_S1.a.i
+description: >
+    const: invalid assignment in Statement body silently fails in non-strict mode
+flags: [noStrict]
+---*/
+
+for (const x in [1, 2, 3]) {
+  let savedValue = x;
+  x++;
+  assert.sameValue(x, savedValue);
+}

--- a/test/language/statements/const/syntax/const-invalid-assignment-statement-body-for-in-strict.js
+++ b/test/language/statements/const/syntax/const-invalid-assignment-statement-body-for-in-strict.js
@@ -3,9 +3,10 @@
 /*---
 es6id: 13.6.4.10_S1.a.i
 description: >
-    const: invalid assignment in Statement body
+    const: invalid assignment in Statement body throws TypeError in strict mode
+flags: [onlyStrict]
 ---*/
 
 assert.throws(TypeError, function() {
-  for (const x of [1, 2, 3]) { x++ }
+  for (const x in [1, 2, 3]) { x++ }
 });

--- a/test/language/statements/const/syntax/const-invalid-assignment-statement-body-for-of-non-strict.js
+++ b/test/language/statements/const/syntax/const-invalid-assignment-statement-body-for-of-non-strict.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2011 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 13.6.4.10_S1.a.i
+description: >
+    const: invalid assignment in Statement body silently fails in non-strict mode
+flags: [noStrict]
+---*/
+
+for (const x of [1, 2, 3]) {
+  let savedValue = x;
+  x++;
+  assert.sameValue(x, savedValue);
+}

--- a/test/language/statements/const/syntax/const-invalid-assignment-statement-body-for-of-strict.js
+++ b/test/language/statements/const/syntax/const-invalid-assignment-statement-body-for-of-strict.js
@@ -3,9 +3,10 @@
 /*---
 es6id: 13.6.4.10_S1.a.i
 description: >
-    const: invalid assignment in Statement body
+    const: invalid assignment in Statement body throws TypeError in strict mode
+flags: [onlyStrict]
 ---*/
 
 assert.throws(TypeError, function() {
-  for (const x in [1, 2, 3]) { x++ }
+  for (const x of [1, 2, 3]) { x++ }
 });


### PR DESCRIPTION
Fix #429.

Also add tests for silent failure of writes to const variables outside of strict mode.

Also, in the case that writing fails silently in strict mode, the for-statement test will now exit instead of entering an infinite loop.