### PR TITLE
Revert primitive wrapper prototypes and String#split to ES5

### DIFF
--- a/test/built-ins/Boolean/prototype/S15.6.3.1_A1.js
+++ b/test/built-ins/Boolean/prototype/S15.6.3.1_A1.js
@@ -15,17 +15,12 @@ if (typeof Boolean.prototype !== "object") {
 }
 
 //CHECK#2
-try {
-  (Boolean.prototype != false);
-  $ERROR('#2: "(Boolean.prototype != false);" lead to throwing exception. Actual: '+(Boolean.prototype != false));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#2.1: "(Boolean.prototype != false)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if (Boolean.prototype != false) {
+  $ERROR('#2: Boolean.prototype == false');
 }
 
 delete Boolean.prototype.toString;
 
-if (Boolean.prototype.toString() !== "[object Object]") {
-  $ERROR('#3: The [[Class]] property of the Boolean prototype object is set to "Object"');
+if (Boolean.prototype.toString() !== "[object Boolean]") {
+  $ERROR('#3: The [[Class]] property of the Boolean prototype object is set to "Boolean"');
 }

--- a/test/built-ins/Boolean/prototype/S15.6.4_A1.js
+++ b/test/built-ins/Boolean/prototype/S15.6.4_A1.js
@@ -3,8 +3,8 @@
 
 /*---
 info: >
-    The Boolean prototype object is itself not a Boolean object
-    (its [[Class]] is "Object")
+    The Boolean prototype object is itself a Boolean object
+    (its [[Class]] is "Boolean") whose value is false
 es5id: 15.6.4_A1
 description: Checking type and value of Boolean.prototype
 ---*/
@@ -15,17 +15,12 @@ if (typeof Boolean.prototype !== "object") {
 }
 
 //CHECK#2
-try {
-  (Boolean.prototype != false);
-  $ERROR('#2: "(Boolean.prototype != false);" lead to throwing exception. Actual: '+(Boolean.prototype != false));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#2.1: "(Boolean.prototype != false)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if (Boolean.prototype != false) {
+  $ERROR('#2: Boolean.prototype == false');
 }
 
 delete Boolean.prototype.toString;
 
-if (Boolean.prototype.toString() !== "[object Object]") {
-  $ERROR('#3: The [[Class]] property of the Boolean prototype object is set to "Object"');
+if (Boolean.prototype.toString() !== "[object Boolean]") {
+  $ERROR('#3: The [[Class]] property of the Boolean prototype object is set to "Boolean"');
 }

--- a/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A1_T1.js
+++ b/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A1_T1.js
@@ -11,13 +11,8 @@ description: no arguments
 ---*/
 
 //CHECK#1
-try {
-  (Boolean.prototype.toString() !== "false");
-  $ERROR('#1: "(Boolean.prototype.toString() !== "false");" lead to throwing exception. Actual: '+(Boolean.prototype.toString() !== "false"));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "(Boolean.prototype.toString() !== "false")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Boolean.prototype.toString() !== "false"){
+  $ERROR('#1: Boolean.prototype.toString() === "false"');
 }
 
 //CHECK#2

--- a/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A1_T2.js
+++ b/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A1_T2.js
@@ -11,13 +11,8 @@ description: with some argument
 ---*/
 
 //CHECK#1
-try {
-  (Boolean.prototype.toString(true) !== "false");
-  $ERROR('#1: "(Boolean.prototype.toString(true) !== "false");" lead to throwing exception. Actual: '+(Boolean.prototype.toString(true) !== "false"));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "(Boolean.prototype.toString(true) !== "false")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Boolean.prototype.toString(true) !== "false"){
+  $ERROR('#1: Boolean.prototype.toString(true) === "false"');
 }
 
 //CHECK#2

--- a/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A1_T1.js
+++ b/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A1_T1.js
@@ -8,13 +8,8 @@ description: no arguments
 ---*/
 
 //CHECK#1
-try {
-  (Boolean.prototype.valueOf() !== false);
-  $ERROR('#1: "(Boolean.prototype.valueOf() !== false);" lead to throwing exception. Actual: '+(Boolean.prototype.valueOf() !== false));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "(Boolean.prototype.valueOf() !== false)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Boolean.prototype.valueOf() !== false){
+  $ERROR('#1: Boolean.prototype.valueOf() === false');
 }
 
 //CHECK#2

--- a/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A1_T2.js
+++ b/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A1_T2.js
@@ -8,13 +8,8 @@ description: calling with argument
 ---*/
 
 //CHECK#1
-try {
-  (Boolean.prototype.valueOf(true) !== false);
-  $ERROR('#1: "(Boolean.prototype.valueOf(true) !== false);" lead to throwing exception. Actual: '+(Boolean.prototype.valueOf(true) !== false));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "(Boolean.prototype.valueOf(true) !== false)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Boolean.prototype.valueOf(true) !== false){
+  $ERROR('#1: Boolean.prototype.valueOf(true) === false');
 }
 
 //CHECK#2

--- a/test/built-ins/Date/15.9.1.15-1.js
+++ b/test/built-ins/Date/15.9.1.15-1.js
@@ -10,7 +10,7 @@ description: >
 ---*/
 
         var result = false;
-        var expectedDateTimeStr = new Date(1970, 0, 1, 0, 0, 0, 0).toISOString();
+        var expectedDateTimeStr = "1970-01-01T00:00:00.000Z";
         var dateObj = new Date("1970");
         var dateStr = dateObj.toISOString();
         result = dateStr === expectedDateTimeStr;

--- a/test/built-ins/Number/15.7.4-1.js
+++ b/test/built-ins/Number/15.7.4-1.js
@@ -3,10 +3,10 @@
 
 /*---
 es5id: 15.7.4-1
-description: "Number prototype object: its [[Class]] must be 'Object'"
+description: "Number prototype object: its [[Class]] must be 'Number'"
 ---*/
 
   var numProto = Object.getPrototypeOf(new Number(42));
   var s = Object.prototype.toString.call(numProto );
 
-assert.sameValue(s, '[object Object]', 's');
+assert.sameValue(s, '[object Number]', 's');

--- a/test/built-ins/Number/prototype/S15.7.3.1_A2_T1.js
+++ b/test/built-ins/Number/prototype/S15.7.3.1_A2_T1.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-info: Number.prototype is itself not a Number object
+info: Number.prototype is itself Number object
 es5id: 15.7.3.1_A2_T1
 description: >
     Checking type of Number.prototype property - test based on
@@ -16,6 +16,6 @@ if (typeof Number.prototype !== "object") {
 
 delete Number.prototype.toString;
 
-if (Number.prototype.toString() !== "[object Object]") {
-  $ERROR('#3: The [[Class]] property of the Number prototype object is set to "Object"');
+if (Number.prototype.toString() !== "[object Number]") {
+  $ERROR('#3: The [[Class]] property of the Number prototype object is set to "Number"');
 }

--- a/test/built-ins/Number/prototype/S15.7.3.1_A2_T2.js
+++ b/test/built-ins/Number/prototype/S15.7.3.1_A2_T2.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-info: Number.prototype is itself not a Number object
+info: Number.prototype is itself Number object
 es5id: 15.7.3.1_A2_T2
 description: >
     Checking type of Number.prototype property - test based on
@@ -16,6 +16,6 @@ if (typeof Number.prototype !== "object") {
 
 Number.prototype.toString = Object.prototype.toString;
 
-if (Number.prototype.toString() !== "[object Object]") {
-  $ERROR('#3: The [[Class]] property of the Number prototype object is set to "Object"');
+if (Number.prototype.toString() !== "[object Number]") {
+  $ERROR('#3: The [[Class]] property of the Number prototype object is set to "Number"');
 }

--- a/test/built-ins/Number/prototype/S15.7.3.1_A3.js
+++ b/test/built-ins/Number/prototype/S15.7.3.1_A3.js
@@ -2,17 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-info: Number.prototype value is not +0
+info: Number.prototype value is +0
 es5id: 15.7.3.1_A3
 description: Checking value of Number.prototype property
 ---*/
 
 //CHECK#1
-try {
-  (Number.prototype != 0);
-  $ERROR('#1: "(Number.prototype != 0);" lead to throwing exception. Actual: '+(Number.prototype != 0));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "(Number.prototype != 0)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if (Number.prototype != 0) {
+  $ERROR('#2: Number.prototype == +0');
+} else if( 1/Number.prototype != Number.POSITIVE_INFINITY){
+  $ERROR('#2: Number.prototype == +0');
 }

--- a/test/built-ins/Number/prototype/S15.7.4_A1.js
+++ b/test/built-ins/Number/prototype/S15.7.4_A1.js
@@ -3,7 +3,7 @@
 
 /*---
 info: >
-    The Number prototype object is itself a not Number object
+    The Number prototype object is itself a Number object
     (its [[Class]] is "Number") whose value is +0
 es5id: 15.7.4_A1
 description: Checking type and value of Number.prototype property
@@ -15,17 +15,14 @@ if (typeof Number.prototype !== "object") {
 }
 
 //CHECK#2
-try {
-  (Number.prototype != 0);
-  $ERROR('#2: "(Number.prototype != 0);" lead to throwing exception. Actual: '+(Number.prototype != 0));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#2.1: "(Number.prototype != 0)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if (Number.prototype != 0) {
+  $ERROR('#2: Number.prototype == +0');
+} else if( 1/Number.prototype != Number.POSITIVE_INFINITY){
+  $ERROR('#2: Number.prototype == +0');
 }
 
 delete Number.prototype.toString;
 
-if (Number.prototype.toString() !== "[object Object]") {
-  $ERROR('#3: The [[Class]] property of the Number prototype object is set to "Object"');
+if (Number.prototype.toString() !== "[object Number]") {
+  $ERROR('#3: The [[Class]] property of the Number prototype object is set to "Number"');
 }

--- a/test/built-ins/Number/prototype/toFixed/S15.7.4.5_A1.1_T01.js
+++ b/test/built-ins/Number/prototype/toFixed/S15.7.4.5_A1.1_T01.js
@@ -10,111 +10,62 @@ description: calling on Number prototype object
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toFixed();
-  $ERROR('#1: "Number.prototype.toFixed();" lead to throwing exception. Actual: '+Number.prototype.toFixed());
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toFixed()" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toFixed() !== "0"){
+  $ERROR('#1: Number.prototype.toFixed() === "0"');
 }
 
 //CHECK#2
-try {
-  Number.prototype.toFixed(0);
-  $ERROR('#2: "Number.prototype.toFixed(0);" lead to throwing exception. Actual: '+Number.prototype.toFixed(0));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#2.1: "Number.prototype.toFixed(0)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toFixed(0) !== "0"){
+  $ERROR('#2: Number.prototype.toFixed(0) === "0"');
 }
 
 //CHECK#3
-try {
-  Number.prototype.toFixed(1);
-  $ERROR('#3: "Number.prototype.toFixed(1);" lead to throwing exception. Actual: '+Number.prototype.toFixed(1));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#3.1: "Number.prototype.toFixed(1)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toFixed(1) !== "0.0"){
+  $ERROR('#3: Number.prototype.toFixed(1) === "0.0"');
 }
 
 //CHECK#4
-try {
-  Number.prototype.toFixed(1.1);
-  $ERROR('#4: "Number.prototype.toFixed(1.1);" lead to throwing exception. Actual: '+Number.prototype.toFixed(1.1));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#4.1: "Number.prototype.toFixed(1.1)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toFixed(1.1) !== "0.0"){
+  $ERROR('#4: Number.prototype.toFixed(1.1) === "0.0"');
 }
 
 //CHECK#5
-try {
-  Number.prototype.toFixed(0.9);
-  $ERROR('#5: "Number.prototype.toFixed(0.9);" lead to throwing exception. Actual: '+Number.prototype.toFixed(0.9));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#5.1: "Number.prototype.toFixed(0.9)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toFixed(0.9) !== "0"){
+  $ERROR('#5: Number.prototype.toFixed(0.9) === "0"');
 }
 
+
 //CHECK#6
-try {
-  Number.prototype.toFixed("1");
-  $ERROR('#6: "Number.prototype.toFixed("1");" lead to throwing exception. Actual: '+Number.prototype.toFixed("1"));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#6.1: "Number.prototype.toFixed("1")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toFixed("1") !== "0.0"){
+  $ERROR('#6: Number.prototype.toFixed("1") === "0.0"');
 }
 
 //CHECK#7
-try {
-  Number.prototype.toFixed("1.1");
-  $ERROR('#7: "Number.prototype.toFixed("1.1");" lead to throwing exception. Actual: '+Number.prototype.toFixed("1.1"));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#7.1: "Number.prototype.toFixed("1.1")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toFixed("1.1") !== "0.0"){
+  $ERROR('#7: Number.prototype.toFixed("1.1") === "0.0"');
 }
 
 //CHECK#8
-try {
-  Number.prototype.toFixed("0.9");
-  $ERROR('#8: "Number.prototype.toFixed("0.9");" lead to throwing exception. Actual: '+Number.prototype.toFixed("0.9"));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#8.1: "Number.prototype.toFixed("0.9")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toFixed("0.9") !== "0"){
+  $ERROR('#8: Number.prototype.toFixed("0.9") === "0"');
 }
 
 //CHECK#9
-try {
-  Number.prototype.toFixed(Number.NaN);
-  $ERROR('#9: "Number.prototype.toFixed(Number.NaN);" lead to throwing exception. Actual: '+Number.prototype.toFixed(Number.NaN));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#9.1: "Number.prototype.toFixed(Number.NaN)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toFixed(Number.NaN) !== "0"){
+  $ERROR('#9: Number.prototype.toFixed(Number.NaN) === "0"');
 }
 
 //CHECK#10
-try {
-  Number.prototype.toFixed("some string");
-  $ERROR('#10: "Number.prototype.toFixed("some string");" lead to throwing exception. Actual: '+Number.prototype.toFixed("some string"));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#10.1: "Number.prototype.toFixed("some string")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toFixed("some string") !== "0"){
+  $ERROR('#9: Number.prototype.toFixed("some string") === "0"');
 }
 
 //CHECK#11
-try {
-  Number.prototype.toFixed(-0.1);
-  $ERROR('#11: "Number.prototype.toFixed(-0.1);" lead to throwing exception. Actual: '+Number.prototype.toFixed(-0.1));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#11.1: "Number.prototype.toFixed(-0.1)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
+try{
+  if(Number.prototype.toFixed(-0.1) !== "0"){
+    $ERROR('#10: Number.prototype.toFixed(-0.1) === "0"');
   }
+}
+catch(e){
+  $ERROR('#10: Number.prototype.toFixed(-0.1) should not throw '+e);
 }

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A1_T01.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A1_T01.js
@@ -11,13 +11,8 @@ description: undefined radix
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString();
-  $ERROR('#1: "Number.prototype.toString();" lead to throwing exception. Actual: '+Number.prototype.toString());
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString()" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString() !== "0"){
+  $ERROR('#1: Number.prototype.toString() === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A1_T02.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A1_T02.js
@@ -11,13 +11,8 @@ description: radix is 10
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(10);
-  $ERROR('#1: "Number.prototype.toString(10);" lead to throwing exception. Actual: '+Number.prototype.toString(10));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(10)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(10) !== "0"){
+  $ERROR('#1: Number.prototype.toString(10) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A1_T03.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A1_T03.js
@@ -11,13 +11,8 @@ description: radix is undefined value
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(undefined);
-  $ERROR('#1: "Number.prototype.toString(undefined);" lead to throwing exception. Actual: '+Number.prototype.toString(undefined));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(undefined)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(undefined) !== "0"){
+  $ERROR('#1: Number.prototype.toString(undefined) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T01.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T01.js
@@ -10,13 +10,8 @@ description: radix is 2
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(2);
-  $ERROR('#1: "Number.prototype.toString(2);" lead to throwing exception. Actual: '+Number.prototype.toString(2));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(2)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(2) !== "0"){
+  $ERROR('#1: Number.prototype.toString(2) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T02.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T02.js
@@ -10,13 +10,8 @@ description: radix is 3
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(3);
-  $ERROR('#1: "Number.prototype.toString(3);" lead to throwing exception. Actual: '+Number.prototype.toString(3));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(3)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(3) !== "0"){
+  $ERROR('#1: Number.prototype.toString(3) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T03.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T03.js
@@ -10,13 +10,8 @@ description: radix is 4
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(4);
-  $ERROR('#1: "Number.prototype.toString(4);" lead to throwing exception. Actual: '+Number.prototype.toString(4));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(4)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(4) !== "0"){
+  $ERROR('#1: Number.prototype.toString(4) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T04.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T04.js
@@ -10,13 +10,8 @@ description: radix is 5
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(5);
-  $ERROR('#1: "Number.prototype.toString(5);" lead to throwing exception. Actual: '+Number.prototype.toString(5));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(5)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(5) !== "0"){
+  $ERROR('#1: Number.prototype.toString(5) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T05.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T05.js
@@ -10,13 +10,8 @@ description: radix is 6
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(6);
-  $ERROR('#1: "Number.prototype.toString(6);" lead to throwing exception. Actual: '+Number.prototype.toString(6));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(6)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(6) !== "0"){
+  $ERROR('#1: Number.prototype.toString(6) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T06.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T06.js
@@ -10,13 +10,8 @@ description: radix is 7
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(7);
-  $ERROR('#1: "Number.prototype.toString(7);" lead to throwing exception. Actual: '+Number.prototype.toString(7));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(7)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(7) !== "0"){
+  $ERROR('#1: Number.prototype.toString(7) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T07.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T07.js
@@ -10,13 +10,8 @@ description: radix is 8
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(8);
-  $ERROR('#1: "Number.prototype.toString(8);" lead to throwing exception. Actual: '+Number.prototype.toString(8));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(8)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(8) !== "0"){
+  $ERROR('#1: Number.prototype.toString(8) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T08.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T08.js
@@ -10,14 +10,10 @@ description: radix is 9
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(9);
-  $ERROR('#1: "Number.prototype.toString(9);" lead to throwing exception. Actual: '+Number.prototype.toString(9));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(9)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(9) !== "0"){
+  $ERROR('#1: Number.prototype.toString(9) === "0"');
 }
+
 //CHECK#2
 if((new Number()).toString(9) !== "0"){
   $ERROR('#2: (new Number()).toString(9) === "0"');

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T09.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T09.js
@@ -10,13 +10,8 @@ description: radix is 11
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(11);
-  $ERROR('#1: "Number.prototype.toString(11);" lead to throwing exception. Actual: '+Number.prototype.toString(11));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(11)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(11) !== "0"){
+  $ERROR('#1: Number.prototype.toString(11) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T10.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T10.js
@@ -10,13 +10,8 @@ description: radix is 12
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(12);
-  $ERROR('#1: "Number.prototype.toString(12);" lead to throwing exception. Actual: '+Number.prototype.toString(12));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(12)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(12) !== "0"){
+  $ERROR('#1: Number.prototype.toString(12) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T11.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T11.js
@@ -10,13 +10,8 @@ description: radix is 13
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(13);
-  $ERROR('#1: "Number.prototype.toString(13);" lead to throwing exception. Actual: '+Number.prototype.toString(13));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(13)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(13) !== "0"){
+  $ERROR('#1: Number.prototype.toString(13) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T12.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T12.js
@@ -10,13 +10,8 @@ description: radix is 14
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(14);
-  $ERROR('#1: "Number.prototype.toString(14);" lead to throwing exception. Actual: '+Number.prototype.toString(14));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(14)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(14) !== "0"){
+  $ERROR('#1: Number.prototype.toString(14) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T13.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T13.js
@@ -10,13 +10,8 @@ description: radix is 15
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(15);
-  $ERROR('#1: "Number.prototype.toString(15);" lead to throwing exception. Actual: '+Number.prototype.toString(15));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(15)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(15) !== "0"){
+  $ERROR('#1: Number.prototype.toString(15) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T14.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T14.js
@@ -10,13 +10,8 @@ description: radix is 16
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(16);
-  $ERROR('#1: "Number.prototype.toString(16);" lead to throwing exception. Actual: '+Number.prototype.toString(16));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(16)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(16) !== "0"){
+  $ERROR('#1: Number.prototype.toString(16) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T15.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T15.js
@@ -10,13 +10,8 @@ description: radix is 17
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(17);
-  $ERROR('#1: "Number.prototype.toString(17);" lead to throwing exception. Actual: '+Number.prototype.toString(17));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(17)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(17) !== "0"){
+  $ERROR('#1: Number.prototype.toString(17) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T16.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T16.js
@@ -10,13 +10,8 @@ description: radix is 18
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(18);
-  $ERROR('#1: "Number.prototype.toString(18);" lead to throwing exception. Actual: '+Number.prototype.toString(18));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(18)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(18) !== "0"){
+  $ERROR('#1: Number.prototype.toString(18) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T17.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T17.js
@@ -10,13 +10,8 @@ description: radix is 19
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(19);
-  $ERROR('#1: "Number.prototype.toString(19);" lead to throwing exception. Actual: '+Number.prototype.toString(19));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(19)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(19) !== "0"){
+  $ERROR('#1: Number.prototype.toString(19) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T18.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T18.js
@@ -10,13 +10,8 @@ description: radix is 20
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(20);
-  $ERROR('#1: "Number.prototype.toString(20);" lead to throwing exception. Actual: '+Number.prototype.toString(20));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(20)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(20) !== "0"){
+  $ERROR('#1: Number.prototype.toString(20) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T19.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T19.js
@@ -10,13 +10,8 @@ description: radix is 21
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(21);
-  $ERROR('#1: "Number.prototype.toString(21);" lead to throwing exception. Actual: '+Number.prototype.toString(21));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(21)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(21) !== "0"){
+  $ERROR('#1: Number.prototype.toString(21) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T20.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T20.js
@@ -10,13 +10,8 @@ description: radix is 22
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(22);
-  $ERROR('#1: "Number.prototype.toString(22);" lead to throwing exception. Actual: '+Number.prototype.toString(22));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(22)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(22) !== "0"){
+  $ERROR('#1: Number.prototype.toString(22) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T21.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T21.js
@@ -10,13 +10,8 @@ description: radix is 23
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(23);
-  $ERROR('#1: "Number.prototype.toString(23);" lead to throwing exception. Actual: '+Number.prototype.toString(23));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(23)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(23) !== "0"){
+  $ERROR('#1: Number.prototype.toString(23) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T22.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T22.js
@@ -10,13 +10,8 @@ description: radix is 24
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(24);
-  $ERROR('#1: "Number.prototype.toString(24);" lead to throwing exception. Actual: '+Number.prototype.toString(24));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(24)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(24) !== "0"){
+  $ERROR('#1: Number.prototype.toString(24) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T23.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T23.js
@@ -10,13 +10,8 @@ description: radix is 25
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(25);
-  $ERROR('#1: "Number.prototype.toString(25);" lead to throwing exception. Actual: '+Number.prototype.toString(25));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(25)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(25) !== "0"){
+  $ERROR('#1: Number.prototype.toString(25) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T24.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T24.js
@@ -10,13 +10,8 @@ description: radix is 26
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(26);
-  $ERROR('#1: "Number.prototype.toString(26);" lead to throwing exception. Actual: '+Number.prototype.toString(26));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(26)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(26) !== "0"){
+  $ERROR('#1: Number.prototype.toString(26) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T25.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T25.js
@@ -10,13 +10,8 @@ description: radix is 27
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(27);
-  $ERROR('#1: "Number.prototype.toString(27);" lead to throwing exception. Actual: '+Number.prototype.toString(27));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(27)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(27) !== "0"){
+  $ERROR('#1: Number.prototype.toString(27) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T26.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T26.js
@@ -10,13 +10,8 @@ description: radix is 28
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(28);
-  $ERROR('#1: "Number.prototype.toString(28);" lead to throwing exception. Actual: '+Number.prototype.toString(28));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(28)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(28) !== "0"){
+  $ERROR('#1: Number.prototype.toString(28) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T27.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T27.js
@@ -10,13 +10,8 @@ description: radix is 29
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(29);
-  $ERROR('#1: "Number.prototype.toString(29);" lead to throwing exception. Actual: '+Number.prototype.toString(29));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(29)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(29) !== "0"){
+  $ERROR('#1: Number.prototype.toString(29) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T28.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T28.js
@@ -10,13 +10,8 @@ description: radix is 30
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(30);
-  $ERROR('#1: "Number.prototype.toString(30);" lead to throwing exception. Actual: '+Number.prototype.toString(30));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(30)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(30) !== "0"){
+  $ERROR('#1: Number.prototype.toString(30) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T29.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T29.js
@@ -10,13 +10,8 @@ description: radix is 31
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(31);
-  $ERROR('#1: "Number.prototype.toString(31);" lead to throwing exception. Actual: '+Number.prototype.toString(31));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(31)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(31) !== "0"){
+  $ERROR('#1: Number.prototype.toString(31) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T30.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T30.js
@@ -10,13 +10,8 @@ description: radix is 32
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(32);
-  $ERROR('#1: "Number.prototype.toString(32);" lead to throwing exception. Actual: '+Number.prototype.toString(32));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(32)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(32) !== "0"){
+  $ERROR('#1: Number.prototype.toString(32) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T31.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T31.js
@@ -10,13 +10,8 @@ description: radix is 33
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(33);
-  $ERROR('#1: "Number.prototype.toString(33);" lead to throwing exception. Actual: '+Number.prototype.toString(33));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(33)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(33) !== "0"){
+  $ERROR('#1: Number.prototype.toString(33) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T32.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T32.js
@@ -10,13 +10,8 @@ description: radix is 34
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(34);
-  $ERROR('#1: "Number.prototype.toString(34);" lead to throwing exception. Actual: '+Number.prototype.toString(34));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(34)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(34) !== "0"){
+  $ERROR('#1: Number.prototype.toString(34) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T33.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T33.js
@@ -10,13 +10,8 @@ description: radix is 35
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(35);
-  $ERROR('#1: "Number.prototype.toString(35);" lead to throwing exception. Actual: '+Number.prototype.toString(35));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(35)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(35) !== "0"){
+  $ERROR('#1: Number.prototype.toString(35) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T34.js
+++ b/test/built-ins/Number/prototype/toString/S15.7.4.2_A2_T34.js
@@ -10,13 +10,8 @@ description: radix is 36
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.toString(36);
-  $ERROR('#1: "Number.prototype.toString(36);" lead to throwing exception. Actual: '+Number.prototype.toString(36));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.toString(36)" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.toString(36) !== "0"){
+  $ERROR('#1: Number.prototype.toString(36) === "0"');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/valueOf/S15.7.4.4_A1_T01.js
+++ b/test/built-ins/Number/prototype/valueOf/S15.7.4.4_A1_T01.js
@@ -8,13 +8,8 @@ description: Call without argument
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.valueOf();
-  $ERROR('#1: "Number.prototype.valueOf();" lead to throwing exception. Actual: '+Number.prototype.valueOf());
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.valueOf()" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.valueOf() !== 0){
+  $ERROR('#1: Number.prototype.valueOf() === 0');
 }
 
 //CHECK#2

--- a/test/built-ins/Number/prototype/valueOf/S15.7.4.4_A1_T02.js
+++ b/test/built-ins/Number/prototype/valueOf/S15.7.4.4_A1_T02.js
@@ -8,13 +8,8 @@ description: calling with argument
 ---*/
 
 //CHECK#1
-try {
-  Number.prototype.valueOf("argument");
-  $ERROR('#1: "Number.prototype.valueOf("argument");" lead to throwing exception. Actual: '+Number.prototype.valueOf("argument"));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "Number.prototype.valueOf("argument")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if(Number.prototype.valueOf("argument") !== 0){
+  $ERROR('#1: Number.prototype.valueOf("argument") === 0');
 }
 
 //CHECK#2

--- a/test/built-ins/String/prototype/S15.5.4_A1.js
+++ b/test/built-ins/String/prototype/S15.5.4_A1.js
@@ -3,8 +3,7 @@
 
 /*---
 info: >
-    The String prototype object is itself not a String object (its [[Class]]
-    is "Object")
+    The String prototype object is itself a String object (its [[Class]] is "String")
 es5id: 15.5.4_A1
 description: >
     first we delete String.prototype.toString cause it overrides
@@ -16,8 +15,8 @@ delete String.prototype.toString;
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
-if (String.prototype.toString() !== "[object "+"Object"+"]") {
-  $ERROR('#1: delete String.prototype.toString; String.prototype.toString() === "[object "+"Object"+"]". Actual: String.prototype.toString() ==='+String.prototype.toString() );
+if (String.prototype.toString() !== "[object "+"String"+"]") {
+  $ERROR('#1: delete String.prototype.toString; String.prototype.toString() === "[object "+"String"+"]". Actual: String.prototype.toString() ==='+String.prototype.toString() );
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/S15.5.4_A2.js
+++ b/test/built-ins/String/prototype/S15.5.4_A2.js
@@ -2,21 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-info: The String prototype object is itself not a String object
+info: The String prototype object is itself a String object whose value is an empty string
 es5id: 15.5.4_A2
 description: Checking String.prototype
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
-try {
-  (String.prototype !="");
-  $ERROR('#1: "(String.prototype !="");" lead to throwing exception. Actual: '+(String.prototype !=""));
-} catch (e) {
-  if (!(e instanceof TypeError)) {
-    $ERROR('#1.1: "(String.prototype !="")" lead to throwing exception. Exception is instance of TypeError. Actual: exception is '+e);
-  }
+if (String.prototype !="") {
+  $ERROR('#1: String.prototype =="". Actual: String.prototype =='+String.prototype );
 }
-
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/S15.5.4_A3.js
+++ b/test/built-ins/String/prototype/S15.5.4_A3.js
@@ -21,8 +21,8 @@ delete String.prototype.toString;
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
-if (String.prototype.toString() != "[object "+"Object"+"]") {
-  $ERROR('#2: delete String.prototype.toString; String.prototype.toString() == "[object "+"Object"+"]". Actual: String.prototype.toString() =='+String.prototype.toString() );
+if (String.prototype.toString() != "[object "+"String"+"]") {
+  $ERROR('#2: delete String.prototype.toString; String.prototype.toString() == "[object "+"String"+"]". Actual: String.prototype.toString() =='+String.prototype.toString() );
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/String/prototype/split/S15.5.4.14_A2_T37.js
+++ b/test/built-ins/String/prototype/split/S15.5.4.14_A2_T37.js
@@ -17,7 +17,7 @@ Number.prototype.split = String.prototype.split;
 
 var __split = __instance.split(1, -Math.pow(2,32)+1);
 
-var __expected = [];
+var __expected = [""];
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1

--- a/test/language/expressions/property-accessors/S11.2.1_A4_T5.js
+++ b/test/language/expressions/property-accessors/S11.2.1_A4_T5.js
@@ -34,5 +34,5 @@ if (typeof String.prototype.toLowerCase !== "function")  $ERROR('#23: typeof Str
 if (typeof String.prototype['toLowerCase'] !== "function")  $ERROR('#24: typeof String.prototype["toLowerCase"] === "function". Actual: ' + (typeof String.prototype["toLowerCase"] ));
 if (typeof String.prototype.toUpperCase !== "function")  $ERROR('#25: typeof String.prototype.toUpperCase === "function". Actual: ' + (typeof String.prototype.toUpperCase ));
 if (typeof String.prototype['toUpperCase'] !== "function")  $ERROR('#26: typeof Array.prototype === "object". Actual: ' + (typeof Array.prototype ));
-if (typeof String.prototype.length  !== "undefined")  $ERROR('#27: typeof String.prototype.length === "undefined". Actual: ' + (typeof String.prototype.length ));
-if (typeof String.prototype['length']  !== "undefined")  $ERROR('#28: typeof String.prototype["length"] === "undefined". Actual: ' + (typeof String.prototype["length"] ));
+if (typeof String.prototype.length  !== "number")  $ERROR('#27: typeof String.prototype.length === "number". Actual: ' + (typeof String.prototype.length ));
+if (typeof String.prototype['length']  !== "number")  $ERROR('#28: typeof String.prototype["length"] === "number". Actual: ' + (typeof String.prototype["length"] ));

--- a/test/language/statements/for/S12.6.3_A9.1.js
+++ b/test/language/statements/for/S12.6.3_A9.1.js
@@ -16,7 +16,7 @@ supreme=5;
 //CHECK#
 try {
 	var __evaluated =  eval("for(count=0;;) {if (count===supreme)break;else count++; }");
-	if (__evaluated !== 4) {
+	if (__evaluated !== void 0) {
 		$ERROR('#1: __evaluated === 4. Actual:  __evaluated ==='+ __evaluated  );
 	}
 } catch (e) {

--- a/test/language/statements/for/S12.6.3_A9.js
+++ b/test/language/statements/for/S12.6.3_A9.js
@@ -16,7 +16,7 @@ supreme=5;
 //CHECK#
 try {
 	var __evaluated =  eval("for(var count=0;;) {if (count===supreme)break;else count++; }");
-	if (__evaluated !== 4) {
+	if (__evaluated !== void 0) {
 		$ERROR('#1: __evaluated === 4. Actual:  __evaluated ==='+ __evaluated  );
 	}
 } catch (e) {


### PR DESCRIPTION
- Revert Number, Boolean and String prototypes to ES5 semantics (https://github.com/tc39/ecma262/pull/83)
- Revert String.prototype.split's to ES5 behavior (https://github.com/tc39/ecma262/pull/86)