### PR TITLE
Remove unnecessary ES2015 syntax; add feature flags where appropriate.

### DIFF
--- a/test/built-ins/Promise/all/S25.4.4.1_A3.1_T3.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A3.1_T3.js
@@ -8,6 +8,7 @@ info: >
 es6id: S25.4.4.1_A3.1_T3
 author: Sam Mikes
 description: Promise.all((throw on GetIterator)) returns Promise rejected with TypeError
+features: [Symbol.iterator]
 ---*/
 
 var iterThrows = {};

--- a/test/built-ins/Promise/all/S25.4.4.1_A5.1_T1.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A5.1_T1.js
@@ -8,6 +8,7 @@ info: >
 es6id: S25.4.4.1_A5.1_T1
 author: Sam Mikes
 description: iterator.next throws, causing Promise.all to reject
+features: [Symbol.iterator]
 ---*/
 
 var iterThrows = {};

--- a/test/built-ins/Promise/executor-function-extensible.js
+++ b/test/built-ins/Promise/executor-function-extensible.js
@@ -13,7 +13,7 @@ info: >
 var executorFunction;
 function NotPromise(executor) {
   executorFunction = executor;
-  executor(() => {}, () => {});
+  executor(function(){}, function(){});
 }
 Promise.resolve.call(NotPromise);
 

--- a/test/built-ins/Promise/executor-function-length.js
+++ b/test/built-ins/Promise/executor-function-length.js
@@ -17,7 +17,7 @@ includes: [propertyHelper.js]
 var executorFunction;
 function NotPromise(executor) {
   executorFunction = executor;
-  executor(() => {}, () => {});
+  executor(function(){}, function(){});
 }
 Promise.resolve.call(NotPromise);
 

--- a/test/built-ins/Promise/executor-function-name.js
+++ b/test/built-ins/Promise/executor-function-name.js
@@ -16,7 +16,7 @@ info: >
 var executorFunction;
 function NotPromise(executor) {
   executorFunction = executor;
-  executor(() => {}, () => {});
+  executor(function(){}, function(){});
 }
 Promise.resolve.call(NotPromise);
 

--- a/test/built-ins/Promise/executor-function-nonconstructor.js
+++ b/test/built-ins/Promise/executor-function-nonconstructor.js
@@ -14,7 +14,7 @@ info: >
 var executorFunction;
 function NotPromise(executor) {
   executorFunction = executor;
-  executor(() => {}, () => {});
+  executor(function(){}, function(){});
 }
 Promise.resolve.call(NotPromise);
 

--- a/test/built-ins/Promise/executor-function-prototype.js
+++ b/test/built-ins/Promise/executor-function-prototype.js
@@ -15,7 +15,7 @@ info: >
 var executorFunction;
 function NotPromise(executor) {
   executorFunction = executor;
-  executor(() => {}, () => {});
+  executor(function(){}, function(){});
 }
 Promise.resolve.call(NotPromise);
 

--- a/test/built-ins/Promise/race/S25.4.4.3_A2.2_T3.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A2.2_T3.js
@@ -9,6 +9,7 @@ info: >
 es6id: S25.4.4.3_A2.2_T3
 author: Sam Mikes
 description: Promise.race rejects if GetIterator throws
+features: [Symbol.iterator]
 ---*/
 
 var iterThrows = {};

--- a/test/built-ins/Promise/race/S25.4.4.3_A4.1_T1.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A4.1_T1.js
@@ -5,6 +5,7 @@
 es6id: S25.4.4.3_A4.1_T1
 author: Sam Mikes
 description: Promise.race rejects if IteratorStep throws
+features: [Symbol.iterator]
 ---*/
 
 var iterThrows = {};

--- a/test/built-ins/Promise/race/S25.4.4.3_A4.1_T2.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A4.1_T2.js
@@ -5,6 +5,7 @@
 es6id: S25.4.4.3_A4.1_T2
 author: Sam Mikes
 description: Promise.race rejects if IteratorStep throws
+features: [Symbol.iterator]
 ---*/
 
 var iterThrows = {};

--- a/test/built-ins/Promise/symbol-species.js
+++ b/test/built-ins/Promise/symbol-species.js
@@ -9,6 +9,7 @@ author: Sam Mikes
 description: Promise[Symbol.species] exists per spec
 includes:
   - propertyHelper.js
+features: [Symbol.species]
 ---*/
 
 assert.sameValue(Promise[Symbol.species], Promise, "Promise[Symbol.species] is Promise");


### PR DESCRIPTION
This allows these tests to be more easily reused to test Promise implementations in isolation (for example, `core-js` and `es6-shim`).