### PR TITLE
Add test cases for recent ES2016 fixes

### DIFF
--- a/harness/testTypedArray.js
+++ b/harness/testTypedArray.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/**
+ * Array containing every typed array constructor.
+ */
+var typedArrayConstructors = [
+  Float64Array,
+  Float32Array,
+  Int32Array,
+  Int16Array,
+  Int8Array,
+  Uint32Array,
+  Uint16Array,
+  Uint8Array,
+  Uint8ClampedArray,
+];
+
+/**
+ * Callback for testing a typed array constructor.
+ *
+ * @callback typedArrayConstructorCallback
+ * @param {Function} Constructor the constructor object to test with.
+ */
+
+/**
+ * Calls the provided function for every typed array constructor.
+ *
+ * @param {typedArrayConstructorCallback} f - the function to call for each typed array constructor.
+ */
+function testWithTypedArrayConstructors(f) {
+  for (var i = 0; i < typedArrayConstructors.length; ++i) {
+    var constructor = typedArrayConstructors[i];
+    try {
+      f(constructor);
+    } catch (e) {
+      e.message += " (Testing with " + constructor.name + ".)";
+      throw e;
+    }
+  }
+}

--- a/test/annexB/__proto__/basic.js
+++ b/test/annexB/__proto__/basic.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: B.3.1
+description: The value of the `__proto__` property key is assigned to the [[Prototype]] internal slot.
+info: >
+  __proto__ Property Names in Object Initializers
+
+  ...
+  6. If propKey is the String value "__proto__" and if IsComputedPropertyKey(propKey) is false, then
+    a. If Type(propValue) is either Object or Null, then
+      i. Return object.[[SetPrototypeOf]](propValue).
+    b. Return NormalCompletion(empty).
+  ...
+---*/
+
+var proto = {};
+
+var object = {
+  __proto__: proto
+};
+
+assert.sameValue(Object.getPrototypeOf(object), proto);

--- a/test/built-ins/DataView/prototype/setFloat32/index-check-before-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setFloat32/index-check-before-value-conversion.js
@@ -1,0 +1,84 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.13
+description: >
+  Throws a RangeError if the index is negative or non-integral number.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Float32", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    5. If numberIndex ≠ getIndex or getIndex < 0, throw a RangeError exception.
+    6. Let numberValue be ? ToNumber(value).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+var poisoned = {
+  valueOf: function() {
+    $ERROR("valueOf called");
+  }
+};
+
+assert.throws(RangeError, function() {
+  dataView.setFloat32(NaN, poisoned);
+}, "setFloat32(NaN, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat32(1.5, poisoned);
+}, "setFloat32(1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat32(-1.5, poisoned);
+}, "setFloat32(-1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat32(-1, poisoned);
+}, "setFloat32(-1, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat32(-Infinity, poisoned);
+}, "setFloat32(-Infinity, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat32(undefined, poisoned);
+}, "setFloat32(undefined, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat32('invalid', poisoned);
+}, "setFloat32('invalid', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat32('NaN', poisoned);
+}, "setFloat32('NaN', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat32('1.5', poisoned);
+}, "setFloat32('1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat32('-1.5', poisoned);
+}, "setFloat32('-1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat32('-1', poisoned);
+}, "setFloat32('-1', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat32('-Infinity', poisoned);
+}, "setFloat32('-Infinity', poisoned)");
+
+var obj = {
+  valueOf: function() {
+    return 1.41421;
+  }
+};
+assert.throws(RangeError, function() {
+  dataView.setFloat32(obj, poisoned);
+}, "setFloat32(obj, poisoned)");

--- a/test/built-ins/DataView/prototype/setFloat32/index-to-integer.js
+++ b/test/built-ins/DataView/prototype/setFloat32/index-to-integer.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 24.2.4.13
+description: >
+  The requested index is converted with ToInteger.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Float32", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ToInteger(numberIndex).
+    5. ReturnIfAbrupt(getIndex).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+dataView.setFloat32(+0, 1);
+assert.sameValue(dataView.getFloat32(0), 1, "setFloat32(+0, 1)");
+
+dataView.setFloat32(-0, 2);
+assert.sameValue(dataView.getFloat32(0), 2, "setFloat32(-0, 2)");
+
+dataView.setFloat32(1, 3);
+assert.sameValue(dataView.getFloat32(1), 3, "setFloat32(1, 3)");
+
+dataView.setFloat32(null, 4);
+assert.sameValue(dataView.getFloat32(0), 4, "setFloat32(null, 4)");
+
+dataView.setFloat32(false, 5);
+assert.sameValue(dataView.getFloat32(0), 5, "setFloat32(false, 5)");
+
+dataView.setFloat32(true, 6);
+assert.sameValue(dataView.getFloat32(1), 6, "setFloat32(true, 6)");
+
+dataView.setFloat32("", 7);
+assert.sameValue(dataView.getFloat32(0), 7, "setFloat32('', 7)");
+
+// Math.pow(2, 31) = 2147483648
+assert.throws(RangeError, function() {
+  dataView.setFloat32(2147483648, 8);
+}, "setFloat32(2147483648, 8)");
+
+// Math.pow(2, 32) = 4294967296
+assert.throws(RangeError, function() {
+  dataView.setFloat32(4294967296, 9);
+}, "setFloat32(4294967296, 9)");
+
+var obj = {
+  valueOf: function() {
+    return 1;
+  }
+};
+dataView.setFloat32(obj, 10);
+assert.sameValue(dataView.getFloat32(1), 10, "setFloat32(obj, 10)");

--- a/test/built-ins/DataView/prototype/setFloat32/range-check-after-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setFloat32/range-check-after-value-conversion.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.13
+description: >
+  Index bounds checks are performed after value conversion.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Float32", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    ...
+    6. Let numberValue be ? ToNumber(value).
+    ...
+    11. Let viewSize be the value of view's [[ByteLength]] internal slot.
+    12. Let elementSize be the Number value of the Element Size value specified in Table 49 for Element Type type.
+    13. If getIndex + elementSize > viewSize, throw a RangeError exception.
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+function DummyError() { }
+
+var poisoned = {
+  valueOf: function() {
+    throw new DummyError();
+  }
+};
+
+assert.throws(DummyError, function() {
+  dataView.setFloat32(Infinity, poisoned);
+}, "setFloat32(Infinity, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setFloat32(100, poisoned);
+}, "setFloat32(100, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setFloat32('Infinity', poisoned);
+}, "setFloat32('Infinity', poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setFloat32('100', poisoned);
+}, "setFloat32('100', poisoned)");

--- a/test/built-ins/DataView/prototype/setFloat64/index-check-before-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setFloat64/index-check-before-value-conversion.js
@@ -1,0 +1,84 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.14
+description: >
+  Throws a RangeError if the index is negative or non-integral number.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Float64", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    5. If numberIndex ≠ getIndex or getIndex < 0, throw a RangeError exception.
+    6. Let numberValue be ? ToNumber(value).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(16));
+
+var poisoned = {
+  valueOf: function() {
+    $ERROR("valueOf called");
+  }
+};
+
+assert.throws(RangeError, function() {
+  dataView.setFloat64(NaN, poisoned);
+}, "setFloat64(NaN, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat64(1.5, poisoned);
+}, "setFloat64(1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat64(-1.5, poisoned);
+}, "setFloat64(-1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat64(-1, poisoned);
+}, "setFloat64(-1, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat64(-Infinity, poisoned);
+}, "setFloat64(-Infinity, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat64(undefined, poisoned);
+}, "setFloat64(undefined, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat64('invalid', poisoned);
+}, "setFloat64('invalid', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat64('NaN', poisoned);
+}, "setFloat64('NaN', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat64('1.5', poisoned);
+}, "setFloat64('1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat64('-1.5', poisoned);
+}, "setFloat64('-1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat64('-1', poisoned);
+}, "setFloat64('-1', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setFloat64('-Infinity', poisoned);
+}, "setFloat64('-Infinity', poisoned)");
+
+var obj = {
+  valueOf: function() {
+    return 1.41421;
+  }
+};
+assert.throws(RangeError, function() {
+  dataView.setFloat64(obj, poisoned);
+}, "setFloat64(obj, poisoned)");

--- a/test/built-ins/DataView/prototype/setFloat64/index-to-integer.js
+++ b/test/built-ins/DataView/prototype/setFloat64/index-to-integer.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 24.2.4.14
+description: >
+  The requested index is converted with ToInteger.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Float64", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ToInteger(numberIndex).
+    5. ReturnIfAbrupt(getIndex).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(16));
+
+dataView.setFloat64(+0, 1);
+assert.sameValue(dataView.getFloat64(0), 1, "setFloat64(+0, 1)");
+
+dataView.setFloat64(-0, 2);
+assert.sameValue(dataView.getFloat64(0), 2, "setFloat64(-0, 2)");
+
+dataView.setFloat64(1, 3);
+assert.sameValue(dataView.getFloat64(1), 3, "setFloat64(1, 3)");
+
+dataView.setFloat64(null, 4);
+assert.sameValue(dataView.getFloat64(0), 4, "setFloat64(null, 4)");
+
+dataView.setFloat64(false, 5);
+assert.sameValue(dataView.getFloat64(0), 5, "setFloat64(false, 5)");
+
+dataView.setFloat64(true, 6);
+assert.sameValue(dataView.getFloat64(1), 6, "setFloat64(true, 6)");
+
+dataView.setFloat64("", 7);
+assert.sameValue(dataView.getFloat64(0), 7, "setFloat64('', 7)");
+
+// Math.pow(2, 31) = 2147483648
+assert.throws(RangeError, function() {
+  dataView.setFloat64(2147483648, 8);
+}, "setFloat64(2147483648, 8)");
+
+// Math.pow(2, 32) = 4294967296
+assert.throws(RangeError, function() {
+  dataView.setFloat64(4294967296, 9);
+}, "setFloat64(4294967296, 9)");
+
+var obj = {
+  valueOf: function() {
+    return 1;
+  }
+};
+dataView.setFloat64(obj, 10);
+assert.sameValue(dataView.getFloat64(1), 10, "setFloat64(obj, 10)");

--- a/test/built-ins/DataView/prototype/setFloat64/range-check-after-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setFloat64/range-check-after-value-conversion.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.14
+description: >
+  Index bounds checks are performed after value conversion.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Float64", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    ...
+    6. Let numberValue be ? ToNumber(value).
+    ...
+    11. Let viewSize be the value of view's [[ByteLength]] internal slot.
+    12. Let elementSize be the Number value of the Element Size value specified in Table 49 for Element Type type.
+    13. If getIndex + elementSize > viewSize, throw a RangeError exception.
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+function DummyError() { }
+
+var poisoned = {
+  valueOf: function() {
+    throw new DummyError();
+  }
+};
+
+assert.throws(DummyError, function() {
+  dataView.setFloat64(Infinity, poisoned);
+}, "setFloat64(Infinity, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setFloat64(100, poisoned);
+}, "setFloat64(100, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setFloat64('Infinity', poisoned);
+}, "setFloat64('Infinity', poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setFloat64('100', poisoned);
+}, "setFloat64('100', poisoned)");

--- a/test/built-ins/DataView/prototype/setInt16/index-check-before-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setInt16/index-check-before-value-conversion.js
@@ -1,0 +1,84 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.16
+description: >
+  Throws a RangeError if the index is negative or non-integral number.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Int16", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    5. If numberIndex ≠ getIndex or getIndex < 0, throw a RangeError exception.
+    6. Let numberValue be ? ToNumber(value).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+var poisoned = {
+  valueOf: function() {
+    $ERROR("valueOf called");
+  }
+};
+
+assert.throws(RangeError, function() {
+  dataView.setInt16(NaN, poisoned);
+}, "setInt16(NaN, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt16(1.5, poisoned);
+}, "setInt16(1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt16(-1.5, poisoned);
+}, "setInt16(-1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt16(-1, poisoned);
+}, "setInt16(-1, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt16(-Infinity, poisoned);
+}, "setInt16(-Infinity, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt16(undefined, poisoned);
+}, "setInt16(undefined, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt16('invalid', poisoned);
+}, "setInt16('invalid', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt16('NaN', poisoned);
+}, "setInt16('NaN', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt16('1.5', poisoned);
+}, "setInt16('1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt16('-1.5', poisoned);
+}, "setInt16('-1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt16('-1', poisoned);
+}, "setInt16('-1', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt16('-Infinity', poisoned);
+}, "setInt16('-Infinity', poisoned)");
+
+var obj = {
+  valueOf: function() {
+    return 1.41421;
+  }
+};
+assert.throws(RangeError, function() {
+  dataView.setInt16(obj, poisoned);
+}, "setInt16(obj, poisoned)");

--- a/test/built-ins/DataView/prototype/setInt16/index-to-integer.js
+++ b/test/built-ins/DataView/prototype/setInt16/index-to-integer.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 24.2.4.16
+description: >
+  The requested index is converted with ToInteger.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Int16", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ToInteger(numberIndex).
+    5. ReturnIfAbrupt(getIndex).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+dataView.setInt16(+0, 1);
+assert.sameValue(dataView.getInt16(0), 1, "setInt16(+0, 1)");
+
+dataView.setInt16(-0, 2);
+assert.sameValue(dataView.getInt16(0), 2, "setInt16(-0, 2)");
+
+dataView.setInt16(1, 3);
+assert.sameValue(dataView.getInt16(1), 3, "setInt16(1, 3)");
+
+dataView.setInt16(null, 4);
+assert.sameValue(dataView.getInt16(0), 4, "setInt16(null, 4)");
+
+dataView.setInt16(false, 5);
+assert.sameValue(dataView.getInt16(0), 5, "setInt16(false, 5)");
+
+dataView.setInt16(true, 6);
+assert.sameValue(dataView.getInt16(1), 6, "setInt16(true, 6)");
+
+dataView.setInt16("", 7);
+assert.sameValue(dataView.getInt16(0), 7, "setInt16('', 7)");
+
+// Math.pow(2, 31) = 2147483648
+assert.throws(RangeError, function() {
+  dataView.setInt16(2147483648, 8);
+}, "setInt16(2147483648, 8)");
+
+// Math.pow(2, 32) = 4294967296
+assert.throws(RangeError, function() {
+  dataView.setInt16(4294967296, 9);
+}, "setInt16(4294967296, 9)");
+
+var obj = {
+  valueOf: function() {
+    return 1;
+  }
+};
+dataView.setInt16(obj, 10);
+assert.sameValue(dataView.getInt16(1), 10, "setInt16(obj, 10)");

--- a/test/built-ins/DataView/prototype/setInt16/range-check-after-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setInt16/range-check-after-value-conversion.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.16
+description: >
+  Index bounds checks are performed after value conversion.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Int16", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    ...
+    6. Let numberValue be ? ToNumber(value).
+    ...
+    11. Let viewSize be the value of view's [[ByteLength]] internal slot.
+    12. Let elementSize be the Number value of the Element Size value specified in Table 49 for Element Type type.
+    13. If getIndex + elementSize > viewSize, throw a RangeError exception.
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+function DummyError() { }
+
+var poisoned = {
+  valueOf: function() {
+    throw new DummyError();
+  }
+};
+
+assert.throws(DummyError, function() {
+  dataView.setInt16(Infinity, poisoned);
+}, "setInt16(Infinity, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setInt16(100, poisoned);
+}, "setInt16(100, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setInt16('Infinity', poisoned);
+}, "setInt16('Infinity', poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setInt16('100', poisoned);
+}, "setInt16('100', poisoned)");

--- a/test/built-ins/DataView/prototype/setInt32/index-check-before-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setInt32/index-check-before-value-conversion.js
@@ -1,0 +1,84 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.17
+description: >
+  Throws a RangeError if the index is negative or non-integral number.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Int32", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    5. If numberIndex ≠ getIndex or getIndex < 0, throw a RangeError exception.
+    6. Let numberValue be ? ToNumber(value).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+var poisoned = {
+  valueOf: function() {
+    $ERROR("valueOf called");
+  }
+};
+
+assert.throws(RangeError, function() {
+  dataView.setInt32(NaN, poisoned);
+}, "setInt32(NaN, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt32(1.5, poisoned);
+}, "setInt32(1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt32(-1.5, poisoned);
+}, "setInt32(-1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt32(-1, poisoned);
+}, "setInt32(-1, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt32(-Infinity, poisoned);
+}, "setInt32(-Infinity, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt32(undefined, poisoned);
+}, "setInt32(undefined, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt32('invalid', poisoned);
+}, "setInt32('invalid', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt32('NaN', poisoned);
+}, "setInt32('NaN', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt32('1.5', poisoned);
+}, "setInt32('1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt32('-1.5', poisoned);
+}, "setInt32('-1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt32('-1', poisoned);
+}, "setInt32('-1', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt32('-Infinity', poisoned);
+}, "setInt32('-Infinity', poisoned)");
+
+var obj = {
+  valueOf: function() {
+    return 1.41421;
+  }
+};
+assert.throws(RangeError, function() {
+  dataView.setInt32(obj, poisoned);
+}, "setInt32(obj, poisoned)");

--- a/test/built-ins/DataView/prototype/setInt32/index-to-integer.js
+++ b/test/built-ins/DataView/prototype/setInt32/index-to-integer.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 24.2.4.17
+description: >
+  The requested index is converted with ToInteger.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Int32", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ToInteger(numberIndex).
+    5. ReturnIfAbrupt(getIndex).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+dataView.setInt32(+0, 1);
+assert.sameValue(dataView.getInt32(0), 1, "setInt32(+0, 1)");
+
+dataView.setInt32(-0, 2);
+assert.sameValue(dataView.getInt32(0), 2, "setInt32(-0, 2)");
+
+dataView.setInt32(1, 3);
+assert.sameValue(dataView.getInt32(1), 3, "setInt32(1, 3)");
+
+dataView.setInt32(null, 4);
+assert.sameValue(dataView.getInt32(0), 4, "setInt32(null, 4)");
+
+dataView.setInt32(false, 5);
+assert.sameValue(dataView.getInt32(0), 5, "setInt32(false, 5)");
+
+dataView.setInt32(true, 6);
+assert.sameValue(dataView.getInt32(1), 6, "setInt32(true, 6)");
+
+dataView.setInt32("", 7);
+assert.sameValue(dataView.getInt32(0), 7, "setInt32('', 7)");
+
+// Math.pow(2, 31) = 2147483648
+assert.throws(RangeError, function() {
+  dataView.setInt32(2147483648, 8);
+}, "setInt32(2147483648, 8)");
+
+// Math.pow(2, 32) = 4294967296
+assert.throws(RangeError, function() {
+  dataView.setInt32(4294967296, 9);
+}, "setInt32(4294967296, 9)");
+
+var obj = {
+  valueOf: function() {
+    return 1;
+  }
+};
+dataView.setInt32(obj, 10);
+assert.sameValue(dataView.getInt32(1), 10, "setInt32(obj, 10)");

--- a/test/built-ins/DataView/prototype/setInt32/range-check-after-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setInt32/range-check-after-value-conversion.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.17
+description: >
+  Index bounds checks are performed after value conversion.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Int32", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    ...
+    6. Let numberValue be ? ToNumber(value).
+    ...
+    11. Let viewSize be the value of view's [[ByteLength]] internal slot.
+    12. Let elementSize be the Number value of the Element Size value specified in Table 49 for Element Type type.
+    13. If getIndex + elementSize > viewSize, throw a RangeError exception.
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+function DummyError() { }
+
+var poisoned = {
+  valueOf: function() {
+    throw new DummyError();
+  }
+};
+
+assert.throws(DummyError, function() {
+  dataView.setInt32(Infinity, poisoned);
+}, "setInt32(Infinity, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setInt32(100, poisoned);
+}, "setInt32(100, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setInt32('Infinity', poisoned);
+}, "setInt32('Infinity', poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setInt32('100', poisoned);
+}, "setInt32('100', poisoned)");

--- a/test/built-ins/DataView/prototype/setInt8/index-check-before-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setInt8/index-check-before-value-conversion.js
@@ -1,0 +1,84 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.15
+description: >
+  Throws a RangeError if the index is negative or non-integral number.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Int8", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    5. If numberIndex ≠ getIndex or getIndex < 0, throw a RangeError exception.
+    6. Let numberValue be ? ToNumber(value).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+var poisoned = {
+  valueOf: function() {
+    $ERROR("valueOf called");
+  }
+};
+
+assert.throws(RangeError, function() {
+  dataView.setInt8(NaN, poisoned);
+}, "setInt8(NaN, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt8(1.5, poisoned);
+}, "setInt8(1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt8(-1.5, poisoned);
+}, "setInt8(-1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt8(-1, poisoned);
+}, "setInt8(-1, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt8(-Infinity, poisoned);
+}, "setInt8(-Infinity, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt8(undefined, poisoned);
+}, "setInt8(undefined, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt8('invalid', poisoned);
+}, "setInt8('invalid', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt8('NaN', poisoned);
+}, "setInt8('NaN', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt8('1.5', poisoned);
+}, "setInt8('1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt8('-1.5', poisoned);
+}, "setInt8('-1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt8('-1', poisoned);
+}, "setInt8('-1', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setInt8('-Infinity', poisoned);
+}, "setInt8('-Infinity', poisoned)");
+
+var obj = {
+  valueOf: function() {
+    return 1.41421;
+  }
+};
+assert.throws(RangeError, function() {
+  dataView.setInt8(obj, poisoned);
+}, "setInt8(obj, poisoned)");

--- a/test/built-ins/DataView/prototype/setInt8/index-to-integer.js
+++ b/test/built-ins/DataView/prototype/setInt8/index-to-integer.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 24.2.4.15
+description: >
+  The requested index is converted with ToInteger.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Int8", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ToInteger(numberIndex).
+    5. ReturnIfAbrupt(getIndex).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+dataView.setInt8(+0, 1);
+assert.sameValue(dataView.getInt8(0), 1, "setInt8(+0, 1)");
+
+dataView.setInt8(-0, 2);
+assert.sameValue(dataView.getInt8(0), 2, "setInt8(-0, 2)");
+
+dataView.setInt8(1, 3);
+assert.sameValue(dataView.getInt8(1), 3, "setInt8(1, 3)");
+
+dataView.setInt8(null, 4);
+assert.sameValue(dataView.getInt8(0), 4, "setInt8(null, 4)");
+
+dataView.setInt8(false, 5);
+assert.sameValue(dataView.getInt8(0), 5, "setInt8(false, 5)");
+
+dataView.setInt8(true, 6);
+assert.sameValue(dataView.getInt8(1), 6, "setInt8(true, 6)");
+
+dataView.setInt8("", 7);
+assert.sameValue(dataView.getInt8(0), 7, "setInt8('', 7)");
+
+// Math.pow(2, 31) = 2147483648
+assert.throws(RangeError, function() {
+  dataView.setInt8(2147483648, 8);
+}, "setInt8(2147483648, 8)");
+
+// Math.pow(2, 32) = 4294967296
+assert.throws(RangeError, function() {
+  dataView.setInt8(4294967296, 9);
+}, "setInt8(4294967296, 9)");
+
+var obj = {
+  valueOf: function() {
+    return 1;
+  }
+};
+dataView.setInt8(obj, 10);
+assert.sameValue(dataView.getInt8(1), 10, "setInt8(obj, 10)");

--- a/test/built-ins/DataView/prototype/setInt8/range-check-after-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setInt8/range-check-after-value-conversion.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.15
+description: >
+  Index bounds checks are performed after value conversion.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Int8", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    ...
+    6. Let numberValue be ? ToNumber(value).
+    ...
+    11. Let viewSize be the value of view's [[ByteLength]] internal slot.
+    12. Let elementSize be the Number value of the Element Size value specified in Table 49 for Element Type type.
+    13. If getIndex + elementSize > viewSize, throw a RangeError exception.
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+function DummyError() { }
+
+var poisoned = {
+  valueOf: function() {
+    throw new DummyError();
+  }
+};
+
+assert.throws(DummyError, function() {
+  dataView.setInt8(Infinity, poisoned);
+}, "setInt8(Infinity, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setInt8(100, poisoned);
+}, "setInt8(100, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setInt8('Infinity', poisoned);
+}, "setInt8('Infinity', poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setInt8('100', poisoned);
+}, "setInt8('100', poisoned)");

--- a/test/built-ins/DataView/prototype/setUint16/index-check-before-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setUint16/index-check-before-value-conversion.js
@@ -1,0 +1,84 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.19
+description: >
+  Throws a RangeError if the index is negative or non-integral number.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Uint16", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    5. If numberIndex ≠ getIndex or getIndex < 0, throw a RangeError exception.
+    6. Let numberValue be ? ToNumber(value).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+var poisoned = {
+  valueOf: function() {
+    $ERROR("valueOf called");
+  }
+};
+
+assert.throws(RangeError, function() {
+  dataView.setUint16(NaN, poisoned);
+}, "setUint16(NaN, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint16(1.5, poisoned);
+}, "setUint16(1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint16(-1.5, poisoned);
+}, "setUint16(-1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint16(-1, poisoned);
+}, "setUint16(-1, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint16(-Infinity, poisoned);
+}, "setUint16(-Infinity, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint16(undefined, poisoned);
+}, "setUint16(undefined, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint16('invalid', poisoned);
+}, "setUint16('invalid', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint16('NaN', poisoned);
+}, "setUint16('NaN', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint16('1.5', poisoned);
+}, "setUint16('1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint16('-1.5', poisoned);
+}, "setUint16('-1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint16('-1', poisoned);
+}, "setUint16('-1', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint16('-Infinity', poisoned);
+}, "setUint16('-Infinity', poisoned)");
+
+var obj = {
+  valueOf: function() {
+    return 1.41421;
+  }
+};
+assert.throws(RangeError, function() {
+  dataView.setUint16(obj, poisoned);
+}, "setUint16(obj, poisoned)");

--- a/test/built-ins/DataView/prototype/setUint16/index-to-integer.js
+++ b/test/built-ins/DataView/prototype/setUint16/index-to-integer.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 24.2.4.19
+description: >
+  The requested index is converted with ToInteger.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Uint16", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ToInteger(numberIndex).
+    5. ReturnIfAbrupt(getIndex).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+dataView.setUint16(+0, 1);
+assert.sameValue(dataView.getUint16(0), 1, "setUint16(+0, 1)");
+
+dataView.setUint16(-0, 2);
+assert.sameValue(dataView.getUint16(0), 2, "setUint16(-0, 2)");
+
+dataView.setUint16(1, 3);
+assert.sameValue(dataView.getUint16(1), 3, "setUint16(1, 3)");
+
+dataView.setUint16(null, 4);
+assert.sameValue(dataView.getUint16(0), 4, "setUint16(null, 4)");
+
+dataView.setUint16(false, 5);
+assert.sameValue(dataView.getUint16(0), 5, "setUint16(false, 5)");
+
+dataView.setUint16(true, 6);
+assert.sameValue(dataView.getUint16(1), 6, "setUint16(true, 6)");
+
+dataView.setUint16("", 7);
+assert.sameValue(dataView.getUint16(0), 7, "setUint16('', 7)");
+
+// Math.pow(2, 31) = 2147483648
+assert.throws(RangeError, function() {
+  dataView.setUint16(2147483648, 8);
+}, "setUint16(2147483648, 8)");
+
+// Math.pow(2, 32) = 4294967296
+assert.throws(RangeError, function() {
+  dataView.setUint16(4294967296, 9);
+}, "setUint16(4294967296, 9)");
+
+var obj = {
+  valueOf: function() {
+    return 1;
+  }
+};
+dataView.setUint16(obj, 10);
+assert.sameValue(dataView.getUint16(1), 10, "setUint16(obj, 10)");

--- a/test/built-ins/DataView/prototype/setUint16/range-check-after-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setUint16/range-check-after-value-conversion.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.19
+description: >
+  Index bounds checks are performed after value conversion.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Uint16", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    ...
+    6. Let numberValue be ? ToNumber(value).
+    ...
+    11. Let viewSize be the value of view's [[ByteLength]] internal slot.
+    12. Let elementSize be the Number value of the Element Size value specified in Table 49 for Element Type type.
+    13. If getIndex + elementSize > viewSize, throw a RangeError exception.
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+function DummyError() { }
+
+var poisoned = {
+  valueOf: function() {
+    throw new DummyError();
+  }
+};
+
+assert.throws(DummyError, function() {
+  dataView.setUint16(Infinity, poisoned);
+}, "setUint16(Infinity, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setUint16(100, poisoned);
+}, "setUint16(100, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setUint16('Infinity', poisoned);
+}, "setUint16('Infinity', poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setUint16('100', poisoned);
+}, "setUint16('100', poisoned)");

--- a/test/built-ins/DataView/prototype/setUint32/index-check-before-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setUint32/index-check-before-value-conversion.js
@@ -1,0 +1,84 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.20
+description: >
+  Throws a RangeError if the index is negative or non-integral number.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Uint32", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    5. If numberIndex ≠ getIndex or getIndex < 0, throw a RangeError exception.
+    6. Let numberValue be ? ToNumber(value).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+var poisoned = {
+  valueOf: function() {
+    $ERROR("valueOf called");
+  }
+};
+
+assert.throws(RangeError, function() {
+  dataView.setUint32(NaN, poisoned);
+}, "setUint32(NaN, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint32(1.5, poisoned);
+}, "setUint32(1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint32(-1.5, poisoned);
+}, "setUint32(-1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint32(-1, poisoned);
+}, "setUint32(-1, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint32(-Infinity, poisoned);
+}, "setUint32(-Infinity, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint32(undefined, poisoned);
+}, "setUint32(undefined, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint32('invalid', poisoned);
+}, "setUint32('invalid', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint32('NaN', poisoned);
+}, "setUint32('NaN', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint32('1.5', poisoned);
+}, "setUint32('1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint32('-1.5', poisoned);
+}, "setUint32('-1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint32('-1', poisoned);
+}, "setUint32('-1', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint32('-Infinity', poisoned);
+}, "setUint32('-Infinity', poisoned)");
+
+var obj = {
+  valueOf: function() {
+    return 1.41421;
+  }
+};
+assert.throws(RangeError, function() {
+  dataView.setUint32(obj, poisoned);
+}, "setUint32(obj, poisoned)");

--- a/test/built-ins/DataView/prototype/setUint32/index-to-integer.js
+++ b/test/built-ins/DataView/prototype/setUint32/index-to-integer.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 24.2.4.20
+description: >
+  The requested index is converted with ToInteger.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Uint32", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ToInteger(numberIndex).
+    5. ReturnIfAbrupt(getIndex).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+dataView.setUint32(+0, 1);
+assert.sameValue(dataView.getUint32(0), 1, "setUint32(+0, 1)");
+
+dataView.setUint32(-0, 2);
+assert.sameValue(dataView.getUint32(0), 2, "setUint32(-0, 2)");
+
+dataView.setUint32(1, 3);
+assert.sameValue(dataView.getUint32(1), 3, "setUint32(1, 3)");
+
+dataView.setUint32(null, 4);
+assert.sameValue(dataView.getUint32(0), 4, "setUint32(null, 4)");
+
+dataView.setUint32(false, 5);
+assert.sameValue(dataView.getUint32(0), 5, "setUint32(false, 5)");
+
+dataView.setUint32(true, 6);
+assert.sameValue(dataView.getUint32(1), 6, "setUint32(true, 6)");
+
+dataView.setUint32("", 7);
+assert.sameValue(dataView.getUint32(0), 7, "setUint32('', 7)");
+
+// Math.pow(2, 31) = 2147483648
+assert.throws(RangeError, function() {
+  dataView.setUint32(2147483648, 8);
+}, "setUint32(2147483648, 8)");
+
+// Math.pow(2, 32) = 4294967296
+assert.throws(RangeError, function() {
+  dataView.setUint32(4294967296, 9);
+}, "setUint32(4294967296, 9)");
+
+var obj = {
+  valueOf: function() {
+    return 1;
+  }
+};
+dataView.setUint32(obj, 10);
+assert.sameValue(dataView.getUint32(1), 10, "setUint32(obj, 10)");

--- a/test/built-ins/DataView/prototype/setUint32/range-check-after-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setUint32/range-check-after-value-conversion.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.20
+description: >
+  Index bounds checks are performed after value conversion.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Uint32", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    ...
+    6. Let numberValue be ? ToNumber(value).
+    ...
+    11. Let viewSize be the value of view's [[ByteLength]] internal slot.
+    12. Let elementSize be the Number value of the Element Size value specified in Table 49 for Element Type type.
+    13. If getIndex + elementSize > viewSize, throw a RangeError exception.
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+function DummyError() { }
+
+var poisoned = {
+  valueOf: function() {
+    throw new DummyError();
+  }
+};
+
+assert.throws(DummyError, function() {
+  dataView.setUint32(Infinity, poisoned);
+}, "setUint32(Infinity, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setUint32(100, poisoned);
+}, "setUint32(100, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setUint32('Infinity', poisoned);
+}, "setUint32('Infinity', poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setUint32('100', poisoned);
+}, "setUint32('100', poisoned)");

--- a/test/built-ins/DataView/prototype/setUint8/index-check-before-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setUint8/index-check-before-value-conversion.js
@@ -1,0 +1,84 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.18
+description: >
+  Throws a RangeError if the index is negative or non-integral number.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Uint8", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    5. If numberIndex ≠ getIndex or getIndex < 0, throw a RangeError exception.
+    6. Let numberValue be ? ToNumber(value).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+var poisoned = {
+  valueOf: function() {
+    $ERROR("valueOf called");
+  }
+};
+
+assert.throws(RangeError, function() {
+  dataView.setUint8(NaN, poisoned);
+}, "setUint8(NaN, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint8(1.5, poisoned);
+}, "setUint8(1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint8(-1.5, poisoned);
+}, "setUint8(-1.5, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint8(-1, poisoned);
+}, "setUint8(-1, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint8(-Infinity, poisoned);
+}, "setUint8(-Infinity, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint8(undefined, poisoned);
+}, "setUint8(undefined, poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint8('invalid', poisoned);
+}, "setUint8('invalid', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint8('NaN', poisoned);
+}, "setUint8('NaN', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint8('1.5', poisoned);
+}, "setUint8('1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint8('-1.5', poisoned);
+}, "setUint8('-1.5', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint8('-1', poisoned);
+}, "setUint8('-1', poisoned)");
+
+assert.throws(RangeError, function() {
+  dataView.setUint8('-Infinity', poisoned);
+}, "setUint8('-Infinity', poisoned)");
+
+var obj = {
+  valueOf: function() {
+    return 1.41421;
+  }
+};
+assert.throws(RangeError, function() {
+  dataView.setUint8(obj, poisoned);
+}, "setUint8(obj, poisoned)");

--- a/test/built-ins/DataView/prototype/setUint8/index-to-integer.js
+++ b/test/built-ins/DataView/prototype/setUint8/index-to-integer.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 24.2.4.18
+description: >
+  The requested index is converted with ToInteger.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Uint8", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ToInteger(numberIndex).
+    5. ReturnIfAbrupt(getIndex).
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+dataView.setUint8(+0, 1);
+assert.sameValue(dataView.getUint8(0), 1, "setUint8(+0, 1)");
+
+dataView.setUint8(-0, 2);
+assert.sameValue(dataView.getUint8(0), 2, "setUint8(-0, 2)");
+
+dataView.setUint8(1, 3);
+assert.sameValue(dataView.getUint8(1), 3, "setUint8(1, 3)");
+
+dataView.setUint8(null, 4);
+assert.sameValue(dataView.getUint8(0), 4, "setUint8(null, 4)");
+
+dataView.setUint8(false, 5);
+assert.sameValue(dataView.getUint8(0), 5, "setUint8(false, 5)");
+
+dataView.setUint8(true, 6);
+assert.sameValue(dataView.getUint8(1), 6, "setUint8(true, 6)");
+
+dataView.setUint8("", 7);
+assert.sameValue(dataView.getUint8(0), 7, "setUint8('', 7)");
+
+// Math.pow(2, 31) = 2147483648
+assert.throws(RangeError, function() {
+  dataView.setUint8(2147483648, 8);
+}, "setUint8(2147483648, 8)");
+
+// Math.pow(2, 32) = 4294967296
+assert.throws(RangeError, function() {
+  dataView.setUint8(4294967296, 9);
+}, "setUint8(4294967296, 9)");
+
+var obj = {
+  valueOf: function() {
+    return 1;
+  }
+};
+dataView.setUint8(obj, 10);
+assert.sameValue(dataView.getUint8(1), 10, "setUint8(obj, 10)");

--- a/test/built-ins/DataView/prototype/setUint8/range-check-after-value-conversion.js
+++ b/test/built-ins/DataView/prototype/setUint8/range-check-after-value-conversion.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 24.2.4.18
+description: >
+  Index bounds checks are performed after value conversion.
+info: >
+  ...
+  3. Return SetViewValue(v, byteOffset, littleEndian, "Uint8", value).
+
+  24.2.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value )
+    ...
+    3. Let numberIndex be ToNumber(requestIndex).
+    4. Let getIndex be ? ToInteger(numberIndex).
+    ...
+    6. Let numberValue be ? ToNumber(value).
+    ...
+    11. Let viewSize be the value of view's [[ByteLength]] internal slot.
+    12. Let elementSize be the Number value of the Element Size value specified in Table 49 for Element Type type.
+    13. If getIndex + elementSize > viewSize, throw a RangeError exception.
+    ...
+---*/
+
+var dataView = new DataView(new ArrayBuffer(8));
+
+function DummyError() { }
+
+var poisoned = {
+  valueOf: function() {
+    throw new DummyError();
+  }
+};
+
+assert.throws(DummyError, function() {
+  dataView.setUint8(Infinity, poisoned);
+}, "setUint8(Infinity, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setUint8(100, poisoned);
+}, "setUint8(100, poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setUint8('Infinity', poisoned);
+}, "setUint8('Infinity', poisoned)");
+
+assert.throws(DummyError, function() {
+  dataView.setUint8('100', poisoned);
+}, "setUint8('100', poisoned)");

--- a/test/built-ins/RegExp/prototype/Symbol.split/last-index-exceeds-str-size.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/last-index-exceeds-str-size.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 21.2.5.11
+description: The `lastIndex` property is clamped to the string size.
+info: >
+  RegExp.prototype [ @@split ] ( string, limit )
+
+  ...
+  19. Repeat, while q < size
+    ...
+    d. Else z is not null,
+      i. Let e be ? ToLength(Get(splitter, "lastIndex")).
+      ii. Let e be min(e, size).
+  ...
+features: [Symbol.split]
+---*/
+
+var regExp = /a/;
+var string = "foo";
+
+RegExp.prototype.exec = function() {
+  this.lastIndex = 100;
+  return {length: 0, index: 0};
+};
+
+var result = regExp[Symbol.split](string);
+
+assert.sameValue(result.length, 2, "result.length");
+assert.sameValue(result[0], "", "result[0]");
+assert.sameValue(result[1], "", "result[1]");

--- a/test/built-ins/TypedArray/negative-zero-byteoffset.js
+++ b/test/built-ins/TypedArray/negative-zero-byteoffset.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: pending
+description: >
+  TypedArray's [[ByteOffset]] internal slot is always a positive number, test with negative zero.
+info: >
+  %TypedArray% ( buffer [ , byteOffset [ , length ] ] )
+
+  ...
+  6. Let offset be ? ToInteger(byteOffset).
+  7. If offset < 0, throw a RangeError exception.
+  8. If offset is -0, let offset be +0.
+  ...
+includes: [testTypedArray.js]
+---*/
+
+testWithTypedArrayConstructors(function(TAConstructor) {
+  var typedArray = new TAConstructor(new ArrayBuffer(8), -0);
+  assert.sameValue(typedArray.byteOffset, +0);
+});

--- a/test/language/eval-code/non-definable-function-with-function.js
+++ b/test/language/eval-code/non-definable-function-with-function.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 18.2.1.2
+description: Global functions are not created if conflicting function declarations were detected.
+info: >
+  Runtime Semantics: EvalDeclarationInstantiation( body, varEnv, lexEnv, strict)
+
+  ...
+  8. For each d in varDeclarations, in reverse list order do
+    a. If d is neither a VariableDeclaration or a ForBinding, then
+      i. Assert: d is either a FunctionDeclaration or a GeneratorDeclaration.
+      ii. NOTE If there are multiple FunctionDeclarations for the same name, the last declaration is used.
+      iii. Let fn be the sole element of the BoundNames of d.
+      iv. If fn is not an element of declaredFunctionNames, then
+        1. If varEnvRec is a global Environment Record, then
+          a. Let fnDefinable be varEnvRec.CanDeclareGlobalFunction(fn).
+          b. ReturnIfAbrupt(fnDefinable).
+          c. If fnDefinable is false, throw TypeError exception.
+  ...
+  14. For each production f in functionsToInitialize, do
+    a. Let fn be the sole element of the BoundNames of f.
+    b. Let fo be the result of performing InstantiateFunctionObject for f with argument lexEnv.
+    c. If varEnvRec is a global Environment Record, then
+      i. Let status be varEnvRec.CreateGlobalFunctionBinding(fn, fo, true).
+      ii. ReturnIfAbrupt(status).
+  ...
+flags: [noStrict]
+---*/
+
+try {
+  eval("function shouldNotBeDefined(){} function NaN(){}");
+} catch (e) {
+  // Ignore TypeError exception.
+}
+
+assert.sameValue(Object.getOwnPropertyDescriptor(this, "shouldNotBeDefined"), undefined);

--- a/test/language/eval-code/non-definable-function-with-variable.js
+++ b/test/language/eval-code/non-definable-function-with-variable.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 18.2.1.2
+description: Global variables are not created if conflicting function declarations were detected.
+info: >
+  Runtime Semantics: EvalDeclarationInstantiation( body, varEnv, lexEnv, strict)
+
+  ...
+  8. For each d in varDeclarations, in reverse list order do
+    a. If d is neither a VariableDeclaration or a ForBinding, then
+      i. Assert: d is either a FunctionDeclaration or a GeneratorDeclaration.
+      ii. NOTE If there are multiple FunctionDeclarations for the same name, the last declaration is used.
+      iii. Let fn be the sole element of the BoundNames of d.
+      iv. If fn is not an element of declaredFunctionNames, then
+        1. If varEnvRec is a global Environment Record, then
+          a. Let fnDefinable be varEnvRec.CanDeclareGlobalFunction(fn).
+          b. ReturnIfAbrupt(fnDefinable).
+          c. If fnDefinable is false, throw TypeError exception.
+  ...
+  15. For each String vn in declaredVarNames, in list order do
+    a. If varEnvRec is a global Environment Record, then
+      i. Let status be varEnvRec.CreateGlobalVarBinding(vn, true).
+      ii. ReturnIfAbrupt(status).
+  ...
+flags: [noStrict]
+---*/
+
+try {
+  eval("var shouldNotBeDefined; function NaN(){}");
+} catch (e) {
+  // Ignore TypeError exception.
+}
+
+assert.sameValue(Object.getOwnPropertyDescriptor(this, "shouldNotBeDefined"), undefined);

--- a/test/language/eval-code/non-definable-global-function.js
+++ b/test/language/eval-code/non-definable-global-function.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 18.2.1.2
+description: Throws a TypeError if a global function cannot be defined.
+info: >
+  Runtime Semantics: EvalDeclarationInstantiation( body, varEnv, lexEnv, strict)
+
+  ...
+  8. For each d in varDeclarations, in reverse list order do
+    a. If d is neither a VariableDeclaration or a ForBinding, then
+      i. Assert: d is either a FunctionDeclaration or a GeneratorDeclaration.
+      ii. NOTE If there are multiple FunctionDeclarations for the same name, the last declaration is used.
+      iii. Let fn be the sole element of the BoundNames of d.
+      iv. If fn is not an element of declaredFunctionNames, then
+        1. If varEnvRec is a global Environment Record, then
+          a. Let fnDefinable be varEnvRec.CanDeclareGlobalFunction(fn).
+          b. ReturnIfAbrupt(fnDefinable).
+          c. If fnDefinable is false, throw TypeError exception.
+        ...
+flags: [noStrict]
+---*/
+
+var error;
+try {
+  eval("function NaN(){}");
+} catch (e) {
+  error = e;
+}
+
+assert(error instanceof TypeError);

--- a/test/language/eval-code/non-definable-global-generator.js
+++ b/test/language/eval-code/non-definable-global-generator.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 18.2.1.2
+description: Throws a TypeError if a global generator function cannot be defined.
+info: >
+  Runtime Semantics: EvalDeclarationInstantiation( body, varEnv, lexEnv, strict)
+
+  ...
+  8. For each d in varDeclarations, in reverse list order do
+    a. If d is neither a VariableDeclaration or a ForBinding, then
+      i. Assert: d is either a FunctionDeclaration or a GeneratorDeclaration.
+      ii. NOTE If there are multiple FunctionDeclarations for the same name, the last declaration is used.
+      iii. Let fn be the sole element of the BoundNames of d.
+      iv. If fn is not an element of declaredFunctionNames, then
+        1. If varEnvRec is a global Environment Record, then
+          a. Let fnDefinable be varEnvRec.CanDeclareGlobalFunction(fn).
+          b. ReturnIfAbrupt(fnDefinable).
+          c. If fnDefinable is false, throw TypeError exception.
+        ...
+flags: [noStrict]
+---*/
+
+var error;
+try {
+  eval("function* NaN(){}");
+} catch (e) {
+  error = e;
+}
+
+assert(error instanceof TypeError);

--- a/test/language/eval-code/non-definable-global-var.js
+++ b/test/language/eval-code/non-definable-global-var.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 18.2.1.2
+description: Throws a TypeError if a global variable cannot be defined.
+info: >
+  Runtime Semantics: EvalDeclarationInstantiation( body, varEnv, lexEnv, strict)
+
+  ...
+  10. For each d in varDeclarations, do
+    a. If d is a VariableDeclaration or a ForBinding, then
+      i. For each String vn in the BoundNames of d, do
+        1. If vn is not an element of declaredFunctionNames, then
+          a. If varEnvRec is a global Environment Record, then
+            i. Let vnDefinable be varEnvRec.CanDeclareGlobalVar(vn).
+            ii. ReturnIfAbrupt(vnDefinable).
+            iii. If vnDefinable is false, throw TypeError exception.
+          ...
+flags: [noStrict]
+---*/
+
+var nonExtensible;
+try {
+  Object.preventExtensions(this);
+  nonExtensible = !Object.isExtensible(this);
+} catch (e) {
+  nonExtensible = false;
+}
+
+// Run test if global object is non-extensible.
+if (nonExtensible) {
+  var error;
+  try {
+    eval("var unlikelyVariableName");
+  } catch (e) {
+    error = e;
+  }
+
+  assert(error instanceof TypeError);
+}

--- a/test/language/expressions/arrow-function/syntax/early-errors/use-strict-with-non-simple-param.js
+++ b/test/language/expressions/arrow-function/syntax/early-errors/use-strict-with-non-simple-param.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 14.2.1
+description: >
+  A SyntaxError is thrown if an arrow function contains a non-simple parameter list and a UseStrict directive.
+info: >
+  Static Semantics: Early Errors
+
+  It is a Syntax Error if ContainsUseStrict of ConciseBody is true and IsSimpleParameterList of ArrowParameters is false.
+negative: SyntaxError
+---*/
+
+var f = (a = 0) => {
+  "use strict";
+};

--- a/test/language/expressions/function/use-strict-with-non-simple-param.js
+++ b/test/language/expressions/function/use-strict-with-non-simple-param.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 14.1.2
+description: >
+  A SyntaxError is thrown if a function contains a non-simple parameter list and a UseStrict directive.
+info: >
+  Static Semantics: Early Errors
+
+  It is a Syntax Error if ContainsUseStrict of FunctionBody is true and IsSimpleParameterList of FormalParameters is false.
+negative: SyntaxError
+---*/
+
+var f = function(a = 0) {
+  "use strict";
+}

--- a/test/language/expressions/generators/use-strict-with-non-simple-param.js
+++ b/test/language/expressions/generators/use-strict-with-non-simple-param.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 14.4.1
+description: >
+  A SyntaxError is thrown if a generator contains a non-simple parameter list and a UseStrict directive.
+info: >
+  Static Semantics: Early Errors
+
+  It is a Syntax Error if ContainsUseStrict of GeneratorBody is true and IsSimpleParameterList of FormalParameters is false.
+negative: SyntaxError
+---*/
+
+var f = function*(a = 0) {
+  "use strict";
+}

--- a/test/language/expressions/object/method-definition/generator-use-strict-with-non-simple-param.js
+++ b/test/language/expressions/object/method-definition/generator-use-strict-with-non-simple-param.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 14.4.1
+description: >
+  A SyntaxError is thrown if a generator method contains a non-simple parameter list and a UseStrict directive.
+info: >
+  Static Semantics: Early Errors
+
+  It is a Syntax Error if ContainsUseStrict of GeneratorBody is true and IsSimpleParameterList of StrictFormalParameters is false.
+negative: SyntaxError
+---*/
+
+var o = {
+  *m(a = 0) {
+    "use strict";
+  }
+};

--- a/test/language/expressions/object/method-definition/setter-use-strict-with-non-simple-param.js
+++ b/test/language/expressions/object/method-definition/setter-use-strict-with-non-simple-param.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 14.3.1
+description: >
+  A SyntaxError is thrown if a setter method contains a non-simple parameter list and a UseStrict directive.
+info: >
+  Static Semantics: Early Errors
+
+  It is a Syntax Error if ContainsUseStrict of FunctionBody is true and IsSimpleParameterList of PropertySetParameterList is false.
+negative: SyntaxError
+---*/
+
+var o = {
+  set m(a = 0) {
+    "use strict";
+  }
+};

--- a/test/language/expressions/object/method-definition/use-strict-with-non-simple-param.js
+++ b/test/language/expressions/object/method-definition/use-strict-with-non-simple-param.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 14.3.1
+description: >
+  A SyntaxError is thrown if a method contains a non-simple parameter list and a UseStrict directive.
+info: >
+  Static Semantics: Early Errors
+
+   It is a Syntax Error if ContainsUseStrict of FunctionBody is true and IsSimpleParameterList of StrictFormalParameters is false.
+negative: SyntaxError
+---*/
+
+var o = {
+  m(a = 0) {
+    "use strict";
+  }
+};

--- a/test/language/function-code/eval-param-env-with-computed-key.js
+++ b/test/language/function-code/eval-param-env-with-computed-key.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 14.1.19
+description: If a computed property key contains a direct eval call, a new declarative environment is created.
+info: >
+  Runtime Semantics: IteratorBindingInitialization
+
+  FormalParameter : BindingElement
+
+  ...
+  2. Let currentContext be the running execution context.
+  3. Let originalEnv be the VariableEnvironment of currentContext.
+  4. Assert: The VariableEnvironment and LexicalEnvironment of currentContext are the same.
+  5. Assert: environment and originalEnv are the same.
+  6. Let paramVarEnv be NewDeclarativeEnvironment(originalEnv).
+  ...
+---*/
+
+var x = "outer";
+
+function evalInComputedPropertyKey({[eval("var x = 'inner'")]: ignored}) {
+  assert.sameValue(x, "outer");
+}
+evalInComputedPropertyKey({});

--- a/test/language/function-code/eval-param-env-with-prop-initializer.js
+++ b/test/language/function-code/eval-param-env-with-prop-initializer.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 14.1.19
+description: If a property initializer contains a direct eval call, a new declarative environment is created.
+info: >
+  Runtime Semantics: IteratorBindingInitialization
+
+  FormalParameter : BindingElement
+
+  ...
+  2. Let currentContext be the running execution context.
+  3. Let originalEnv be the VariableEnvironment of currentContext.
+  4. Assert: The VariableEnvironment and LexicalEnvironment of currentContext are the same.
+  5. Assert: environment and originalEnv are the same.
+  6. Let paramVarEnv be NewDeclarativeEnvironment(originalEnv).
+  ...
+---*/
+
+var x = "outer";
+
+function evalInPropertyInitializer({a: ignored = eval("var x = 'inner'")}) {
+  assert.sameValue(x, "outer");
+}
+evalInPropertyInitializer({});

--- a/test/language/rest-parameters/array-pattern.js
+++ b/test/language/rest-parameters/array-pattern.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 13.3.3
+description: >
+  The rest parameter can be a binding pattern.
+info: >
+  Destructuring Binding Patterns - Syntax
+
+  BindingRestElement[Yield]:
+    ...BindingPattern[?Yield]
+---*/
+
+function empty(...[]) {}
+
+function emptyWithArray(...[[]]) {}
+
+function emptyWithObject(...[{}]) {}
+
+function emptyWithRest(...[...[]]) {}
+
+function emptyWithLeading(x, ...[]) {}
+
+
+function singleElement(...[a]) {}
+
+function singleElementWithInitializer(...[a = 0]) {}
+
+function singleElementWithArray(...[[a]]) {}
+
+function singleElementWithObject(...[{p: q}]) {}
+
+function singleElementWithRest(...[...a]) {}
+
+function singleElementWithLeading(x, ...[a]) {}
+
+
+function multiElement(...[a, b, c]) {}
+
+function multiElementWithInitializer(...[a = 0, b, c = 1]) {}
+
+function multiElementWithArray(...[[a], b, [c]]) {}
+
+function multiElementWithObject(...[{p: q}, {r}, {s = 0}]) {}
+
+function multiElementWithRest(...[a, b, ...c]) {}
+
+function multiElementWithLeading(x, y, ...[a, b, c]) {}

--- a/test/language/rest-parameters/object-pattern.js
+++ b/test/language/rest-parameters/object-pattern.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 13.3.3
+description: >
+  The rest parameter can be a binding pattern.
+info: >
+  Destructuring Binding Patterns - Syntax
+
+  BindingRestElement[Yield]:
+    ...BindingPattern[?Yield]
+---*/
+
+function empty(...{}) {}
+
+function emptyWithArray(...{p: []}) {}
+
+function emptyWithObject(...{p: {}}) {}
+
+function emptyWithLeading(x, ...{}) {}
+
+
+function singleElement(...{a: b}) {}
+
+function singleElementWithInitializer(...{a: b = 0}) {}
+
+function singleElementWithArray(...{p: [a]}) {}
+
+function singleElementWithObject(...{p: {a: b}}) {}
+
+function singleElementWithLeading(x, ...{a: b}) {}
+
+
+function multiElement(...{a: r, b: s, c: t}) {}
+
+function multiElementWithInitializer(...{a: r = 0, b: s, c: t = 1}) {}
+
+function multiElementWithArray(...{p: [a], b, q: [c]}) {}
+
+function multiElementWithObject(...{a: {p: q}, b: {r}, c: {s = 0}}) {}
+
+function multiElementWithLeading(x, y, ...{a: r, b: s, c: t}) {}
+

--- a/test/language/statements/function/use-strict-with-non-simple-param.js
+++ b/test/language/statements/function/use-strict-with-non-simple-param.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 14.1.2
+description: >
+  A SyntaxError is thrown if a function contains a non-simple parameter list and a UseStrict directive.
+info: >
+  Static Semantics: Early Errors
+
+  It is a Syntax Error if ContainsUseStrict of FunctionBody is true and IsSimpleParameterList of FormalParameters is false.
+negative: SyntaxError
+---*/
+
+function f(a = 0) {
+  "use strict";
+}

--- a/test/language/statements/generators/use-strict-with-non-simple-param.js
+++ b/test/language/statements/generators/use-strict-with-non-simple-param.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es7id: 14.4.1
+description: >
+  A SyntaxError is thrown if a generator contains a non-simple parameter list and a UseStrict directive.
+info: >
+  Static Semantics: Early Errors
+
+  It is a Syntax Error if ContainsUseStrict of GeneratorBody is true and IsSimpleParameterList of FormalParameters is false.
+negative: SyntaxError
+---*/
+
+function* f(a = 0) {
+  "use strict";
+}


### PR DESCRIPTION
- lastIndex in RegExp.prototype[Symbol.split]: tc39/ecma262@08b4756747f9c967058239df627da544412740a6
- Missing number conversion in DataView.prototype.setXXX: tc39/ecma262@4f875fe96dcbd5e6363dd3d5b510cd5109199f5b
- Negative zero byteoffset in TypedArray: tc39/ecma262@2d1ed20db778e8f69f66ba76b351b9322fd38495
- EvalDeclarationInstantiation throws TypeError: tc39/ecma262@2be6968715946a4763f6ca8633e311ab7ce63577
- BindingRestElement allows BindingPattern: tc39/ecma262@d322357e6be95bc4bd3e03f5944a736aac55fa50
- Eval in parameters with computed property keys: tc39/ecma262@04e2e9b7197a33612202e85065e3f8d8385fbcef
- Use strict with non-simple parameters: tc39/ecma262@15b0db41edd0e519e94668bf13765fe458840766
- \__proto__ in strict mode: tc39/ecma262@5c1984334d6d42538527bd022e68bfbfee5cb652