### PR TITLE
Don't stomp on the object in `verifyConfigurable` test.

### DIFF
--- a/harness/propertyHelper.js
+++ b/harness/propertyHelper.js
@@ -1,5 +1,6 @@
 
 function isConfigurable(obj, name) {
+    var desc = Object.getOwnPropertyDescriptor(obj, name);
     try {
         delete obj[name];
     } catch (e) {
@@ -7,7 +8,12 @@ function isConfigurable(obj, name) {
             $ERROR("Expected TypeError, got " + e);
         }
     }
-    return !Object.prototype.hasOwnProperty.call(obj, name);
+    var result = !Object.prototype.hasOwnProperty.call(obj, name);
+    if (result) {
+        // Put things back the way we found them.
+        Object.defineProperty(obj, name, desc);
+    }
+    return result;
 }
 
 function isEnumerable(obj, name) {


### PR DESCRIPTION
Just as we do for `isWritable`, revert the change after we've verified the property.

This helps us run tests in environments without full isolation between tests, as well as protecting test authors from shooting themselves in the foot inadvertently.
