### PR TITLE
Destructuring Binding - syntax and simple initialization

### DIFF
--- a/test/language/destructuring/binding/initialization-requires-object-coercible-null.js
+++ b/test/language/destructuring/binding/initialization-requires-object-coercible-null.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3.5
+description: >
+  Cannot convert null argument value to object
+info: >
+  13.3.3.5 Runtime Semantics: BindingInitialization
+
+  BindingPattern : ObjectBindingPattern
+
+  1. Let valid be RequireObjectCoercible(value).
+  2. ReturnIfAbrupt(valid).
+---*/
+
+function fn({}) {}
+
+assert.throws(TypeError, function() {
+  fn(null);
+});

--- a/test/language/destructuring/binding/initialization-requires-object-coercible-undefined.js
+++ b/test/language/destructuring/binding/initialization-requires-object-coercible-undefined.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3.5
+description: >
+  Cannot convert undefined argument value to object
+info: >
+  13.3.3.5 Runtime Semantics: BindingInitialization
+
+  BindingPattern : ObjectBindingPattern
+
+  1. Let valid be RequireObjectCoercible(value).
+  2. ReturnIfAbrupt(valid).
+---*/
+
+function fn({}) {}
+
+assert.throws(TypeError, function() {
+  fn();
+});

--- a/test/language/destructuring/binding/initialization-returns-normal-completion-for-empty-objects.js
+++ b/test/language/destructuring/binding/initialization-returns-normal-completion-for-empty-objects.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3.5
+description: >
+  Normal completion when initializing an empty ObjectBindingPattern
+info: >
+  13.3.3.5 Runtime Semantics: BindingInitialization
+
+  BindingPattern : ObjectBindingPattern
+
+  ...
+  3. Return the result of performing BindingInitialization for
+  ObjectBindingPattern using value and environment as arguments.
+
+  ObjectBindingPattern : { }
+
+  1. Return NormalCompletion(empty).
+
+---*/
+
+function fn({}) { return true; }
+
+assert(fn(0));
+assert(fn(NaN));
+assert(fn(''));
+assert(fn(false));
+assert(fn({}));
+assert(fn([]));

--- a/test/language/destructuring/binding/syntax/array-elements-with-initializer.js
+++ b/test/language/destructuring/binding/syntax/array-elements-with-initializer.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3
+description: >
+  The ArrayBindingPattern with an element list with initializers
+info: >
+  Destructuring Binding Patterns - Syntax
+
+  ArrayBindingPattern[Yield] :
+    [ Elisionopt BindingRestElement[?Yield]opt ]
+    [ BindingElementList[?Yield] ]
+    [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+
+  BindingElementList[Yield] :
+    BindingElisionElement[?Yield]
+    BindingElementList[?Yield] , BindingElisionElement[?Yield]
+
+  BindingElisionElement[Yield] :
+    Elisionopt BindingElement[?Yield]
+
+  BindingElement[Yield ] :
+    SingleNameBinding[?Yield]
+    BindingPattern[?Yield] Initializer[In, ?Yield]opt
+---*/
+
+function fn1([a, b = 42]) {}
+
+function fn2([a = 42, b,]) {}
+
+function fn3([a,, b = a, c = 42]) {}

--- a/test/language/destructuring/binding/syntax/array-elements-with-object-patterns.js
+++ b/test/language/destructuring/binding/syntax/array-elements-with-object-patterns.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3
+description: >
+  The ArrayBindingPattern with Object patterns on the element list
+info: >
+  Destructuring Binding Patterns - Syntax
+
+  ArrayBindingPattern[Yield] :
+    [ Elisionopt BindingRestElement[?Yield]opt ]
+    [ BindingElementList[?Yield] ]
+    [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+
+  BindingElementList[Yield] :
+    BindingElisionElement[?Yield]
+    BindingElementList[?Yield] , BindingElisionElement[?Yield]
+
+  BindingElisionElement[Yield] :
+    Elisionopt BindingElement[?Yield]
+
+  BindingElement[Yield ] :
+    SingleNameBinding[?Yield]
+    BindingPattern[?Yield] Initializer[In, ?Yield]opt
+---*/
+
+function fn1([{}]) {}
+
+function fn2([{} = 42]) {}
+
+function fn3([a, {b: c}]) {}
+
+function fn4([a, {b: []}]) {}

--- a/test/language/destructuring/binding/syntax/array-elements-without-initializer.js
+++ b/test/language/destructuring/binding/syntax/array-elements-without-initializer.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3
+description: >
+  The ArrayBindingPattern with an element list without initializers
+info: >
+  Destructuring Binding Patterns - Syntax
+
+  ArrayBindingPattern[Yield] :
+    [ Elisionopt BindingRestElement[?Yield]opt ]
+    [ BindingElementList[?Yield] ]
+    [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+
+  BindingElementList[Yield] :
+    BindingElisionElement[?Yield]
+    BindingElementList[?Yield] , BindingElisionElement[?Yield]
+
+  BindingElisionElement[Yield] :
+    Elisionopt BindingElement[?Yield]
+
+  BindingElement[Yield ] :
+    SingleNameBinding[?Yield]
+    BindingPattern[?Yield] Initializer[In, ?Yield]opt
+---*/
+
+function fn1([a, b]) {}
+
+function fn2([a, b,]) {}
+
+function fn3([a,, b,]) {}

--- a/test/language/destructuring/binding/syntax/array-pattern-with-elisions.js
+++ b/test/language/destructuring/binding/syntax/array-pattern-with-elisions.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3
+description: >
+  The ArrayBindingPattern with elisions only
+info: >
+  Destructuring Binding Patterns - Syntax
+
+  ArrayBindingPattern[Yield] :
+    [ Elisionopt BindingRestElement[?Yield]opt ]
+    [ BindingElementList[?Yield] ]
+    [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+function fn1([,]) {}
+function fn2([,,]) {}

--- a/test/language/destructuring/binding/syntax/array-pattern-with-no-elements.js
+++ b/test/language/destructuring/binding/syntax/array-pattern-with-no-elements.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3
+description: >
+  The ArrayBindingPattern with no elements
+info: >
+  Destructuring Binding Patterns - Syntax
+
+  ArrayBindingPattern[Yield] :
+    [ Elisionopt BindingRestElement[?Yield]opt ]
+    [ BindingElementList[?Yield] ]
+    [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+function fn([]) {}

--- a/test/language/destructuring/binding/syntax/array-rest-elements.js
+++ b/test/language/destructuring/binding/syntax/array-rest-elements.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3
+description: >
+  Array Binding Pattern with Rest Element
+info: >
+  Destructuring Binding Patterns - Syntax
+
+  ArrayBindingPattern[Yield] :
+    [ Elisionopt BindingRestElement[?Yield]opt ]
+    [ BindingElementList[?Yield] ]
+    [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+
+  BindingRestElement[Yield] :
+    ... BindingIdentifier[?Yield]
+---*/
+
+function fn1([...args]) {}
+
+function fn2([,,,,,,,...args]) {}
+
+function fn3([x, {y}, ...z]) {}
+
+function fn4([,x, {y}, , ...z]) {}
+
+function fn5({x: [...y]}) {}

--- a/test/language/destructuring/binding/syntax/object-pattern-with-no-property-list.js
+++ b/test/language/destructuring/binding/syntax/object-pattern-with-no-property-list.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3
+description: >
+  The ObjectBindingPattern can be `{ }`
+info: >
+  Destructuring Binding Patterns - Syntax
+
+  ObjectBindingPattern[Yield] :
+    { }
+    { BindingPropertyList[?Yield] }
+    { BindingPropertyList[?Yield] , }
+
+---*/
+
+function fn({}) {}

--- a/test/language/destructuring/binding/syntax/property-list-bindings-elements.js
+++ b/test/language/destructuring/binding/syntax/property-list-bindings-elements.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3
+description: >
+  The ObjectBindingPattern with binding elements
+info: >
+  Destructuring Binding Patterns - Syntax
+
+  ObjectBindingPattern[Yield] :
+    { }
+    { BindingPropertyList[?Yield] }
+    { BindingPropertyList[?Yield] , }
+
+  BindingPropertyList[Yield] :
+    BindingProperty[?Yield]
+    BindingPropertyList[?Yield] , BindingProperty[?Yield]
+
+  BindingProperty[Yield] :
+    SingleNameBinding[?Yield]
+    PropertyName[?Yield] : BindingElement[?Yield]
+
+  BindingElement[Yield ] :
+    SingleNameBinding[?Yield]
+    BindingPattern[?Yield] Initializer[In, ?Yield]opt
+
+  SingleNameBinding[Yield] :
+    BindingIdentifier[?Yield] Initializer[In, ?Yield]opt
+
+---*/
+
+// BindingElement w/ SingleNameBinding
+function fna({x: y}) {}
+
+// BindingElement w/ SingleNameBinding with initializer
+function fnb({x: y = 42}) {}
+
+// BindingElement w/ BindingPattern
+function fnc({x: {}}) {}
+function fnd({x: {y}}) {}
+
+// BindingElement w/ BindingPattern w/ initializer
+function fne({x: {} = 42}) {}
+function fnf({x: {y} = 42}) {}

--- a/test/language/destructuring/binding/syntax/property-list-followed-by-a-single-comma.js
+++ b/test/language/destructuring/binding/syntax/property-list-followed-by-a-single-comma.js
@@ -19,6 +19,4 @@ function fn1({x,}) {}
 
 function fn2({a: {p: q, }, }) {}
 
-function fn3({x,,}) {}
-
-function fn4({x,,,,,,,}) {}
+function fn3({x,}) {}

--- a/test/language/destructuring/binding/syntax/property-list-followed-by-a-single-comma.js
+++ b/test/language/destructuring/binding/syntax/property-list-followed-by-a-single-comma.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3
+description: >
+  The Binding Property List followed by a single comma is a valid syntax
+info: >
+  Destructuring Binding Patterns - Syntax
+
+  ObjectBindingPattern[Yield] :
+    { }
+    { BindingPropertyList[?Yield] }
+    { BindingPropertyList[?Yield] , }
+
+---*/
+
+function fn1({x,}) {}
+
+function fn2({a: {p: q, }, }) {}
+
+function fn3({x,,}) {}
+
+function fn4({x,,,,,,,}) {}

--- a/test/language/destructuring/binding/syntax/property-list-single-name-bindings.js
+++ b/test/language/destructuring/binding/syntax/property-list-single-name-bindings.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3
+description: >
+  The ObjectBindingPattern with a simple property list and single name binding
+info: >
+  Destructuring Binding Patterns - Syntax
+
+  ObjectBindingPattern[Yield] :
+    { }
+    { BindingPropertyList[?Yield] }
+    { BindingPropertyList[?Yield] , }
+
+  BindingPropertyList[Yield] :
+    BindingProperty[?Yield]
+    BindingPropertyList[?Yield] , BindingProperty[?Yield]
+
+  BindingProperty[Yield] :
+    SingleNameBinding[?Yield]
+    PropertyName[?Yield] : BindingElement[?Yield]
+
+  SingleNameBinding[Yield] :
+    BindingIdentifier[?Yield] Initializer[In, ?Yield]opt
+
+---*/
+
+function fna({x}) {}
+function fnb({x, y}) {}
+function fnc({x = 42}) {}
+function fnd({x, y = 42}) {}

--- a/test/language/destructuring/binding/syntax/property-list-with-property-list.js
+++ b/test/language/destructuring/binding/syntax/property-list-with-property-list.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3
+description: >
+  The ObjectBindingPattern with deep binding property lists
+info: >
+  Destructuring Binding Patterns - Syntax
+
+  ObjectBindingPattern[Yield] :
+    { }
+    { BindingPropertyList[?Yield] }
+    { BindingPropertyList[?Yield] , }
+
+  BindingPropertyList[Yield] :
+    BindingProperty[?Yield]
+    BindingPropertyList[?Yield] , BindingProperty[?Yield]
+
+---*/
+
+function fn1({a: {p: q}, b: {r}, c: {s = 0}, d: {}}) {}
+
+function fn2(x, {a: r, b: s, c: t}, y) {}
+
+function fn3({x: {y: {z: {} = 42}}}) {}

--- a/test/language/destructuring/binding/syntax/recursive-array-and-object-patterns.js
+++ b/test/language/destructuring/binding/syntax/recursive-array-and-object-patterns.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 13.3.3
+description: >
+  Recursive array and object binding patterns
+info: >
+  Destructuring Binding Patterns - Syntax
+
+  BindingPattern[Yield] :
+    ObjectBindingPattern[?Yield]
+    ArrayBindingPattern[?Yield]
+---*/
+
+function fn1([{}]) {}
+
+function fn2([{a: [{}]}]) {}
+
+function fn3({a: [,,,] = 42}) {}
+
+function fn4([], [[]], [[[[[[[[[x]]]]]]]]]) {}
+
+function fn4([[x, y, ...z]]) {}


### PR DESCRIPTION
I believe at least the minimal tests for syntax is ready, but there's a lot of other tests to bring to this PR.

Possibly coming up next week:

- [ ] complete tests for ObjectBindingPattern initilization (13.3.3.5)
- [ ] ArrayBindingPattern initialization (IteratorBindingInitialization 13.3.3.6)
- [ ] KeyedBindingInitialization (13.3.3.7)
- [ ] BindingPattern statements
- [ ] Function length based on parameters list (13.3.3.4)

Extra, maybe not necessary for this coverage goal:

- [ ] check tests for BoundNames
- [ ] destructuring binding on variable declarations
- [ ] ForDeclaration/ForBinding 
- [ ] CatchParameter
