### PR TITLE
Add tests for iterator expression in ForIn/Of head

### DIFF
--- a/test/language/statements/for-in/head-decl-expr.js
+++ b/test/language/statements/for-in/head-decl-expr.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Expression is allowed in head
+info: >
+    IterationStatement : for ( ForDeclaration in Expression ) Statement
+
+    1. Let keyResult be the result of performing
+       ForIn/OfHeadEvaluation(BoundNames of ForDeclaration, Expression,
+       enumerate).
+    2. ReturnIfAbrupt(keyResult).
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+es6id: 13.7.5.11
+---*/
+
+var iterCount = 0;
+
+for (let x in null, { key: 0 }) {
+  assert.sameValue(x, 'key');
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1);

--- a/test/language/statements/for-in/head-expr-expr.js
+++ b/test/language/statements/for-in/head-expr-expr.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Expression is allowed in head
+info: >
+    IterationStatement : for ( ForDeclaration in Expression ) Statement
+
+    1. Let keyResult be the result of performing
+       ForIn/OfHeadEvaluation(BoundNames of ForDeclaration, Expression,
+       enumerate).
+    2. ReturnIfAbrupt(keyResult).
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+es6id: 13.7.5.11
+---*/
+
+var iterCount = 0;
+var x;
+
+for (x in null, { key: 0 }) {
+  assert.sameValue(x, 'key');
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1);

--- a/test/language/statements/for-in/head-var-expr.js
+++ b/test/language/statements/for-in/head-var-expr.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Expression is allowed in head
+info: >
+    IterationStatement : for ( ForDeclaration in Expression ) Statement
+
+    1. Let keyResult be the result of performing
+       ForIn/OfHeadEvaluation(BoundNames of ForDeclaration, Expression,
+       enumerate).
+    2. ReturnIfAbrupt(keyResult).
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+es6id: 13.7.5.11
+---*/
+
+var iterCount = 0;
+
+for (var x in null, { key: 0 }) {
+  assert.sameValue(x, 'key');
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1);

--- a/test/language/statements/for-of/head-decl-no-expr.js
+++ b/test/language/statements/for-of/head-decl-no-expr.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Expression not allowed in head's AssignmentExpression position
+info: >
+    IterationStatement :
+        for ( ForDeclaration of AssignmentExpression ) Statement
+es6id: 13.7
+negative: SyntaxError
+---*/
+
+for (let x of [], []) {}

--- a/test/language/statements/for-of/head-expr-no-expr.js
+++ b/test/language/statements/for-of/head-expr-no-expr.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Expression not allowed in head's AssignmentExpression position
+info: >
+    IterationStatement :
+        for ( LeftHandSideExpression of AssignmentExpression ) Statement
+es6id: 13.7
+negative: SyntaxError
+---*/
+
+var x;
+for (x of [], []) {}

--- a/test/language/statements/for-of/head-var-no-expr.js
+++ b/test/language/statements/for-of/head-var-no-expr.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Expression not allowed in head's AssignmentExpression position
+info: >
+    IterationStatement :
+        for ( var ForBinding of AssignmentExpression ) Statement
+es6id: 13.7
+negative: SyntaxError
+---*/
+
+for (var x of [], []) {}


### PR DESCRIPTION
Although the `for..in` statement allows Expressions to define the
iterator, only an AssignmentExpression may occupy this position in the
`for..of` statement.