### PR TITLE
Fix trivial typo in test

### DIFF
--- a/test/annexB/Date/prototype/toGMTString/name.js
+++ b/test/annexB/Date/prototype/toGMTString/name.js
@@ -19,7 +19,7 @@ info: >
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Date.prototype.toGMTString.name, "toUTCString");
+assert.sameValue(Date.prototype.toGMTString.name, "toGMTString");
 
 verifyNotEnumerable(Date.prototype.toGMTString, "name");
 verifyNotWritable(Date.prototype.toGMTString, "name");


### PR DESCRIPTION
Date.prototype.toGMTString.name should be "toGMTString", not "toUTCString".