### PR TITLE
Add tests for [[SetPrototypeOf]] on immutable prototype exotic objects

### DIFF
--- a/test/built-ins/Object/prototype/extensibility.js
+++ b/test/built-ins/Object/prototype/extensibility.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+id: sec-properties-of-the-object-prototype-object
+description: >
+  Object.prototype is still extensible and may have extensions prevented
+info: >
+  19.1.3 Properties of the Object Prototype Object
+
+  The value of the [[Prototype]] internal slot of the Object prototype object is
+  null and the initial value of the [[Extensible]] internal slot is true.
+---*/
+
+assert(
+  Object.isExtensible(Object.prototype),
+  "Object.prototype is extensible"
+);
+
+assert.sameValue(
+  Object.preventExtensions(Object.prototype),
+  Object.prototype,
+  "Object.prototype may have extensions prevented"
+);
+
+assert.sameValue(
+  Object.isExtensible(Object.prototype),
+  false,
+  "Object.prototype is not extensible after a preventExtensions operation"
+);

--- a/test/built-ins/Object/prototype/proto.js
+++ b/test/built-ins/Object/prototype/proto.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+id: sec-properties-of-the-object-prototype-object
+description: >
+  The value of the [[Prototype]] internal slot of Object.prototype is null
+info: >
+  19.1.3 Properties of the Object Prototype Object
+
+  The value of the [[Prototype]] internal slot of the Object prototype object is
+  null and the initial value of the [[Extensible]] internal slot is true.
+---*/
+
+assert.sameValue(Object.getPrototypeOf(Object.prototype), null);

--- a/test/built-ins/Object/prototype/setPrototypeOf-with-different-values.js
+++ b/test/built-ins/Object/prototype/setPrototypeOf-with-different-values.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+id: sec-immutable-prototype-exotic-objects-setprototypeof-v
+description: >
+  Object.prototype's [[SetPrototypeOf]] returns false if value is not the same
+info: >
+  9.4.7.1 [[SetPrototypeOf]] (V)
+
+  ...
+  2. Let current be the value of the [[Prototype]] internal slot of O.
+  3. If SameValue(V, current), return true.
+  4. Return false.
+
+  19.1.3 Properties of the Object Prototype Object
+
+  The value of the [[Prototype]] internal slot of the Object prototype object is
+  null and the initial value of the [[Extensible]] internal slot is true.
+features: [Reflect.setPrototypeOf]
+---*/
+
+var ObjProto = Object.prototype;
+
+assert.throws(TypeError, function() {
+  Object.setPrototypeOf(ObjProto, {});
+}, "Object.setPrototypeOf(ObjProto, {}) throws a TypeError");
+
+assert.throws(TypeError, function() {
+  Object.setPrototypeOf(ObjProto, Array.prototype);
+}, "Object.setPrototypeOf(ObjProto, Array.prototype) throws a TypeError");
+
+assert.throws(TypeError, function() {
+  Object.setPrototypeOf(ObjProto, ObjProto);
+}, "Object.setPrototypeOf(ObjProto, ObjProto) throws a TypeError");
+
+assert.sameValue(
+  Reflect.setPrototypeOf(ObjProto, {}),
+  false,
+  "Reflect.setPrototypeOf(ObjProto, {}) returns false"
+);
+
+assert.sameValue(
+  Reflect.setPrototypeOf(ObjProto, Array.prototype),
+  false,
+  "Reflect.setPrototypeOf(ObjProto, Array.prototype) returns false"
+);
+
+assert.sameValue(
+  Reflect.setPrototypeOf(ObjProto, ObjProto),
+  false,
+  "Reflect.setPrototypeOf(ObjProto, ObjProto) returns false"
+);

--- a/test/built-ins/Object/prototype/setPrototypeOf-with-same-value.js
+++ b/test/built-ins/Object/prototype/setPrototypeOf-with-same-value.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+id: sec-immutable-prototype-exotic-objects-setprototypeof-v
+description: >
+  Object.prototype's [[SetPrototypeOf]] returns true if value is same
+info: >
+  9.4.7.1 [[SetPrototypeOf]] (V)
+
+  ...
+  2. Let current be the value of the [[Prototype]] internal slot of O.
+  3. If SameValue(V, current), return true.
+  4. Return false.
+
+  19.1.3 Properties of the Object Prototype Object
+
+  The value of the [[Prototype]] internal slot of the Object prototype object is
+  null and the initial value of the [[Extensible]] internal slot is true.
+features: [Reflect.setPrototypeOf]
+---*/
+
+var ObjProto = Object.prototype;
+
+assert.sameValue(
+  Object.setPrototypeOf(ObjProto, null),
+  ObjProto,
+  "Object.setPrototypeOf(ObjProto, null) returns the Object.prototype"
+);
+
+assert(
+  Object.isExtensible(ObjProto),
+  "Object.prototype is still extensible after a setPrototypeOf operation - #1"
+);
+
+assert.sameValue(
+  Reflect.setPrototypeOf(ObjProto, null),
+  true,
+  "Reflect.setPrototypeOf(ObjProto, null) returns true"
+);
+
+assert(
+  Object.isExtensible(ObjProto),
+  "Object.prototype is still extensible after a setPrototypeOf operation - #2"
+);


### PR DESCRIPTION
Ref tc39/ecma262#308

The second commit covers the suggestion at https://github.com/tc39/ecma262/pull/308/files#r50536782 and it might be squashed or discarded regarding the discussion there.

This is an anticipated PR and needs to wait until the effective merge on the PR for tc39/ecma262.

cc @littledan 