### PR TITLE
Add tests for tail-call optimization

### DIFF
--- a/harness/tco-helper.js
+++ b/harness/tco-helper.js
@@ -1,0 +1,4 @@
+// This defines the number of consecutive recursive function calls that must be
+// made in order to prove that stack frames are properly destroyed according to
+// ES2015 tail call optimization semantics.
+var $MAX_ITERATIONS = 100000;

--- a/test/language/expressions/call/tco-call-args.js
+++ b/test/language/expressions/call/tco-call-args.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  function getF() { return f; }
+  return getF()(n - 1);
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/call/tco-member-args.js
+++ b/test/language/expressions/call/tco-member-args.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  return f(n - 1);
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/comma/tco-final.js
+++ b/test/language/expressions/comma/tco-final.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  return 0, f(n - 1);
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/conditional/tco-cond.js
+++ b/test/language/expressions/conditional/tco-cond.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  return true ? f(n - 1) : 0;
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/conditional/tco-pos.js
+++ b/test/language/expressions/conditional/tco-pos.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  return false ? 0 : f(n - 1);
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/logical-and/tco-right.js
+++ b/test/language/expressions/logical-and/tco-right.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  return true && f(n - 1);
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/logical-or/tco-right.js
+++ b/test/language/expressions/logical-or/tco-right.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  return false || f(n - 1);
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/tagged-template/tco-call.js
+++ b/test/language/expressions/tagged-template/tco-call.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+(function() {
+  var finished = false;
+  function getF() {
+    return f;
+  }
+  function f(_, n) {
+    if (n === 0) {
+      finished = true;
+      return;
+    }
+    return getF()`${n-1}`;
+  }
+  f(null, $MAX_ITERATIONS);
+  return finished;
+}());

--- a/test/language/expressions/tagged-template/tco-member.js
+++ b/test/language/expressions/tagged-template/tco-member.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+(function() {
+  var finished = false;
+  function f(_, n) {
+    if (n === 0) {
+      finished = true;
+      return;
+    }
+    return f`${n-1}`;
+  }
+  f(null, $MAX_ITERATIONS);
+  return finished;
+}());

--- a/test/language/expressions/tco-pos.js
+++ b/test/language/expressions/tco-pos.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  return (f(n - 1));
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/block/tco-stmt-list.js
+++ b/test/language/statements/block/tco-stmt-list.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  { void 0; return f(n - 1); }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/block/tco-stmt.js
+++ b/test/language/statements/block/tco-stmt.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  { return f(n - 1); }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/do-while/tco-body.js
+++ b/test/language/statements/do-while/tco-body.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  do {
+    return f(n - 1);
+  } while (false)
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/for/tco-const-body.js
+++ b/test/language/statements/for/tco-const-body.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  for (const x = 0; ;) {
+    return f(n - 1);
+  }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/for/tco-let-body.js
+++ b/test/language/statements/for/tco-let-body.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  for (let x = 0; ;) {
+    return f(n - 1);
+  }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/for/tco-lhs-body.js
+++ b/test/language/statements/for/tco-lhs-body.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  var x;
+  for (x = 0; x < 1; ++x) {
+    return f(n - 1);
+  }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/for/tco-var-body.js
+++ b/test/language/statements/for/tco-var-body.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  for (var x = 0; ;) {
+    return f(n - 1);
+  }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/if/tco-else-body.js
+++ b/test/language/statements/if/tco-else-body.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  if (false) { } else { return f(n - 1); }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/if/tco-if-body.js
+++ b/test/language/statements/if/tco-if-body.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  if (true) { return f(n - 1); }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/labeled/tco.js
+++ b/test/language/statements/labeled/tco.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  test262: return f(n - 1);
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/return/tco.js
+++ b/test/language/statements/return/tco.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  return f(n - 1);
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/switch/tco-case-body-dflt.js
+++ b/test/language/statements/switch/tco-case-body-dflt.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  switch(0) { case 0: return f(n - 1); default: }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/switch/tco-case-body.js
+++ b/test/language/statements/switch/tco-case-body.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  switch(0) { case 0: return f(n - 1); }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/switch/tco-dftl-body.js
+++ b/test/language/statements/switch/tco-dftl-body.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  switch(0) { default: return f(n - 1); }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/try/tco-catch-finally.js
+++ b/test/language/statements/try/tco-catch-finally.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  try { } catch (err) { } finally {
+    return f(n - 1);
+  }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/try/tco-catch.js
+++ b/test/language/statements/try/tco-catch.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  try {
+    throw null;
+  } catch (err) {
+    return f(n - 1);
+  }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/try/tco-finally.js
+++ b/test/language/statements/try/tco-finally.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  try { } finally {
+    return f(n - 1);
+  }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);

--- a/test/language/statements/while/tco-body.js
+++ b/test/language/statements/while/tco-body.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement within statement is a candidate for tail-call optimization.
+id: static-semantics-hasproductionintailposition
+flags: [onlyStrict]
+features: [tail-call-optimization]
+includes: [tco-helper.js]
+---*/
+
+var callCount = 0;
+(function f(n) {
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  while (true) {
+    return f(n - 1);
+  }
+}($MAX_ITERATIONS));
+assert.sameValue(callCount, 1);


### PR DESCRIPTION
I'm using the testing strategy discussed in gh-466 to assert proper tail call optimization. As noted in that discussion, runtime behavior in the event of a stack overflow is not currently specified. The `callCount` variable in these tests is intended to guard against bizarre runtime behavior in these cases--even if the failed recursion does not throw a runtime error or crash outright, the final assertion will fail.

Unfortunately, the lack of standard behavior in the event of stack overflow makes asserting the negative case (i.e. "no optimization occurs") impossible. Many runtimes throw an error of some sort, and I think that is reasonable behavior to standardize. To that end, [I have submitted a patch to the specification](https://github.com/tc39/ecma262/pull/319), and I have tagged a full set of "negative" tests that hinge on that behavior: https://github.com/jugglinmike/test262/commit/tco-negative If the language patch is accepted, I will swoon and then submit a pull request with these "negative" tests.