### PR TITLE
Fix location based return value for Date on subclassing tests

### DIFF
--- a/test/language/statements/class/subclass/builtin-objects/Date/regular-subclassing.js
+++ b/test/language/statements/class/subclass/builtin-objects/Date/regular-subclassing.js
@@ -20,10 +20,10 @@ info: >
 
 class D extends Date {}
 
-var d1 = new D(1859, '10', 24);
-assert.sameValue(d1.getUTCFullYear(), 1859);
-assert.sameValue(d1.getUTCMonth(), 10);
-assert.sameValue(d1.getUTCDate(), 24);
+var d1 = new D(1859, '10', 24, 11);
+assert.sameValue(d1.getFullYear(), 1859);
+assert.sameValue(d1.getMonth(), 10);
+assert.sameValue(d1.getDate(), 24);
 
 var d2 = new D(-3474558000000);
 assert.sameValue(d2.getUTCFullYear(), 1859);
@@ -32,6 +32,6 @@ assert.sameValue(d2.getUTCDate(), 24);
 
 var d3 = new D();
 var d4 = new Date();
-assert.sameValue(d3.getUTCFullYear(), d4.getUTCFullYear());
-assert.sameValue(d3.getUTCMonth(), d4.getUTCMonth());
-assert.sameValue(d3.getUTCDate(), d4.getUTCDate());
+assert.sameValue(d3.getFullYear(), d4.getFullYear());
+assert.sameValue(d3.getMonth(), d4.getMonth());
+assert.sameValue(d3.getDate(), d4.getDate());


### PR DESCRIPTION
Closes #489

After some quick searches through the repo, it seems that was the only case with this particular issue.

The tests for several Date.prototype methods needs improvement, as most of them does not have any tests for returned values.