### PR TITLE
Enable parallel test execution in console runner

### DIFF
--- a/CONSOLE-RUNNER.md
+++ b/CONSOLE-RUNNER.md
@@ -40,6 +40,7 @@ Name | Action
 -----|-------
 -h, --help | displays a brief help message
 --command=COMMAND | **required** command which invokes javascript engine to be tested
+-j, --workers-count | Number of tests to run in parallel (defaults to number of cores - 1)
 --tests=TESTS | path to the test suite; default is current directory
 --cat | don't execute tests, just print code that would be run
 --summary | generate a summary at end of execution
@@ -49,9 +50,9 @@ Name | Action
 --unmarked_default=MODE | mode to use for tests that are not marked **onlyStrict** or **noStrict** ; MODE can be `strict` or `non_strict` or `both`
 --logname=LOGNAME | write output to file (in addition to stdout)
 --junitname=JUNITNAME | write test results to file in JUnit XML format
---loglevel=LOGLEVEL | set log level, primarily useful for debugging `test262.py` 
+--loglevel=LOGLEVEL | set log level, primarily useful for debugging `test262.py`
 --print-handle=FUNC | enable async test logging via javascript function e.g., `console.log`
- 
+
 ### Usage Notes
 
 Non-option arguments are used as filters to match test names.  If no filters are found, the whole test suite is run.
@@ -66,7 +67,7 @@ The COMMAND argument can be a quoted string.  This is useful when testing ECMASc
 
 ```
 $ test262.py --command="node --harmony" es6
-``` 
+```
 
 #### Async Tests
 
@@ -81,7 +82,7 @@ JavaScriptCore<sup>2</sup> | jsc | print
 
 ***Notes:***
 1. As of 2014-Jul-23, SpiderMonkey does not support Promise in the `js` executable ([see bug 911216](https://bugzilla.mozilla.org/show_bug.cgi?id=911216) )
-2. As of 2014-Jul-23, JavaScriptCore does not support Promise in the `jsc` executable 
+2. As of 2014-Jul-23, JavaScriptCore does not support Promise in the `jsc` executable
 
 
 ### Troubleshooting


### PR DESCRIPTION
Adds a `-j`/`--workers-count` parameter to `tools/packaging/test262.py`, defaulting to `[number of cores] - 1`.

Speeds up running the test suite by about ~3x on my 4-core machine, with the SpiderMonkey shell. This could certainly be optimized more by just appending test results to per-thread lists and merging them at the end, but it's better than nothing.