### PR TITLE
Avoid Race Conditions in Test Runner

### DIFF
--- a/tools/packaging/test262.py
+++ b/tools/packaging/test262.py
@@ -583,6 +583,7 @@ class TestSuite(object):
           SkipCaseElement.append(SkipElement)
           TestSuiteElement.append(SkipCaseElement)
 
+    threads = []
     if workers_count > 1:
       pool_sem = threading.Semaphore(workers_count)
       log_lock = threading.Lock()
@@ -613,11 +614,13 @@ class TestSuite(object):
         exec_case()
       else:
         pool_sem.acquire()
-        threading.Thread(target=exec_case).start()
+        thread = threading.Thread(target=exec_case)
+        threads.append(thread)
+        thread.start()
         pool_sem.release()
 
-    if workers_count > 1:
-      log_lock.acquire()
+    for thread in threads:
+      thread.join()
 
     if print_summary:
       self.PrintSummary(progress, logname)
@@ -627,9 +630,6 @@ class TestSuite(object):
         print
         print "Use --full-summary to see output from failed tests"
     print
-
-    if workers_count > 1:
-      log_lock.release()
 
     return progress.failed
 

--- a/tools/packaging/test262.py
+++ b/tools/packaging/test262.py
@@ -606,10 +606,11 @@ class TestSuite(object):
           if logname:
             self.WriteLog(result)
         finally:
+          progress.HasRun(result)
+
           if workers_count > 1:
             log_lock.release()
 
-        progress.HasRun(result)
       if workers_count == 1:
         exec_case()
       else:


### PR DESCRIPTION
Now that the test runner is capable of running tests in parallel using threads,
it's possible for race conditions to effect the output. Care was taken to
ensure that threads safely share access to the output file resource (when
specified), but there are some issues with text printed to standard output:

    $ ./tools/packaging/test262.py --command d8 built-ins/undefined --full-summary -j 4

    built-ins/undefined/S15.1.1.3_A1 passed in strict mode
    built-ins/undefined/15.1.1.3-0 passed in non-strict mode
    built-ins/undefined/15.1.1.3-2 passed in strict mode

    === Summary ===
     - Ran 12 tests
     - All tests succeeded

    built-ins/undefined/S15.1.1.3_A3_T1 passed in non-strict mode
    built-ins/undefined/S15.1.1.3_A1 passed in non-strict mode
    built-ins/undefined/15.1.1.3-0 passed in strict mode
     built-ins/undefined/S15.1.1.3_A3_T1 passed in strict mode
     built-ins/undefined/15.1.1.3-3 passed in non-strict mode
    built-ins/undefined/15.1.1.3-1 passed in non-strict mode
    built-ins/undefined/S15.1.1.3_A3_T2 passed in non-strict mode
    built-ins/undefined/S15.1.1.3_A4 passed in non-strict mode
    built-ins/undefined/S15.1.1.3_A4 passed in strict mode

There are two distinct errors in this output:

1. Placement of the "summary"
2. Indenting of some individual test results

After application of this patch:

    $ git checkout runner-race

    $ ./tools/packaging/test262.py --command d8 built-ins/undefined --full-summary -j 4
    built-ins/undefined/S15.1.1.3_A1 passed in strict mode
    built-ins/undefined/S15.1.1.3_A1 passed in non-strict mode
    built-ins/undefined/S15.1.1.3_A3_T1 passed in non-strict mode
    built-ins/undefined/S15.1.1.3_A4 passed in strict mode
    built-ins/undefined/15.1.1.3-2 passed in strict mode
    built-ins/undefined/15.1.1.3-2 passed in strict mode
    built-ins/undefined/15.1.1.3-3 passed in non-strict mode
    built-ins/undefined/S15.1.1.3_A3_T2 passed in non-strict mode
    built-ins/undefined/15.1.1.3-0 passed in non-strict mode
    built-ins/undefined/S15.1.1.3_A3_T1 passed in non-strict mode
    built-ins/undefined/15.1.1.3-0 passed in strict mode
    built-ins/undefined/S15.1.1.3_A4 passed in non-strict mode

    === Summary ===
     - Ran 12 tests
     - All tests succeeded

@tschneidereit would you mind giving this a review?