### PR TITLE
Make asynchronous test configuration explicit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,8 @@ This tag is for boolean properties associated with the test.
 - **`raw`** - execute the test without any modification (no helpers will be
   available); necessary to test the behavior of directive prologue; implies
   `noStrict`
+- **`async`** - defer interpretation of test results until after the invocation
+  of the global $DONE` function
 
 #### features
 **features**: [list]
@@ -198,7 +200,7 @@ assert.throws(ReferenceError, function() {
 
 ## Writing Asynchronous Tests
 
-An asynchronous test is any test that includes the string `$DONE` anywhere in the test file.  The test runner checks for the presence of this string; if it is found, the runner expects that the `$DONE()` function will be called to signal test completion.
+An asynchronous test is any test that include the `async` frontmatter flag. When executing such tests, the runner expects that the global `$DONE()` function will be called to signal test completion.
 
  * If the argument to `$DONE` is omitted, is `undefined`, or is any other falsy value, the test is considered to have passed.
 

--- a/test/built-ins/Promise/S25.4.3.1_A2.3_T1.js
+++ b/test/built-ins/Promise/S25.4.3.1_A2.3_T1.js
@@ -7,6 +7,7 @@ info: >
 es6id: S25.4.3.1_A2.3_T1
 author: Sam Mikes
 description: Promise.call(resolved Promise) throws TypeError
+flags: [async]
 ---*/
 
 var p = new Promise(function(resolve) { resolve(1); });

--- a/test/built-ins/Promise/S25.4.3.1_A2.4_T1.js
+++ b/test/built-ins/Promise/S25.4.3.1_A2.4_T1.js
@@ -7,6 +7,7 @@ info: >
 es6id: S25.4.3.1_A2.4_T1
 author: Sam Mikes
 description: Promise.call(rejected Promise) throws TypeError
+flags: [async]
 ---*/
 
 var p = new Promise(function(resolve, reject) { reject(1) });

--- a/test/built-ins/Promise/S25.4.3.1_A4.1_T1.js
+++ b/test/built-ins/Promise/S25.4.3.1_A4.1_T1.js
@@ -8,6 +8,7 @@ info: >
 es6id: S25.4.3.1_A4.1_T1
 author: Sam Mikes
 description: new Promise(function () { throw }) should reject
+flags: [async]
 ---*/
 
 var errorObject = {},

--- a/test/built-ins/Promise/S25.4.3.1_A5.1_T1.js
+++ b/test/built-ins/Promise/S25.4.3.1_A5.1_T1.js
@@ -9,7 +9,7 @@ info: >
 es6id: S25.4.3.1_A5.1_T1
 author: Sam Mikes
 description: Promise executor gets default handling for 'this'
-flags: [noStrict]
+flags: [async, noStrict]
 includes: [fnGlobalObject.js]
 ---*/
 

--- a/test/built-ins/Promise/S25.4.3.1_A5.1_T2.js
+++ b/test/built-ins/Promise/S25.4.3.1_A5.1_T2.js
@@ -9,7 +9,7 @@ info: >
 es6id: S25.4.3.1_A5.1_T2
 author: Sam Mikes
 description: Promise executor gets default handling for 'this'
-flags: [onlyStrict]
+flags: [async, onlyStrict]
 ---*/
 
 var expectedThis = undefined;

--- a/test/built-ins/Promise/all/S25.4.4.1_A2.2_T1.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A2.2_T1.js
@@ -7,6 +7,7 @@ es6id: 25.4.4.1_A2.2_T1
 author: Sam Mikes
 includes: [PromiseHelper.js]
 description: Promise.all([]) returns immediately
+flags: [async]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/all/S25.4.4.1_A2.3_T1.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A2.3_T1.js
@@ -6,6 +6,7 @@ info: Promise.all([]) returns a promise for a new empty array
 es6id: 25.4.4.1_A2.3_T1
 author: Sam Mikes
 description: Promise.all([]) returns a promise for an array
+flags: [async]
 ---*/
 
 var arg = [];

--- a/test/built-ins/Promise/all/S25.4.4.1_A2.3_T2.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A2.3_T2.js
@@ -6,6 +6,7 @@ info: Promise.all is resolved with a new empty array
 es6id: 25.4.4.1_A2.3_T2
 author: Sam Mikes
 description: Promise.all([]) returns a Promise for an empty array
+flags: [async]
 ---*/
 
 var arg = [];

--- a/test/built-ins/Promise/all/S25.4.4.1_A2.3_T3.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A2.3_T3.js
@@ -6,6 +6,7 @@ info: Promise.all([]) is resolved with Promise for a new empty array
 es6id: 25.4.4.1_A2.3_T3
 author: Sam Mikes
 description: Promise.all([]) is resolved with a Promise for a new array
+flags: [async]
 ---*/
 
 var arg = [];

--- a/test/built-ins/Promise/all/S25.4.4.1_A3.1_T1.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A3.1_T1.js
@@ -9,6 +9,7 @@ info: >
 es6id: 25.4.4.1_A3.1_T1
 author: Sam Mikes
 description: Promise.all(3) returns Promise rejected with TypeError
+flags: [async]
 ---*/
 
 var nonIterable = 3;

--- a/test/built-ins/Promise/all/S25.4.4.1_A3.1_T2.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A3.1_T2.js
@@ -10,6 +10,7 @@ info: >
 es6id: S25.4.4.1_A3.1_T2
 author: Sam Mikes
 description: Promise.all(new Error()) returns Promise rejected with TypeError
+flags: [async]
 ---*/
 
 Promise.all(new Error("abrupt")).then(function () {

--- a/test/built-ins/Promise/all/S25.4.4.1_A3.1_T3.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A3.1_T3.js
@@ -9,6 +9,7 @@ es6id: S25.4.4.1_A3.1_T3
 author: Sam Mikes
 description: Promise.all((throw on GetIterator)) returns Promise rejected with TypeError
 features: [Symbol.iterator]
+flags: [async]
 ---*/
 
 var iterThrows = {};

--- a/test/built-ins/Promise/all/S25.4.4.1_A5.1_T1.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A5.1_T1.js
@@ -9,6 +9,7 @@ es6id: S25.4.4.1_A5.1_T1
 author: Sam Mikes
 description: iterator.next throws, causing Promise.all to reject
 features: [Symbol.iterator]
+flags: [async]
 ---*/
 
 var iterThrows = {};

--- a/test/built-ins/Promise/all/S25.4.4.1_A6.1_T2.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A6.1_T2.js
@@ -8,6 +8,7 @@ info: >
 es6id: S25.4.4.1_A6.1_T2
 author: Sam Mikes
 description: Promise.all([]) returns a promise for an empty array
+flags: [async]
 ---*/
 
 var p = Promise.all([]);

--- a/test/built-ins/Promise/all/S25.4.4.1_A7.1_T1.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A7.1_T1.js
@@ -8,6 +8,7 @@ info: >
 es6id: S25.4.4.1_A6.1_T2
 author: Sam Mikes
 description: Promise.all([p1]) is resolved with a promise for a one-element array
+flags: [async]
 ---*/
 
 var p1 = Promise.resolve(3);

--- a/test/built-ins/Promise/all/S25.4.4.1_A7.2_T1.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A7.2_T1.js
@@ -9,6 +9,7 @@ es6id: S25.4.4.1_A7.2_T1
 author: Sam Mikes
 description: Promise.all() accepts a one-element array
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/all/S25.4.4.1_A8.1_T1.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A8.1_T1.js
@@ -6,6 +6,7 @@ es6id: S25.4.4.1_A8.1_T1
 author: Sam Mikes
 description: Promise.all([p1, p2]) resolution functions are called in predictable sequence
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/all/S25.4.4.1_A8.2_T1.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A8.2_T1.js
@@ -8,6 +8,7 @@ es6id: S25.4.4.1_A8.1_T1
 author: Sam Mikes
 description: Promise.all() rejects when a promise in its array rejects
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var rejectP1,

--- a/test/built-ins/Promise/all/S25.4.4.1_A8.2_T2.js
+++ b/test/built-ins/Promise/all/S25.4.4.1_A8.2_T2.js
@@ -8,6 +8,7 @@ es6id: S25.4.4.1_A8.2_T2
 author: Sam Mikes
 description: Promise.all() rejects when second promise in array rejects
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var rejectP2,

--- a/test/built-ins/Promise/all/does-not-invoke-array-setters.js
+++ b/test/built-ins/Promise/all/does-not-invoke-array-setters.js
@@ -24,6 +24,7 @@ info: >
       a. Let status be CreateDataProperty(array, ToString(n), e).
       b. Assert: status is true.
     ...
+flags: [async]
 ---*/
 
 Object.defineProperty(Array.prototype, 0, {

--- a/test/built-ins/Promise/all/invoke-resolve-get-error.js
+++ b/test/built-ins/Promise/all/invoke-resolve-get-error.js
@@ -21,6 +21,7 @@ info: >
         [...]
         i. Let nextPromise be Invoke(constructor, "resolve", «nextValue»).
         j. ReturnIfAbrupt(nextPromise ).
+flags: [async]
 ---*/
 
 var error = new Test262Error();

--- a/test/built-ins/Promise/all/invoke-then-error.js
+++ b/test/built-ins/Promise/all/invoke-then-error.js
@@ -22,6 +22,7 @@ info: >
         r. Let result be Invoke(nextPromise, "then", «resolveElement,
            resultCapability.[[Reject]]»).
         s. ReturnIfAbrupt(result).
+flags: [async]
 ---*/
 
 var promise = new Promise(function() {});

--- a/test/built-ins/Promise/all/iter-next-val-err.js
+++ b/test/built-ins/Promise/all/iter-next-val-err.js
@@ -24,6 +24,7 @@ info: >
            true.
         g. ReturnIfAbrupt(nextValue).
 features: [Symbol.iterator]
+flags: [async]
 ---*/
 
 var iterNextValThrows = {};

--- a/test/built-ins/Promise/all/iter-step-err.js
+++ b/test/built-ins/Promise/all/iter-step-err.js
@@ -23,6 +23,7 @@ info: >
            true.
         c. ReturnIfAbrupt(next).
 features: [Symbol.iterator]
+flags: [async]
 ---*/
 
 var iterStepThrows = {};

--- a/test/built-ins/Promise/all/reject-deferred.js
+++ b/test/built-ins/Promise/all/reject-deferred.js
@@ -20,6 +20,7 @@ info: >
     25.4.1.3.1 Promise Reject Functions
     [...]
     6. Return RejectPromise(promise, reason).
+flags: [async]
 ---*/
 
 var thenable = {

--- a/test/built-ins/Promise/all/reject-ignored-deferred.js
+++ b/test/built-ins/Promise/all/reject-ignored-deferred.js
@@ -25,6 +25,7 @@ info: >
     3. Let alreadyResolved be the value of F's [[AlreadyResolved]] internal
        slot.
     4. If alreadyResolved.[[value]] is true, return undefined.
+flags: [async]
 ---*/
 
 var fulfiller = {

--- a/test/built-ins/Promise/all/reject-ignored-immed.js
+++ b/test/built-ins/Promise/all/reject-ignored-immed.js
@@ -25,6 +25,7 @@ info: >
     3. Let alreadyResolved be the value of F's [[AlreadyResolved]] internal
        slot.
     4. If alreadyResolved.[[value]] is true, return undefined.
+flags: [async]
 ---*/
 
 var fulfiller = {

--- a/test/built-ins/Promise/all/reject-immed.js
+++ b/test/built-ins/Promise/all/reject-immed.js
@@ -20,6 +20,7 @@ info: >
     25.4.1.3.1 Promise Reject Functions
     [...]
     6. Return RejectPromise(promise, reason).
+flags: [async]
 ---*/
 
 var thenable = {

--- a/test/built-ins/Promise/all/resolve-non-thenable.js
+++ b/test/built-ins/Promise/all/resolve-non-thenable.js
@@ -31,6 +31,7 @@ info: >
     10. Let thenAction be then.[[value]].
     11. If IsCallable(thenAction) is false, then
         a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var v1 = {};

--- a/test/built-ins/Promise/all/resolve-poisoned-then.js
+++ b/test/built-ins/Promise/all/resolve-poisoned-then.js
@@ -40,6 +40,7 @@ info: >
     8. Let then be Get(resolution, "then").
     9. If then is an abrupt completion, then
        a. Return RejectPromise(promise, then.[[value]]).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/all/resolve-thenable.js
+++ b/test/built-ins/Promise/all/resolve-thenable.js
@@ -45,6 +45,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/exception-after-resolve-in-executor.js
+++ b/test/built-ins/Promise/exception-after-resolve-in-executor.js
@@ -15,6 +15,7 @@ info: >
     a. Let status be Call(resolvingFunctions.[[Reject]], undefined, «completion.[[value]]»).
     b. ReturnIfAbrupt(status).
   ...
+flags: [async]
 ---*/
 
 var thenable = {

--- a/test/built-ins/Promise/exception-after-resolve-in-thenable-job.js
+++ b/test/built-ins/Promise/exception-after-resolve-in-thenable-job.js
@@ -14,6 +14,7 @@ info: >
     a. Let status be Call(resolvingFunctions.[[Reject]], undefined, «thenCallResult.[[value]]»)
     b. NextJob Completion(status).
   ...
+flags: [async]
 ---*/
 
 var thenable = {

--- a/test/built-ins/Promise/prototype/catch/S25.4.5.1_A3.1_T1.js
+++ b/test/built-ins/Promise/prototype/catch/S25.4.5.1_A3.1_T1.js
@@ -7,6 +7,7 @@ info: >
 es6id: S25.4.5.1_A3.1_T1
 author: Sam Mikes
 description: catch is implemented in terms of then
+flags: [async]
 ---*/
 
 var obj = {};

--- a/test/built-ins/Promise/prototype/catch/S25.4.5.1_A3.1_T2.js
+++ b/test/built-ins/Promise/prototype/catch/S25.4.5.1_A3.1_T2.js
@@ -7,6 +7,7 @@ info: >
 es6id: S25.4.5.1_A3.1_T2
 author: Sam Mikes
 description: catch is implemented in terms of then
+flags: [async]
 ---*/
 
 var obj = {};

--- a/test/built-ins/Promise/prototype/then/S25.4.4_A1.1_T1.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.4_A1.1_T1.js
@@ -9,6 +9,7 @@ es6id: S25.4.2.1_A3.2_T2
 author: Sam Mikes
 description: Promise onResolved functions are called in predictable sequence
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/prototype/then/S25.4.4_A2.1_T1.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.4_A2.1_T1.js
@@ -10,6 +10,7 @@ es6id: S25.4.4_A2.1_T1
 author: Sam Mikes
 description: Promise onResolved functions are called in predictable sequence
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var resolveP1, rejectP2, sequence = [];

--- a/test/built-ins/Promise/prototype/then/S25.4.4_A2.1_T2.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.4_A2.1_T2.js
@@ -10,6 +10,7 @@ es6id: S25.4.4_A2.1_T2
 author: Sam Mikes
 description: Promise onResolved functions are called in predictable sequence
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var resolveP1, rejectP2, p1, p2,

--- a/test/built-ins/Promise/prototype/then/S25.4.4_A2.1_T3.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.4_A2.1_T3.js
@@ -10,6 +10,7 @@ es6id: S25.4.4_A2.1_T3
 author: Sam Mikes
 description: Promise onResolved functions are called in predictable sequence
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var resolveP1, rejectP2, p1, p2,

--- a/test/built-ins/Promise/prototype/then/S25.4.5.3_A4.1_T1.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.5.3_A4.1_T1.js
@@ -8,6 +8,7 @@ info: >
 es6id: S25.4.5.3_A4.1_T1
 author: Sam Mikes
 description: Promise.prototype.then accepts 'undefined' as arg1, arg2
+flags: [async]
 ---*/
 
 var obj = {};

--- a/test/built-ins/Promise/prototype/then/S25.4.5.3_A4.1_T2.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.5.3_A4.1_T2.js
@@ -8,6 +8,7 @@ info: >
 es6id: S25.4.5.3_A4.1_T2
 author: Sam Mikes
 description: Promise.prototype.then accepts 'undefined' as arg1, arg2
+flags: [async]
 ---*/
 
 var obj = {};

--- a/test/built-ins/Promise/prototype/then/S25.4.5.3_A4.2_T1.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.5.3_A4.2_T1.js
@@ -8,6 +8,7 @@ info: >
 es6id: S25.4.5.3_A4.2_T1
 author: Sam Mikes
 description: Promise.prototype.then treats non-callable arg1, arg2 as undefined
+flags: [async]
 ---*/
 
 var obj = {};

--- a/test/built-ins/Promise/prototype/then/S25.4.5.3_A4.2_T2.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.5.3_A4.2_T2.js
@@ -8,6 +8,7 @@ info: >
 es6id: S25.4.5.3_A4.2_T2
 author: Sam Mikes
 description: Promise.prototype.then treats non-callable arg1, arg2 as undefined
+flags: [async]
 ---*/
 
 var obj = {};

--- a/test/built-ins/Promise/prototype/then/S25.4.5.3_A5.1_T1.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.5.3_A5.1_T1.js
@@ -9,6 +9,7 @@ es6id: S25.4.5.3_A5.1_T1
 author: Sam Mikes
 description: Promise.prototype.then enqueues handler if pending
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [],

--- a/test/built-ins/Promise/prototype/then/S25.4.5.3_A5.2_T1.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.5.3_A5.2_T1.js
@@ -9,6 +9,7 @@ es6id: S25.4.5.3_A5.2_T1
 author: Sam Mikes
 description: Promise.prototype.then immediately queues handler if fulfilled
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [],

--- a/test/built-ins/Promise/prototype/then/S25.4.5.3_A5.3_T1.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.5.3_A5.3_T1.js
@@ -9,6 +9,7 @@ es6id: S25.4.5.3_A5.3_T1
 author: Sam Mikes
 description: Promise.prototype.then immediately queues handler if rejected
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [],

--- a/test/built-ins/Promise/prototype/then/deferred-is-resolved-value.js
+++ b/test/built-ins/Promise/prototype/then/deferred-is-resolved-value.js
@@ -34,6 +34,7 @@ info: >
     8. Let status be Call(promiseCapability.[[Resolve]], undefined, «handlerResult.[[value]]»).
     9. NextJob Completion(status).
 features: [class]
+flags: [async]
 ---*/
 
 var createBadPromise = false;

--- a/test/built-ins/Promise/prototype/then/prfm-fulfilled.js
+++ b/test/built-ins/Promise/prototype/then/prfm-fulfilled.js
@@ -16,6 +16,7 @@ info: >
        b. Perform EnqueueJob("PromiseJobs", PromiseReactionJob,
           «fulfillReaction, value»).
     [...]
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/prfm-pending-fulfulled.js
+++ b/test/built-ins/Promise/prototype/then/prfm-pending-fulfulled.js
@@ -16,6 +16,7 @@ info: >
        b. Append rejectReaction as the last element of the List that is the
           value of promise's [[PromiseRejectReactions]] internal slot.
     [...]
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/prfm-pending-rejected.js
+++ b/test/built-ins/Promise/prototype/then/prfm-pending-rejected.js
@@ -16,6 +16,7 @@ info: >
        b. Append rejectReaction as the last element of the List that is the
           value of promise's [[PromiseRejectReactions]] internal slot.
     [...]
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/prfm-rejected.js
+++ b/test/built-ins/Promise/prototype/then/prfm-rejected.js
@@ -16,6 +16,7 @@ info: >
        b. Perform EnqueueJob("PromiseJobs", PromiseReactionJob,
           «rejectReaction, reason»).
     [...]
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/reject-pending-fulfilled.js
+++ b/test/built-ins/Promise/prototype/then/reject-pending-fulfilled.js
@@ -18,6 +18,7 @@ info: >
     25.4.1.3.1 Promise Reject Functions
     [...]
     6. Return RejectPromise(promise, reason).
+flags: [async]
 ---*/
 
 var resolve;

--- a/test/built-ins/Promise/prototype/then/reject-pending-rejected.js
+++ b/test/built-ins/Promise/prototype/then/reject-pending-rejected.js
@@ -19,6 +19,7 @@ info: >
     25.4.1.3.1 Promise Reject Functions
     [...]
     6. Return RejectPromise(promise, reason).
+flags: [async]
 ---*/
 
 var reject;

--- a/test/built-ins/Promise/prototype/then/reject-settled-fulfilled.js
+++ b/test/built-ins/Promise/prototype/then/reject-settled-fulfilled.js
@@ -26,6 +26,7 @@ info: >
     25.4.1.3.1 Promise Reject Functions
     [...]
     6. Return RejectPromise(promise, reason).
+flags: [async]
 ---*/
 
 var thenable = new Promise(function(resolve) { resolve(); });

--- a/test/built-ins/Promise/prototype/then/reject-settled-rejected.js
+++ b/test/built-ins/Promise/prototype/then/reject-settled-rejected.js
@@ -26,6 +26,7 @@ info: >
     25.4.1.3.1 Promise Reject Functions
     [...]
     6. Return RejectPromise(promise, reason).
+flags: [async]
 ---*/
 
 var thenable = new Promise(function(resolve) { resolve(); });

--- a/test/built-ins/Promise/prototype/then/resolve-pending-fulfilled-non-obj.js
+++ b/test/built-ins/Promise/prototype/then/resolve-pending-fulfilled-non-obj.js
@@ -18,6 +18,7 @@ info: >
     25.4.1.3.2 Promise Resolve Functions
     7. If Type(resolution) is not Object, then
        a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var resolve;

--- a/test/built-ins/Promise/prototype/then/resolve-pending-fulfilled-non-thenable.js
+++ b/test/built-ins/Promise/prototype/then/resolve-pending-fulfilled-non-thenable.js
@@ -23,6 +23,7 @@ info: >
     10. Let thenAction be then.[[value]].
     11. If IsCallable(thenAction) is false, then
         a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var nonThenable = { then: null };

--- a/test/built-ins/Promise/prototype/then/resolve-pending-fulfilled-poisoned-then.js
+++ b/test/built-ins/Promise/prototype/then/resolve-pending-fulfilled-poisoned-then.js
@@ -20,6 +20,7 @@ info: >
     8. Let then be Get(resolution, "then").
     9. If then is an abrupt completion, then
        a. Return RejectPromise(promise, then.[[value]]).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/resolve-pending-fulfilled-self.js
+++ b/test/built-ins/Promise/prototype/then/resolve-pending-fulfilled-self.js
@@ -20,6 +20,7 @@ info: >
     6. If SameValue(resolution, promise) is true, then
        a. Let selfResolutionError be a newly created TypeError object.
        b. Return RejectPromise(promise, selfResolutionError).
+flags: [async]
 ---*/
 
 var resolve;

--- a/test/built-ins/Promise/prototype/then/resolve-pending-fulfilled-thenable.js
+++ b/test/built-ins/Promise/prototype/then/resolve-pending-fulfilled-thenable.js
@@ -25,6 +25,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/resolve-pending-rejected-non-obj.js
+++ b/test/built-ins/Promise/prototype/then/resolve-pending-rejected-non-obj.js
@@ -19,6 +19,7 @@ info: >
     25.4.1.3.2 Promise Resolve Functions
     7. If Type(resolution) is not Object, then
        a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var reject;

--- a/test/built-ins/Promise/prototype/then/resolve-pending-rejected-non-thenable.js
+++ b/test/built-ins/Promise/prototype/then/resolve-pending-rejected-non-thenable.js
@@ -24,6 +24,7 @@ info: >
     10. Let thenAction be then.[[value]].
     11. If IsCallable(thenAction) is false, then
         a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var nonThenable = { then: null };

--- a/test/built-ins/Promise/prototype/then/resolve-pending-rejected-poisoned-then.js
+++ b/test/built-ins/Promise/prototype/then/resolve-pending-rejected-poisoned-then.js
@@ -21,6 +21,7 @@ info: >
     8. Let then be Get(resolution, "then").
     9. If then is an abrupt completion, then
        a. Return RejectPromise(promise, then.[[value]]).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/resolve-pending-rejected-self.js
+++ b/test/built-ins/Promise/prototype/then/resolve-pending-rejected-self.js
@@ -21,6 +21,7 @@ info: >
     6. If SameValue(resolution, promise) is true, then
        a. Let selfResolutionError be a newly created TypeError object.
        b. Return RejectPromise(promise, selfResolutionError).
+flags: [async]
 ---*/
 
 var reject;

--- a/test/built-ins/Promise/prototype/then/resolve-pending-rejected-thenable.js
+++ b/test/built-ins/Promise/prototype/then/resolve-pending-rejected-thenable.js
@@ -26,6 +26,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/resolve-settled-fulfilled-non-obj.js
+++ b/test/built-ins/Promise/prototype/then/resolve-settled-fulfilled-non-obj.js
@@ -25,6 +25,7 @@ info: >
     25.4.1.3.2 Promise Resolve Functions
     7. If Type(resolution) is not Object, then
        a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var p1 = new Promise(function(resolve) { resolve(); });

--- a/test/built-ins/Promise/prototype/then/resolve-settled-fulfilled-non-thenable.js
+++ b/test/built-ins/Promise/prototype/then/resolve-settled-fulfilled-non-thenable.js
@@ -30,6 +30,7 @@ info: >
     10. Let thenAction be then.[[value]].
     11. If IsCallable(thenAction) is false, then
         a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var nonThenable = { then: null };

--- a/test/built-ins/Promise/prototype/then/resolve-settled-fulfilled-poisoned-then.js
+++ b/test/built-ins/Promise/prototype/then/resolve-settled-fulfilled-poisoned-then.js
@@ -27,6 +27,7 @@ info: >
     8. Let then be Get(resolution, "then").
     9. If then is an abrupt completion, then
        a. Return RejectPromise(promise, then.[[value]]).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/resolve-settled-fulfilled-self.js
+++ b/test/built-ins/Promise/prototype/then/resolve-settled-fulfilled-self.js
@@ -27,6 +27,7 @@ info: >
     6. If SameValue(resolution, promise) is true, then
        a. Let selfResolutionError be a newly created TypeError object.
        b. Return RejectPromise(promise, selfResolutionError).
+flags: [async]
 ---*/
 
 var p1 = new Promise(function(resolve) { resolve(); });

--- a/test/built-ins/Promise/prototype/then/resolve-settled-fulfilled-thenable.js
+++ b/test/built-ins/Promise/prototype/then/resolve-settled-fulfilled-thenable.js
@@ -32,6 +32,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/resolve-settled-rejected-non-obj.js
+++ b/test/built-ins/Promise/prototype/then/resolve-settled-rejected-non-obj.js
@@ -25,6 +25,7 @@ info: >
     25.4.1.3.2 Promise Resolve Functions
     7. If Type(resolution) is not Object, then
        a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var p1 = new Promise(function(_, reject) { reject(); });

--- a/test/built-ins/Promise/prototype/then/resolve-settled-rejected-non-thenable.js
+++ b/test/built-ins/Promise/prototype/then/resolve-settled-rejected-non-thenable.js
@@ -30,6 +30,7 @@ info: >
     10. Let thenAction be then.[[value]].
     11. If IsCallable(thenAction) is false, then
         a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var nonThenable = { then: null };

--- a/test/built-ins/Promise/prototype/then/resolve-settled-rejected-poisoned-then.js
+++ b/test/built-ins/Promise/prototype/then/resolve-settled-rejected-poisoned-then.js
@@ -27,6 +27,7 @@ info: >
     8. Let then be Get(resolution, "then").
     9. If then is an abrupt completion, then
        a. Return RejectPromise(promise, then.[[value]]).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/resolve-settled-rejected-self.js
+++ b/test/built-ins/Promise/prototype/then/resolve-settled-rejected-self.js
@@ -27,6 +27,7 @@ info: >
     6. If SameValue(resolution, promise) is true, then
        a. Let selfResolutionError be a newly created TypeError object.
        b. Return RejectPromise(promise, selfResolutionError).
+flags: [async]
 ---*/
 
 var p1 = new Promise(function(_, reject) { reject(); });

--- a/test/built-ins/Promise/prototype/then/resolve-settled-rejected-thenable.js
+++ b/test/built-ins/Promise/prototype/then/resolve-settled-rejected-thenable.js
@@ -32,6 +32,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/rxn-handler-fulfilled-invoke-nonstrict.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-fulfilled-invoke-nonstrict.js
@@ -9,7 +9,7 @@ es6id: S25.4.2.1_A3.1_T1
 author: Sam Mikes
 description: >
     "fulfilled" handler invoked correctly outside of strict mode
-flags: [noStrict]
+flags: [async, noStrict]
 includes: [fnGlobalObject.js]
 ---*/
 

--- a/test/built-ins/Promise/prototype/then/rxn-handler-fulfilled-invoke-strict.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-fulfilled-invoke-strict.js
@@ -9,7 +9,7 @@ es6id: S25.4.2.1_A3.1_T2
 author: Sam Mikes
 description: >
     "fulfilled" handler invoked correctly in strict mode
-flags: [onlyStrict]
+flags: [async, onlyStrict]
 ---*/
 
 var expectedThis = undefined,

--- a/test/built-ins/Promise/prototype/then/rxn-handler-fulfilled-next-abrupt.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-fulfilled-next-abrupt.js
@@ -12,6 +12,7 @@ info: >
     8. Let status be Call(promiseCapability.[[Resolve]], undefined,
        «handlerResult.[[value]]»).
     9. NextJob Completion(status).
+flags: [async]
 ---*/
 
 var promise = new Promise(function(resolve) {

--- a/test/built-ins/Promise/prototype/then/rxn-handler-fulfilled-next.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-fulfilled-next.js
@@ -12,6 +12,7 @@ info: >
     8. Let status be Call(promiseCapability.[[Resolve]], undefined,
        «handlerResult.[[value]]»).
     9. NextJob Completion(status).
+flags: [async]
 ---*/
 
 var promise = new Promise(function(resolve) {

--- a/test/built-ins/Promise/prototype/then/rxn-handler-fulfilled-return-abrupt.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-fulfilled-return-abrupt.js
@@ -25,6 +25,7 @@ info: >
     8. Let status be Call(promiseCapability.[[Resolve]], undefined,
        «handlerResult.[[value]]»).
     9. NextJob Completion(status).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/rxn-handler-fulfilled-return-normal.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-fulfilled-return-normal.js
@@ -25,6 +25,7 @@ info: >
     8. Let status be Call(promiseCapability.[[Resolve]], undefined,
        «handlerResult.[[value]]»).
     9. NextJob Completion(status).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/rxn-handler-identity.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-identity.js
@@ -7,6 +7,7 @@ info: >
 es6id: S25.4.2.1_A1.1_T1
 author: Sam Mikes
 description: argument passes through "Identity"
+flags: [async]
 ---*/
 
 var obj = {};

--- a/test/built-ins/Promise/prototype/then/rxn-handler-rejected-invoke-nonstrict.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-rejected-invoke-nonstrict.js
@@ -9,7 +9,7 @@ es6id: S25.4.2.1_A3.2_T1
 author: Sam Mikes
 description: >
     "rejected" handler invoked correctly outside of strict mode
-flags: [noStrict]
+flags: [async, noStrict]
 includes: [fnGlobalObject.js]
 ---*/
 

--- a/test/built-ins/Promise/prototype/then/rxn-handler-rejected-invoke-strict.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-rejected-invoke-strict.js
@@ -9,7 +9,7 @@ es6id: S25.4.2.1_A3.2_T2
 author: Sam Mikes
 description: >
     "rejected" handler invoked correctly in strict mode
-flags: [onlyStrict]
+flags: [async, onlyStrict]
 ---*/
 
 var expectedThis = undefined,

--- a/test/built-ins/Promise/prototype/then/rxn-handler-rejected-next-abrupt.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-rejected-next-abrupt.js
@@ -12,6 +12,7 @@ info: >
     8. Let status be Call(promiseCapability.[[Resolve]], undefined,
        «handlerResult.[[value]]»).
     9. NextJob Completion(status).
+flags: [async]
 ---*/
 
 var promise = new Promise(function(_, reject) {

--- a/test/built-ins/Promise/prototype/then/rxn-handler-rejected-next.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-rejected-next.js
@@ -12,6 +12,7 @@ info: >
     8. Let status be Call(promiseCapability.[[Resolve]], undefined,
        «handlerResult.[[value]]»).
     9. NextJob Completion(status).
+flags: [async]
 ---*/
 
 var promise = new Promise(function(_, reject) {

--- a/test/built-ins/Promise/prototype/then/rxn-handler-rejected-return-abrupt.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-rejected-return-abrupt.js
@@ -25,6 +25,7 @@ info: >
     8. Let status be Call(promiseCapability.[[Resolve]], undefined,
        «handlerResult.[[value]]»).
     9. NextJob Completion(status).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/rxn-handler-rejected-return-normal.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-rejected-return-normal.js
@@ -25,6 +25,7 @@ info: >
     8. Let status be Call(promiseCapability.[[Resolve]], undefined,
        «handlerResult.[[value]]»).
     9. NextJob Completion(status).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/rxn-handler-thrower.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-thrower.js
@@ -7,6 +7,7 @@ info: >
 es6id: S25.4.2.1_A2.1_T1
 author: Sam Mikes
 description: argument thrown through "Thrower"
+flags: [async]
 ---*/
 
 var obj = {};

--- a/test/built-ins/Promise/race/S25.4.4.3_A2.2_T1.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A2.2_T1.js
@@ -6,6 +6,7 @@ info: Promise.race rejects on non-iterable argument
 es6id: S25.4.4.3_A2.2_T1
 author: Sam Mikes
 description: Promise.race rejects if argument is not object or is non-iterable
+flags: [async]
 ---*/
 
 var nonIterable = 3;

--- a/test/built-ins/Promise/race/S25.4.4.3_A2.2_T2.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A2.2_T2.js
@@ -6,6 +6,7 @@ info: Promise.race rejects on non-iterable argument
 es6id: S25.4.4.3_A2.2_T2
 author: Sam Mikes
 description: Promise.race rejects if argument is not object or is non-iterable
+flags: [async]
 ---*/
 
 Promise.race(new Error("abrupt")).then(function () {

--- a/test/built-ins/Promise/race/S25.4.4.3_A2.2_T3.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A2.2_T3.js
@@ -10,6 +10,7 @@ es6id: S25.4.4.3_A2.2_T3
 author: Sam Mikes
 description: Promise.race rejects if GetIterator throws
 features: [Symbol.iterator]
+flags: [async]
 ---*/
 
 var iterThrows = {};

--- a/test/built-ins/Promise/race/S25.4.4.3_A4.1_T1.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A4.1_T1.js
@@ -6,6 +6,7 @@ es6id: S25.4.4.3_A4.1_T1
 author: Sam Mikes
 description: Promise.race rejects if IteratorStep throws
 features: [Symbol.iterator]
+flags: [async]
 ---*/
 
 var iterThrows = {};

--- a/test/built-ins/Promise/race/S25.4.4.3_A4.1_T2.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A4.1_T2.js
@@ -6,6 +6,7 @@ es6id: S25.4.4.3_A4.1_T2
 author: Sam Mikes
 description: Promise.race rejects if IteratorStep throws
 features: [Symbol.iterator]
+flags: [async]
 ---*/
 
 var iterThrows = {};

--- a/test/built-ins/Promise/race/S25.4.4.3_A5.1_T1.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A5.1_T1.js
@@ -5,6 +5,7 @@
 es6id: S25.4.4.3_A5.1_T1
 author: Sam Mikes
 description: Promise.race([]) never settles
+flags: [async]
 ---*/
 
 var p = Promise.race([]);

--- a/test/built-ins/Promise/race/S25.4.4.3_A6.1_T1.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A6.1_T1.js
@@ -6,6 +6,7 @@ es6id: S25.4.4.3_A6.1_T1
 author: Sam Mikes
 description: Promise.race([1]) settles immediately
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/race/S25.4.4.3_A6.2_T1.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A6.2_T1.js
@@ -6,6 +6,7 @@ es6id: S25.4.4.3_A6.2_T1
 author: Sam Mikes
 description: Promise.race([p1]) settles immediately
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/race/S25.4.4.3_A7.1_T1.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A7.1_T1.js
@@ -6,6 +6,7 @@ es6id: S25.4.4.3_A7.1_T1
 author: Sam Mikes
 description: Promise.race([p1, p2]) settles when first settles
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/race/S25.4.4.3_A7.1_T2.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A7.1_T2.js
@@ -6,6 +6,7 @@ es6id: S25.4.4.3_A7.1_T2
 author: Sam Mikes
 description: Promise.race([p1, p2]) settles when first settles
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/race/S25.4.4.3_A7.1_T3.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A7.1_T3.js
@@ -6,6 +6,7 @@ es6id: S25.4.4.3_A7.1_T3
 author: Sam Mikes
 description: Promise.race([p1, p2]) settles when first settles
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/race/S25.4.4.3_A7.2_T1.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A7.2_T1.js
@@ -6,6 +6,7 @@ es6id: S25.4.4.3_A7.2_T1
 author: Sam Mikes
 description: Promise.race([p1, p2]) settles when first settles
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/race/S25.4.4.3_A7.3_T1.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A7.3_T1.js
@@ -5,6 +5,7 @@
 es6id: S25.4.4.3_A7.3_T1
 author: Sam Mikes
 description: Promise.race([p1, p2]) settles when first settles
+flags: [async]
 ---*/
 
 var resolveP1, rejectP2,

--- a/test/built-ins/Promise/race/S25.4.4.3_A7.3_T2.js
+++ b/test/built-ins/Promise/race/S25.4.4.3_A7.3_T2.js
@@ -5,6 +5,7 @@
 es6id: S25.4.4.3_A7.3_T2
 author: Sam Mikes
 description: Promise.race([p1, p2]) settles when first settles
+flags: [async]
 ---*/
 
 var resolveP1, rejectP2,

--- a/test/built-ins/Promise/race/invoke-resolve-get-error.js
+++ b/test/built-ins/Promise/race/invoke-resolve-get-error.js
@@ -20,6 +20,7 @@ info: >
         [...]
         h. Let nextPromise be Invoke(C, "resolve", «nextValue»).
         i. ReturnIfAbrupt(nextPromise).
+flags: [async]
 ---*/
 
 var error = new Test262Error();

--- a/test/built-ins/Promise/race/invoke-then-error.js
+++ b/test/built-ins/Promise/race/invoke-then-error.js
@@ -21,6 +21,7 @@ info: >
         j. Let result be Invoke(nextPromise, "then",
            «promiseCapability.[[Resolve]], promiseCapability.[[Reject]]»).
         k. ReturnIfAbrupt(result).
+flags: [async]
 ---*/
 
 var promise = new Promise(function() {});

--- a/test/built-ins/Promise/race/iter-close.js
+++ b/test/built-ins/Promise/race/iter-close.js
@@ -20,6 +20,7 @@ info: >
        h. Let nextPromise be Invoke(C, "resolve", «nextValue»).
        i. ReturnIfAbrupt(nextPromise).
 features: [Symbol.iterator]
+flags: [async]
 ---*/
 
 var err = new Test262Error();

--- a/test/built-ins/Promise/race/iter-next-val-err.js
+++ b/test/built-ins/Promise/race/iter-next-val-err.js
@@ -23,6 +23,7 @@ info: >
            true.
         g. ReturnIfAbrupt(nextValue).
 features: [Symbol.iterator]
+flags: [async]
 ---*/
 
 var iterNextValThrows = {};

--- a/test/built-ins/Promise/race/iter-step-err.js
+++ b/test/built-ins/Promise/race/iter-step-err.js
@@ -19,6 +19,7 @@ info: >
        b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
        c. ReturnIfAbrupt(next).
 features: [Symbol.iterator]
+flags: [async]
 ---*/
 
 var iterStepThrows = {};

--- a/test/built-ins/Promise/race/reject-deferred.js
+++ b/test/built-ins/Promise/race/reject-deferred.js
@@ -19,6 +19,7 @@ info: >
     25.4.1.3.1 Promise Reject Functions
     [...]
     6. Return RejectPromise(promise, reason).
+flags: [async]
 ---*/
 
 var thenable = {

--- a/test/built-ins/Promise/race/reject-ignored-deferred.js
+++ b/test/built-ins/Promise/race/reject-ignored-deferred.js
@@ -24,6 +24,7 @@ info: >
     3. Let alreadyResolved be the value of F's [[AlreadyResolved]] internal
        slot.
     4. If alreadyResolved.[[value]] is true, return undefined.
+flags: [async]
 ---*/
 
 var fulfiller = {

--- a/test/built-ins/Promise/race/reject-ignored-immed.js
+++ b/test/built-ins/Promise/race/reject-ignored-immed.js
@@ -24,6 +24,7 @@ info: >
     3. Let alreadyResolved be the value of F's [[AlreadyResolved]] internal
        slot.
     4. If alreadyResolved.[[value]] is true, return undefined.
+flags: [async]
 ---*/
 
 var fulfiller = {

--- a/test/built-ins/Promise/race/reject-immed.js
+++ b/test/built-ins/Promise/race/reject-immed.js
@@ -19,6 +19,7 @@ info: >
     25.4.1.3.1 Promise Reject Functions
     [...]
     6. Return RejectPromise(promise, reason).
+flags: [async]
 ---*/
 
 var thenable = {

--- a/test/built-ins/Promise/race/resolve-non-obj.js
+++ b/test/built-ins/Promise/race/resolve-non-obj.js
@@ -20,6 +20,7 @@ info: >
     [...]
     7. If Type(resolution) is not Object, then
        a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var thenable = {

--- a/test/built-ins/Promise/race/resolve-non-thenable.js
+++ b/test/built-ins/Promise/race/resolve-non-thenable.js
@@ -24,6 +24,7 @@ info: >
     10. Let thenAction be then.[[value]].
     11. If IsCallable(thenAction) is false, then
         a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/race/resolve-poisoned-then.js
+++ b/test/built-ins/Promise/race/resolve-poisoned-then.js
@@ -20,6 +20,7 @@ info: >
     8. Let then be Get(resolution, "then").
     9. If then is an abrupt completion, then
        a. Return RejectPromise(promise, then.[[value]]).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/race/resolve-self.js
+++ b/test/built-ins/Promise/race/resolve-self.js
@@ -20,6 +20,7 @@ info: >
     6. If SameValue(resolution, promise) is true, then
        a. Let selfResolutionError be a newly created TypeError object.
        b. Return RejectPromise(promise, selfResolutionError).
+flags: [async]
 ---*/
 
 var self, resolve;

--- a/test/built-ins/Promise/race/resolve-thenable.js
+++ b/test/built-ins/Promise/race/resolve-thenable.js
@@ -26,6 +26,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/reject-ignored-via-abrupt.js
+++ b/test/built-ins/Promise/reject-ignored-via-abrupt.js
@@ -18,6 +18,7 @@ info: >
     3. Let alreadyResolved be the value of F's [[AlreadyResolved]] internal
        slot.
     4. If alreadyResolved.[[value]] is true, return undefined.
+flags: [async]
 ---*/
 
 var thenable = new Promise(function() {});

--- a/test/built-ins/Promise/reject-ignored-via-fn-deferred.js
+++ b/test/built-ins/Promise/reject-ignored-via-fn-deferred.js
@@ -18,6 +18,7 @@ info: >
     3. Let alreadyResolved be the value of F's [[AlreadyResolved]] internal
        slot.
     4. If alreadyResolved.[[value]] is true, return undefined.
+flags: [async]
 ---*/
 
 var thenable = new Promise(function() {});

--- a/test/built-ins/Promise/reject-ignored-via-fn-immed.js
+++ b/test/built-ins/Promise/reject-ignored-via-fn-immed.js
@@ -18,6 +18,7 @@ info: >
     3. Let alreadyResolved be the value of F's [[AlreadyResolved]] internal
        slot.
     4. If alreadyResolved.[[value]] is true, return undefined.
+flags: [async]
 ---*/
 
 var thenable = new Promise(function() {});

--- a/test/built-ins/Promise/reject-via-abrupt.js
+++ b/test/built-ins/Promise/reject-via-abrupt.js
@@ -16,6 +16,7 @@ info: >
     25.4.1.3.1 Promise Reject Functions
     [...]
     6. Return RejectPromise(promise, reason).
+flags: [async]
 ---*/
 
 var thenable = new Promise(function() {});

--- a/test/built-ins/Promise/reject-via-fn-deferred.js
+++ b/test/built-ins/Promise/reject-via-fn-deferred.js
@@ -14,6 +14,7 @@ info: >
     25.4.1.3.1 Promise Reject Functions
     [...]
     6. Return RejectPromise(promise, reason).
+flags: [async]
 ---*/
 
 var thenable = new Promise(function() {});

--- a/test/built-ins/Promise/reject-via-fn-immed.js
+++ b/test/built-ins/Promise/reject-via-fn-immed.js
@@ -14,6 +14,7 @@ info: >
     25.4.1.3.1 Promise Reject Functions
     [...]
     6. Return RejectPromise(promise, reason).
+flags: [async]
 ---*/
 
 var thenable = new Promise(function() {});

--- a/test/built-ins/Promise/reject/S25.4.4.4_A2.1_T1.js
+++ b/test/built-ins/Promise/reject/S25.4.4.4_A2.1_T1.js
@@ -13,6 +13,7 @@ info: >
 es6id: 25.4.4.4
 author: Sam Mikes
 description: Promise.reject creates a new settled promise
+flags: [async]
 ---*/
 
 var p = Promise.reject(3);

--- a/test/built-ins/Promise/resolve-non-obj-deferred.js
+++ b/test/built-ins/Promise/resolve-non-obj-deferred.js
@@ -13,6 +13,7 @@ info: >
     25.4.1.3.2 Promise Resolve Functions
     7. If Type(resolution) is not Object, then
        a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var resolve;

--- a/test/built-ins/Promise/resolve-non-obj-immed.js
+++ b/test/built-ins/Promise/resolve-non-obj-immed.js
@@ -12,6 +12,7 @@ info: >
     25.4.1.3.2 Promise Resolve Functions
     7. If Type(resolution) is not Object, then
        a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var promise = new Promise(function(resolve) {

--- a/test/built-ins/Promise/resolve-non-thenable-deferred.js
+++ b/test/built-ins/Promise/resolve-non-thenable-deferred.js
@@ -18,6 +18,7 @@ info: >
     10. Let thenAction be then.[[value]].
     11. If IsCallable(thenAction) is false, then
         a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var nonThenable = { then: null };

--- a/test/built-ins/Promise/resolve-non-thenable-immed.js
+++ b/test/built-ins/Promise/resolve-non-thenable-immed.js
@@ -18,6 +18,7 @@ info: >
     10. Let thenAction be then.[[value]].
     11. If IsCallable(thenAction) is false, then
         a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var nonThenable = { then: null };

--- a/test/built-ins/Promise/resolve-poisoned-then-deferred.js
+++ b/test/built-ins/Promise/resolve-poisoned-then-deferred.js
@@ -14,6 +14,7 @@ info: >
     25.4.1.3.2 Promise Resolve Functions
     7. If Type(resolution) is not Object, then
        a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/resolve-poisoned-then-immed.js
+++ b/test/built-ins/Promise/resolve-poisoned-then-immed.js
@@ -14,6 +14,7 @@ info: >
     25.4.1.3.2 Promise Resolve Functions
     7. If Type(resolution) is not Object, then
        a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/resolve-self.js
+++ b/test/built-ins/Promise/resolve-self.js
@@ -14,6 +14,7 @@ info: >
     6. If SameValue(resolution, promise) is true, then
        a. Let selfResolutionError be a newly created TypeError object.
        b. Return RejectPromise(promise, selfResolutionError).
+flags: [async]
 ---*/
 
 var resolve;

--- a/test/built-ins/Promise/resolve-thenable-deferred.js
+++ b/test/built-ins/Promise/resolve-thenable-deferred.js
@@ -21,6 +21,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/resolve-thenable-immed.js
+++ b/test/built-ins/Promise/resolve-thenable-immed.js
@@ -20,6 +20,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/resolve/S25.4.4.5_A2.2_T1.js
+++ b/test/built-ins/Promise/resolve/S25.4.4.5_A2.2_T1.js
@@ -5,6 +5,7 @@
 es6id: S25.4.4.5_A2.2_T1
 author: Sam Mikes
 description: Promise.resolve passes through an unsettled promise w/ same Constructor
+flags: [async]
 ---*/
 
 var resolveP1,

--- a/test/built-ins/Promise/resolve/S25.4.4.5_A2.3_T1.js
+++ b/test/built-ins/Promise/resolve/S25.4.4.5_A2.3_T1.js
@@ -5,6 +5,7 @@
 es6id: S25.4.4.5_A2.3_T1
 author: Sam Mikes
 description: Promise.resolve passes through an unsettled promise w/ same Constructor
+flags: [async]
 ---*/
 
 var rejectP1,

--- a/test/built-ins/Promise/resolve/S25.4.4.5_A3.1_T1.js
+++ b/test/built-ins/Promise/resolve/S25.4.4.5_A3.1_T1.js
@@ -8,6 +8,7 @@ es6id: S25.4.4.5_A3.1_T1
 author: Sam Mikes
 description: Promise.resolve delegates to foreign thenable
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/resolve/S25.4.4.5_A4.1_T1.js
+++ b/test/built-ins/Promise/resolve/S25.4.4.5_A4.1_T1.js
@@ -7,6 +7,7 @@ info: >
 es6id: S25.4.4.5_A3.1_T1
 author: Sam Mikes
 description: self-resolved Promise throws TypeError
+flags: [async]
 ---*/
 
 var resolveP,

--- a/test/built-ins/Promise/resolve/S25.Promise_resolve_foreign_thenable_1.js
+++ b/test/built-ins/Promise/resolve/S25.Promise_resolve_foreign_thenable_1.js
@@ -8,6 +8,7 @@ es6id: S25.4.4.5
 author: Sam Mikes
 description: Promise.resolve delegates to foreign thenable
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/resolve/S25.Promise_resolve_foreign_thenable_2.js
+++ b/test/built-ins/Promise/resolve/S25.Promise_resolve_foreign_thenable_2.js
@@ -8,6 +8,7 @@ es6id: S25.4.4.5
 author: Sam Mikes
 description: Promise.resolve delegates to foreign thenable
 includes: [PromiseHelper.js]
+flags: [async]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/resolve/arg-non-thenable.js
+++ b/test/built-ins/Promise/resolve/arg-non-thenable.js
@@ -18,6 +18,7 @@ info: >
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
     13. Return undefined.
+flags: [async]
 ---*/
 
 var nonThenable = {

--- a/test/built-ins/Promise/resolve/arg-poisoned-then.js
+++ b/test/built-ins/Promise/resolve/arg-poisoned-then.js
@@ -16,6 +16,7 @@ info: >
     8. Let then be Get(resolution, "then").
     9. If then is an abrupt completion, then
        a. Return RejectPromise(promise, then.[[value]]).
+flags: [async]
 ---*/
 
 var poisonedThen = {};

--- a/test/built-ins/Promise/resolve/resolve-non-obj.js
+++ b/test/built-ins/Promise/resolve/resolve-non-obj.js
@@ -13,6 +13,7 @@ info: >
     [...]
     7. If Type(resolution) is not Object, then
        a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 Promise.resolve(23).then(function(value) {

--- a/test/built-ins/Promise/resolve/resolve-non-thenable.js
+++ b/test/built-ins/Promise/resolve/resolve-non-thenable.js
@@ -17,6 +17,7 @@ info: >
     10. Let thenAction be then.[[value]].
     11. If IsCallable(thenAction) is false, then
         a. Return FulfillPromise(promise, resolution).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/resolve/resolve-poisoned-then.js
+++ b/test/built-ins/Promise/resolve/resolve-poisoned-then.js
@@ -14,6 +14,7 @@ info: >
     8. Let then be Get(resolution, "then").
     9. If then is an abrupt completion, then
        a. Return RejectPromise(promise, then.[[value]]).
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/resolve/resolve-self.js
+++ b/test/built-ins/Promise/resolve/resolve-self.js
@@ -17,6 +17,7 @@ info: >
     6. If SameValue(resolution, promise) is true, then
        a. Let selfResolutionError be a newly created TypeError object.
        b. Return RejectPromise(promise, selfResolutionError).
+flags: [async]
 ---*/
 
 var resolve, reject;

--- a/test/built-ins/Promise/resolve/resolve-thenable.js
+++ b/test/built-ins/Promise/resolve/resolve-thenable.js
@@ -19,6 +19,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var value = {};

--- a/tools/packaging/test262.py
+++ b/tools/packaging/test262.py
@@ -309,7 +309,7 @@ class TestCase(object):
     return 'raw' in self.testRecord
 
   def IsAsyncTest(self):
-    return '$DONE' in self.test
+    return 'async' in self.testRecord
 
   def GetIncludeList(self):
     if self.testRecord.get('includes'):


### PR DESCRIPTION
For asynchronous tests, the contract between test file and test runner
is implicit: runners are expected to inspect the source code for
references to a global `$DONE` identifier.

Promote a more explicit contract between test file and test runner by
introducing a new frontmatter "tag", `async`. This brings asynchronous
test configuration in-line with other configuration mechanisms and also
provides a more natural means of test filtering.

The modifications to test files was made programatically using the
`grep` and `sed` utilities:

    $ grep "\$DONE" test/ -r --files-with-match --null | \
        xargs -0 sed -i 's/^\(flags:\s*\)\[/\1[async, /g'
    $ grep "\$DONE" test/ -rl --null | \
        xargs -0 grep -E '^flags:' --files-without-match --null | \
        xargs -0 sed -i 's/^---\*\//flags: [async]\n---*\//'