### PR TITLE
Remove unused harness file

### DIFF
--- a/harness/Test262Error.js
+++ b/harness/Test262Error.js
@@ -1,7 +1,0 @@
-//function Test262Error(message) {
-//    if (message) this.message = message;
-//}
-//
-//Test262Error.prototype.toString = function () {
-//    return "Test262 Error: " + this.message;
-//};

--- a/test/built-ins/Error/prototype/S15.11.4_A3.js
+++ b/test/built-ins/Error/prototype/S15.11.4_A3.js
@@ -5,8 +5,6 @@
 info: Since Error prototype object is not function it has no [[Call]] method
 es5id: 15.11.4_A3
 description: Checking if call of Error prototype as a function fails
-includes:
-    - Test262Error.js
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/Error/prototype/S15.11.4_A4.js
+++ b/test/built-ins/Error/prototype/S15.11.4_A4.js
@@ -5,8 +5,6 @@
 info: Since Error prototype object is not function it has no [[Construct]] method
 es5id: 15.11.4_A4
 description: Checking if creating "new Error.prototype" fails
-includes:
-    - Test262Error.js
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////

--- a/test/built-ins/Proxy/apply/return-abrupt.js
+++ b/test/built-ins/Proxy/apply/return-abrupt.js
@@ -4,7 +4,6 @@
 es6id: 9.5.13
 description: >
     Return is an abrupt completion
-includes: [Test262Error.js]
 ---*/
 
 var target = function(a, b) { return a + b; };

--- a/test/built-ins/Proxy/construct/return-is-abrupt.js
+++ b/test/built-ins/Proxy/construct/return-is-abrupt.js
@@ -9,7 +9,6 @@ info: >
 
     9. Let newObj be Call(trap, handler, «target, argArray, newTarget »).
     10. ReturnIfAbrupt(newObj).
-includes: [Test262Error.js]
 ---*/
 
 function Target() {}

--- a/test/built-ins/Proxy/defineProperty/return-is-abrupt.js
+++ b/test/built-ins/Proxy/defineProperty/return-is-abrupt.js
@@ -12,7 +12,6 @@ info: >
     descObj»)).
     11. ReturnIfAbrupt(booleanTrapResult).
     ...
-includes: [Test262Error.js]
 ---*/
 
 var p = new Proxy({}, {

--- a/test/built-ins/Proxy/deleteProperty/return-is-abrupt.js
+++ b/test/built-ins/Proxy/deleteProperty/return-is-abrupt.js
@@ -7,7 +7,6 @@ description: >
 info: >
     9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P»)).
     10. ReturnIfAbrupt(booleanTrapResult).
-includes: [Test262Error.js]
 ---*/
 
 var p = new Proxy({}, {

--- a/test/built-ins/Proxy/enumerate/return-is-abrupt.js
+++ b/test/built-ins/Proxy/enumerate/return-is-abrupt.js
@@ -9,7 +9,6 @@ info: >
 
     8. Let trapResult be Call(trap, handler, «target»).
     9. ReturnIfAbrupt(trapResult).
-includes: [Test262Error.js]
 ---*/
 
 var x;

--- a/test/built-ins/Proxy/get/return-is-abrupt.js
+++ b/test/built-ins/Proxy/get/return-is-abrupt.js
@@ -9,7 +9,6 @@ info: >
 
     9. Let trapResult be Call(trap, handler, «target, P, Receiver»).
     10. ReturnIfAbrupt(trapResult).
-includes: [Test262Error.js]
 ---*/
 
 var p = new Proxy({}, {

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/return-is-abrupt.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/return-is-abrupt.js
@@ -11,7 +11,6 @@ info: >
     9. Let trapResultObj be Call(trap, handler, «target, P»).
     10. ReturnIfAbrupt(trapResultObj).
     ...
-includes: [Test262Error.js]
 ---*/
 
 var p = new Proxy({}, {

--- a/test/built-ins/Proxy/getPrototypeOf/return-is-abrupt.js
+++ b/test/built-ins/Proxy/getPrototypeOf/return-is-abrupt.js
@@ -7,7 +7,6 @@ description: >
 info: >
     8. Let handlerProto be Call(trap, handler, «target»).
     9. ReturnIfAbrupt(handlerProto).
-includes: [Test262Error.js]
 ---*/
 
 var p = new Proxy({}, {

--- a/test/built-ins/Proxy/has/return-is-abrupt-in.js
+++ b/test/built-ins/Proxy/has/return-is-abrupt-in.js
@@ -11,7 +11,6 @@ info: >
     9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P»)).
     10. ReturnIfAbrupt(booleanTrapResult).
     ...
-includes: [Test262Error.js]
 ---*/
 
 var p = new Proxy({}, {

--- a/test/built-ins/Proxy/has/return-is-abrupt-with.js
+++ b/test/built-ins/Proxy/has/return-is-abrupt-with.js
@@ -12,7 +12,6 @@ info: >
     10. ReturnIfAbrupt(booleanTrapResult).
     ...
 flags: [noStrict]
-includes: [Test262Error.js]
 ---*/
 
 var p = new Proxy({}, {

--- a/test/built-ins/Proxy/isExtensible/return-is-abrupt.js
+++ b/test/built-ins/Proxy/isExtensible/return-is-abrupt.js
@@ -11,7 +11,6 @@ info: >
     8. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target»)).
     9. ReturnIfAbrupt(booleanTrapResult).
     ...
-includes: [Test262Error.js]
 ---*/
 
 var p = new Proxy({}, {

--- a/test/built-ins/Proxy/ownKeys/return-is-abrupt.js
+++ b/test/built-ins/Proxy/ownKeys/return-is-abrupt.js
@@ -14,7 +14,6 @@ info: >
 
         1. ReturnIfAbrupt(obj).
     ...
-includes: [Test262Error.js]
 ---*/
 
 var p = new Proxy({}, {

--- a/test/built-ins/Proxy/preventExtensions/return-is-abrupt.js
+++ b/test/built-ins/Proxy/preventExtensions/return-is-abrupt.js
@@ -11,7 +11,6 @@ info: >
     8. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target»)).
     9. ReturnIfAbrupt(booleanTrapResult).
     ...
-includes: [Test262Error.js]
 ---*/
 
 var p = new Proxy({}, {

--- a/test/built-ins/Proxy/set/return-is-abrupt.js
+++ b/test/built-ins/Proxy/set/return-is-abrupt.js
@@ -11,7 +11,6 @@ info: >
     9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P, V, Receiver»)).
     10. ReturnIfAbrupt(booleanTrapResult).
     ...
-includes: [Test262Error.js]
 ---*/
 
 var p = new Proxy({}, {

--- a/test/built-ins/Proxy/setPrototypeOf/return-is-abrupt.js
+++ b/test/built-ins/Proxy/setPrototypeOf/return-is-abrupt.js
@@ -9,7 +9,6 @@ info: >
 
     9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, V»)).
     10. ReturnIfAbrupt(booleanTrapResult).
-includes: [Test262Error.js]
 ---*/
 
 var p = new Proxy({}, {

--- a/test/built-ins/String/fromCharCode/S15.5.3.2_A4.js
+++ b/test/built-ins/String/fromCharCode/S15.5.3.2_A4.js
@@ -5,8 +5,6 @@
 info: String.fromCharCode has not [[construct]] method
 es5id: 15.5.3.2_A4
 description: Checking if creating "new String.fromCharCode" fails
-includes:
-    - Test262Error.js
 ---*/
 
 var __fcc__func = String.fromCharCode;

--- a/test/built-ins/String/prototype/charCodeAt/S15.5.4.5_A7.js
+++ b/test/built-ins/String/prototype/charCodeAt/S15.5.4.5_A7.js
@@ -5,8 +5,6 @@
 info: String.prototype.charCodeAt can't be used as constructor
 es5id: 15.5.4.5_A7
 description: Checking if creating the String.prototype.charCodeAt object fails
-includes:
-    - Test262Error.js
 ---*/
 
 var __FACTORY = String.prototype.charCodeAt;

--- a/test/built-ins/String/prototype/concat/S15.5.4.6_A7.js
+++ b/test/built-ins/String/prototype/concat/S15.5.4.6_A7.js
@@ -5,8 +5,6 @@
 info: String.prototype.concat can't be used as constructor
 es5id: 15.5.4.6_A7
 description: Checking if creating the String.prototype.concat object fails
-includes:
-    - Test262Error.js
 ---*/
 
 var __FACTORY = String.prototype.concat;

--- a/test/built-ins/String/prototype/localeCompare/S15.5.4.9_A7.js
+++ b/test/built-ins/String/prototype/localeCompare/S15.5.4.9_A7.js
@@ -7,8 +7,6 @@ es5id: 15.5.4.9_A7
 description: >
     Checking if creating the String.prototype.localeCompare object
     fails
-includes:
-    - Test262Error.js
 ---*/
 
 var __FACTORY = String.prototype.localeCompare;

--- a/test/built-ins/String/prototype/match/S15.5.4.10_A7.js
+++ b/test/built-ins/String/prototype/match/S15.5.4.10_A7.js
@@ -5,8 +5,6 @@
 info: String.prototype.match can't be used as constructor
 es5id: 15.5.4.10_A7
 description: Checking if creating "String.prototype.match object" fails
-includes:
-    - Test262Error.js
 ---*/
 
 var __FACTORY = String.prototype.match;

--- a/test/built-ins/String/prototype/replace/S15.5.4.11_A7.js
+++ b/test/built-ins/String/prototype/replace/S15.5.4.11_A7.js
@@ -5,8 +5,6 @@
 info: String.prototype.replace can't be used as constructor
 es5id: 15.5.4.11_A7
 description: Checking if creating the String.prototype.replace object fails
-includes:
-    - Test262Error.js
 ---*/
 
 var __FACTORY = String.prototype.replace;

--- a/test/built-ins/String/prototype/split/S15.5.4.14_A7.js
+++ b/test/built-ins/String/prototype/split/S15.5.4.14_A7.js
@@ -5,8 +5,6 @@
 info: String.prototype.split can't be used as constructor
 es5id: 15.5.4.14_A7
 description: Checking if creating the String.prototype.split object fails
-includes:
-    - Test262Error.js
 ---*/
 
 var __FACTORY = String.prototype.split;

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.2_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.2_T1.js
@@ -5,7 +5,6 @@
 info: If B1 = 0xxxxxxxx ([0x00 - 0x7F]), without [uriReserved, #], return B1
 es5id: 15.1.3.1_A2.2_T1
 description: Complex tests, use RFC 3629
-includes: [Test262Error.js]
 ---*/
 
 var errorCount = 0;

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.3_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.3_T1.js
@@ -7,7 +7,6 @@ info: >
     B1 = [0xC0, 0xC1], return UTF8(B1, B2)
 es5id: 15.1.3.1_A2.3_T1
 description: Complex tests, use RFC 3629
-includes: [Test262Error.js]
 ---*/
 
 var errorCount = 0;

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
@@ -8,7 +8,6 @@ info: >
     0xDFFF), return UTF8(B1, B2, B3)
 es5id: 15.1.3.1_A2.4_T1
 description: Complex tests, use RFC 3629
-includes: [Test262Error.js]
 ---*/
 
 var errorCount = 0;

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
@@ -8,7 +8,6 @@ info: >
     return UTF8(B1, B2, B3, B4)
 es5id: 15.1.3.1_A2.5_T1
 description: Complex tests, use RFC 3629
-includes: [Test262Error.js]
 ---*/
 
 var errorCount = 0;

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.2_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.2_T1.js
@@ -5,7 +5,6 @@
 info: If B1 = 0xxxxxxxx ([0x00 - 0x7F]), return B1
 es5id: 15.1.3.2_A2.2_T1
 description: Complex tests, use RFC 3629
-includes: [Test262Error.js]
 ---*/
 
 var errorCount = 0;

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
@@ -7,7 +7,6 @@ info: >
     B1 = [0xC0, 0xC1], return UTF8(B1, B2)
 es5id: 15.1.3.2_A2.3_T1
 description: Complex tests, use RFC 3629
-includes: [Test262Error.js]
 ---*/
 
 var errorCount = 0;

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
@@ -8,7 +8,6 @@ info: >
     0xDFFF), return UTF8(B1, B2, B3)
 es5id: 15.1.3.2_A2.4_T1
 description: Complex tests, use RFC 3629
-includes: [Test262Error.js]
 ---*/
 
 var errorCount = 0;

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
@@ -8,7 +8,6 @@ info: >
     return UTF8(B1, B2, B3, B4)
 es5id: 15.1.3.2_A2.5_T1
 description: Complex tests, use RFC 3629
-includes: [Test262Error.js]
 ---*/
 
 var errorCount = 0;

--- a/test/language/statements/do-while/S12.6.1_A2.js
+++ b/test/language/statements/do-while/S12.6.1_A2.js
@@ -7,7 +7,6 @@ info: >
     evaluated first and only after it is done Expression is checked
 es5id: 12.6.1_A2
 description: Evaluating Statement with error Expression
-includes: [Test262Error.js]
 ---*/
 
 var __in__do;

--- a/test/language/statements/do-while/S12.6.1_A9.js
+++ b/test/language/statements/do-while/S12.6.1_A9.js
@@ -5,7 +5,6 @@
 info: "\"do-while\" Statement is evaluated without syntax checks"
 es5id: 12.6.1_A9
 description: Throwing system exception whithin a "do-while" loop
-includes: [Test262Error.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////

--- a/test/language/statements/function/S13.2.1_A7_T3.js
+++ b/test/language/statements/function/S13.2.1_A7_T3.js
@@ -8,7 +8,6 @@ info: >
     if Result.type is returned  then Result.value is returned too
 es5id: 13.2.1_A7_T3
 description: Returning number. Declaring a function with "function __func()"
-includes: [Test262Error.js]
 flags: [noStrict]
 ---*/
 

--- a/test/language/statements/function/S13.2.1_A7_T4.js
+++ b/test/language/statements/function/S13.2.1_A7_T4.js
@@ -8,7 +8,6 @@ info: >
     if Result.type is returned  then Result.value is returned too
 es5id: 13.2.1_A7_T4
 description: Returning boolean. Declaring a function with "function __func()"
-includes: [Test262Error.js]
 ---*/
 
 function __func(){

--- a/test/language/statements/function/S13.2.2_A11.js
+++ b/test/language/statements/function/S13.2.2_A11.js
@@ -9,7 +9,6 @@ es5id: 13.2.2_A11
 description: >
     Calling a function as a constructor after it has been declared
     with "function func()"
-includes: [Test262Error.js]
 ---*/
 
 function FACTORY(){

--- a/test/language/statements/function/S13.2.2_A13.js
+++ b/test/language/statements/function/S13.2.2_A13.js
@@ -9,7 +9,6 @@ es5id: 13.2.2_A13
 description: >
     Calling a function as a constructor after it has been declared by
     eval
-includes: [Test262Error.js]
 ---*/
 
 function FACTORY(){

--- a/test/language/statements/function/S13.2.2_A9.js
+++ b/test/language/statements/function/S13.2.2_A9.js
@@ -7,7 +7,6 @@ info: >
     this.any_Function is called before it is declared
 es5id: 13.2.2_A9
 description: Calling a function as a constructor
-includes: [Test262Error.js]
 ---*/
 
 function FACTORY(){

--- a/test/language/statements/while/S12.6.2_A9.js
+++ b/test/language/statements/while/S12.6.2_A9.js
@@ -5,7 +5,6 @@
 info: "\"while\" Statement is evaluated without syntax checks"
 es5id: 12.6.2_A9
 description: Throwing system exception inside "while" loop
-includes: [Test262Error.js]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////

--- a/test/language/types/reference/8.7.2-3-a-2gs.js
+++ b/test/language/types/reference/8.7.2-3-a-2gs.js
@@ -7,7 +7,6 @@ description: >
     Strict Mode - 'runtime' error is thrown before LeftHandSide
     evaluates to an unresolvable Reference
 flags: [onlyStrict]
-includes: [Test262Error.js]
 ---*/
 
 assert.throws(Test262Error, function() {


### PR DESCRIPTION
The harness file `Test262Error.js` has not contained executable code since it
was introduced in this project [1]. The definition of the `Test262Error`
function has consistently been located in the `sta.js` harness file which test
runners are expected to inject into the test environment.

Remove the file and all references to it.

[1] See commit c33bf0e0439e6f6bf084c1524d7df8d2b41c515d