### PR TITLE
Add tests for _TypedArrays_(object) using object properties

### DIFF
--- a/test/built-ins/TypedArrays/object-arg-throws-setting-obj-to-primitive-typeerror.js
+++ b/test/built-ins/TypedArrays/object-arg-throws-setting-obj-to-primitive-typeerror.js
@@ -1,0 +1,77 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+id: sec-typedarray-object
+description: >
+  Throw TypeError from @@toPrimitive returning an Object when setting a property
+info: >
+  22.2.4.4 TypedArray ( object )
+
+  This description applies only if the TypedArray function is called with at
+  least one argument and the Type of the first argument is Object and that
+  object does not have either a [[TypedArrayName]] or an [[ArrayBufferData]]
+  internal slot.
+
+  ...
+  8. Repeat, while k < len
+    ...
+    b. Let kValue be ? Get(arrayLike, Pk).
+    c. Perform ? Set(O, Pk, kValue, true).
+  ...
+
+  9.4.5.5 [[Set]] ( P, V, Receiver)
+
+  ...
+  2. If Type(P) is String and if SameValue(O, Receiver) is true, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      i. Return ? IntegerIndexedElementSet(O, numericIndex, V).
+  ...
+
+  9.4.5.9 IntegerIndexedElementSet ( O, index, value )
+
+  ...
+  3. Let numValue be ? ToNumber(value).
+  ...
+
+  7.1.3 ToNumber ( argument )
+
+  Object, Apply the following steps:
+
+    1. Let primValue be ? ToPrimitive(argument, hint Number).
+    2. Return ? ToNumber(primValue).
+
+  7.1.1 ToPrimitive ( input [ , PreferredType ] )
+
+  ...
+  4. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+  5. If exoticToPrim is not undefined, then
+    a. Let result be ? Call(exoticToPrim, input, « hint »).
+    b. If Type(result) is not Object, return result.
+    c. Throw a TypeError exception.
+  ...
+includes: [testTypedArray.js]
+features: [Symbol.toPrimitive]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new Int8Array(1);
+  var toPrimitive = 0;
+  var valueOf = 0;
+
+  sample[Symbol.toPrimitive] = function() {
+    toPrimitive++;
+    return {};
+  };
+
+  sample.valueOf = function() {
+    valueOf++;
+  };
+
+  assert.throws(TypeError, function() {
+    new TA([8, sample]);
+  }, "abrupt completion from sample @@toPrimitive");
+
+  assert.sameValue(toPrimitive, 1, "toPrimitive was called once");
+  assert.sameValue(valueOf, 0, "sample.valueOf is not called");
+});

--- a/test/built-ins/TypedArrays/object-arg-throws-setting-obj-to-primitive.js
+++ b/test/built-ins/TypedArrays/object-arg-throws-setting-obj-to-primitive.js
@@ -1,0 +1,75 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+id: sec-typedarray-object
+description: >
+  Return abrupt from @@toPrimitive when setting a property
+info: >
+  22.2.4.4 TypedArray ( object )
+
+  This description applies only if the TypedArray function is called with at
+  least one argument and the Type of the first argument is Object and that
+  object does not have either a [[TypedArrayName]] or an [[ArrayBufferData]]
+  internal slot.
+
+  ...
+  8. Repeat, while k < len
+    ...
+    b. Let kValue be ? Get(arrayLike, Pk).
+    c. Perform ? Set(O, Pk, kValue, true).
+  ...
+
+  9.4.5.5 [[Set]] ( P, V, Receiver)
+
+  ...
+  2. If Type(P) is String and if SameValue(O, Receiver) is true, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      i. Return ? IntegerIndexedElementSet(O, numericIndex, V).
+  ...
+
+  9.4.5.9 IntegerIndexedElementSet ( O, index, value )
+
+  ...
+  3. Let numValue be ? ToNumber(value).
+  ...
+
+  7.1.3 ToNumber ( argument )
+
+  Object, Apply the following steps:
+
+    1. Let primValue be ? ToPrimitive(argument, hint Number).
+    2. Return ? ToNumber(primValue).
+
+  7.1.1 ToPrimitive ( input [ , PreferredType ] )
+
+  ...
+  4. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+  5. If exoticToPrim is not undefined, then
+    a. Let result be ? Call(exoticToPrim, input, « hint »).
+  ...
+includes: [testTypedArray.js]
+features: [Symbol.toPrimitive]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new Int8Array(1);
+  var toPrimitive = 0;
+  var valueOf = 0;
+
+  sample[Symbol.toPrimitive] = function() {
+    toPrimitive++;
+    throw new Test262Error();
+  };
+
+  sample.valueOf = function() {
+    valueOf++;
+  };
+
+  assert.throws(Test262Error, function() {
+    new TA([8, sample]);
+  }, "abrupt completion from sample @@toPrimitive");
+
+  assert.sameValue(toPrimitive, 1, "toPrimitive was called once");
+  assert.sameValue(valueOf, 0, "it does not call sample.valueOf");
+});

--- a/test/built-ins/TypedArrays/object-arg-throws-setting-obj-tostring.js
+++ b/test/built-ins/TypedArrays/object-arg-throws-setting-obj-tostring.js
@@ -1,0 +1,87 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+id: sec-typedarray-object
+description: >
+  Return abrupt from toString() when setting a property
+info: >
+  22.2.4.4 TypedArray ( object )
+
+  This description applies only if the TypedArray function is called with at
+  least one argument and the Type of the first argument is Object and that
+  object does not have either a [[TypedArrayName]] or an [[ArrayBufferData]]
+  internal slot.
+
+  ...
+  8. Repeat, while k < len
+    ...
+    b. Let kValue be ? Get(arrayLike, Pk).
+    c. Perform ? Set(O, Pk, kValue, true).
+  ...
+
+  9.4.5.5 [[Set]] ( P, V, Receiver)
+
+  ...
+  2. If Type(P) is String and if SameValue(O, Receiver) is true, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      i. Return ? IntegerIndexedElementSet(O, numericIndex, V).
+  ...
+
+  9.4.5.9 IntegerIndexedElementSet ( O, index, value )
+
+  ...
+  3. Let numValue be ? ToNumber(value).
+  ...
+
+  7.1.3 ToNumber ( argument )
+
+  Object, Apply the following steps:
+
+    1. Let primValue be ? ToPrimitive(argument, hint Number).
+    2. Return ? ToNumber(primValue).
+
+  7.1.1 ToPrimitive ( input [ , PreferredType ] )
+
+  ...
+  4. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+  5. If exoticToPrim is not undefined, then
+    a. Let result be ? Call(exoticToPrim, input, « hint »).
+    b. If Type(result) is not Object, return result.
+    c. Throw a TypeError exception.
+  ...
+  7. Return ? OrdinaryToPrimitive(input, hint).
+
+  OrdinaryToPrimitive
+
+  ...
+  5. For each name in methodNames in List order, do
+    a. Let method be ? Get(O, name).
+    b. If IsCallable(method) is true, then
+      i. Let result be ? Call(method, O).
+  ...
+includes: [testTypedArray.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new Int8Array(1);
+  var valueOf = 0;
+  var toString = 0;
+
+  sample.valueOf = function() {
+    valueOf++;
+    return {};
+  };
+
+  sample.toString = function() {
+    toString++;
+    throw new Test262Error();
+  };
+
+  assert.throws(Test262Error, function() {
+    new TA([8, sample]);
+  }, "abrupt completion from ToNumber(sample)");
+
+  assert.sameValue(valueOf, 1, "valueOf called once");
+  assert.sameValue(toString, 1, "toString called once");
+});

--- a/test/built-ins/TypedArrays/object-arg-throws-setting-obj-valueof-typeerror.js
+++ b/test/built-ins/TypedArrays/object-arg-throws-setting-obj-valueof-typeerror.js
@@ -1,0 +1,88 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+id: sec-typedarray-object
+description: >
+  Throw TypeError from OrdinaryToPrimitive when setting a property
+info: >
+  22.2.4.4 TypedArray ( object )
+
+  This description applies only if the TypedArray function is called with at
+  least one argument and the Type of the first argument is Object and that
+  object does not have either a [[TypedArrayName]] or an [[ArrayBufferData]]
+  internal slot.
+
+  ...
+  8. Repeat, while k < len
+    ...
+    b. Let kValue be ? Get(arrayLike, Pk).
+    c. Perform ? Set(O, Pk, kValue, true).
+  ...
+
+  9.4.5.5 [[Set]] ( P, V, Receiver)
+
+  ...
+  2. If Type(P) is String and if SameValue(O, Receiver) is true, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      i. Return ? IntegerIndexedElementSet(O, numericIndex, V).
+  ...
+
+  9.4.5.9 IntegerIndexedElementSet ( O, index, value )
+
+  ...
+  3. Let numValue be ? ToNumber(value).
+  ...
+
+  7.1.3 ToNumber ( argument )
+
+  Object, Apply the following steps:
+
+    1. Let primValue be ? ToPrimitive(argument, hint Number).
+    2. Return ? ToNumber(primValue).
+
+  7.1.1 ToPrimitive ( input [ , PreferredType ] )
+
+  ...
+  4. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+  5. If exoticToPrim is not undefined, then
+    a. Let result be ? Call(exoticToPrim, input, « hint »).
+    b. If Type(result) is not Object, return result.
+    c. Throw a TypeError exception.
+  ...
+  7. Return ? OrdinaryToPrimitive(input, hint).
+
+  OrdinaryToPrimitive
+
+  ...
+  5. For each name in methodNames in List order, do
+    a. Let method be ? Get(O, name).
+    b. If IsCallable(method) is true, then
+      i. Let result be ? Call(method, O).
+      ii. If Type(result) is not Object, return result.
+  6. Throw a TypeError exception.
+includes: [testTypedArray.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new Int8Array(1);
+  var valueOf = 0;
+  var toString = 0;
+
+  sample.valueOf = function() {
+    valueOf++;
+    return {};
+  };
+
+  sample.toString = function() {
+    toString++;
+    return {};
+  };
+
+  assert.throws(TypeError, function() {
+    new TA([8, sample]);
+  }, "abrupt completion from ToNumber(sample)");
+
+  assert.sameValue(valueOf, 1, "valueOf called once");
+  assert.sameValue(toString, 1, "toString called once");
+});

--- a/test/built-ins/TypedArrays/object-arg-throws-setting-obj-valueof.js
+++ b/test/built-ins/TypedArrays/object-arg-throws-setting-obj-valueof.js
@@ -1,0 +1,81 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+id: sec-typedarray-object
+description: >
+  Return abrupt from valueOf() when setting a property
+info: >
+  22.2.4.4 TypedArray ( object )
+
+  This description applies only if the TypedArray function is called with at
+  least one argument and the Type of the first argument is Object and that
+  object does not have either a [[TypedArrayName]] or an [[ArrayBufferData]]
+  internal slot.
+
+  ...
+  8. Repeat, while k < len
+    ...
+    b. Let kValue be ? Get(arrayLike, Pk).
+    c. Perform ? Set(O, Pk, kValue, true).
+  ...
+
+  9.4.5.5 [[Set]] ( P, V, Receiver)
+
+  ...
+  2. If Type(P) is String and if SameValue(O, Receiver) is true, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      i. Return ? IntegerIndexedElementSet(O, numericIndex, V).
+  ...
+
+  9.4.5.9 IntegerIndexedElementSet ( O, index, value )
+
+  ...
+  3. Let numValue be ? ToNumber(value).
+  ...
+
+  7.1.3 ToNumber ( argument )
+
+  Object, Apply the following steps:
+
+    1. Let primValue be ? ToPrimitive(argument, hint Number).
+    2. Return ? ToNumber(primValue).
+
+  7.1.1 ToPrimitive ( input [ , PreferredType ] )
+
+  ...
+  4. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+  5. If exoticToPrim is not undefined, then
+    a. Let result be ? Call(exoticToPrim, input, « hint »).
+    b. If Type(result) is not Object, return result.
+    c. Throw a TypeError exception.
+  ...
+  7. Return ? OrdinaryToPrimitive(input, hint).
+
+  OrdinaryToPrimitive
+
+  ...
+  5. For each name in methodNames in List order, do
+    a. Let method be ? Get(O, name).
+    b. If IsCallable(method) is true, then
+      i. Let result be ? Call(method, O).
+      ii. If Type(result) is not Object, return result.
+  6. Throw a TypeError exception.
+includes: [testTypedArray.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new Int8Array(1);
+  var valueOf = 0;
+
+  sample.valueOf = function() {
+    valueOf++;
+    throw new Test262Error();
+  };
+
+  assert.throws(Test262Error, function() {
+    new TA([8, sample]);
+  }, "abrupt completion from ToNumber(sample)");
+
+  assert.sameValue(valueOf, 1, "valueOf called once");
+});

--- a/test/built-ins/TypedArrays/object-arg-throws-setting-typedarray-property.js
+++ b/test/built-ins/TypedArrays/object-arg-throws-setting-typedarray-property.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+id: sec-typedarray-object
+description: >
+  Return abrupt from setting a TypedArray instance property
+info: >
+  22.2.4.4 TypedArray ( object )
+
+  This description applies only if the TypedArray function is called with at
+  least one argument and the Type of the first argument is Object and that
+  object does not have either a [[TypedArrayName]] or an [[ArrayBufferData]]
+  internal slot.
+
+  ...
+  8. Repeat, while k < len
+    ...
+    b. Let kValue be ? Get(arrayLike, Pk).
+    c. Perform ? Set(O, Pk, kValue, true).
+  ...
+
+  9.4.5.5 [[Set]] ( P, V, Receiver)
+
+  ...
+  2. If Type(P) is String and if SameValue(O, Receiver) is true, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      i. Return ? IntegerIndexedElementSet(O, numericIndex, V).
+  ...
+
+  9.4.5.9 IntegerIndexedElementSet ( O, index, value )
+
+  ...
+  3. Let numValue be ? ToNumber(value).
+  ...
+
+  7.1.3 ToNumber ( argument )
+
+  Object, Apply the following steps:
+
+    1. Let primValue be ? ToPrimitive(argument, hint Number).
+    2. Return ? ToNumber(primValue).
+
+  7.1.1 ToPrimitive ( input [ , PreferredType ] )
+
+  ...
+  4. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+  5. If exoticToPrim is not undefined, then
+    a. Let result be ? Call(exoticToPrim, input, « hint »).
+    b. If Type(result) is not Object, return result.
+    c. Throw a TypeError exception.
+  ...
+  7. Return ? OrdinaryToPrimitive(input, hint).
+
+  OrdinaryToPrimitive
+
+  ...
+  5. For each name in methodNames in List order, do
+    a. Let method be ? Get(O, name).
+    b. If IsCallable(method) is true, then
+      i. Let result be ? Call(method, O).
+      ii. If Type(result) is not Object, return result.
+  6. Throw a TypeError exception.
+includes: [testTypedArray.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new Int8Array(1);
+
+  assert.throws(TypeError, function() {
+    new TA([8, sample]);
+  });
+});


### PR DESCRIPTION
After [playing with some typedArray samples](https://gist.github.com/leobalter/a64665cd62490582f980) I found some runtimes accepting typedArrays as a property on the object argument, like: `new Int8Array([8, new Int8Array(1)])`.

Running through the specs it seems this is a bug on the runtimes, so here are some tests to prevent it, along with other tests covering extra toPrimitive and valueOf operations