### PR TITLE
Fix test for TypedArrays.from on callable function

### DIFF
--- a/test/built-ins/TypedArrays/from/mapfn-is-not-callable.js
+++ b/test/built-ins/TypedArrays/from/mapfn-is-not-callable.js
@@ -52,10 +52,6 @@ testWithTypedArrayConstructors(function(TA) {
     TA.from(arrayLike, s);
   }, "mapfn is a symbol");
 
-  assert.throws(TypeError, function() {
-    TA.from(arrayLike, TA);
-  }, "mapfn is a TypedArray constructor (not callable)");
-
   assert.sameValue(
     getIterator, 0,
     "IsCallable(mapfn) check occurs before getting source[@@iterator]"


### PR DESCRIPTION
TypedArrays constructors are still callable even if they trigger a
TypeError Exception when a new target is not defined