### PR TITLE
Console Runner: Revert Parallelization and Formally Deprecate

### DIFF
--- a/CONSOLE-RUNNER.md
+++ b/CONSOLE-RUNNER.md
@@ -40,7 +40,6 @@ Name | Action
 -----|-------
 -h, --help | displays a brief help message
 --command=COMMAND | **required** command which invokes javascript engine to be tested
--j, --workers-count | Number of tests to run in parallel (defaults to number of cores - 1)
 --tests=TESTS | path to the test suite; default is current directory
 --cat | don't execute tests, just print code that would be run
 --summary | generate a summary at end of execution
@@ -50,9 +49,9 @@ Name | Action
 --unmarked_default=MODE | mode to use for tests that are not marked **onlyStrict** or **noStrict** ; MODE can be `strict` or `non_strict` or `both`
 --logname=LOGNAME | write output to file (in addition to stdout)
 --junitname=JUNITNAME | write test results to file in JUnit XML format
---loglevel=LOGLEVEL | set log level, primarily useful for debugging `test262.py`
+--loglevel=LOGLEVEL | set log level, primarily useful for debugging `test262.py` 
 --print-handle=FUNC | enable async test logging via javascript function e.g., `console.log`
-
+ 
 ### Usage Notes
 
 Non-option arguments are used as filters to match test names.  If no filters are found, the whole test suite is run.
@@ -67,7 +66,7 @@ The COMMAND argument can be a quoted string.  This is useful when testing ECMASc
 
 ```
 $ test262.py --command="node --harmony" es6
-```
+``` 
 
 #### Async Tests
 
@@ -82,7 +81,7 @@ JavaScriptCore<sup>2</sup> | jsc | print
 
 ***Notes:***
 1. As of 2014-Jul-23, SpiderMonkey does not support Promise in the `js` executable ([see bug 911216](https://bugzilla.mozilla.org/show_bug.cgi?id=911216) )
-2. As of 2014-Jul-23, JavaScriptCore does not support Promise in the `jsc` executable
+2. As of 2014-Jul-23, JavaScriptCore does not support Promise in the `jsc` executable 
 
 
 ### Troubleshooting

--- a/tools/CONSOLE-RUNNER.md
+++ b/tools/CONSOLE-RUNNER.md
@@ -1,5 +1,8 @@
 ## Using the Console Test Runner
 
+**Note** This utility has been deprecated. It will not be updated with new
+features; future changes will be limited to bug fixes only.
+
 The console test runner is used to test browserless implementations of ECMAScript, e.g., [v8](http://en.wikipedia.org/wiki/V8_(JavaScript_engine)), [node](http://en.wikipedia.org/wiki/Node.js), or [js24](http://packages.ubuntu.com/trusty/libmozjs-24-bin) 
 
 ### Requirements

--- a/tools/packaging/test262.py
+++ b/tools/packaging/test262.py
@@ -606,11 +606,10 @@ class TestSuite(object):
           if logname:
             self.WriteLog(result)
         finally:
-          progress.HasRun(result)
-
           if workers_count > 1:
             log_lock.release()
 
+        progress.HasRun(result)
       if workers_count == 1:
         exec_case()
       else:

--- a/tools/packaging/test262.py
+++ b/tools/packaging/test262.py
@@ -583,7 +583,6 @@ class TestSuite(object):
           SkipCaseElement.append(SkipElement)
           TestSuiteElement.append(SkipCaseElement)
 
-    threads = []
     if workers_count > 1:
       pool_sem = threading.Semaphore(workers_count)
       log_lock = threading.Lock()
@@ -614,13 +613,11 @@ class TestSuite(object):
         exec_case()
       else:
         pool_sem.acquire()
-        thread = threading.Thread(target=exec_case)
-        threads.append(thread)
-        thread.start()
+        threading.Thread(target=exec_case).start()
         pool_sem.release()
 
-    for thread in threads:
-      thread.join()
+    if workers_count > 1:
+      log_lock.acquire()
 
     if print_summary:
       self.PrintSummary(progress, logname)
@@ -630,6 +627,9 @@ class TestSuite(object):
         print
         print "Use --full-summary to see output from failed tests"
     print
+
+    if workers_count > 1:
+      log_lock.release()
 
     return progress.failed
 

--- a/tools/packaging/test262.py
+++ b/tools/packaging/test262.py
@@ -18,7 +18,6 @@ import subprocess
 import sys
 import tempfile
 import time
-import threading
 import xml.dom.minidom
 import datetime
 import shutil
@@ -55,8 +54,6 @@ EXCLUDE_LIST = [x.getAttribute("id") for x in EXCLUDE_LIST]
 def BuildOptions():
   result = optparse.OptionParser()
   result.add_option("--command", default=None, help="The command-line to run")
-  result.add_option("-j", "--workers-count", type=int, default=max(1, GetCPUCount() - 1),
-                    help="Number of tests to run in parallel (default %default)")
   result.add_option("--tests", default=path.abspath('.'),
                     help="Path to the tests")
   result.add_option("--cat", default=False, action="store_true",
@@ -95,35 +92,6 @@ def IsWindows():
   p = platform.system()
   return (p == 'Windows') or (p == 'Microsoft')
 
-def GetCPUCount():
-    """
-    Guess at a reasonable parallelism count to set as the default for the
-    current machine and run.
-    """
-    # Python 2.6+
-    try:
-        import multiprocessing
-        return multiprocessing.cpu_count()
-    except (ImportError, NotImplementedError):
-        pass
-
-    # POSIX
-    try:
-        res = int(os.sysconf('SC_NPROCESSORS_ONLN'))
-        if res > 0:
-            return res
-    except (AttributeError, ValueError):
-        pass
-
-    # Windows
-    try:
-        res = int(os.environ['NUMBER_OF_PROCESSORS'])
-        if res > 0:
-            return res
-    except (KeyError, ValueError):
-        pass
-
-    return 1
 
 class TempFile(object):
 
@@ -558,7 +526,7 @@ class TestSuite(object):
       print
       result.ReportOutcome(False)
 
-  def Run(self, command_template, tests, print_summary, full_summary, logname, junitfile, workers_count):
+  def Run(self, command_template, tests, print_summary, full_summary, logname, junitfile):
     if not "{{path}}" in command_template:
       command_template += " {{path}}"
     cases = self.EnumerateTests(tests)
@@ -583,41 +551,16 @@ class TestSuite(object):
           SkipCaseElement.append(SkipElement)
           TestSuiteElement.append(SkipCaseElement)
 
-    if workers_count > 1:
-      pool_sem = threading.Semaphore(workers_count)
-      log_lock = threading.Lock()
-    else:
-      log_lock = None
-
     for case in cases:
-      def exec_case():
-        result = case.Run(command_template)
-
-        try:
-          if workers_count > 1:
-            log_lock.acquire()
-
-          if junitfile:
-            TestCaseElement = result.XmlAssemble(result)
-            TestSuiteElement.append(TestCaseElement)
-            if case == cases[len(cases)-1]:
-                 xmlj.ElementTree(TestSuitesElement).write(junitfile, "UTF-8")
-          if logname:
-            self.WriteLog(result)
-        finally:
-          if workers_count > 1:
-            log_lock.release()
-
-        progress.HasRun(result)
-      if workers_count == 1:
-        exec_case()
-      else:
-        pool_sem.acquire()
-        threading.Thread(target=exec_case).start()
-        pool_sem.release()
-
-    if workers_count > 1:
-      log_lock.acquire()
+      result = case.Run(command_template)
+      if junitfile:
+        TestCaseElement = result.XmlAssemble(result)
+        TestSuiteElement.append(TestCaseElement)
+        if case == cases[len(cases)-1]:
+             xmlj.ElementTree(TestSuitesElement).write(junitfile, "UTF-8")
+      if logname:
+        self.WriteLog(result)
+      progress.HasRun(result)
 
     if print_summary:
       self.PrintSummary(progress, logname)
@@ -627,10 +570,6 @@ class TestSuite(object):
         print
         print "Use --full-summary to see output from failed tests"
     print
-
-    if workers_count > 1:
-      log_lock.release()
-
     return progress.failed
 
   def WriteLog(self, result):
@@ -695,8 +634,7 @@ def Main():
                           options.summary or options.full_summary,
                           options.full_summary,
                           options.logname,
-                          options.junitname,
-                          options.workers_count)
+                          options.junitname)
   return code
 
 if __name__ == '__main__':


### PR DESCRIPTION
I've heard it mentioned that the Python "console runner" utility is deprecated,
but there is no documentation in this project to suggest this. If it is the
case, we should be more clear about it in order to better set expectations for
consumers and contributors.

A decision to deprecate would also motivate the removal of a recent feature
addition to the console runner--support for parallelization. To date, three
bugs have been found in that implementation. As an optimization to a deprecated
tool, the maintenance overhead is not justified.

Resolves gh-512.