### PR TITLE
Console Runner: Fix Race Condition

### DIFF
--- a/tools/packaging/test262.py
+++ b/tools/packaging/test262.py
@@ -591,7 +591,7 @@ class TestSuite(object):
       log_lock = None
 
     for case in cases:
-      def exec_case():
+      def exec_case(case):
         result = case.Run(command_template)
 
         try:
@@ -615,7 +615,7 @@ class TestSuite(object):
         exec_case()
       else:
         pool_sem.acquire()
-        thread = threading.Thread(target=exec_case)
+        thread = threading.Thread(target=exec_case, args=(case,))
         threads.append(thread)
         thread.start()
         pool_sem.release()


### PR DESCRIPTION
When spawning threads from within a `for` loop, the original
parallelization implementation relied on a function closure to access
each `TestCase` instance.  Due to the concurrent and non-deterministic
nature of thread processing, the value of this reference at execution
time was unstable.

Explicitly specify the `TestCase` instance to the `Thread` constructor,
ensuring that each thread is run with the intended value, regardless of
execution order.

Resolves gh-512.