### PR TITLE
Add tests for module code

### DIFF
--- a/CONSOLE-RUNNER.md
+++ b/CONSOLE-RUNNER.md
@@ -41,6 +41,7 @@ Name | Action
 -h, --help | displays a brief help message
 --command=COMMAND | **required** command which invokes javascript engine to be tested
 -j, --workers-count | Number of tests to run in parallel (defaults to number of cores - 1)
+--module_command | command which invokes the JavaScript engine to be tested for tests labeled as ES2015 modules
 --tests=TESTS | path to the test suite; default is current directory
 --cat | don't execute tests, just print code that would be run
 --summary | generate a summary at end of execution

--- a/test/language/eval-code/export.js
+++ b/test/language/eval-code/export.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: The `export` declaration may not appear within eval code
+id: sec-scripts
+flags: [module]
+info: |
+     Eval code is the source text supplied to the built-in eval function. More
+     precisely, if the parameter to the built-in eval function is a String, it
+     is treated as an ECMAScript Script. The eval code for a particular
+     invocation of eval is the global code portion of that Script.
+
+     A.5 Scripts and Modules
+
+     Script:
+         ScriptBodyopt
+
+     ScriptBody:
+         StatementList
+---*/
+
+assert.throws(SyntaxError, function() {
+  eval('export default null;');
+});

--- a/test/language/eval-code/import.js
+++ b/test/language/eval-code/import.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: The `import` declaration may not appear within eval code
+id: sec-scripts
+flags: [module]
+info: |
+     Eval code is the source text supplied to the built-in eval function. More
+     precisely, if the parameter to the built-in eval function is a String, it
+     is treated as an ECMAScript Script. The eval code for a particular
+     invocation of eval is the global code portion of that Script.
+
+     A.5 Scripts and Modules
+
+     Script:
+         ScriptBodyopt
+
+     ScriptBody:
+         StatementList
+---*/
+
+assert.throws(SyntaxError, function() {
+  eval('import v from "./import.js";');
+});

--- a/test/language/global-code/export.js
+++ b/test/language/global-code/export.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: The `export` declaration may not appear within a ScriptBody
+id: sec-scripts
+negative: SyntaxError
+info: |
+     A.5 Scripts and Modules
+
+     Script:
+         ScriptBodyopt
+
+     ScriptBody:
+         StatementList
+---*/
+
+export default null;

--- a/test/language/global-code/import.js
+++ b/test/language/global-code/import.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: The `import` declaration may not appear within a ScriptBody
+id: sec-scripts
+negative: SyntaxError
+info: |
+     A.5 Scripts and Modules
+
+     Script:
+         ScriptBodyopt
+
+     ScriptBody:
+         StatementList
+---*/
+
+import v from './import.js';

--- a/test/language/module-code/decl-pos-export-arrow-function.js
+++ b/test/language/module-code/decl-pos-export-arrow-function.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+() => { export default null; };

--- a/test/language/module-code/decl-pos-export-block-stmt-list.js
+++ b/test/language/module-code/decl-pos-export-block-stmt-list.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+{ void 0; export default null; }

--- a/test/language/module-code/decl-pos-export-block-stmt.js
+++ b/test/language/module-code/decl-pos-export-block-stmt.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+{ export default null; }

--- a/test/language/module-code/decl-pos-export-class-decl-meth-static.js
+++ b/test/language/module-code/decl-pos-export-class-decl-meth-static.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+class C { static method() { export default null; } }

--- a/test/language/module-code/decl-pos-export-class-decl-meth.js
+++ b/test/language/module-code/decl-pos-export-class-decl-meth.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+class C { method() { export default null; } }

--- a/test/language/module-code/decl-pos-export-class-decl-method-gen-static.js
+++ b/test/language/module-code/decl-pos-export-class-decl-method-gen-static.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+class C { static *method() { export default null; } }

--- a/test/language/module-code/decl-pos-export-class-decl-method-gen.js
+++ b/test/language/module-code/decl-pos-export-class-decl-method-gen.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+class C { *method() { export default null; } }

--- a/test/language/module-code/decl-pos-export-class-expr-meth-gen-static.js
+++ b/test/language/module-code/decl-pos-export-class-expr-meth-gen-static.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+(class { static *method() { export default null; } });

--- a/test/language/module-code/decl-pos-export-class-expr-meth-gen.js
+++ b/test/language/module-code/decl-pos-export-class-expr-meth-gen.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+(class { *method() { export default null; } });

--- a/test/language/module-code/decl-pos-export-class-expr-meth-static.js
+++ b/test/language/module-code/decl-pos-export-class-expr-meth-static.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+(class { static method() { export default null; } });

--- a/test/language/module-code/decl-pos-export-class-expr-meth.js
+++ b/test/language/module-code/decl-pos-export-class-expr-meth.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+(class { method() { export default null; } });

--- a/test/language/module-code/decl-pos-export-do-while.js
+++ b/test/language/module-code/decl-pos-export-do-while.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+do export default null; while (false)

--- a/test/language/module-code/decl-pos-export-for-const.js
+++ b/test/language/module-code/decl-pos-export-for-const.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (const x = 0; false;)
+  export default null;

--- a/test/language/module-code/decl-pos-export-for-in-const.js
+++ b/test/language/module-code/decl-pos-export-for-in-const.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (const y in [])
+  export default null;

--- a/test/language/module-code/decl-pos-export-for-in-let.js
+++ b/test/language/module-code/decl-pos-export-for-in-let.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (let y in [])
+  export default null;

--- a/test/language/module-code/decl-pos-export-for-in-lhs.js
+++ b/test/language/module-code/decl-pos-export-for-in-lhs.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (y in [])
+  export default null;

--- a/test/language/module-code/decl-pos-export-for-in-var.js
+++ b/test/language/module-code/decl-pos-export-for-in-var.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (var y in [])
+  export default null;

--- a/test/language/module-code/decl-pos-export-for-let.js
+++ b/test/language/module-code/decl-pos-export-for-let.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (let x = 0; false;)
+  export default null;

--- a/test/language/module-code/decl-pos-export-for-lhs.js
+++ b/test/language/module-code/decl-pos-export-for-lhs.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (x = 0; false;)
+  export default null;

--- a/test/language/module-code/decl-pos-export-for-of-const.js
+++ b/test/language/module-code/decl-pos-export-for-of-const.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (const y of [])
+  export default null;

--- a/test/language/module-code/decl-pos-export-for-of-let.js
+++ b/test/language/module-code/decl-pos-export-for-of-let.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (let y of [])
+  export default null;

--- a/test/language/module-code/decl-pos-export-for-of-lhs.js
+++ b/test/language/module-code/decl-pos-export-for-of-lhs.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (y of [])
+  export default null;

--- a/test/language/module-code/decl-pos-export-for-of-var.js
+++ b/test/language/module-code/decl-pos-export-for-of-var.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (var y of [])
+  export default null;

--- a/test/language/module-code/decl-pos-export-for-var.js
+++ b/test/language/module-code/decl-pos-export-for-var.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (var x = 0; false;)
+  export default null;

--- a/test/language/module-code/decl-pos-export-function-decl.js
+++ b/test/language/module-code/decl-pos-export-function-decl.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+function f() { export default null; }

--- a/test/language/module-code/decl-pos-export-function-expr.js
+++ b/test/language/module-code/decl-pos-export-function-expr.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+(function() { export default null; });

--- a/test/language/module-code/decl-pos-export-generator-decl.js
+++ b/test/language/module-code/decl-pos-export-generator-decl.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+function* g() { export default null; }

--- a/test/language/module-code/decl-pos-export-generator-expr.js
+++ b/test/language/module-code/decl-pos-export-generator-expr.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+(function*() { export default null; });

--- a/test/language/module-code/decl-pos-export-if-else.js
+++ b/test/language/module-code/decl-pos-export-if-else.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+if (true) { } else export default null;

--- a/test/language/module-code/decl-pos-export-if-if.js
+++ b/test/language/module-code/decl-pos-export-if-if.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+if (false) export default null;

--- a/test/language/module-code/decl-pos-export-labeled.js
+++ b/test/language/module-code/decl-pos-export-labeled.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+test262: export default null;

--- a/test/language/module-code/decl-pos-export-object-gen-method.js
+++ b/test/language/module-code/decl-pos-export-object-gen-method.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+({ *m() { export default null; } });

--- a/test/language/module-code/decl-pos-export-object-getter.js
+++ b/test/language/module-code/decl-pos-export-object-getter.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+({ get m() { export default null; } });

--- a/test/language/module-code/decl-pos-export-object-method.js
+++ b/test/language/module-code/decl-pos-export-object-method.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+({ m() { export default null; } });

--- a/test/language/module-code/decl-pos-export-object-setter.js
+++ b/test/language/module-code/decl-pos-export-object-setter.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+({ set m(x) { export default null; } });

--- a/test/language/module-code/decl-pos-export-switch-case-dflt.js
+++ b/test/language/module-code/decl-pos-export-switch-case-dflt.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+switch(0) { case 1: export default null; default: }

--- a/test/language/module-code/decl-pos-export-switch-case.js
+++ b/test/language/module-code/decl-pos-export-switch-case.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+switch(0) { case 1: export default null; }

--- a/test/language/module-code/decl-pos-export-switch-dftl.js
+++ b/test/language/module-code/decl-pos-export-switch-dftl.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+switch(0) { default: export default null; }

--- a/test/language/module-code/decl-pos-export-try-catch-finally.js
+++ b/test/language/module-code/decl-pos-export-try-catch-finally.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+try { } catch (err) { } finally {
+  export default null;
+}

--- a/test/language/module-code/decl-pos-export-try-catch.js
+++ b/test/language/module-code/decl-pos-export-try-catch.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+try { } catch (err) {
+  export default null;
+}

--- a/test/language/module-code/decl-pos-export-try-finally.js
+++ b/test/language/module-code/decl-pos-export-try-finally.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+try { } finally {
+  export default null;
+}

--- a/test/language/module-code/decl-pos-export-try-try.js
+++ b/test/language/module-code/decl-pos-export-try-try.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+try {
+  export default null;
+} catch (err) { }

--- a/test/language/module-code/decl-pos-export-while.js
+++ b/test/language/module-code/decl-pos-export-while.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `export` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+while (false) export default null;

--- a/test/language/module-code/decl-pos-import-arrow-function.js
+++ b/test/language/module-code/decl-pos-import-arrow-function.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+() => { import v from './decl-pos-import-arrow-function.js'; };

--- a/test/language/module-code/decl-pos-import-block-stmt-list.js
+++ b/test/language/module-code/decl-pos-import-block-stmt-list.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+{ void 0; import v from './decl-pos-import-block-stmt-list.js'; }

--- a/test/language/module-code/decl-pos-import-block-stmt.js
+++ b/test/language/module-code/decl-pos-import-block-stmt.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+{ import v from './decl-pos-import-block-stmt.js'; }

--- a/test/language/module-code/decl-pos-import-class-decl-meth-static.js
+++ b/test/language/module-code/decl-pos-import-class-decl-meth-static.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+class C { static method() { import v from './decl-pos-import-class-decl-meth-static.js'; } }

--- a/test/language/module-code/decl-pos-import-class-decl-meth.js
+++ b/test/language/module-code/decl-pos-import-class-decl-meth.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+class C { method() { import v from './decl-pos-import-class-decl-meth.js'; } }

--- a/test/language/module-code/decl-pos-import-class-decl-method-gen-static.js
+++ b/test/language/module-code/decl-pos-import-class-decl-method-gen-static.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+class C { static *method() { import v from './decl-pos-import-class-decl-method-gen-static.js'; } }

--- a/test/language/module-code/decl-pos-import-class-decl-method-gen.js
+++ b/test/language/module-code/decl-pos-import-class-decl-method-gen.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+class C { *method() { import v from './decl-pos-import-class-decl-method-gen.js'; } }

--- a/test/language/module-code/decl-pos-import-class-expr-meth-gen-static.js
+++ b/test/language/module-code/decl-pos-import-class-expr-meth-gen-static.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+(class { static *method() { import v from './decl-pos-import-class-expr-meth-gen-static.js'; } });

--- a/test/language/module-code/decl-pos-import-class-expr-meth-gen.js
+++ b/test/language/module-code/decl-pos-import-class-expr-meth-gen.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+(class { *method() { import v from './decl-pos-import-class-expr-meth-gen.js'; } });

--- a/test/language/module-code/decl-pos-import-class-expr-meth-static.js
+++ b/test/language/module-code/decl-pos-import-class-expr-meth-static.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+(class { static method() { import v from './decl-pos-import-class-expr-meth-static.js'; } });

--- a/test/language/module-code/decl-pos-import-class-expr-meth.js
+++ b/test/language/module-code/decl-pos-import-class-expr-meth.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+(class { method() { import v from './decl-pos-import-class-expr-meth.js'; } });

--- a/test/language/module-code/decl-pos-import-do-while.js
+++ b/test/language/module-code/decl-pos-import-do-while.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+do import v from './decl-pos-import-do-while.js'; while (false)

--- a/test/language/module-code/decl-pos-import-for-const.js
+++ b/test/language/module-code/decl-pos-import-for-const.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (const x = 0; false;)
+  import v from './decl-pos-import-for-const.js';

--- a/test/language/module-code/decl-pos-import-for-in-const.js
+++ b/test/language/module-code/decl-pos-import-for-in-const.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (const y in [])
+  import v from './decl-pos-import-for-in-const.js';

--- a/test/language/module-code/decl-pos-import-for-in-let.js
+++ b/test/language/module-code/decl-pos-import-for-in-let.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (let y in [])
+  import v from './decl-pos-import-for-in-let.js';

--- a/test/language/module-code/decl-pos-import-for-in-lhs.js
+++ b/test/language/module-code/decl-pos-import-for-in-lhs.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (y in [])
+  import v from './decl-pos-import-for-in-lhs.js';

--- a/test/language/module-code/decl-pos-import-for-in-var.js
+++ b/test/language/module-code/decl-pos-import-for-in-var.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (var y in [])
+  import v from './decl-pos-import-for-in-var.js';

--- a/test/language/module-code/decl-pos-import-for-let.js
+++ b/test/language/module-code/decl-pos-import-for-let.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (let x = 0; false;)
+  import v from './decl-pos-import-for-let.js';

--- a/test/language/module-code/decl-pos-import-for-lhs.js
+++ b/test/language/module-code/decl-pos-import-for-lhs.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (x = 0; false;)
+  import v from './decl-pos-import-for-lhs.js';

--- a/test/language/module-code/decl-pos-import-for-of-const.js
+++ b/test/language/module-code/decl-pos-import-for-of-const.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (const y of [])
+  import v from './decl-pos-import-for-of-const.js';

--- a/test/language/module-code/decl-pos-import-for-of-let.js
+++ b/test/language/module-code/decl-pos-import-for-of-let.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (let y of [])
+  import v from './decl-pos-import-for-of-let.js';

--- a/test/language/module-code/decl-pos-import-for-of-lhs.js
+++ b/test/language/module-code/decl-pos-import-for-of-lhs.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (y of [])
+  import v from './decl-pos-import-for-of-lhs.js';

--- a/test/language/module-code/decl-pos-import-for-of-var.js
+++ b/test/language/module-code/decl-pos-import-for-of-var.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (var y of [])
+  import v from './decl-pos-import-for-of-var.js';

--- a/test/language/module-code/decl-pos-import-for-var.js
+++ b/test/language/module-code/decl-pos-import-for-var.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+for (var x = 0; false;)
+  import v from './decl-pos-import-for-var.js';

--- a/test/language/module-code/decl-pos-import-function-decl.js
+++ b/test/language/module-code/decl-pos-import-function-decl.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+function f() { import v from './decl-pos-import-function-decl.js'; }

--- a/test/language/module-code/decl-pos-import-function-expr.js
+++ b/test/language/module-code/decl-pos-import-function-expr.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+(function() { import v from './decl-pos-import-function-expr.js'; });

--- a/test/language/module-code/decl-pos-import-generator-decl.js
+++ b/test/language/module-code/decl-pos-import-generator-decl.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+function* g() { import v from './decl-pos-import-generator-decl.js'; }

--- a/test/language/module-code/decl-pos-import-generator-expr.js
+++ b/test/language/module-code/decl-pos-import-generator-expr.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+(function*() { import v from './decl-pos-import-generator-expr.js'; });

--- a/test/language/module-code/decl-pos-import-if-else.js
+++ b/test/language/module-code/decl-pos-import-if-else.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+if (true) { } else import v from './decl-pos-import-if-else.js';

--- a/test/language/module-code/decl-pos-import-if-if.js
+++ b/test/language/module-code/decl-pos-import-if-if.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+if (false) import v from './decl-pos-import-if-if.js';

--- a/test/language/module-code/decl-pos-import-labeled.js
+++ b/test/language/module-code/decl-pos-import-labeled.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+test262: import v from './decl-pos-import-labeled.js';

--- a/test/language/module-code/decl-pos-import-object-gen-method.js
+++ b/test/language/module-code/decl-pos-import-object-gen-method.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+({ *m() { import v from './decl-pos-import-object-gen-method.js'; } });

--- a/test/language/module-code/decl-pos-import-object-getter.js
+++ b/test/language/module-code/decl-pos-import-object-getter.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+({ get m() { import v from './decl-pos-import-object-getter.js'; } });

--- a/test/language/module-code/decl-pos-import-object-method.js
+++ b/test/language/module-code/decl-pos-import-object-method.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+({ m() { import v from './decl-pos-import-object-method.js'; } });

--- a/test/language/module-code/decl-pos-import-object-setter.js
+++ b/test/language/module-code/decl-pos-import-object-setter.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Expression cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+({ set m(x) { import v from './decl-pos-import-object-setter.js'; } });

--- a/test/language/module-code/decl-pos-import-switch-case-dflt.js
+++ b/test/language/module-code/decl-pos-import-switch-case-dflt.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+switch(0) { case 1: import v from './decl-pos-import-switch-case-dflt.js'; default: }

--- a/test/language/module-code/decl-pos-import-switch-case.js
+++ b/test/language/module-code/decl-pos-import-switch-case.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+switch(0) { case 1: import v from './decl-pos-import-switch-case.js'; }

--- a/test/language/module-code/decl-pos-import-switch-dftl.js
+++ b/test/language/module-code/decl-pos-import-switch-dftl.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+switch(0) { default: import v from './decl-pos-import-switch-dftl.js'; }

--- a/test/language/module-code/decl-pos-import-try-catch-finally.js
+++ b/test/language/module-code/decl-pos-import-try-catch-finally.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+try { } catch (err) { } finally {
+  import v from './decl-pos-import-try-catch-finally.js';
+}

--- a/test/language/module-code/decl-pos-import-try-catch.js
+++ b/test/language/module-code/decl-pos-import-try-catch.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+try { } catch (err) {
+  import v from './decl-pos-import-try-catch.js';
+}

--- a/test/language/module-code/decl-pos-import-try-finally.js
+++ b/test/language/module-code/decl-pos-import-try-finally.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+try { } finally {
+  import v from './decl-pos-import-try-finally.js';
+}

--- a/test/language/module-code/decl-pos-import-try-try.js
+++ b/test/language/module-code/decl-pos-import-try-try.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+try {
+  import v from './decl-pos-import-try-try.js';
+} catch (err) { }

--- a/test/language/module-code/decl-pos-import-while.js
+++ b/test/language/module-code/decl-pos-import-while.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Statement cannot contain an `import` declaration
+id: sec-modules
+negative: SyntaxError
+flags: [module]
+---*/
+
+while (false) import v from './decl-pos-import-while.js';

--- a/test/language/module-code/strict-mode.js
+++ b/test/language/module-code/strict-mode.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Module code is always strict mode code.
+es6id: 10.2.1
+id: sec-strict-mode-code
+flags: [module]
+negative: SyntaxError
+---*/
+
+$ERROR('This statement should not be executed.');
+var public;

--- a/test/language/reserved-words/await-module.js
+++ b/test/language/reserved-words/await-module.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+id: sec-reserved-words
+es6id: 11.6.2
+description: The `await` token is not permitted as an identifier in module code
+flags: [module]
+negative: SyntaxError
+---*/
+
+var await;

--- a/test/language/reserved-words/await-script.js
+++ b/test/language/reserved-words/await-script.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+id: sec-reserved-words
+es6id: 11.6.2
+description: The `await` token is permitted as an identifier in script code
+---*/
+
+var await;


### PR DESCRIPTION
I've tried to cover all the aspects of ES2015 modules that do *not* depend on a loader. As you might expect, it's not very much!

Test262 already maintains a few tests for module code (specifically: tests for early errors). Unfortunately, early errors from correct interpretation of module code are indistinguishable from parsing errors from incorrectly interpreting as script code. In other words, consumers can pass most of these tests by ignoring the `module` flag and interpreting the source text as script code.

The significance of this changeset is that it introduces the first tests (`language/module-code/strict-mode.js` and `language/reserved-words/await-module.js`) that runtimes cannot pass by simply interpreting module code as script code. I'm hoping that having all the negative tests in place initially will still help avoid errors as implementors begin add support for modules.