### PR TITLE
Improve coverage %ThrowTypeError% and default class constructors

### DIFF
--- a/test/built-ins/ThrowTypeError/extensible.js
+++ b/test/built-ins/ThrowTypeError/extensible.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2016 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%throwtypeerror%
+description: >
+  %ThrowTypeError% is not extensible.
+info: >
+  %ThrowTypeError% ( )
+
+  The value of the [[Extensible]] internal slot of a %ThrowTypeError%
+  function is false.
+---*/
+
+var ThrowTypeError = Object.getOwnPropertyDescriptor(function(){ "use strict"; return arguments; }(), "callee").get;
+
+assert.sameValue(Object.isExtensible(ThrowTypeError), false);

--- a/test/built-ins/ThrowTypeError/forbidden-arguments.js
+++ b/test/built-ins/ThrowTypeError/forbidden-arguments.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%throwtypeerror%
+description: >
+  %ThrowTypeError% does not have an own "arguments" property.
+info: >
+  %ThrowTypeError% ( )
+
+  The %ThrowTypeError% intrinsic is an anonymous built-in function
+  object that is defined once for each realm.
+
+  16.2 Forbidden Extensions
+
+    Other than as defined in this specification, ECMAScript Function
+    objects defined using syntactic constructors in strict mode code
+    must not be created with own properties named "caller" or
+    "arguments" other than those that are created by applying the
+    AddRestrictedFunctionProperties abstract operation (9.2.7) to
+    the function. [...] Built-in functions, strict mode functions
+    created using the Function constructor, generator functions
+    created using the Generator constructor, and functions created
+    using the bind method also must not be created with such own
+    properties.
+---*/
+
+var ThrowTypeError = Object.getOwnPropertyDescriptor(function(){ "use strict"; return arguments; }(), "callee").get;
+
+assert.sameValue(Object.prototype.hasOwnProperty.call(ThrowTypeError, "arguments"), false);

--- a/test/built-ins/ThrowTypeError/forbidden-caller.js
+++ b/test/built-ins/ThrowTypeError/forbidden-caller.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%throwtypeerror%
+description: >
+  %ThrowTypeError% does not have an own "caller" property.
+info: >
+  %ThrowTypeError% ( )
+
+  The %ThrowTypeError% intrinsic is an anonymous built-in function
+  object that is defined once for each realm.
+
+  16.2 Forbidden Extensions
+
+    Other than as defined in this specification, ECMAScript Function
+    objects defined using syntactic constructors in strict mode code
+    must not be created with own properties named "caller" or
+    "arguments" other than those that are created by applying the
+    AddRestrictedFunctionProperties abstract operation (9.2.7) to
+    the function. [...] Built-in functions, strict mode functions
+    created using the Function constructor, generator functions
+    created using the Generator constructor, and functions created
+    using the bind method also must not be created with such own
+    properties.
+---*/
+
+var ThrowTypeError = Object.getOwnPropertyDescriptor(function(){ "use strict"; return arguments; }(), "callee").get;
+
+assert.sameValue(Object.prototype.hasOwnProperty.call(ThrowTypeError, "caller"), false);

--- a/test/built-ins/ThrowTypeError/frozen.js
+++ b/test/built-ins/ThrowTypeError/frozen.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%throwtypeerror%
+description: >
+  The integrity level of %ThrowTypeError% is "frozen".
+info: >
+  %ThrowTypeError% ( )
+
+  The value of the [[Extensible]] internal slot of a %ThrowTypeError%
+  function is false.
+  The length property of a %ThrowTypeError% function has the attributes
+  { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.
+---*/
+
+var ThrowTypeError = Object.getOwnPropertyDescriptor(function(){ "use strict"; return arguments; }(), "callee").get;
+
+assert.sameValue(Object.isFrozen(ThrowTypeError), true);

--- a/test/built-ins/ThrowTypeError/is-function.js
+++ b/test/built-ins/ThrowTypeError/is-function.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2016 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%throwtypeerror%
+description: >
+  %ThrowTypeError% is a function object.
+info: >
+  %ThrowTypeError% ( )
+
+  The %ThrowTypeError% intrinsic is an anonymous built-in function
+  object that is defined once for each realm.
+---*/
+
+var ThrowTypeError = Object.getOwnPropertyDescriptor(function(){ "use strict"; return arguments; }(), "callee").get;
+
+assert.sameValue(typeof ThrowTypeError, "function");

--- a/test/built-ins/ThrowTypeError/length.js
+++ b/test/built-ins/ThrowTypeError/length.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%throwtypeerror%
+description: >
+  %ThrowTypeError%.length is 0.
+info: >
+  %ThrowTypeError% ( )
+
+  The length property of a %ThrowTypeError% function has the attributes
+  { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+---*/
+
+var ThrowTypeError = Object.getOwnPropertyDescriptor(function(){ "use strict"; return arguments; }(), "callee").get;
+
+assert.sameValue(ThrowTypeError.length, 0);
+
+verifyNotEnumerable(ThrowTypeError, "length");
+verifyNotWritable(ThrowTypeError, "length");
+verifyNotConfigurable(ThrowTypeError, "length");

--- a/test/built-ins/ThrowTypeError/name.js
+++ b/test/built-ins/ThrowTypeError/name.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2016 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%throwtypeerror%
+description: >
+  %ThrowTypeError% is an anonymous function.
+info: >
+  %ThrowTypeError% ( )
+
+  The %ThrowTypeError% intrinsic is an anonymous built-in function
+  object that is defined once for each Realm.
+---*/
+
+var ThrowTypeError = Object.getOwnPropertyDescriptor(function(){ "use strict"; return arguments; }(), "callee").get;
+
+assert.sameValue(Object.prototype.hasOwnProperty.call(ThrowTypeError, "name"), false);

--- a/test/built-ins/ThrowTypeError/prototype.js
+++ b/test/built-ins/ThrowTypeError/prototype.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%throwtypeerror%
+description: >
+  The value of the [[Prototype]] internal slot of %ThrowTypeError% is the
+  intrinsic object %FunctionPrototype%.
+info: >
+  8.2.2 CreateIntrinsics ( realmRec )
+
+  ...
+  6. Let thrower be CreateBuiltinFunction(realmRec, throwerSteps, null).
+  7. Set intrinsics.[[%ThrowTypeError%]] to thrower.
+  8. Let noSteps be an empty sequence of algorithm steps.
+  9. Let funcProto be CreateBuiltinFunction(realmRec, noSteps, objProto).
+  10. Set intrinsics.[[%FunctionPrototype%]] to funcProto.
+  11. Call thrower.[[SetPrototypeOf]](funcProto).
+  ...
+---*/
+
+var ThrowTypeError = Object.getOwnPropertyDescriptor(function(){ "use strict"; return arguments; }(), "callee").get;
+
+assert.sameValue(Object.getPrototypeOf(ThrowTypeError), Function.prototype);

--- a/test/built-ins/ThrowTypeError/throws-type-error.js
+++ b/test/built-ins/ThrowTypeError/throws-type-error.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%throwtypeerror%
+description: >
+  %ThrowTypeError% throws a TypeError when called.
+info: >
+  %ThrowTypeError% ( )
+
+  When %ThrowTypeError% is called it performs the following steps:
+
+    1. Throw a TypeError exception.
+---*/
+
+var ThrowTypeError = Object.getOwnPropertyDescriptor(function(){ "use strict"; return arguments; }(), "callee").get;
+
+assert.throws(TypeError, function() {
+  ThrowTypeError();
+});

--- a/test/built-ins/ThrowTypeError/unique-per-realm-function-proto.js
+++ b/test/built-ins/ThrowTypeError/unique-per-realm-function-proto.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%throwtypeerror%
+description: >
+  %ThrowTypeError% is defined once for each realm.
+info: >
+  %ThrowTypeError% ( )
+
+  The %ThrowTypeError% intrinsic is an anonymous built-in function
+  object that is defined once for each realm.
+---*/
+
+var ThrowTypeError = Object.getOwnPropertyDescriptor(function(){ "use strict"; return arguments; }(), "callee").get;
+
+// Test with Function.prototype.arguments and Function.prototype.caller properties.
+var argumentsDesc = Object.getOwnPropertyDescriptor(Function.prototype, "arguments");
+var callerDesc = Object.getOwnPropertyDescriptor(Function.prototype, "caller");
+
+assert.sameValue(ThrowTypeError, argumentsDesc.get, "arguments.get");
+assert.sameValue(ThrowTypeError, argumentsDesc.set, "arguments.set");
+assert.sameValue(ThrowTypeError, callerDesc.set, "caller.set");
+assert.sameValue(ThrowTypeError, callerDesc.get, "caller.get");

--- a/test/built-ins/ThrowTypeError/unique-per-realm-non-simple.js
+++ b/test/built-ins/ThrowTypeError/unique-per-realm-non-simple.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%throwtypeerror%
+description: >
+  %ThrowTypeError% is defined once for each realm.
+info: >
+  %ThrowTypeError% ( )
+
+  The %ThrowTypeError% intrinsic is an anonymous built-in function
+  object that is defined once for each realm.
+---*/
+
+var ThrowTypeError = Object.getOwnPropertyDescriptor(function(){ "use strict"; return arguments; }(), "callee").get;
+
+// Test with unmapped arguments object from function with non-simple parameters list.
+function nonSimple(a = 0) {
+  return arguments;
+}
+var unmappedCalleeDesc = Object.getOwnPropertyDescriptor(nonSimple(), "callee");
+var unmappedCallerDesc = Object.getOwnPropertyDescriptor(nonSimple(), "caller");
+
+assert.sameValue(ThrowTypeError, unmappedCalleeDesc.get, "callee.get");
+assert.sameValue(ThrowTypeError, unmappedCalleeDesc.set, "callee.set");
+assert.sameValue(ThrowTypeError, unmappedCallerDesc.get, "caller.get");
+assert.sameValue(ThrowTypeError, unmappedCallerDesc.set, "caller.set");

--- a/test/built-ins/ThrowTypeError/unique-per-realm-unmapped-args.js
+++ b/test/built-ins/ThrowTypeError/unique-per-realm-unmapped-args.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%throwtypeerror%
+description: >
+  %ThrowTypeError% is defined once for each realm.
+info: >
+  %ThrowTypeError% ( )
+
+  The %ThrowTypeError% intrinsic is an anonymous built-in function
+  object that is defined once for each realm.
+---*/
+
+var ThrowTypeError = Object.getOwnPropertyDescriptor(function(){ "use strict"; return arguments; }(), "callee").get;
+
+// Test with unmapped arguments object from strict-mode function.
+function strictFn() {
+  "use strict";
+  return arguments;
+}
+var unmappedCalleeDesc = Object.getOwnPropertyDescriptor(strictFn(), "callee");
+var unmappedCallerDesc = Object.getOwnPropertyDescriptor(strictFn(), "caller");
+
+assert.sameValue(ThrowTypeError, unmappedCalleeDesc.get, "callee.get");
+assert.sameValue(ThrowTypeError, unmappedCalleeDesc.set, "callee.set");
+assert.sameValue(ThrowTypeError, unmappedCallerDesc.get, "caller.get");
+assert.sameValue(ThrowTypeError, unmappedCallerDesc.set, "caller.set");

--- a/test/language/statements/class/subclass/default-constructor-spread-override.js
+++ b/test/language/statements/class/subclass/default-constructor-spread-override.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2016 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-classdefinitionevaluation
+description: >
+  Default class constructor uses standard iterator spread semantics.
+info: >
+  14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+    ...
+    10. If constructor is empty, then
+      a. If ClassHeritageopt is present, then
+          i Let constructor be the result of parsing the source text
+              constructor(...args){ super(...args); }
+            using the syntactic grammar with the goal symbol MethodDefinition.
+    ...
+
+  14.1.19 Runtime Semantics: IteratorBindingInitialization
+    `FunctionRestParameter : BindingRestElement`
+    ...
+    9. Let result be the result of performing IteratorBindingInitialization for BindingRestElement using iteratorRecord and environment as the arguments.
+    ...
+
+  13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    `BindingRestElement : ...BindingIdentifier`
+    ...
+    2. Let A be ArrayCreate(0).
+    ...
+
+  12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+    `ArgumentList : ArgumentList , ...AssignmentExpression`
+    ...
+    3. Let iterator be ? GetIterator(? GetValue(spreadRef)).
+    ...
+features: [Symbol.iterator]
+---*/
+
+var arrayIterator = Array.prototype[Symbol.iterator];
+
+// Redefine Array iterator to change the result of spreading `args` in `super(...args)`.
+Array.prototype[Symbol.iterator] = function() {
+  return arrayIterator.call(["spread-value"]);
+};
+
+var receivedValue;
+
+class Base {
+  constructor(value) {
+    receivedValue = value;
+  }
+}
+
+class Derived extends Base {}
+
+new Derived();
+
+assert.sameValue(receivedValue, "spread-value");


### PR DESCRIPTION
Increases the coverage for %ThrowTypeError% and adds an _interesting_ test case for default class constructors (https://bugzilla.mozilla.org/show_bug.cgi?id=1234702). 