### PR TITLE
Add tests for detached buffer validation on TypedArray methods

### DIFF
--- a/harness/detachArrayBuffer.js
+++ b/harness/detachArrayBuffer.js
@@ -1,0 +1,3 @@
+function $DETACHBUFFER(buffer) {
+  throw new Test262Error("No method available to detach an ArrayBuffer");
+}

--- a/test/built-ins/TypedArray/prototype/Symbol.toStringTag/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/Symbol.toStringTag/detached-buffer.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-%typedarray%.prototype-@@tostringtag
+description: The getter method does not throw with a detached buffer
+info: >
+  22.2.3.32 get %TypedArray%.prototype [ @@toStringTag ]
+
+  ...
+  4. Let name be the value of O's [[TypedArrayName]] internal slot.
+  5. Assert: name is a String value.
+  6. Return name.
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.sameValue(sample[Symbol.toStringTag], TA.name);
+});

--- a/test/built-ins/TypedArray/prototype/buffer/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/buffer/detached-buffer.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-%typedarray%.prototype.buffer
+description: The getter method does not throw with a detached buffer
+info: >
+  22.2.3.1 get %TypedArray%.prototype.buffer
+
+  ...
+  4. Let buffer be the value of O's [[ViewedArrayBuffer]] internal slot.
+  5. Return buffer.
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var buffer = new ArrayBuffer(8);
+  var sample = new TA(buffer, 0, 1);
+  $DETACHBUFFER(sample.buffer);
+  assert.sameValue(sample.buffer, buffer);
+});

--- a/test/built-ins/TypedArray/prototype/byteLength/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/byteLength/detached-buffer.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-%typedarray%.prototype.bytelength
+description: Returns 0 if the instance has a detached buffer
+info: >
+  22.2.3.2 get %TypedArray%.prototype.byteLength
+
+  ...
+  4. Let buffer be the value of O's [[ViewedArrayBuffer]] internal slot.
+  5. If IsDetachedBuffer(buffer) is true, return 0.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.sameValue(sample.byteLength, 0);
+});

--- a/test/built-ins/TypedArray/prototype/byteOffset/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/byteOffset/detached-buffer.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-%typedarray%.prototype.byteoffset
+description: Returns 0 if the instance has a detached buffer
+info: >
+  22.2.3.3 get %TypedArray%.prototype.byteOffset
+
+  ...
+  4. Let buffer be the value of O's [[ViewedArrayBuffer]] internal slot.
+  5. If IsDetachedBuffer(buffer) is true, return 0.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var buffer = new ArrayBuffer(128);
+  var sample = new TA(buffer, 8, 1);
+  $DETACHBUFFER(sample.buffer);
+  assert.sameValue(sample.byteOffset, 0);
+});

--- a/test/built-ins/TypedArray/prototype/copyWithin/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/detached-buffer.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.copywithin
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.5 %TypedArray%.prototype.copyWithin (target, start [, end ] )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var obj = {
+  valueOf() {
+    throw new Test262Error();
+  }
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.copyWithin(obj, obj);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/copyWithin/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/detached-buffer.js
@@ -19,7 +19,7 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 ---*/
 
 var obj = {
-  valueOf() {
+  valueOf: function() {
     throw new Test262Error();
   }
 };

--- a/test/built-ins/TypedArray/prototype/entries/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/entries/detached-buffer.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.entries
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.6 %TypedArray%.prototype.entries ( )
+
+  1. Let O be the this value.
+  2. Perform ? ValidateTypedArray(O).
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.entries();
+  });
+});

--- a/test/built-ins/TypedArray/prototype/every/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/every/detached-buffer.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.every
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.7 %TypedArray%.prototype.every ( callbackfn [ , thisArg ] )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var callbackfn = function() {
+  throw new Test262Error();
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.every(callbackfn);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/fill/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/fill/detached-buffer.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.fill
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.8 %TypedArray%.prototype.fill (value [ , start [ , end ] ] )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var obj = {
+  valueOf() {
+    throw new Test262Error();
+  }
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.fill(obj);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/fill/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/fill/detached-buffer.js
@@ -19,7 +19,7 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 ---*/
 
 var obj = {
-  valueOf() {
+  valueOf: function() {
     throw new Test262Error();
   }
 };

--- a/test/built-ins/TypedArray/prototype/filter/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/filter/detached-buffer.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.filter
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.9 %TypedArray%.prototype.filter ( callbackfn [ , thisArg ] )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var callbackfn = function() {
+  throw new Test262Error();
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.filter(callbackfn);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/find/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/find/detached-buffer.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.find
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.10 %TypedArray%.prototype.find (predicate [ , thisArg ] )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var predicate = function() {
+  throw new Test262Error();
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.find(predicate);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/findIndex/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/detached-buffer.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.findindex
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.11 %TypedArray%.prototype.findIndex ( predicate [ , thisArg ] )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var predicate = function() {
+  throw new Test262Error();
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.findIndex(predicate);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/forEach/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/forEach/detached-buffer.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.foreach
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.12 %TypedArray%.prototype.forEach ( callbackfn [ , thisArg ] )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var callbackfn = function() {
+  throw new Test262Error();
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.forEach(callbackfn);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/includes/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/includes/detached-buffer.js
@@ -18,16 +18,10 @@ info: >
 includes: [testTypedArray.js, detachArrayBuffer.js]
 ---*/
 
-var searchElement = {
-  valueOf() {
-    throw new Test262Error();
-  }
-};
-
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA(1);
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
-    sample.includes(searchElement);
+    sample.includes(0);
   });
 });

--- a/test/built-ins/TypedArray/prototype/includes/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/includes/detached-buffer.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.includes
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.14 %TypedArray%.prototype.includes ( searchElement [ , fromIndex ] )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var searchElement = {
+  valueOf() {
+    throw new Test262Error();
+  }
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.includes(searchElement);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/indexOf/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/detached-buffer.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.indexof
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.13 %TypedArray%.prototype.indexOf (searchElement [ , fromIndex ] )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var searchElement = {
+  valueOf() {
+    throw new Test262Error();
+  }
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.indexOf(searchElement);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/indexOf/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/detached-buffer.js
@@ -18,16 +18,10 @@ info: >
 includes: [testTypedArray.js, detachArrayBuffer.js]
 ---*/
 
-var searchElement = {
-  valueOf() {
-    throw new Test262Error();
-  }
-};
-
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA(1);
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
-    sample.indexOf(searchElement);
+    sample.indexOf(0);
   });
 });

--- a/test/built-ins/TypedArray/prototype/join/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/join/detached-buffer.js
@@ -19,7 +19,7 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 ---*/
 
 var obj = {
-  valueOf() {
+  toString: function() {
     throw new Test262Error();
   }
 };

--- a/test/built-ins/TypedArray/prototype/join/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/join/detached-buffer.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.join
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.15 %TypedArray%.prototype.join ( separator )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var obj = {
+  valueOf() {
+    throw new Test262Error();
+  }
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.join(obj);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/keys/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/keys/detached-buffer.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.keys
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.16 %TypedArray%.prototype.keys ( )
+
+  1. Let O be the this value.
+  2. Perform ? ValidateTypedArray(O).
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.keys();
+  });
+});

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/detached-buffer.js
@@ -18,16 +18,10 @@ info: >
 includes: [testTypedArray.js, detachArrayBuffer.js]
 ---*/
 
-var searchElement = {
-  valueOf() {
-    throw new Test262Error();
-  }
-};
-
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA(1);
   $DETACHBUFFER(sample.buffer);
   assert.throws(TypeError, function() {
-    sample.lastIndexOf(searchElement);
+    sample.lastIndexOf(0);
   });
 });

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/detached-buffer.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.lastindexof
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.17 %TypedArray%.prototype.lastIndexOf ( searchElement [ , fromIndex ] )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var searchElement = {
+  valueOf() {
+    throw new Test262Error();
+  }
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.lastIndexOf(searchElement);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/length/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/length/detached-buffer.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-%typedarray%.prototype.length
+description: Returns 0 if the instance has a detached buffer
+info: >
+  22.2.3.18 get %TypedArray%.prototype.length
+
+  ...
+  5. Let buffer be the value of O's [[ViewedArrayBuffer]] internal slot.
+  6. If IsDetachedBuffer(buffer) is true, return 0.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(42);
+  $DETACHBUFFER(sample.buffer);
+  assert.sameValue(sample.length, 0);
+});

--- a/test/built-ins/TypedArray/prototype/map/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/map/detached-buffer.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  1. Let O be the this value.
+  2. Perform ? ValidateTypedArray(O).
+  ...
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var callbackfn = function() {
+  throw new Test262Error();
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.map(callbackfn);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/reduce/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/reduce/detached-buffer.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.reduce
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.20 %TypedArray%.prototype.reduce ( callbackfn [ , initialValue ] )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var callbackfn = function() {
+  throw new Test262Error();
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.reduce(callbackfn);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/reduceRight/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/detached-buffer.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.reduceright
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.21 %TypedArray%.prototype.reduceRight ( callbackfn [ , initialValue ] )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var callbackfn = function() {
+  throw new Test262Error();
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.reduceRight(callbackfn);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/reverse/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/reverse/detached-buffer.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.reverse
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.22 %TypedArray%.prototype.reverse ( )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.reverse();
+  });
+});

--- a/test/built-ins/TypedArray/prototype/set/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/set/detached-buffer.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.set
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.23 %TypedArray%.prototype.set ( overloaded [ , offset ])
+
+  22.2.3.23.1 %TypedArray%.prototype.set (array [ , offset ] )
+
+  ...
+  9. If IsDetachedBuffer(targetBuffer) is true, throw a TypeError exception.
+  ...
+
+  22.2.3.23.2 %TypedArray%.prototype.set(typedArray [ , offset ] )
+
+  ...
+  9. If IsDetachedBuffer(targetBuffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA();
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.set([]);
+  }, "argument is an array");
+
+  assert.throws(TypeError, function() {
+    sample.set(sample);
+  }, "argument is a TypedArray object");
+});

--- a/test/built-ins/TypedArray/prototype/slice/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/slice/detached-buffer.js
@@ -18,7 +18,7 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 ---*/
 
 var obj = {
-  valueOf() {
+  valueOf: function() {
     throw new Test262Error();
   }
 };

--- a/test/built-ins/TypedArray/prototype/slice/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/slice/detached-buffer.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.slice
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.24 %TypedArray%.prototype.slice ( start, end )
+
+  1. Let O be the this value.
+  2. Perform ? ValidateTypedArray(O).
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var obj = {
+  valueOf() {
+    throw new Test262Error();
+  }
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.slice(obj, obj);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/some/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/some/detached-buffer.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.some
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.25 %TypedArray%.prototype.some ( callbackfn [ , thisArg ] )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var callbackfn = function() {
+  throw new Test262Error();
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.some(callbackfn);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/sort/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/sort/detached-buffer.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.sort
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.26 %TypedArray%.prototype.sort ( comparefn )
+
+  1. Let obj be the this value.
+  2. Let buffer be ? ValidateTypedArray(obj).
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var comparefn = function() {
+  throw new Test262Error();
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.sort(comparefn);
+  });
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/detached-buffer.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.tolocalestring
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.28 %TypedArray%.prototype.toLocaleString ([ reserved1 [ , reserved2 ] ])
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.toLocaleString();
+  });
+});

--- a/test/built-ins/TypedArray/prototype/toString/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/toString/detached-buffer.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.tostring
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.29 %TypedArray%.prototype.toString ()
+
+  ...
+
+  22.2.3.15 %TypedArray%.prototype.join ( separator )
+
+  This function is not generic. ValidateTypedArray is applied to the this value
+  prior to evaluating the algorithm. If its result is an abrupt completion that
+  exception is thrown instead of evaluating the algorithm.
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.toString();
+  });
+});

--- a/test/built-ins/TypedArray/prototype/values/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/values/detached-buffer.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.values
+description: Throws a TypeError if this has a detached buffer
+info: >
+  22.2.3.30 %TypedArray%.prototype.values ( )
+
+  1. Let O be the this value.
+  2. Perform ? ValidateTypedArray(O).
+
+  22.2.3.5.1 Runtime Semantics: ValidateTypedArray ( O )
+
+  ...
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(1);
+  $DETACHBUFFER(sample.buffer);
+  assert.throws(TypeError, function() {
+    sample.values();
+  });
+});


### PR DESCRIPTION
these tests requires an extra implementation on the runners. Ref `harness/detachArrayBuffer.js` 