### PR TITLE
Remove a blank line to stop confusing YAML parsers

### DIFF
--- a/test/language/asi/S7.9_A5.7_T1.js
+++ b/test/language/asi/S7.9_A5.7_T1.js
@@ -3,7 +3,6 @@
 
 /*---
 info: >
-
     Since LineTerminator(LT) between Postfix Increment/Decrement
     Operator(I/DO) and operand is not allowed, two IO(just as two DO
     and their combination) between two references separated by [LT]


### PR DESCRIPTION
V8 ran into an issue where the YAML parser our test setup is using
didn't understand the newline, and failed to parser the negative
test expectation below, causing the test to fail. This patch fixes
the issue.