### PR TITLE
Add tests for `debugger` statement

### DIFF
--- a/test/language/statements/debugger/expression.js
+++ b/test/language/statements/debugger/expression.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: The `debugger` token may not occupy an expression position
+esid: sec-debugger-statement
+es6id: 13.16
+negative: SyntaxError
+---*/
+
+(debugger);

--- a/test/language/statements/debugger/statement.js
+++ b/test/language/statements/debugger/statement.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: The `debugger` token may occupy a statement position
+esid: sec-debugger-statement
+es6id: 13.16
+---*/
+
+// Expressing within a `while` statement ensures that the `debugger  keyword is
+// not erroneously interpreted as a declaration. It also avoids statement
+// evaluation, which is host-defined an may interrupt test execution.
+while (false) debugger;


### PR DESCRIPTION
The runtime semantics of this statement are host-defined and therefore
untestable, but the statement's affect on the formal grammar should be
consistent across all implementations.