### PR TITLE
Avoid false positives

### DIFF
--- a/test/built-ins/Math/random/S15.8.2.14_A1.js
+++ b/test/built-ins/Math/random/S15.8.2.14_A1.js
@@ -15,6 +15,12 @@ description: >
 for (var i = 0; i < 100; i++)
 {
 	var val = Math.random();
+
+	assert.sameValue(
+		typeof val, 'number', 'should not produce a non-numeric value: ' + val
+	);
+	assert.notSameValue(val, NaN, 'should not produce NaN');
+
 	if (val < 0 || val >= 1)
 	{
 		$ERROR("#1: Math.random() = " + val);


### PR DESCRIPTION
As written, the test for `Math.random` would pass if the runtime
erroneously produced a non-numeric value. Add the necessary assertions
to guard against this case.