### PR TITLE
Correct example in contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,8 +193,8 @@ var var = var;
 Expectations for **runtime errors** should be defined using the `assert.throws` method and the appropriate JavaScript Error constructor function:
 
 ```javascript
-assert.throws(ReferenceError, function() {
-  1 += 1; // expect this to throw ReferenceError
+assert.throws(TypeError, function() {
+  null(); // expect this statement to throw a TypeError
 });
 ```
 


### PR DESCRIPTION
As written, the example for asserting runtime errors is written with an
early error. Because the error is expected to be reported prior to
program execution, the `assert.throws` function cannot be used to detect
it.

Demonstrate the usage of the helper function with a runtime error.