### PR TITLE
Add tests for RegExp literal early errors

### DIFF
--- a/test/language/literals/regexp/early-err-bad-flag.js
+++ b/test/language/literals/regexp/early-err-bad-flag.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Literal may not contain an unrecognized flag (early error)
+esid: sec-primary-expression-regular-expression-literals-static-semantics-early-errors
+info: >
+    It is a Syntax Error if FlagText of RegularExpressionLiteral contains any
+    code points other than "g", "i", "m", "u", or "y", or if it contains the
+    same code point more than once.
+negative: SyntaxError
+---*/
+
+throw new Test262Error();
+
+/./G;

--- a/test/language/literals/regexp/early-err-dup-flag.js
+++ b/test/language/literals/regexp/early-err-dup-flag.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Literal may not contain duplicate flags (early error)
+esid: sec-primary-expression-regular-expression-literals-static-semantics-early-errors
+info: >
+    It is a Syntax Error if FlagText of RegularExpressionLiteral contains any
+    code points other than "g", "i", "m", "u", or "y", or if it contains the
+    same code point more than once.
+negative: SyntaxError
+---*/
+
+throw new Test262Error();
+
+/./gig;

--- a/test/language/literals/regexp/early-err-pattern.js
+++ b/test/language/literals/regexp/early-err-pattern.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Literal may not describe an invalid pattern (early error)
+esid: sec-primary-expression-regular-expression-literals-static-semantics-early-errors
+info: >
+    It is a Syntax Error if BodyText of RegularExpressionLiteral cannot be
+    recognized using the goal symbol Pattern of the ECMAScript RegExp grammar
+    specified in 21.2.1.
+negative: SyntaxError
+---*/
+
+throw new Test262Error();
+
+/?/;


### PR DESCRIPTION
@littledan V8 fails `early-err-pattern.js`, previously reported at https://bugs.chromium.org/p/v8/issues/detail?id=896