### PR TITLE
Correct invalid tests for the Date constructor

### DIFF
--- a/harness/assertRelativeDateMs.js
+++ b/harness/assertRelativeDateMs.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/**
+ * Verify that the given date object's Number representation describes the
+ * correct number of milliseconds since the Unix epoch relative to the local
+ * time zone (as interpreted at the specified date).
+ *
+ * @param {Date} date
+ * @param {Number} expectedMs
+ */
+function assertRelativeDateMs(date, expectedMs) {
+  var actualMs = date.valueOf();
+  var localOffset = date.getTimezoneOffset() * 60000;
+
+  if (actualMs - localOffset !== expectedMs) {
+    $ERROR(
+      'Expected ' + date + ' to be ' + expectedMs +
+      ' milliseconds from the Unix epoch'
+    );
+  }
+}

--- a/test/built-ins/Date/S15.9.3.1_A5_T1.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T1.js
@@ -1,7 +1,7 @@
 // Copyright 2009 the Sputnik authors.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
+esid: sec-date-constructor
 info: >
     The [[Value]] property of the newly constructed object
     is set by following steps:
@@ -14,56 +14,29 @@ info: >
     TimeClip(UTC(Result(11)))
 es5id: 15.9.3.1_A5_T1
 description: 2 arguments, (year, month)
-includes:
-    - numeric_conversion.js
-    - Date_constants.js
-    - Date_library.js
+includes: [assertRelativeDateMs.js]
 ---*/
 
-if (-2211638400000 !== new Date(1899, 11).valueOf()) {
-  $ERROR("#1: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1899, 11), -2211667200000);
 
-if (-2208960000000 !== new Date(1899, 12).valueOf()) {
-  $ERROR("#2: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1899, 12), -2208988800000);
 
-if (-2208960000000 !== new Date(1900, 0).valueOf()) {
-  $ERROR("#3: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1900, 0), -2208988800000);
 
-if (-2649600000 !== new Date(1969, 11).valueOf()) {
-  $ERROR("#4: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1969, 11), -2678400000);
 
-if (28800000 !== new Date(1969, 12).valueOf()) {
-  $ERROR("#5: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1969, 12), 0);
 
-if (28800000 !== new Date(1970, 0).valueOf()) {
-  $ERROR("#6: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1970, 0), 0);
 
-if (944035200000 !== new Date(1999, 11).valueOf()) {
-  $ERROR("#7: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1999, 11), 944006400000);
 
-if (946713600000 !== new Date(1999, 12).valueOf()) {
-  $ERROR("#8: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1999, 12), 946684800000);
 
-if (946713600000 !== new Date(2000, 0).valueOf()) {
-  $ERROR("#9: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2000, 0),  946684800000);
 
-if (4099795200000 !== new Date(2099, 11).valueOf()) {
-  $ERROR("#10: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2099, 11), 4099766400000);
 
-if (4102473600000 !== new Date(2099, 12).valueOf()) {
-  $ERROR("#11: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2099, 12), 4102444800000);
 
-if (4102473600000 !== new Date(2100, 0).valueOf()) {
-  $ERROR("#12: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2100, 0), 4102444800000);

--- a/test/built-ins/Date/S15.9.3.1_A5_T2.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T2.js
@@ -1,7 +1,7 @@
 // Copyright 2009 the Sputnik authors.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
+esid: sec-date-constructor
 info: >
     The [[Value]] property of the newly constructed object
     is set by following steps:

--- a/test/built-ins/Date/S15.9.3.1_A5_T2.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T2.js
@@ -14,56 +14,29 @@ info: >
     TimeClip(UTC(Result(11)))
 es5id: 15.9.3.1_A5_T2
 description: 3 arguments, (year, month, date)
-includes:
-    - numeric_conversion.js
-    - Date_constants.js
-    - Date_library.js
+includes: [assertRelativeDateMs.js]
 ---*/
 
-if (-2209046400000 !== new Date(1899, 11, 31).valueOf()) {
-  $ERROR("#1: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1899, 11, 31), -2209075200000);
 
-if (-2208960000000 !== new Date(1899, 12, 1).valueOf()) {
-  $ERROR("#2: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1899, 12, 1), -2208988800000);
 
-if (-2208960000000 !== new Date(1900, 0, 1).valueOf()) {
-  $ERROR("#3: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1900, 0, 1), -2208988800000);
 
-if (-57600000 !== new Date(1969, 11, 31).valueOf()) {
-  $ERROR("#4: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1969, 11, 31), -86400000);
 
-if (28800000 !== new Date(1969, 12, 1).valueOf()) {
-  $ERROR("#5: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1969, 12, 1), 0);
 
-if (28800000 !== new Date(1970, 0, 1).valueOf()) {
-  $ERROR("#6: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1970, 0, 1), 0);
 
-if (946627200000 !== new Date(1999, 11, 31).valueOf()) {
-  $ERROR("#7: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1999, 11, 31), 946598400000);
 
-if (946713600000 !== new Date(1999, 12, 1).valueOf()) {
-  $ERROR("#8: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1999, 12, 1), 946684800000);
 
-if (946713600000 !== new Date(2000, 0, 1).valueOf()) {
-  $ERROR("#9: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2000, 0, 1), 946684800000);
 
-if (4102387200000 !== new Date(2099, 11, 31).valueOf()) {
-  $ERROR("#10: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2099, 11, 31), 4102358400000);
 
-if (4102473600000 !== new Date(2099, 12, 1).valueOf()) {
-  $ERROR("#11: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2099, 12, 1), 4102444800000);
 
-if (4102473600000 !== new Date(2100, 0, 1).valueOf()) {
-  $ERROR("#12: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2100, 0, 1), 4102444800000);

--- a/test/built-ins/Date/S15.9.3.1_A5_T3.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T3.js
@@ -1,7 +1,7 @@
 // Copyright 2009 the Sputnik authors.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
+esid: sec-date-constructor
 info: >
     The [[Value]] property of the newly constructed object
     is set by following steps:
@@ -14,56 +14,29 @@ info: >
     TimeClip(UTC(Result(11)))
 es5id: 15.9.3.1_A5_T3
 description: 4 arguments, (year, month, date, hours)
-includes:
-    - numeric_conversion.js
-    - Date_constants.js
-    - Date_library.js
+includes: [assertRelativeDateMs.js]
 ---*/
 
-if (-2208963600000 !== new Date(1899, 11, 31, 23).valueOf()) {
-  $ERROR("#1: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1899, 11, 31, 23), -2208992400000);
 
-if (-2208960000000 !== new Date(1899, 12, 1, 0).valueOf()) {
-  $ERROR("#2: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1899, 12, 1, 0), -2208988800000);
 
-if (-2208960000000 !== new Date(1900, 0, 1, 0).valueOf()) {
-  $ERROR("#3: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1900, 0, 1, 0), -2208988800000);
 
-if (25200000 !== new Date(1969, 11, 31, 23).valueOf()) {
-  $ERROR("#4: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1969, 11, 31, 23), -3600000);
 
-if (28800000 !== new Date(1969, 12, 1, 0).valueOf()) {
-  $ERROR("#5: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1969, 12, 1, 0), 0);
 
-if (28800000 !== new Date(1970, 0, 1, 0).valueOf()) {
-  $ERROR("#6: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1970, 0, 1, 0), 0);
 
-if (946710000000 !== new Date(1999, 11, 31, 23).valueOf()) {
-  $ERROR("#7: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1999, 11, 31, 23), 946681200000);
 
-if (946713600000 !== new Date(1999, 12, 1, 0).valueOf()) {
-  $ERROR("#8: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1999, 12, 1, 0), 946684800000);
 
-if (946713600000 !== new Date(2000, 0, 1, 0).valueOf()) {
-  $ERROR("#9: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2000, 0, 1, 0), 946684800000);
 
-if (4102470000000 !== new Date(2099, 11, 31, 23).valueOf()) {
-  $ERROR("#10: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2099, 11, 31, 23), 4102441200000);
 
-if (4102473600000 !== new Date(2099, 12, 1, 0).valueOf()) {
-  $ERROR("#11: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2099, 12, 1, 0), 4102444800000);
 
-if (4102473600000 !== new Date(2100, 0, 1, 0).valueOf()) {
-  $ERROR("#12: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2100, 0, 1, 0), 4102444800000);

--- a/test/built-ins/Date/S15.9.3.1_A5_T4.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T4.js
@@ -1,7 +1,7 @@
 // Copyright 2009 the Sputnik authors.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
+esid: sec-date-constructor
 info: >
     The [[Value]] property of the newly constructed object
     is set by following steps:
@@ -14,56 +14,29 @@ info: >
     TimeClip(UTC(Result(11)))
 es5id: 15.9.3.1_A5_T4
 description: 5 arguments, (year, month, date, hours, minutes)
-includes:
-    - numeric_conversion.js
-    - Date_constants.js
-    - Date_library.js
+includes: [assertRelativeDateMs.js]
 ---*/
 
-if (-2208960060000 !== new Date(1899, 11, 31, 23, 59).valueOf()) {
-  $ERROR("#1: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1899, 11, 31, 23, 59), -2208988860000);
 
-if (-2208960000000 !== new Date(1899, 12, 1, 0, 0).valueOf()) {
-  $ERROR("#2: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1899, 12, 1, 0, 0), -2208988800000);
 
-if (-2208960000000 !== new Date(1900, 0, 1, 0, 0).valueOf()) {
-  $ERROR("#3: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1900, 0, 1, 0, 0), -2208988800000);
 
-if (28740000 !== new Date(1969, 11, 31, 23, 59).valueOf()) {
-  $ERROR("#4: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1969, 11, 31, 23, 59), -60000);
 
-if (28800000 !== new Date(1969, 12, 1, 0, 0).valueOf()) {
-  $ERROR("#5: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1969, 12, 1, 0, 0), 0);
 
-if (28800000 !== new Date(1970, 0, 1, 0, 0).valueOf()) {
-  $ERROR("#6: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1970, 0, 1, 0, 0), 0);
 
-if (946713540000 !== new Date(1999, 11, 31, 23, 59).valueOf()) {
-  $ERROR("#7: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1999, 11, 31, 23, 59), 946684740000);
 
-if (946713600000 !== new Date(1999, 12, 1, 0, 0).valueOf()) {
-  $ERROR("#8: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1999, 12, 1, 0, 0), 946684800000);
 
-if (946713600000 !== new Date(2000, 0, 1, 0, 0).valueOf()) {
-  $ERROR("#9: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2000, 0, 1, 0, 0), 946684800000);
 
-if (4102473540000 !== new Date(2099, 11, 31, 23, 59).valueOf()) {
-  $ERROR("#10: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2099, 11, 31, 23, 59), 4102444740000);
 
-if (4102473600000 !== new Date(2099, 12, 1, 0, 0).valueOf()) {
-  $ERROR("#11: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2099, 12, 1, 0, 0), 4102444800000);
 
-if (4102473600000 !== new Date(2100, 0, 1, 0, 0).valueOf()) {
-  $ERROR("#12: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2100, 0, 1, 0, 0), 4102444800000);

--- a/test/built-ins/Date/S15.9.3.1_A5_T5.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T5.js
@@ -1,7 +1,7 @@
 // Copyright 2009 the Sputnik authors.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
+esid: sec-date-constructor
 info: >
     The [[Value]] property of the newly constructed object
     is set by following steps:
@@ -14,56 +14,29 @@ info: >
     TimeClip(UTC(Result(11)))
 es5id: 15.9.3.1_A5_T5
 description: 6 arguments, (year, month, date, hours, minutes, seconds)
-includes:
-    - numeric_conversion.js
-    - Date_constants.js
-    - Date_library.js
+includes: [assertRelativeDateMs.js]
 ---*/
 
-if (-2208960001000 !== new Date(1899, 11, 31, 23, 59, 59).valueOf()) {
-  $ERROR("#1: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1899, 11, 31, 23, 59, 59), -2208988801000);
 
-if (-2208960000000 !== new Date(1899, 12, 1, 0, 0, 0).valueOf()) {
-  $ERROR("#2: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1899, 12, 1, 0, 0, 0), -2208988800000);
 
-if (-2208960000000 !== new Date(1900, 0, 1, 0, 0, 0).valueOf()) {
-  $ERROR("#3: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1900, 0, 1, 0, 0, 0), -2208988800000);
 
-if (28799000 !== new Date(1969, 11, 31, 23, 59, 59).valueOf()) {
-  $ERROR("#4: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1969, 11, 31, 23, 59, 59), -1000);
 
-if (28800000 !== new Date(1969, 12, 1, 0, 0, 0).valueOf()) {
-  $ERROR("#5: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1969, 12, 1, 0, 0, 0), 0);
 
-if (28800000 !== new Date(1970, 0, 1, 0, 0, 0).valueOf()) {
-  $ERROR("#6: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1970, 0, 1, 0, 0, 0), 0);
 
-if (946713599000 !== new Date(1999, 11, 31, 23, 59, 59).valueOf()) {
-  $ERROR("#7: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1999, 11, 31, 23, 59, 59), 946684799000);
 
-if (946713600000 !== new Date(1999, 12, 1, 0, 0, 0).valueOf()) {
-  $ERROR("#8: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1999, 12, 1, 0, 0, 0), 946684800000);
 
-if (946713600000 !== new Date(2000, 0, 1, 0, 0, 0).valueOf()) {
-  $ERROR("#9: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2000, 0, 1, 0, 0, 0), 946684800000);
 
-if (4102473599000 !== new Date(2099, 11, 31, 23, 59, 59).valueOf()) {
-  $ERROR("#10: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2099, 11, 31, 23, 59, 59), 4102444799000);
 
-if (4102473600000 !== new Date(2099, 12, 1, 0, 0, 0).valueOf()) {
-  $ERROR("#11: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2099, 12, 1, 0, 0, 0), 4102444800000);
 
-if (4102473600000 !== new Date(2100, 0, 1, 0, 0, 0).valueOf()) {
-  $ERROR("#12: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2100, 0, 1, 0, 0, 0), 4102444800000);

--- a/test/built-ins/Date/S15.9.3.1_A5_T6.js
+++ b/test/built-ins/Date/S15.9.3.1_A5_T6.js
@@ -1,7 +1,7 @@
 // Copyright 2009 the Sputnik authors.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
+esid: sec-date-constructor
 info: >
     The [[Value]] property of the newly constructed object
     is set by following steps:
@@ -14,56 +14,29 @@ info: >
     TimeClip(UTC(Result(11)))
 es5id: 15.9.3.1_A5_T6
 description: 7 arguments, (year, month, date, hours, minutes, seconds, ms)
-includes:
-    - numeric_conversion.js
-    - Date_constants.js
-    - Date_library.js
+includes: [assertRelativeDateMs.js]
 ---*/
 
-if (-2208960000001 !== new Date(1899, 11, 31, 23, 59, 59, 999).valueOf()) {
-  $ERROR("#1: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1899, 11, 31, 23, 59, 59, 999), -2208988800001);
 
-if (-2208960000000 !== new Date(1899, 12, 1, 0, 0, 0, 0).valueOf()) {
-  $ERROR("#2: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1899, 12, 1, 0, 0, 0, 0), -2208988800000);
 
-if (-2208960000000 !== new Date(1900, 0, 1, 0, 0, 0, 0).valueOf()) {
-  $ERROR("#3: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1900, 0, 1, 0, 0, 0, 0), -2208988800000);
 
-if (28799999 !== new Date(1969, 11, 31, 23, 59, 59, 999).valueOf()) {
-  $ERROR("#4: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1969, 11, 31, 23, 59, 59, 999), -1);
 
-if (28800000 !== new Date(1969, 12, 1, 0, 0, 0, 0).valueOf()) {
-  $ERROR("#5: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1969, 12, 1, 0, 0, 0, 0), 0);
 
-if (28800000 !== new Date(1970, 0, 1, 0, 0, 0, 0).valueOf()) {
-  $ERROR("#6: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1970, 0, 1, 0, 0, 0, 0), 0);
 
-if (946713599999 !== new Date(1999, 11, 31, 23, 59, 59, 999).valueOf()) {
-  $ERROR("#7: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1999, 11, 31, 23, 59, 59, 999), 946684799999);
 
-if (946713600000 !== new Date(1999, 12, 1, 0, 0, 0, 0).valueOf()) {
-  $ERROR("#8: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(1999, 12, 1, 0, 0, 0, 0), 946684800000);
 
-if (946713600000 !== new Date(2000, 0, 1, 0, 0, 0, 0).valueOf()) {
-  $ERROR("#9: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2000, 0, 1, 0, 0, 0, 0), 946684800000);
 
-if (4102473599999 !== new Date(2099, 11, 31, 23, 59, 59, 999).valueOf()) {
-  $ERROR("#10: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2099, 11, 31, 23, 59, 59, 999), 4102444799999);
 
-if (4102473600000 !== new Date(2099, 12, 1, 0, 0, 0, 0).valueOf()) {
-  $ERROR("#11: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2099, 12, 1, 0, 0, 0, 0), 4102444800000);
 
-if (4102473600000 !== new Date(2100, 0, 1, 0, 0, 0, 0).valueOf()) {
-  $ERROR("#12: Incorrect value of Date");
-}
+assertRelativeDateMs(new Date(2100, 0, 1, 0, 0, 0, 0), 4102444800000);

--- a/test/harness/assertRelativeDateMs.js
+++ b/test/harness/assertRelativeDateMs.js
@@ -1,0 +1,80 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+     Only passes when the provided date is exactly the specified number of
+     milliseconds from the Unix epoch
+includes: [assertRelativeDateMs.js]
+---*/
+
+var thrown;
+
+assertRelativeDateMs(new Date(1970, 0), 0);
+assertRelativeDateMs(new Date(1970, 0, 1, 0, 0, 0, 0), 0);
+assertRelativeDateMs(new Date(1970, 0, 1, 0, 0, 0, 1), 1);
+assertRelativeDateMs(new Date(1970, 0, 1, 0, 0, 0, -1), -1);
+assertRelativeDateMs(new Date(1970, 0, 1, 0, 0, 1, 0), 1000);
+assertRelativeDateMs(new Date(1970, 0, 1, 0, 0, -1, 0), -1000);
+assertRelativeDateMs(new Date(1970, 0, 1, 0, 2, 0, 0), 120000);
+assertRelativeDateMs(new Date(1970, 0, 1, 0, -2, 0, 0), -120000);
+assertRelativeDateMs(new Date(2016, 3, 12, 13, 21, 23, 24), 1460467283024);
+
+thrown = null;
+try {
+  assertRelativeDateMs(new Date(1), 0);
+} catch (err) {
+  thrown = err;
+}
+if (!thrown) {
+  $ERROR('Expected error, but no error was thrown.');
+} else if (thrown.constructor !== Test262Error) {
+  $ERROR('Expected error of type Test262Error.');
+}
+
+thrown = null;
+try {
+  assertRelativeDateMs(new Date(-1), 0);
+} catch (err) {
+  thrown = err;
+}
+if (!thrown) {
+  $ERROR('Expected error, but no error was thrown.');
+} else if (thrown.constructor !== Test262Error) {
+  $ERROR('Expected error of type Test262Error.');
+}
+
+thrown = null;
+try {
+  assertRelativeDateMs(new Date(1970, 0), 1);
+} catch (err) {
+  thrown = err;
+}
+if (!thrown) {
+  $ERROR('Expected error, but no error was thrown.');
+} else if (thrown.constructor !== Test262Error) {
+  $ERROR('Expected error of type Test262Error.');
+}
+
+thrown = null;
+try {
+  assertRelativeDateMs(new Date(1970, 0), -1);
+} catch (err) {
+  thrown = err;
+}
+if (!thrown) {
+  $ERROR('Expected error, but no error was thrown.');
+} else if (thrown.constructor !== Test262Error) {
+  $ERROR('Expected error of type Test262Error.');
+}
+
+thrown = null;
+try {
+  assertRelativeDateMs(new Date('invalid'), NaN);
+} catch (err) {
+  thrown = err;
+}
+if (!thrown) {
+  $ERROR('Expected error, but no error was thrown.');
+} else if (thrown.constructor !== Test262Error) {
+  $ERROR('Expected error of type Test262Error.');
+}


### PR DESCRIPTION
The millisecond representation of a given Date instance is dependent on
the local system's time zone settings. In order to pass consistently
across contexts, tests for this value must take the system configuration
into account.

Introduce a test harness utility function to encapsulate these concerns.
Re-use this function across all test files that assert the exact
millisecond representation of Date instances.

@littledan As noted in the original BugZilla report, this approach complicates
the tests, but it doesn't quite depend on the semantics under test, so it
should be "safe."

That said, another solution occurred to me while writing this: we could make a
specific time zone (say, Greenwich Mean Time) a formal requirement to executing
Test262. This seems like the same class of problems I am trying to address in
gh-508. That is: limiting runtime variability through requirements
specification.

...But maybe it's a little too presumptuous to ask consumers to re-configure
their system clocks before running the tests. It certainly seems like overkill
for these 6 files, but doing so would let us forget about this detail entirely
(instead of carrying around another helper function and remembering to use it).

Resolves gh-528 (and https://bugs.ecmascript.org/show_bug.cgi?id=293 before it)