### PR TITLE
Correct tests for native functions' toString value

### DIFF
--- a/harness/nativeFunctionMatcher.js
+++ b/harness/nativeFunctionMatcher.js
@@ -1,1 +1,1 @@
-const NATIVE_FUNCTION_RE = /\bfunction\b[\s\S]+\b\w+\b[\s\S]*\([\s\S]*\)[\s\S]*\{[\s\S]*\[[\s\S]*\bnative\b[\s\S]+\bcode\b[\s\S]*\][\s\S]*\}/;
+const NATIVE_FUNCTION_RE = /\bfunction\b(\s+[\s\S]+|\s*)\([\s\S]*\)[\s\S]*\{[\s\S]*\[[\s\S]*\bnative\b[\s\S]+\bcode\b[\s\S]*\][\s\S]*\}/;

--- a/harness/nativeFunctionMatcher.js
+++ b/harness/nativeFunctionMatcher.js
@@ -1,1 +1,5 @@
-const NATIVE_FUNCTION_RE = /\bfunction\b(\s+[\s\S]+|\s*)\([\s\S]*\)[\s\S]*\{[\s\S]*\[[\s\S]*\bnative\b[\s\S]+\bcode\b[\s\S]*\][\s\S]*\}/;
+/**
+ * This regex makes a best-effort determination that the tested string matches
+ * the NativeFunction grammar production without requiring a correct tokeniser.
+ */
+const NATIVE_FUNCTION_RE = /\bfunction\b[\s\S]*\([\s\S]*\)[\s\S]*\{[\s\S]*\[[\s\S]*\bnative\b[\s\S]+\bcode\b[\s\S]*\][\s\S]*\}/;

--- a/test/harness/nativeFunctionMatcher.js
+++ b/test/harness/nativeFunctionMatcher.js
@@ -3,9 +3,8 @@
 
 /*---
 description: >
-    Provides a regex that makes a best-effort determination that the tested
-    string matches the NativeFunction grammar production without requiring a
-    correct tokeniser
+    Ensure that the regular expression generally distinguishes between valid
+    and invalid forms of the NativeFunction grammar production.
 includes: [nativeFunctionMatcher.js]
 ---*/
 

--- a/test/harness/nativeFunctionMatcher.js
+++ b/test/harness/nativeFunctionMatcher.js
@@ -6,18 +6,45 @@ description: >
     Provides a regex that makes a best-effort determination that the tested
     string matches the NativeFunction grammar production without requiring a
     correct tokeniser
-includes: [nativeFunctionHelper.js]
+includes: [nativeFunctionMatcher.js]
 ---*/
 
-if (!(
-  NATIVE_FUNCTION_RE.test('function(){[native function]}') &&
-  NATIVE_FUNCTION_RE.test('function(){ [native function] }') &&
-  NATIVE_FUNCTION_RE.test('function ( ) { [ native function ] }') &&
-  NATIVE_FUNCTION_RE.test('function a(){ [native function] }') &&
-  NATIVE_FUNCTION_RE.test('function a(){ /* } */ [native function] }') &&
-  !NATIVE_FUNCTION_RE.test('') &&
-  !NATIVE_FUNCTION_RE.test('native function') &&
-  !NATIVE_FUNCTION_RE.test('function(){}') &&
-  !NATIVE_FUNCTION_RE.test('function(){ "native function" }') &&
-  !NATIVE_FUNCTION_RE.test('function(){ [] native function }')
-)) $ERROR('NATIVE_FUNCTION_RE failed');
+if (!NATIVE_FUNCTION_RE.test('function(){[native code]}')) {
+  $ERROR('expected string to pass: "function(){[native code]}"');
+}
+
+if (!NATIVE_FUNCTION_RE.test('function(){ [native code] }')) {
+  $ERROR('expected string to pass: "function(){ [native code] }"');
+}
+
+if (!NATIVE_FUNCTION_RE.test('function ( ) { [ native code ] }')) {
+  $ERROR('expected string to pass: "function ( ) { [ native code ] }"');
+}
+
+if (!NATIVE_FUNCTION_RE.test('function a(){ [native code] }')) {
+  $ERROR('expected string to pass: "function a(){ [native code] }"');
+}
+
+if (!NATIVE_FUNCTION_RE.test('function a(){ /* } */ [native code] }')) {
+  $ERROR('expected string to pass: "function a(){ /* } */ [native code] }"');
+}
+
+if (NATIVE_FUNCTION_RE.test('')) {
+  $ERROR('expected string to fail: ""');
+}
+
+if (NATIVE_FUNCTION_RE.test('native code')) {
+  $ERROR('expected string to fail: "native code"');
+}
+
+if (NATIVE_FUNCTION_RE.test('function(){}')) {
+  $ERROR('expected string to fail: "function(){}"');
+}
+
+if (NATIVE_FUNCTION_RE.test('function(){ "native code" }')) {
+  $ERROR('expected string to fail: "function(){ "native code" }"');
+}
+
+if (NATIVE_FUNCTION_RE.test('function(){ [] native code }')) {
+  $ERROR('expected string to fail: "function(){ [] native code }"');
+}


### PR DESCRIPTION
Modify the regular expression for native functions' toString value to
satisfy all test cases. Correct the test file's reference to the harness
file. Re-format the test file's assertions to aid debugging in the event
of failure.

@michaelficarra Would you mind taking a look?