### PR TITLE
[generation] Support changing to existing files

### DIFF
--- a/tools/generation/generator.py
+++ b/tools/generation/generator.py
@@ -43,14 +43,15 @@ def create(args):
         for test in exp.expand('utf-8', caseFile):
             if args.out:
                 try:
-                    test.load(args.out)
+                    existing = Test(test.file_name)
+                    existing.load(args.out)
 
                     if args.no_clobber:
                         print_error(
                             'Refusing to overwrite file: ' + test.file_name)
                         exit(1)
 
-                    if not test.is_generated():
+                    if not existing.is_generated():
                         print_error(
                             'Refusing to overwrite non-generated file: ' +
                             test.file_name)


### PR DESCRIPTION
When inspecting previously-generated files, a new `Test` instance should
be used. This avoids over-writing the in-memory representation of the
latest test, and allows previously-existing test files to be partially
updated according to subsequent changes in their respective source/case
files.

(I discovered this oversight while updating the yet-to-be-submitted first batch of procedurally-generated tests.)