### PR TITLE
Add tests for the spread operator (procedurally generated)

### DIFF
--- a/src/spread/default/call-expr.template
+++ b/src/spread/default/call-expr.template
@@ -3,6 +3,7 @@
 /*---
 path: language/expressions/call/spread-
 name: CallExpression
+esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
 info: |
     CallExpression : MemberExpression Arguments

--- a/src/spread/default/member-expr.template
+++ b/src/spread/default/member-expr.template
@@ -4,6 +4,7 @@
 path: language/expressions/new/spread-
 name: >
     `new` operator
+esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/src/spread/default/super-call.template
+++ b/src/spread/default/super-call.template
@@ -3,6 +3,7 @@
 /*---
 path: language/expressions/super/spread-
 name: SuperCall
+esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
 info: |
     SuperCall : super Arguments

--- a/src/spread/error/call-expr.template
+++ b/src/spread/error/call-expr.template
@@ -3,6 +3,7 @@
 /*---
 path: language/expressions/call/spread-err-
 name: CallExpression
+esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
 info: |
     CallExpression : MemberExpression Arguments

--- a/src/spread/error/member-expr.template
+++ b/src/spread/error/member-expr.template
@@ -4,6 +4,7 @@
 path: language/expressions/new/spread-err-
 name: >
     `new` operator
+esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/src/spread/error/super-call.template
+++ b/src/spread/error/super-call.template
@@ -3,6 +3,7 @@
 /*---
 path: language/expressions/super/spread-err-
 name: SuperCall
+esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
 info: |
     SuperCall : super Arguments

--- a/src/spread/mult-empty.case
+++ b/src/spread/mult-empty.case
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Spread operator following other arguments when no iteration occurs
+template: default
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return precedingArgs.
+---*/
+
+//- args
+1, 2, 3, ...[]
+//- body
+assert.sameValue(arguments.length, 3);
+assert.sameValue(arguments[0], 1);
+assert.sameValue(arguments[1], 2);
+assert.sameValue(arguments[2], 3);

--- a/src/spread/mult-err-expr-throws.case
+++ b/src/spread/mult-err-expr-throws.case
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Spread operator following other arguments when evaluation throws
+template: error
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+---*/
+
+//- error
+Test262Error
+//- args
+0, ...function*() { throw new Test262Error(); }()

--- a/src/spread/mult-err-iter-get-value.case
+++ b/src/spread/mult-err-iter-get-value.case
@@ -1,0 +1,36 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+    Spread operator following other arguments when GetIterator fails
+    (@@iterator function return value)
+template: error
+features: [Symbol.iterator]
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    2. Let iterator be ? Call(method, obj).
+    3. If Type(iterator) is not Object, throw a TypeError exception.
+---*/
+
+//- setup
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    return null;
+  }
+});
+//- error
+TypeError
+//- args
+0, ...iter

--- a/src/spread/mult-err-itr-get-call.case
+++ b/src/spread/mult-err-itr-get-call.case
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+    Spread operator following other arguments when GetIterator fails
+    (@@iterator function invocation)
+template: error
+features: [Symbol.iterator]
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    3. Let iterator be Call(method,obj).
+    4. ReturnIfAbrupt(iterator).
+---*/
+
+//- setup
+var iter = {};
+iter[Symbol.iterator] = function() {
+  throw new Test262Error();
+};
+//- error
+Test262Error
+//- args
+0, ...iter

--- a/src/spread/mult-err-itr-get-get.case
+++ b/src/spread/mult-err-itr-get-get.case
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+    Spread operator following other arguments when GetIterator fails
+    (@@iterator property access)
+template: error
+features: [Symbol.iterator]
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    1. If method was not passed, then
+       a. Let method be ? GetMethod(obj, @@iterator).
+---*/
+
+//- setup
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+//- error
+Test262Error
+//- args
+0, ...iter

--- a/src/spread/mult-err-itr-step.case
+++ b/src/spread/mult-err-itr-step.case
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Spread operator following other arguments when IteratorStep fails
+template: error
+features: [Symbol.iterator]
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.5 IteratorStep ( iterator )
+
+    1. Let result be IteratorNext(iterator).
+    2. ReturnIfAbrupt(result).
+
+    7.4.2 IteratorNext ( iterator, value )
+
+    1. If value was not passed, then
+       a. Let result be Invoke(iterator, "next", « »).
+    [...]
+    3. ReturnIfAbrupt(result).
+---*/
+
+//- setup
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      throw new Test262Error();
+    }
+  };
+};
+//- error
+Test262Error
+//- args
+0, ...iter

--- a/src/spread/mult-err-itr-value.case
+++ b/src/spread/mult-err-itr-value.case
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Spread operator following other arguments when IteratorValue fails
+template: error
+features: [Symbol.iterator]
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.4 IteratorValue ( iterResult )
+
+    1. Assert: Type(iterResult) is Object.
+    2. Return Get(iterResult, "value").
+
+    7.3.1 Get (O, P)
+
+    [...]
+    3. Return O.[[Get]](P, O).
+---*/
+
+//- setup
+var iter = {};
+var poisonedValue = Object.defineProperty({}, 'value', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return poisonedValue;
+    }
+  };
+};
+//- error
+Test262Error
+//- args
+0, ...iter

--- a/src/spread/mult-err-unresolvable.case
+++ b/src/spread/mult-err-unresolvable.case
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Spread operator following other arguments when reference is unresolvable
+template: error
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    6.2.3.1 GetValue (V)
+
+    1. ReturnIfAbrupt(V).
+    2. If Type(V) is not Reference, return V.
+    3. Let base be GetBase(V).
+    4. If IsUnresolvableReference(V), throw a ReferenceError exception.
+---*/
+
+//- error
+ReferenceError
+//- args
+0, ...unresolvableReference

--- a/src/spread/mult-iter.case
+++ b/src/spread/mult-iter.case
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Spread operator following other arguments with a valid iterator
+template: default
+features: [Symbol.iterator]
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+       f. Append nextArg as the last element of list.
+---*/
+
+//- setup
+var iter = {};
+iter[Symbol.iterator] = function() {
+  var nextCount = 3;
+  return {
+    next: function() {
+      nextCount += 1;
+      return { done: nextCount === 6, value: nextCount };
+    }
+  };
+};
+//- args
+1, 2, 3, ...iter
+//- body
+assert.sameValue(arguments.length, 5);
+assert.sameValue(arguments[0], 1);
+assert.sameValue(arguments[1], 2);
+assert.sameValue(arguments[2], 3);
+assert.sameValue(arguments[3], 4);
+assert.sameValue(arguments[4], 5);

--- a/src/spread/sngl-empty.case
+++ b/src/spread/sngl-empty.case
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Spread operator applied to the only argument when no iteration occurs
+template: default
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       [...]
+---*/
+
+//- params
+//- args
+...[]
+//- body
+assert.sameValue(arguments.length, 0);

--- a/src/spread/sngl-err-itr-get-call.case
+++ b/src/spread/sngl-err-itr-get-call.case
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+    Spread operator applied to the only argument when GetIterator fails
+    (@@iterator function invocation)
+template: error
+features: [Symbol.iterator]
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    3. Let iterator be Call(method,obj).
+    4. ReturnIfAbrupt(iterator).
+---*/
+
+//- setup
+var iter = {};
+iter[Symbol.iterator] = function() {
+  throw new Test262Error();
+};
+//- error
+Test262Error
+//- args
+...iter

--- a/src/spread/sngl-err-itr-get-get.case
+++ b/src/spread/sngl-err-itr-get-get.case
@@ -1,0 +1,36 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+    Spread operator applied to the only argument when GetIterator fails
+    (@@iterator property access)
+template: error
+features: [Symbol.iterator]
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    1. If method was not passed, then
+       a. Let method be ? GetMethod(obj, @@iterator).
+---*/
+
+//- setup
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+//- error
+Test262Error
+//- args
+...iter

--- a/src/spread/sngl-err-itr-get-value.case
+++ b/src/spread/sngl-err-itr-get-value.case
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+    Spread operator applied to the only argument when GetIterator fails
+    (@@iterator function return value)
+template: error
+features: [Symbol.iterator]
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    2. Let iterator be ? Call(method, obj).
+    3. If Type(iterator) is not Object, throw a TypeError exception.
+---*/
+
+//- setup
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return null;
+};
+//- error
+TypeError
+//- args
+...iter

--- a/src/spread/sngl-err-itr-step.case
+++ b/src/spread/sngl-err-itr-step.case
@@ -1,0 +1,46 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Spread operator applied to the only argument when IteratorStep fails
+template: error
+features: [Symbol.iterator]
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+
+    7.4.5 IteratorStep ( iterator )
+
+    1. Let result be IteratorNext(iterator).
+    2. ReturnIfAbrupt(result).
+
+    7.4.2 IteratorNext ( iterator, value )
+
+    1. If value was not passed, then
+       a. Let result be Invoke(iterator, "next", « »).
+    [...]
+    3. ReturnIfAbrupt(result).
+---*/
+
+//- setup
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      throw new Test262Error();
+    }
+  };
+};
+//- error
+Test262Error
+//- args
+...iter

--- a/src/spread/sngl-err-itr-value.case
+++ b/src/spread/sngl-err-itr-value.case
@@ -1,0 +1,52 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Spread operator applied to the only argument when IteratorValue fails
+template: error
+features: [Symbol.iterator]
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+
+    7.4.4 IteratorValue ( iterResult )
+
+    1. Assert: Type(iterResult) is Object.
+    2. Return Get(iterResult, "value").
+
+    7.3.1 Get (O, P)
+
+    [...]
+    3. Return O.[[Get]](P, O).
+---*/
+
+//- setup
+var iter = {};
+var poisonedValue = Object.defineProperty({}, 'value', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return poisonedValue;
+    }
+  };
+};
+//- error
+Test262Error
+//- args
+...iter

--- a/src/spread/sngl-err-unresolvable.case
+++ b/src/spread/sngl-err-unresolvable.case
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Spread operator applied to the only argument when reference is unresolvable
+template: error
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+
+    6.2.3.1 GetValue (V)
+
+    1. ReturnIfAbrupt(V).
+    2. If Type(V) is not Reference, return V.
+    3. Let base be GetBase(V).
+    4. If IsUnresolvableReference(V), throw a ReferenceError exception.
+---*/
+
+//- error
+ReferenceError
+//- args
+...unresolvableReference

--- a/src/spread/sngl-iter.case
+++ b/src/spread/sngl-iter.case
@@ -26,11 +26,11 @@ info: |
 //- setup
 var iter = {};
 iter[Symbol.iterator] = function() {
-  var callCount = 0;
+  var nextCount = 0;
   return {
     next: function() {
-      callCount += 1;
-      return { done: callCount === 3, value: callCount };
+      nextCount += 1;
+      return { done: nextCount === 3, value: nextCount };
     }
   };
 };

--- a/test/language/expressions/call/spread-err-mult-err-expr-throws.js
+++ b/test/language/expressions/call/spread-err-mult-err-expr-throws.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/mult-err-expr-throws.case
 // - src/spread/error/call-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (CallExpression)
+description: Spread operator following other arguments when evaluation throws (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
-features: [generators]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments
@@ -22,15 +21,14 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
 ---*/
 
 assert.throws(Test262Error, function() {
-  (function() {}(...function*() { throw new Test262Error(); }()));
+  (function() {}(0, ...function*() { throw new Test262Error(); }()));
 });

--- a/test/language/expressions/call/spread-err-mult-err-iter-get-value.js
+++ b/test/language/expressions/call/spread-err-mult-err-iter-get-value.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-err-iter-get-value.case
+// - src/spread/error/call-expr.template
+/*---
+description: Spread operator following other arguments when GetIterator fails (@@iterator function return value) (CallExpression)
+esid: sec-function-calls-runtime-semantics-evaluation
+es6id: 12.3.4.1
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    CallExpression : MemberExpression Arguments
+
+    [...]
+    9. Return EvaluateDirectCall(func, thisValue, Arguments, tailCall).
+
+    12.3.4.3 Runtime Semantics: EvaluateDirectCall
+
+    1. Let argList be ArgumentListEvaluation(arguments).
+    [...]
+    6. Let result be Call(func, thisValue, argList).
+    [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    2. Let iterator be ? Call(method, obj).
+    3. If Type(iterator) is not Object, throw a TypeError exception.
+---*/
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    return null;
+  }
+});
+
+assert.throws(TypeError, function() {
+  (function() {}(0, ...iter));
+});

--- a/test/language/expressions/call/spread-err-mult-err-itr-get-call.js
+++ b/test/language/expressions/call/spread-err-mult-err-itr-get-call.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/mult-err-itr-get-call.case
 // - src/spread/error/call-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (CallExpression)
+description: Spread operator following other arguments when GetIterator fails (@@iterator function invocation) (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments
@@ -22,15 +22,24 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    3. Let iterator be Call(method,obj).
+    4. ReturnIfAbrupt(iterator).
 ---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  throw new Test262Error();
+};
 
 assert.throws(Test262Error, function() {
-  (function() {}(...function*() { throw new Test262Error(); }()));
+  (function() {}(0, ...iter));
 });

--- a/test/language/expressions/call/spread-err-mult-err-itr-get-get.js
+++ b/test/language/expressions/call/spread-err-mult-err-itr-get-get.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/mult-err-itr-get-get.case
 // - src/spread/error/call-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (CallExpression)
+description: Spread operator following other arguments when GetIterator fails (@@iterator property access) (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments
@@ -22,15 +22,25 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    1. If method was not passed, then
+       a. Let method be ? GetMethod(obj, @@iterator).
 ---*/
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
 
 assert.throws(Test262Error, function() {
-  (function() {}(...function*() { throw new Test262Error(); }()));
+  (function() {}(0, ...iter));
 });

--- a/test/language/expressions/call/spread-err-mult-err-itr-step.js
+++ b/test/language/expressions/call/spread-err-mult-err-itr-step.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-err-itr-step.case
+// - src/spread/error/call-expr.template
+/*---
+description: Spread operator following other arguments when IteratorStep fails (CallExpression)
+esid: sec-function-calls-runtime-semantics-evaluation
+es6id: 12.3.4.1
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    CallExpression : MemberExpression Arguments
+
+    [...]
+    9. Return EvaluateDirectCall(func, thisValue, Arguments, tailCall).
+
+    12.3.4.3 Runtime Semantics: EvaluateDirectCall
+
+    1. Let argList be ArgumentListEvaluation(arguments).
+    [...]
+    6. Let result be Call(func, thisValue, argList).
+    [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.5 IteratorStep ( iterator )
+
+    1. Let result be IteratorNext(iterator).
+    2. ReturnIfAbrupt(result).
+
+    7.4.2 IteratorNext ( iterator, value )
+
+    1. If value was not passed, then
+       a. Let result be Invoke(iterator, "next", « »).
+    [...]
+    3. ReturnIfAbrupt(result).
+---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      throw new Test262Error();
+    }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  (function() {}(0, ...iter));
+});

--- a/test/language/expressions/call/spread-err-mult-err-itr-value.js
+++ b/test/language/expressions/call/spread-err-mult-err-itr-value.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-err-itr-value.case
+// - src/spread/error/call-expr.template
+/*---
+description: Spread operator following other arguments when IteratorValue fails (CallExpression)
+esid: sec-function-calls-runtime-semantics-evaluation
+es6id: 12.3.4.1
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    CallExpression : MemberExpression Arguments
+
+    [...]
+    9. Return EvaluateDirectCall(func, thisValue, Arguments, tailCall).
+
+    12.3.4.3 Runtime Semantics: EvaluateDirectCall
+
+    1. Let argList be ArgumentListEvaluation(arguments).
+    [...]
+    6. Let result be Call(func, thisValue, argList).
+    [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.4 IteratorValue ( iterResult )
+
+    1. Assert: Type(iterResult) is Object.
+    2. Return Get(iterResult, "value").
+
+    7.3.1 Get (O, P)
+
+    [...]
+    3. Return O.[[Get]](P, O).
+---*/
+var iter = {};
+var poisonedValue = Object.defineProperty({}, 'value', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return poisonedValue;
+    }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  (function() {}(0, ...iter));
+});

--- a/test/language/expressions/call/spread-err-mult-err-unresolvable.js
+++ b/test/language/expressions/call/spread-err-mult-err-unresolvable.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/mult-err-unresolvable.case
 // - src/spread/error/call-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (CallExpression)
+description: Spread operator following other arguments when reference is unresolvable (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
-features: [generators]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments
@@ -22,15 +21,21 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    6.2.3.1 GetValue (V)
+
+    1. ReturnIfAbrupt(V).
+    2. If Type(V) is not Reference, return V.
+    3. Let base be GetBase(V).
+    4. If IsUnresolvableReference(V), throw a ReferenceError exception.
 ---*/
 
-assert.throws(Test262Error, function() {
-  (function() {}(...function*() { throw new Test262Error(); }()));
+assert.throws(ReferenceError, function() {
+  (function() {}(0, ...unresolvableReference));
 });

--- a/test/language/expressions/call/spread-err-sngl-err-itr-get-call.js
+++ b/test/language/expressions/call/spread-err-sngl-err-itr-get-call.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-get-call.case
 // - src/spread/error/call-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (CallExpression)
+description: Spread operator applied to the only argument when GetIterator fails (@@iterator function invocation) (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments
@@ -29,8 +29,18 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    3. Let iterator be Call(method,obj).
+    4. ReturnIfAbrupt(iterator).
 ---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  throw new Test262Error();
+};
 
 assert.throws(Test262Error, function() {
-  (function() {}(...function*() { throw new Test262Error(); }()));
+  (function() {}(...iter));
 });

--- a/test/language/expressions/call/spread-err-sngl-err-itr-get-get.js
+++ b/test/language/expressions/call/spread-err-sngl-err-itr-get-get.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-get-get.case
 // - src/spread/error/call-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (CallExpression)
+description: Spread operator applied to the only argument when GetIterator fails (@@iterator property access) (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments
@@ -29,8 +29,19 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    1. If method was not passed, then
+       a. Let method be ? GetMethod(obj, @@iterator).
 ---*/
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
 
 assert.throws(Test262Error, function() {
-  (function() {}(...function*() { throw new Test262Error(); }()));
+  (function() {}(...iter));
 });

--- a/test/language/expressions/call/spread-err-sngl-err-itr-get-value.js
+++ b/test/language/expressions/call/spread-err-sngl-err-itr-get-value.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-get-value.case
 // - src/spread/error/call-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (CallExpression)
+description: Spread operator applied to the only argument when GetIterator fails (@@iterator function return value) (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments
@@ -29,8 +29,18 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
----*/
 
-assert.throws(Test262Error, function() {
-  (function() {}(...function*() { throw new Test262Error(); }()));
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    2. Let iterator be ? Call(method, obj).
+    3. If Type(iterator) is not Object, throw a TypeError exception.
+---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return null;
+};
+
+assert.throws(TypeError, function() {
+  (function() {}(...iter));
 });

--- a/test/language/expressions/call/spread-err-sngl-err-itr-step.js
+++ b/test/language/expressions/call/spread-err-sngl-err-itr-step.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-step.case
 // - src/spread/error/call-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (CallExpression)
+description: Spread operator applied to the only argument when IteratorStep fails (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments
@@ -29,8 +29,31 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+
+    7.4.5 IteratorStep ( iterator )
+
+    1. Let result be IteratorNext(iterator).
+    2. ReturnIfAbrupt(result).
+
+    7.4.2 IteratorNext ( iterator, value )
+
+    1. If value was not passed, then
+       a. Let result be Invoke(iterator, "next", « »).
+    [...]
+    3. ReturnIfAbrupt(result).
 ---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      throw new Test262Error();
+    }
+  };
+};
 
 assert.throws(Test262Error, function() {
-  (function() {}(...function*() { throw new Test262Error(); }()));
+  (function() {}(...iter));
 });

--- a/test/language/expressions/call/spread-err-sngl-err-itr-value.js
+++ b/test/language/expressions/call/spread-err-sngl-err-itr-value.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-value.case
 // - src/spread/error/call-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (CallExpression)
+description: Spread operator applied to the only argument when IteratorValue fails (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments
@@ -29,8 +29,37 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+
+    7.4.4 IteratorValue ( iterResult )
+
+    1. Assert: Type(iterResult) is Object.
+    2. Return Get(iterResult, "value").
+
+    7.3.1 Get (O, P)
+
+    [...]
+    3. Return O.[[Get]](P, O).
 ---*/
+var iter = {};
+var poisonedValue = Object.defineProperty({}, 'value', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return poisonedValue;
+    }
+  };
+};
 
 assert.throws(Test262Error, function() {
-  (function() {}(...function*() { throw new Test262Error(); }()));
+  (function() {}(...iter));
 });

--- a/test/language/expressions/call/spread-err-sngl-err-unresolvable.js
+++ b/test/language/expressions/call/spread-err-sngl-err-unresolvable.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-unresolvable.case
 // - src/spread/error/call-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (CallExpression)
+description: Spread operator applied to the only argument when reference is unresolvable (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
-features: [generators]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments
@@ -29,8 +28,15 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+
+    6.2.3.1 GetValue (V)
+
+    1. ReturnIfAbrupt(V).
+    2. If Type(V) is not Reference, return V.
+    3. Let base be GetBase(V).
+    4. If IsUnresolvableReference(V), throw a ReferenceError exception.
 ---*/
 
-assert.throws(Test262Error, function() {
-  (function() {}(...function*() { throw new Test262Error(); }()));
+assert.throws(ReferenceError, function() {
+  (function() {}(...unresolvableReference));
 });

--- a/test/language/expressions/call/spread-mult-empty.js
+++ b/test/language/expressions/call/spread-mult-empty.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-iter.case
+// - src/spread/mult-empty.case
 // - src/spread/default/call-expr.template
 /*---
-description: Spread operator applied to the only argument with a valid iterator (CallExpression)
+description: Spread operator following other arguments when no iteration occurs (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
-features: [Symbol.iterator]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments
@@ -22,39 +21,26 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
-    6. Repeat
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
        a. Let next be IteratorStep(iterator).
        b. ReturnIfAbrupt(next).
-       c. If next is false, return list.
-       d. Let nextArg be IteratorValue(next).
-       e. ReturnIfAbrupt(nextArg).
-       f. Append nextArg as the last element of list.
+       c. If next is false, return precedingArgs.
 ---*/
-var iter = {};
-iter[Symbol.iterator] = function() {
-  var nextCount = 0;
-  return {
-    next: function() {
-      nextCount += 1;
-      return { done: nextCount === 3, value: nextCount };
-    }
-  };
-};
 
 var callCount = 0;
 
 (function() {
-  assert.sameValue(arguments.length, 2);
+  assert.sameValue(arguments.length, 3);
   assert.sameValue(arguments[0], 1);
   assert.sameValue(arguments[1], 2);
+  assert.sameValue(arguments[2], 3);
   callCount += 1;
-}(...iter));
+}(1, 2, 3, ...[]));
 
 assert.sameValue(callCount, 1);

--- a/test/language/expressions/call/spread-mult-iter.js
+++ b/test/language/expressions/call/spread-mult-iter.js
@@ -1,23 +1,24 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-iter.case
-// - src/spread/default/member-expr.template
+// - src/spread/mult-iter.case
+// - src/spread/default/call-expr.template
 /*---
-description: Spread operator applied to the only argument with a valid iterator (`new` operator)
-esid: sec-new-operator-runtime-semantics-evaluation
-es6id: 12.3.3.1
+description: Spread operator following other arguments with a valid iterator (CallExpression)
+esid: sec-function-calls-runtime-semantics-evaluation
+es6id: 12.3.4.1
 features: [Symbol.iterator]
 flags: [generated]
 info: |
-    MemberExpression : new MemberExpression Arguments
+    CallExpression : MemberExpression Arguments
 
-    1. Return EvaluateNew(MemberExpression, Arguments).
+    [...]
+    9. Return EvaluateDirectCall(func, thisValue, Arguments, tailCall).
 
-    12.3.3.1.1 Runtime Semantics: EvaluateNew
+    12.3.4.3 Runtime Semantics: EvaluateDirectCall
 
-    6. If arguments is empty, let argList be an empty List.
-    7. Else,
-       a. Let argList be ArgumentListEvaluation of arguments.
-       [...]
+    1. Let argList be ArgumentListEvaluation(arguments).
+    [...]
+    6. Let result be Call(func, thisValue, argList).
+    [...]
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
@@ -38,22 +39,25 @@ info: |
 ---*/
 var iter = {};
 iter[Symbol.iterator] = function() {
-  var nextCount = 0;
+  var nextCount = 3;
   return {
     next: function() {
       nextCount += 1;
-      return { done: nextCount === 3, value: nextCount };
+      return { done: nextCount === 6, value: nextCount };
     }
   };
 };
 
 var callCount = 0;
 
-new function() {
-  assert.sameValue(arguments.length, 2);
+(function() {
+  assert.sameValue(arguments.length, 5);
   assert.sameValue(arguments[0], 1);
   assert.sameValue(arguments[1], 2);
+  assert.sameValue(arguments[2], 3);
+  assert.sameValue(arguments[3], 4);
+  assert.sameValue(arguments[4], 5);
   callCount += 1;
-}(...iter);
+}(1, 2, 3, ...iter));
 
 assert.sameValue(callCount, 1);

--- a/test/language/expressions/call/spread-sngl-empty.js
+++ b/test/language/expressions/call/spread-sngl-empty.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
-// - src/spread/error/call-expr.template
+// - src/spread/sngl-empty.case
+// - src/spread/default/call-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (CallExpression)
+description: Spread operator applied to the only argument when no iteration occurs (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
-features: [generators]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments
@@ -29,8 +28,18 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       [...]
 ---*/
 
-assert.throws(Test262Error, function() {
-  (function() {}(...function*() { throw new Test262Error(); }()));
-});
+var callCount = 0;
+
+(function() {
+  assert.sameValue(arguments.length, 0);
+  callCount += 1;
+}(...[]));
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/new/spread-err-mult-err-expr-throws.js
+++ b/test/language/expressions/new/spread-err-mult-err-expr-throws.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/mult-err-expr-throws.case
 // - src/spread/error/member-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (`new` operator)
+description: Spread operator following other arguments when evaluation throws (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
-features: [generators]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments
@@ -21,15 +20,14 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
 ---*/
 
 assert.throws(Test262Error, function() {
-  new function() {}(...function*() { throw new Test262Error(); }());
+  new function() {}(0, ...function*() { throw new Test262Error(); }());
 });

--- a/test/language/expressions/new/spread-err-mult-err-iter-get-value.js
+++ b/test/language/expressions/new/spread-err-mult-err-iter-get-value.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-err-iter-get-value.case
+// - src/spread/error/member-expr.template
+/*---
+description: Spread operator following other arguments when GetIterator fails (@@iterator function return value) (`new` operator)
+esid: sec-new-operator-runtime-semantics-evaluation
+es6id: 12.3.3.1
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    MemberExpression : new MemberExpression Arguments
+
+    1. Return EvaluateNew(MemberExpression, Arguments).
+
+    12.3.3.1.1 Runtime Semantics: EvaluateNew
+
+    6. If arguments is empty, let argList be an empty List.
+    7. Else,
+       a. Let argList be ArgumentListEvaluation of arguments.
+       [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    2. Let iterator be ? Call(method, obj).
+    3. If Type(iterator) is not Object, throw a TypeError exception.
+---*/
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    return null;
+  }
+});
+
+assert.throws(TypeError, function() {
+  new function() {}(0, ...iter);
+});

--- a/test/language/expressions/new/spread-err-mult-err-itr-get-call.js
+++ b/test/language/expressions/new/spread-err-mult-err-itr-get-call.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/mult-err-itr-get-call.case
 // - src/spread/error/member-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (`new` operator)
+description: Spread operator following other arguments when GetIterator fails (@@iterator function invocation) (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments
@@ -21,15 +21,24 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    3. Let iterator be Call(method,obj).
+    4. ReturnIfAbrupt(iterator).
 ---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  throw new Test262Error();
+};
 
 assert.throws(Test262Error, function() {
-  new function() {}(...function*() { throw new Test262Error(); }());
+  new function() {}(0, ...iter);
 });

--- a/test/language/expressions/new/spread-err-mult-err-itr-get-get.js
+++ b/test/language/expressions/new/spread-err-mult-err-itr-get-get.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/mult-err-itr-get-get.case
 // - src/spread/error/member-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (`new` operator)
+description: Spread operator following other arguments when GetIterator fails (@@iterator property access) (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments
@@ -21,15 +21,25 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    1. If method was not passed, then
+       a. Let method be ? GetMethod(obj, @@iterator).
 ---*/
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
 
 assert.throws(Test262Error, function() {
-  new function() {}(...function*() { throw new Test262Error(); }());
+  new function() {}(0, ...iter);
 });

--- a/test/language/expressions/new/spread-err-mult-err-itr-step.js
+++ b/test/language/expressions/new/spread-err-mult-err-itr-step.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-err-itr-step.case
+// - src/spread/error/member-expr.template
+/*---
+description: Spread operator following other arguments when IteratorStep fails (`new` operator)
+esid: sec-new-operator-runtime-semantics-evaluation
+es6id: 12.3.3.1
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    MemberExpression : new MemberExpression Arguments
+
+    1. Return EvaluateNew(MemberExpression, Arguments).
+
+    12.3.3.1.1 Runtime Semantics: EvaluateNew
+
+    6. If arguments is empty, let argList be an empty List.
+    7. Else,
+       a. Let argList be ArgumentListEvaluation of arguments.
+       [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.5 IteratorStep ( iterator )
+
+    1. Let result be IteratorNext(iterator).
+    2. ReturnIfAbrupt(result).
+
+    7.4.2 IteratorNext ( iterator, value )
+
+    1. If value was not passed, then
+       a. Let result be Invoke(iterator, "next", « »).
+    [...]
+    3. ReturnIfAbrupt(result).
+---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      throw new Test262Error();
+    }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  new function() {}(0, ...iter);
+});

--- a/test/language/expressions/new/spread-err-mult-err-itr-value.js
+++ b/test/language/expressions/new/spread-err-mult-err-itr-value.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-err-itr-value.case
+// - src/spread/error/member-expr.template
+/*---
+description: Spread operator following other arguments when IteratorValue fails (`new` operator)
+esid: sec-new-operator-runtime-semantics-evaluation
+es6id: 12.3.3.1
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    MemberExpression : new MemberExpression Arguments
+
+    1. Return EvaluateNew(MemberExpression, Arguments).
+
+    12.3.3.1.1 Runtime Semantics: EvaluateNew
+
+    6. If arguments is empty, let argList be an empty List.
+    7. Else,
+       a. Let argList be ArgumentListEvaluation of arguments.
+       [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.4 IteratorValue ( iterResult )
+
+    1. Assert: Type(iterResult) is Object.
+    2. Return Get(iterResult, "value").
+
+    7.3.1 Get (O, P)
+
+    [...]
+    3. Return O.[[Get]](P, O).
+---*/
+var iter = {};
+var poisonedValue = Object.defineProperty({}, 'value', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return poisonedValue;
+    }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  new function() {}(0, ...iter);
+});

--- a/test/language/expressions/new/spread-err-mult-err-unresolvable.js
+++ b/test/language/expressions/new/spread-err-mult-err-unresolvable.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/mult-err-unresolvable.case
 // - src/spread/error/member-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (`new` operator)
+description: Spread operator following other arguments when reference is unresolvable (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
-features: [generators]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments
@@ -21,15 +20,21 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    6.2.3.1 GetValue (V)
+
+    1. ReturnIfAbrupt(V).
+    2. If Type(V) is not Reference, return V.
+    3. Let base be GetBase(V).
+    4. If IsUnresolvableReference(V), throw a ReferenceError exception.
 ---*/
 
-assert.throws(Test262Error, function() {
-  new function() {}(...function*() { throw new Test262Error(); }());
+assert.throws(ReferenceError, function() {
+  new function() {}(0, ...unresolvableReference);
 });

--- a/test/language/expressions/new/spread-err-sngl-err-itr-get-call.js
+++ b/test/language/expressions/new/spread-err-sngl-err-itr-get-call.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-get-call.case
 // - src/spread/error/member-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (`new` operator)
+description: Spread operator applied to the only argument when GetIterator fails (@@iterator function invocation) (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments
@@ -28,8 +28,18 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    3. Let iterator be Call(method,obj).
+    4. ReturnIfAbrupt(iterator).
 ---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  throw new Test262Error();
+};
 
 assert.throws(Test262Error, function() {
-  new function() {}(...function*() { throw new Test262Error(); }());
+  new function() {}(...iter);
 });

--- a/test/language/expressions/new/spread-err-sngl-err-itr-get-get.js
+++ b/test/language/expressions/new/spread-err-sngl-err-itr-get-get.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-get-get.case
 // - src/spread/error/member-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (`new` operator)
+description: Spread operator applied to the only argument when GetIterator fails (@@iterator property access) (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments
@@ -28,8 +28,19 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    1. If method was not passed, then
+       a. Let method be ? GetMethod(obj, @@iterator).
 ---*/
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
 
 assert.throws(Test262Error, function() {
-  new function() {}(...function*() { throw new Test262Error(); }());
+  new function() {}(...iter);
 });

--- a/test/language/expressions/new/spread-err-sngl-err-itr-get-value.js
+++ b/test/language/expressions/new/spread-err-sngl-err-itr-get-value.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-get-value.case
 // - src/spread/error/member-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (`new` operator)
+description: Spread operator applied to the only argument when GetIterator fails (@@iterator function return value) (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments
@@ -28,8 +28,18 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
----*/
 
-assert.throws(Test262Error, function() {
-  new function() {}(...function*() { throw new Test262Error(); }());
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    2. Let iterator be ? Call(method, obj).
+    3. If Type(iterator) is not Object, throw a TypeError exception.
+---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return null;
+};
+
+assert.throws(TypeError, function() {
+  new function() {}(...iter);
 });

--- a/test/language/expressions/new/spread-err-sngl-err-itr-step.js
+++ b/test/language/expressions/new/spread-err-sngl-err-itr-step.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-step.case
 // - src/spread/error/member-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (`new` operator)
+description: Spread operator applied to the only argument when IteratorStep fails (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments
@@ -28,8 +28,31 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+
+    7.4.5 IteratorStep ( iterator )
+
+    1. Let result be IteratorNext(iterator).
+    2. ReturnIfAbrupt(result).
+
+    7.4.2 IteratorNext ( iterator, value )
+
+    1. If value was not passed, then
+       a. Let result be Invoke(iterator, "next", « »).
+    [...]
+    3. ReturnIfAbrupt(result).
 ---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      throw new Test262Error();
+    }
+  };
+};
 
 assert.throws(Test262Error, function() {
-  new function() {}(...function*() { throw new Test262Error(); }());
+  new function() {}(...iter);
 });

--- a/test/language/expressions/new/spread-err-sngl-err-itr-value.js
+++ b/test/language/expressions/new/spread-err-sngl-err-itr-value.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-value.case
 // - src/spread/error/member-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (`new` operator)
+description: Spread operator applied to the only argument when IteratorValue fails (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments
@@ -28,8 +28,37 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+
+    7.4.4 IteratorValue ( iterResult )
+
+    1. Assert: Type(iterResult) is Object.
+    2. Return Get(iterResult, "value").
+
+    7.3.1 Get (O, P)
+
+    [...]
+    3. Return O.[[Get]](P, O).
 ---*/
+var iter = {};
+var poisonedValue = Object.defineProperty({}, 'value', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return poisonedValue;
+    }
+  };
+};
 
 assert.throws(Test262Error, function() {
-  new function() {}(...function*() { throw new Test262Error(); }());
+  new function() {}(...iter);
 });

--- a/test/language/expressions/new/spread-err-sngl-err-unresolvable.js
+++ b/test/language/expressions/new/spread-err-sngl-err-unresolvable.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-unresolvable.case
 // - src/spread/error/member-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (`new` operator)
+description: Spread operator applied to the only argument when reference is unresolvable (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
-features: [generators]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments
@@ -28,8 +27,15 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+
+    6.2.3.1 GetValue (V)
+
+    1. ReturnIfAbrupt(V).
+    2. If Type(V) is not Reference, return V.
+    3. Let base be GetBase(V).
+    4. If IsUnresolvableReference(V), throw a ReferenceError exception.
 ---*/
 
-assert.throws(Test262Error, function() {
-  new function() {}(...function*() { throw new Test262Error(); }());
+assert.throws(ReferenceError, function() {
+  new function() {}(...unresolvableReference);
 });

--- a/test/language/expressions/new/spread-mult-empty.js
+++ b/test/language/expressions/new/spread-mult-empty.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-iter.case
+// - src/spread/mult-empty.case
 // - src/spread/default/member-expr.template
 /*---
-description: Spread operator applied to the only argument with a valid iterator (`new` operator)
+description: Spread operator following other arguments when no iteration occurs (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
-features: [Symbol.iterator]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments
@@ -21,39 +20,26 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
-    6. Repeat
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
        a. Let next be IteratorStep(iterator).
        b. ReturnIfAbrupt(next).
-       c. If next is false, return list.
-       d. Let nextArg be IteratorValue(next).
-       e. ReturnIfAbrupt(nextArg).
-       f. Append nextArg as the last element of list.
+       c. If next is false, return precedingArgs.
 ---*/
-var iter = {};
-iter[Symbol.iterator] = function() {
-  var nextCount = 0;
-  return {
-    next: function() {
-      nextCount += 1;
-      return { done: nextCount === 3, value: nextCount };
-    }
-  };
-};
 
 var callCount = 0;
 
 new function() {
-  assert.sameValue(arguments.length, 2);
+  assert.sameValue(arguments.length, 3);
   assert.sameValue(arguments[0], 1);
   assert.sameValue(arguments[1], 2);
+  assert.sameValue(arguments[2], 3);
   callCount += 1;
-}(...iter);
+}(1, 2, 3, ...[]);
 
 assert.sameValue(callCount, 1);

--- a/test/language/expressions/new/spread-mult-iter.js
+++ b/test/language/expressions/new/spread-mult-iter.js
@@ -1,8 +1,8 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-iter.case
+// - src/spread/mult-iter.case
 // - src/spread/default/member-expr.template
 /*---
-description: Spread operator applied to the only argument with a valid iterator (`new` operator)
+description: Spread operator following other arguments with a valid iterator (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
 features: [Symbol.iterator]
@@ -38,11 +38,11 @@ info: |
 ---*/
 var iter = {};
 iter[Symbol.iterator] = function() {
-  var nextCount = 0;
+  var nextCount = 3;
   return {
     next: function() {
       nextCount += 1;
-      return { done: nextCount === 3, value: nextCount };
+      return { done: nextCount === 6, value: nextCount };
     }
   };
 };
@@ -50,10 +50,13 @@ iter[Symbol.iterator] = function() {
 var callCount = 0;
 
 new function() {
-  assert.sameValue(arguments.length, 2);
+  assert.sameValue(arguments.length, 5);
   assert.sameValue(arguments[0], 1);
   assert.sameValue(arguments[1], 2);
+  assert.sameValue(arguments[2], 3);
+  assert.sameValue(arguments[3], 4);
+  assert.sameValue(arguments[4], 5);
   callCount += 1;
-}(...iter);
+}(1, 2, 3, ...iter);
 
 assert.sameValue(callCount, 1);

--- a/test/language/expressions/new/spread-sngl-empty.js
+++ b/test/language/expressions/new/spread-sngl-empty.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
-// - src/spread/error/member-expr.template
+// - src/spread/sngl-empty.case
+// - src/spread/default/member-expr.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (`new` operator)
+description: Spread operator applied to the only argument when no iteration occurs (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
-features: [generators]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments
@@ -28,8 +27,18 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       [...]
 ---*/
 
-assert.throws(Test262Error, function() {
-  new function() {}(...function*() { throw new Test262Error(); }());
-});
+var callCount = 0;
+
+new function() {
+  assert.sameValue(arguments.length, 0);
+  callCount += 1;
+}(...[]);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/super/spread-err-mult-err-expr-throws.js
+++ b/test/language/expressions/super/spread-err-mult-err-expr-throws.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/mult-err-expr-throws.case
 // - src/spread/error/super-call.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (SuperCall)
+description: Spread operator following other arguments when evaluation throws (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
-features: [generators]
 flags: [generated]
 info: |
     SuperCall : super Arguments
@@ -19,13 +18,12 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
 ---*/
 
 class Test262ParentClass {
@@ -34,7 +32,7 @@ class Test262ParentClass {
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...function*() { throw new Test262Error(); }());
+    super(0, ...function*() { throw new Test262Error(); }());
   }
 }
 

--- a/test/language/expressions/super/spread-err-mult-err-iter-get-value.js
+++ b/test/language/expressions/super/spread-err-mult-err-iter-get-value.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/mult-err-iter-get-value.case
 // - src/spread/error/super-call.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (SuperCall)
+description: Spread operator following other arguments when GetIterator fails (@@iterator function return value) (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     SuperCall : super Arguments
@@ -19,14 +19,25 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    2. Let iterator be ? Call(method, obj).
+    3. If Type(iterator) is not Object, throw a TypeError exception.
 ---*/
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    return null;
+  }
+});
 
 class Test262ParentClass {
   constructor() {}
@@ -34,10 +45,10 @@ class Test262ParentClass {
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...function*() { throw new Test262Error(); }());
+    super(0, ...iter);
   }
 }
 
-assert.throws(Test262Error, function() {
+assert.throws(TypeError, function() {
   new Test262ChildClass();
 });

--- a/test/language/expressions/super/spread-err-mult-err-itr-get-call.js
+++ b/test/language/expressions/super/spread-err-mult-err-itr-get-call.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/mult-err-itr-get-call.case
 // - src/spread/error/super-call.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (SuperCall)
+description: Spread operator following other arguments when GetIterator fails (@@iterator function invocation) (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     SuperCall : super Arguments
@@ -19,14 +19,23 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    3. Let iterator be Call(method,obj).
+    4. ReturnIfAbrupt(iterator).
 ---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  throw new Test262Error();
+};
 
 class Test262ParentClass {
   constructor() {}
@@ -34,7 +43,7 @@ class Test262ParentClass {
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...function*() { throw new Test262Error(); }());
+    super(0, ...iter);
   }
 }
 

--- a/test/language/expressions/super/spread-err-mult-err-itr-get-get.js
+++ b/test/language/expressions/super/spread-err-mult-err-itr-get-get.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/mult-err-itr-get-get.case
 // - src/spread/error/super-call.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (SuperCall)
+description: Spread operator following other arguments when GetIterator fails (@@iterator property access) (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     SuperCall : super Arguments
@@ -19,14 +19,24 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    1. If method was not passed, then
+       a. Let method be ? GetMethod(obj, @@iterator).
 ---*/
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
 
 class Test262ParentClass {
   constructor() {}
@@ -34,7 +44,7 @@ class Test262ParentClass {
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...function*() { throw new Test262Error(); }());
+    super(0, ...iter);
   }
 }
 

--- a/test/language/expressions/super/spread-err-mult-err-itr-step.js
+++ b/test/language/expressions/super/spread-err-mult-err-itr-step.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/mult-err-itr-step.case
 // - src/spread/error/super-call.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (SuperCall)
+description: Spread operator following other arguments when IteratorStep fails (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     SuperCall : super Arguments
@@ -19,14 +19,33 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.5 IteratorStep ( iterator )
+
+    1. Let result be IteratorNext(iterator).
+    2. ReturnIfAbrupt(result).
+
+    7.4.2 IteratorNext ( iterator, value )
+
+    1. If value was not passed, then
+       a. Let result be Invoke(iterator, "next", « »).
+    [...]
+    3. ReturnIfAbrupt(result).
 ---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      throw new Test262Error();
+    }
+  };
+};
 
 class Test262ParentClass {
   constructor() {}
@@ -34,7 +53,7 @@ class Test262ParentClass {
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...function*() { throw new Test262Error(); }());
+    super(0, ...iter);
   }
 }
 

--- a/test/language/expressions/super/spread-err-mult-err-itr-value.js
+++ b/test/language/expressions/super/spread-err-mult-err-itr-value.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-err-itr-value.case
+// - src/spread/error/super-call.template
+/*---
+description: Spread operator following other arguments when IteratorValue fails (SuperCall)
+esid: sec-super-keyword-runtime-semantics-evaluation
+es6id: 12.3.5.1
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    SuperCall : super Arguments
+
+    1. Let newTarget be GetNewTarget().
+    2. If newTarget is undefined, throw a ReferenceError exception.
+    3. Let func be GetSuperConstructor().
+    4. ReturnIfAbrupt(func).
+    5. Let argList be ArgumentListEvaluation of Arguments.
+    [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.4 IteratorValue ( iterResult )
+
+    1. Assert: Type(iterResult) is Object.
+    2. Return Get(iterResult, "value").
+
+    7.3.1 Get (O, P)
+
+    [...]
+    3. Return O.[[Get]](P, O).
+---*/
+var iter = {};
+var poisonedValue = Object.defineProperty({}, 'value', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return poisonedValue;
+    }
+  };
+};
+
+class Test262ParentClass {
+  constructor() {}
+}
+
+class Test262ChildClass extends Test262ParentClass {
+  constructor() {
+    super(0, ...iter);
+  }
+}
+
+assert.throws(Test262Error, function() {
+  new Test262ChildClass();
+});

--- a/test/language/expressions/super/spread-err-mult-err-unresolvable.js
+++ b/test/language/expressions/super/spread-err-mult-err-unresolvable.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/mult-err-unresolvable.case
 // - src/spread/error/super-call.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (SuperCall)
+description: Spread operator following other arguments when reference is unresolvable (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
-features: [generators]
 flags: [generated]
 info: |
     SuperCall : super Arguments
@@ -19,13 +18,19 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    6.2.3.1 GetValue (V)
+
+    1. ReturnIfAbrupt(V).
+    2. If Type(V) is not Reference, return V.
+    3. Let base be GetBase(V).
+    4. If IsUnresolvableReference(V), throw a ReferenceError exception.
 ---*/
 
 class Test262ParentClass {
@@ -34,10 +39,10 @@ class Test262ParentClass {
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...function*() { throw new Test262Error(); }());
+    super(0, ...unresolvableReference);
   }
 }
 
-assert.throws(Test262Error, function() {
+assert.throws(ReferenceError, function() {
   new Test262ChildClass();
 });

--- a/test/language/expressions/super/spread-err-sngl-err-itr-get-call.js
+++ b/test/language/expressions/super/spread-err-sngl-err-itr-get-call.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-get-call.case
 // - src/spread/error/super-call.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (SuperCall)
+description: Spread operator applied to the only argument when GetIterator fails (@@iterator function invocation) (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     SuperCall : super Arguments
@@ -26,7 +26,17 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    3. Let iterator be Call(method,obj).
+    4. ReturnIfAbrupt(iterator).
 ---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  throw new Test262Error();
+};
 
 class Test262ParentClass {
   constructor() {}
@@ -34,7 +44,7 @@ class Test262ParentClass {
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...function*() { throw new Test262Error(); }());
+    super(...iter);
   }
 }
 

--- a/test/language/expressions/super/spread-err-sngl-err-itr-get-get.js
+++ b/test/language/expressions/super/spread-err-sngl-err-itr-get-get.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-get-get.case
 // - src/spread/error/super-call.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (SuperCall)
+description: Spread operator applied to the only argument when GetIterator fails (@@iterator property access) (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     SuperCall : super Arguments
@@ -26,7 +26,18 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    1. If method was not passed, then
+       a. Let method be ? GetMethod(obj, @@iterator).
 ---*/
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
 
 class Test262ParentClass {
   constructor() {}
@@ -34,7 +45,7 @@ class Test262ParentClass {
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...function*() { throw new Test262Error(); }());
+    super(...iter);
   }
 }
 

--- a/test/language/expressions/super/spread-err-sngl-err-itr-get-value.js
+++ b/test/language/expressions/super/spread-err-sngl-err-itr-get-value.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-get-value.case
 // - src/spread/error/super-call.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (SuperCall)
+description: Spread operator applied to the only argument when GetIterator fails (@@iterator function return value) (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     SuperCall : super Arguments
@@ -26,7 +26,17 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    2. Let iterator be ? Call(method, obj).
+    3. If Type(iterator) is not Object, throw a TypeError exception.
 ---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return null;
+};
 
 class Test262ParentClass {
   constructor() {}
@@ -34,10 +44,10 @@ class Test262ParentClass {
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...function*() { throw new Test262Error(); }());
+    super(...iter);
   }
 }
 
-assert.throws(Test262Error, function() {
+assert.throws(TypeError, function() {
   new Test262ChildClass();
 });

--- a/test/language/expressions/super/spread-err-sngl-err-itr-step.js
+++ b/test/language/expressions/super/spread-err-sngl-err-itr-step.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-step.case
 // - src/spread/error/super-call.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (SuperCall)
+description: Spread operator applied to the only argument when IteratorStep fails (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     SuperCall : super Arguments
@@ -26,7 +26,30 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+
+    7.4.5 IteratorStep ( iterator )
+
+    1. Let result be IteratorNext(iterator).
+    2. ReturnIfAbrupt(result).
+
+    7.4.2 IteratorNext ( iterator, value )
+
+    1. If value was not passed, then
+       a. Let result be Invoke(iterator, "next", « »).
+    [...]
+    3. ReturnIfAbrupt(result).
 ---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      throw new Test262Error();
+    }
+  };
+};
 
 class Test262ParentClass {
   constructor() {}
@@ -34,7 +57,7 @@ class Test262ParentClass {
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...function*() { throw new Test262Error(); }());
+    super(...iter);
   }
 }
 

--- a/test/language/expressions/super/spread-err-sngl-err-itr-value.js
+++ b/test/language/expressions/super/spread-err-sngl-err-itr-value.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-itr-value.case
 // - src/spread/error/super-call.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (SuperCall)
+description: Spread operator applied to the only argument when IteratorValue fails (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
-features: [generators]
+features: [Symbol.iterator]
 flags: [generated]
 info: |
     SuperCall : super Arguments
@@ -26,7 +26,36 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+
+    7.4.4 IteratorValue ( iterResult )
+
+    1. Assert: Type(iterResult) is Object.
+    2. Return Get(iterResult, "value").
+
+    7.3.1 Get (O, P)
+
+    [...]
+    3. Return O.[[Get]](P, O).
 ---*/
+var iter = {};
+var poisonedValue = Object.defineProperty({}, 'value', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return poisonedValue;
+    }
+  };
+};
 
 class Test262ParentClass {
   constructor() {}
@@ -34,7 +63,7 @@ class Test262ParentClass {
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...function*() { throw new Test262Error(); }());
+    super(...iter);
   }
 }
 

--- a/test/language/expressions/super/spread-err-sngl-err-unresolvable.js
+++ b/test/language/expressions/super/spread-err-sngl-err-unresolvable.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
+// - src/spread/sngl-err-unresolvable.case
 // - src/spread/error/super-call.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (SuperCall)
+description: Spread operator applied to the only argument when reference is unresolvable (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
-features: [generators]
 flags: [generated]
 info: |
     SuperCall : super Arguments
@@ -26,6 +25,13 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+
+    6.2.3.1 GetValue (V)
+
+    1. ReturnIfAbrupt(V).
+    2. If Type(V) is not Reference, return V.
+    3. Let base be GetBase(V).
+    4. If IsUnresolvableReference(V), throw a ReferenceError exception.
 ---*/
 
 class Test262ParentClass {
@@ -34,10 +40,10 @@ class Test262ParentClass {
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...function*() { throw new Test262Error(); }());
+    super(...unresolvableReference);
   }
 }
 
-assert.throws(Test262Error, function() {
+assert.throws(ReferenceError, function() {
   new Test262ChildClass();
 });

--- a/test/language/expressions/super/spread-mult-empty.js
+++ b/test/language/expressions/super/spread-mult-empty.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-iter.case
+// - src/spread/mult-empty.case
 // - src/spread/default/super-call.template
 /*---
-description: Spread operator applied to the only argument with a valid iterator (SuperCall)
+description: Spread operator following other arguments when no iteration occurs (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
-features: [Symbol.iterator]
 flags: [generated]
 info: |
     SuperCall : super Arguments
@@ -19,46 +18,33 @@ info: |
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
 
-    ArgumentList : ... AssignmentExpression
+    ArgumentList : ArgumentList , ... AssignmentExpression
 
-    1. Let list be an empty List.
+    1. Let precedingArgs be the result of evaluating ArgumentList.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
-    3. Let spreadObj be GetValue(spreadRef).
-    4. Let iterator be GetIterator(spreadObj).
-    5. ReturnIfAbrupt(iterator).
-    6. Repeat
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
        a. Let next be IteratorStep(iterator).
        b. ReturnIfAbrupt(next).
-       c. If next is false, return list.
-       d. Let nextArg be IteratorValue(next).
-       e. ReturnIfAbrupt(nextArg).
-       f. Append nextArg as the last element of list.
+       c. If next is false, return precedingArgs.
 ---*/
-var iter = {};
-iter[Symbol.iterator] = function() {
-  var nextCount = 0;
-  return {
-    next: function() {
-      nextCount += 1;
-      return { done: nextCount === 3, value: nextCount };
-    }
-  };
-};
 
 var callCount = 0;
 
 class Test262ParentClass {
   constructor() {
-    assert.sameValue(arguments.length, 2);
+    assert.sameValue(arguments.length, 3);
     assert.sameValue(arguments[0], 1);
     assert.sameValue(arguments[1], 2);
+    assert.sameValue(arguments[2], 3);
     callCount += 1;
   }
 }
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...iter);
+    super(1, 2, 3, ...[]);
   }
 }
 

--- a/test/language/expressions/super/spread-mult-iter.js
+++ b/test/language/expressions/super/spread-mult-iter.js
@@ -1,8 +1,8 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-iter.case
+// - src/spread/mult-iter.case
 // - src/spread/default/super-call.template
 /*---
-description: Spread operator applied to the only argument with a valid iterator (SuperCall)
+description: Spread operator following other arguments with a valid iterator (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
 features: [Symbol.iterator]
@@ -36,11 +36,11 @@ info: |
 ---*/
 var iter = {};
 iter[Symbol.iterator] = function() {
-  var nextCount = 0;
+  var nextCount = 3;
   return {
     next: function() {
       nextCount += 1;
-      return { done: nextCount === 3, value: nextCount };
+      return { done: nextCount === 6, value: nextCount };
     }
   };
 };
@@ -49,16 +49,19 @@ var callCount = 0;
 
 class Test262ParentClass {
   constructor() {
-    assert.sameValue(arguments.length, 2);
+    assert.sameValue(arguments.length, 5);
     assert.sameValue(arguments[0], 1);
     assert.sameValue(arguments[1], 2);
+    assert.sameValue(arguments[2], 3);
+    assert.sameValue(arguments[3], 4);
+    assert.sameValue(arguments[4], 5);
     callCount += 1;
   }
 }
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...iter);
+    super(1, 2, 3, ...iter);
   }
 }
 

--- a/test/language/expressions/super/spread-sngl-empty.js
+++ b/test/language/expressions/super/spread-sngl-empty.js
@@ -1,11 +1,10 @@
 // This file was procedurally generated from the following sources:
-// - src/spread/sngl-err-expr-throws.case
-// - src/spread/error/super-call.template
+// - src/spread/sngl-empty.case
+// - src/spread/default/super-call.template
 /*---
-description: Spread operator applied to the only argument when evaluation throws (SuperCall)
+description: Spread operator applied to the only argument when no iteration occurs (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
-features: [generators]
 flags: [generated]
 info: |
     SuperCall : super Arguments
@@ -26,18 +25,27 @@ info: |
     3. Let spreadObj be GetValue(spreadRef).
     4. Let iterator be GetIterator(spreadObj).
     5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       [...]
 ---*/
 
+var callCount = 0;
+
 class Test262ParentClass {
-  constructor() {}
+  constructor() {
+    assert.sameValue(arguments.length, 0);
+    callCount += 1;
+  }
 }
 
 class Test262ChildClass extends Test262ParentClass {
   constructor() {
-    super(...function*() { throw new Test262Error(); }());
+    super(...[]);
   }
 }
 
-assert.throws(Test262Error, function() {
-  new Test262ChildClass();
-});
+new Test262ChildClass();
+assert.sameValue(callCount, 1);


### PR DESCRIPTION
Just like in gh-584, I've tried to aid review by organizing
procedurally-generated changes in separate commits. And also like that pull
request, this one includes a commit to introduce the `esid` frontmatter tag.