### PR TITLE
Increase coverage for Symbol constructor

### DIFF
--- a/test/built-ins/String/symbol-wrapping.js
+++ b/test/built-ins/String/symbol-wrapping.js
@@ -1,19 +1,20 @@
-// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-string-constructor
 es6id: 21.1.1
-description: Symbol value may be coerced to a String
+description: Symbol value may not be wrapped
 info: |
     1. If no arguments were passed to this function invocation, let s be "".
     2. Else,
        a. If NewTarget is undefined and Type(value) is Symbol, return
           SymbolDescriptiveString(value).
+       b. Let s be ? ToString(value).
 features: [Symbol]
 ---*/
 
-assert.sameValue(String(Symbol('66')), 'Symbol(66)');
-assert.sameValue(String(Symbol()), 'Symbol()', 'implicit `undefined`');
-assert.sameValue(
-  String(Symbol(undefined)), 'Symbol()', 'explicit `undefined`'
-);
+var s = Symbol('66');
+
+assert.throws(TypeError, function() {
+  new String(s);
+});

--- a/test/built-ins/Symbol/desc-to-string-symbol.js
+++ b/test/built-ins/Symbol/desc-to-string-symbol.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol-constructor
+es6id: 19.4.1
+description: The first argument is coerced to a String value
+info: |
+    1. If NewTarget is not undefined, throw a TypeError exception.
+    2. If description is undefined, let descString be undefined.
+    2. Else, let descString be ? ToString(description).
+    3. Return a new unique Symbol value whose [[Description]] value is
+       descString.
+---*/
+
+var s = Symbol('1');
+
+assert.throws(TypeError, function() {
+  Symbol(s);
+});

--- a/test/built-ins/Symbol/desc-to-string-symbol.js
+++ b/test/built-ins/Symbol/desc-to-string-symbol.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-symbol-constructor
 es6id: 19.4.1
-description: The first argument is coerced to a String value
+description: The first argument is coerced to a String value (from a Symbol)
 info: |
     1. If NewTarget is not undefined, throw a TypeError exception.
     2. If description is undefined, let descString be undefined.

--- a/test/built-ins/Symbol/desc-to-string.js
+++ b/test/built-ins/Symbol/desc-to-string.js
@@ -1,0 +1,88 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol-constructor
+es6id: 19.4.1
+description: The first argument is coerced to a String value
+info: |
+    1. If NewTarget is not undefined, throw a TypeError exception.
+    2. If description is undefined, let descString be undefined.
+    2. Else, let descString be ? ToString(description).
+    3. Return a new unique Symbol value whose [[Description]] value is
+       descString.
+---*/
+
+var calls, val;
+
+val = {
+  toString: function() {
+    calls += 'toString';
+    return {};
+  },
+  valueOf: function() {
+    calls += 'valueOf';
+  }
+};
+
+calls = '';
+Symbol(val);
+assert.sameValue(calls, 'toStringvalueOf');
+
+val = {
+  toString: function() {
+    calls += 'toString';
+  },
+  valueOf: function() {
+    calls += 'valueOf';
+  }
+};
+
+calls = '';
+Symbol(val);
+assert.sameValue(calls, 'toString');
+
+val = {
+  toString: null,
+  valueOf: function() {
+    calls += 'valueOf';
+  }
+};
+
+calls = '';
+Symbol(val);
+assert.sameValue(calls, 'valueOf');
+
+val = {
+  toString: null,
+  valueOf: function() {
+    calls += 'valueOf';
+    return {};
+  }
+};
+
+calls = '';
+assert.throws(TypeError, function() {
+  Symbol(val);
+});
+assert.sameValue(calls, 'valueOf');
+
+val = {
+  toString: function() {
+    calls += 'toString';
+    return {};
+  },
+  valueOf: function() {
+    calls += 'valueOf';
+    return {};
+  }
+};
+
+calls = '';
+assert.throws(TypeError, function() {
+  Symbol(val);
+});
+assert.sameValue(calls, 'toStringvalueOf');
+
+assert.throws(TypeError, function() {
+  Symbol(Symbol('1'));
+});

--- a/test/built-ins/Symbol/desc-to-string.js
+++ b/test/built-ins/Symbol/desc-to-string.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-symbol-constructor
 es6id: 19.4.1
-description: The first argument is coerced to a String value
+description: The first argument is coerced to a String value (from an object)
 info: |
     1. If NewTarget is not undefined, throw a TypeError exception.
     2. If description is undefined, let descString be undefined.

--- a/test/built-ins/Symbol/desc-to-string.js
+++ b/test/built-ins/Symbol/desc-to-string.js
@@ -63,8 +63,10 @@ val = {
 calls = '';
 assert.throws(TypeError, function() {
   Symbol(val);
-});
-assert.sameValue(calls, 'valueOf');
+}, '`toString` is not callable, and `valueOf` returns a non-primitive value');
+assert.sameValue(
+  calls, 'valueOf', 'invocation pattern for non-callable `toString`'
+);
 
 val = {
   toString: function() {
@@ -80,9 +82,9 @@ val = {
 calls = '';
 assert.throws(TypeError, function() {
   Symbol(val);
-});
-assert.sameValue(calls, 'toStringvalueOf');
-
-assert.throws(TypeError, function() {
-  Symbol(Symbol('1'));
-});
+}, '`toString` nor `valueOf` both return non-primitive values');
+assert.sameValue(
+  calls,
+  'toStringvalueOf',
+  'invocation pattern for non-callable `toString` and `valueOf`'
+);

--- a/test/built-ins/Symbol/invoked-with-new.js
+++ b/test/built-ins/Symbol/invoked-with-new.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol-constructor
+es6id: 19.4.1
+description: The Symbol constructor may not be invoked with `new`
+info: |
+    1. If NewTarget is not undefined, throw a TypeError exception.
+---*/
+
+assert.throws(TypeError, function() {
+  new Symbol();
+});
+
+assert.throws(TypeError, function() {
+  new Symbol('1');
+});

--- a/test/built-ins/Symbol/prototype/toString/undefined.js
+++ b/test/built-ins/Symbol/prototype/toString/undefined.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol-constructor
+es6id: 19.4.1
+description: The value "undefined" is reported as the empty string
+info: |
+    1. If NewTarget is not undefined, throw a TypeError exception.
+    2. If description is undefined, let descString be undefined.
+    2. Else, let descString be ? ToString(description).
+    3. Return a new unique Symbol value whose [[Description]] value is
+       descString.
+
+    19.4.3.2.1 Runtime Semantics: SymbolDescriptiveString
+
+    1. Assert: Type(sym) is Symbol.
+    2. Let desc be sym's [[Description]] value.
+    3. If desc is undefined, let desc be the empty string.
+    4. Assert: Type(desc) is String.
+    5. Return the result of concatenating the strings "Symbol(", desc, and ")".
+---*/
+
+assert.sameValue(Symbol().toString(), 'Symbol()', 'implicit value');
+assert.sameValue(Symbol(undefined).toString(), 'Symbol()', 'explicit value');

--- a/test/built-ins/Symbol/uniqueness.js
+++ b/test/built-ins/Symbol/uniqueness.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol-constructor
+es6id: 19.4.1
+description: The Symbol constructor returns a unique value
+info: |
+    1. If NewTarget is not undefined, throw a TypeError exception.
+    2. If description is undefined, let descString be undefined.
+    2. Else, let descString be ? ToString(description).
+    3. Return a new unique Symbol value whose [[Description]] value is
+       descString.
+---*/
+
+assert.notSameValue(Symbol(''), Symbol(''), 'empty string');
+assert.notSameValue(Symbol(), Symbol(), 'undefined');
+assert.notSameValue(Symbol(null), Symbol(null), 'null value');
+assert.notSameValue(Symbol('x'), Symbol('x'), 'string "x"');

--- a/test/language/expressions/addition/symbol-to-string.js
+++ b/test/language/expressions/addition/symbol-to-string.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-addition-operator-plus
+es6id: 12.7.3
+description: Symbol value cannot be converted to a String
+info: |
+    [...]
+    7. If Type(lprim) is String or Type(rprim) is String, then
+       a. Let lstr be ? ToString(lprim).
+features: [Symbol]
+---*/
+
+var s = Symbol('66');
+assert.throws(TypeError, function() {
+  s + '';
+});


### PR DESCRIPTION
I realized that we were missing a test for `new Symbol()` while review one of
@leobalter's pull requests. When I went to add it, I found that still other
tests were missing, and that some of the existing tests weren't organized
correctly.

> Add new tests for invocation requirements; re-organize existing files
> according to the language feature under test.