### PR TITLE
Reduce reliance on `fnGlobalObject.js`

### DIFF
--- a/test/annexB/built-ins/escape/B.2.1.js
+++ b/test/annexB/built-ins/escape/B.2.1.js
@@ -6,12 +6,10 @@ es5id: B.2.1
 description: >
     Object.getOwnPropertyDescriptor returns data desc for functions on
     built-ins (Global.escape)
-includes:
-    - fnGlobalObject.js
-    - propertyHelper.js
+includes: [propertyHelper.js]
 ---*/
 
-var global = fnGlobalObject();
+var global = this;
 
 verifyWritable(global, "escape");
 verifyNotEnumerable(global, "escape");

--- a/test/annexB/built-ins/unescape/B.2.2.js
+++ b/test/annexB/built-ins/unescape/B.2.2.js
@@ -6,13 +6,9 @@ es5id: B.2.2
 description: >
     Object.getOwnPropertyDescriptor returns data desc for functions on
     built-ins (Global.unescape)
-includes:
-    - fnGlobalObject.js
-    - propertyHelper.js
+includes: [propertyHelper.js]
 ---*/
 
-var global = fnGlobalObject();
-
-verifyWritable(global, "unescape");
-verifyNotEnumerable(global, "unescape");
-verifyConfigurable(global, "unescape");
+verifyWritable(this, "unescape");
+verifyNotEnumerable(this, "unescape");
+verifyConfigurable(this, "unescape");

--- a/test/built-ins/Array/isArray/15.4.3.2-1-15.js
+++ b/test/built-ins/Array/isArray/15.4.3.2-1-15.js
@@ -4,7 +4,6 @@
 /*---
 es5id: 15.4.3.2-1-15
 description: Array.isArray applied to the global object
-includes: [fnGlobalObject.js]
 ---*/
 
-assert.sameValue(Array.isArray(fnGlobalObject()), false, 'Array.isArray(fnGlobalObject())');
+assert.sameValue(Array.isArray(this), false, 'Array.isArray(fnGlobalObject())');

--- a/test/built-ins/Array/isArray/15.4.3.2-1-15.js
+++ b/test/built-ins/Array/isArray/15.4.3.2-1-15.js
@@ -6,4 +6,4 @@ es5id: 15.4.3.2-1-15
 description: Array.isArray applied to the global object
 ---*/
 
-assert.sameValue(Array.isArray(this), false, 'Array.isArray(fnGlobalObject())');
+assert.sameValue(Array.isArray(this), false, 'Array.isArray(this)');

--- a/test/built-ins/Array/prototype/every/15.4.4.16-2-15.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-2-15.js
@@ -4,7 +4,6 @@
 /*---
 es5id: 15.4.4.16-2-15
 description: Array.prototype.every - 'length' is property of the global object
-includes: [fnGlobalObject.js]
 ---*/
 
         function callbackfn1(val, idx, obj) {
@@ -15,11 +14,11 @@ includes: [fnGlobalObject.js]
             return val > 11;
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 12;
-            fnGlobalObject()[1] = 11;
-            fnGlobalObject()[2] = 9;
-            fnGlobalObject().length = 2;
+            var oldLen = this.length;
+            this[0] = 12;
+            this[1] = 11;
+            this[2] = 9;
+            this.length = 2;
 
-assert(Array.prototype.every.call(fnGlobalObject(), callbackfn1), 'Array.prototype.every.call(fnGlobalObject(), callbackfn1) !== true');
-assert.sameValue(Array.prototype.every.call(fnGlobalObject(), callbackfn2), false, 'Array.prototype.every.call(fnGlobalObject(), callbackfn2)');
+assert(Array.prototype.every.call(this, callbackfn1), 'Array.prototype.every.call(this, callbackfn1) !== true');
+assert.sameValue(Array.prototype.every.call(this, callbackfn2), false, 'Array.prototype.every.call(this, callbackfn2)');

--- a/test/built-ins/Array/prototype/every/15.4.4.16-5-1.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-5-1.js
@@ -5,12 +5,13 @@
 es5id: 15.4.4.16-5-1
 description: Array.prototype.every - thisArg not passed
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
   function callbackfn(val, idx, obj)
   {
-    return this === fnGlobalObject();
+    return this === global;
   }
 
   var arr = [1];

--- a/test/built-ins/Array/prototype/every/15.4.4.16-5-21.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-5-21.js
@@ -4,15 +4,15 @@
 /*---
 es5id: 15.4.4.16-5-21
 description: Array.prototype.every - the global object can be used as thisArg
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
         var accessed = false;
 
         function callbackfn(val, idx, obj) {
             accessed = true;
-            return this === fnGlobalObject();
+            return this === global;
         }
 
-assert([11].every(callbackfn, fnGlobalObject()), '[11].every(callbackfn, fnGlobalObject()) !== true');
+assert([11].every(callbackfn, global), '[11].every(callbackfn, fnGlobalObject()) !== true');
 assert(accessed, 'accessed !== true');

--- a/test/built-ins/Array/prototype/every/15.4.4.16-5-21.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-5-21.js
@@ -14,5 +14,5 @@ var global = this;
             return this === global;
         }
 
-assert([11].every(callbackfn, global), '[11].every(callbackfn, fnGlobalObject()) !== true');
+assert([11].every(callbackfn, global), '[11].every(callbackfn, global) !== true');
 assert(accessed, 'accessed !== true');

--- a/test/built-ins/Array/prototype/every/15.4.4.16-7-c-i-23.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-7-c-i-23.js
@@ -6,7 +6,6 @@ es5id: 15.4.4.16-7-c-i-23
 description: >
     Array.prototype.every - This object is an global object which
     contains index property
-includes: [fnGlobalObject.js]
 ---*/
 
         function callbackfn(val, idx, obj) {
@@ -17,8 +16,8 @@ includes: [fnGlobalObject.js]
             }
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 11;
-            fnGlobalObject().length = 1;
+            var oldLen = this.length;
+            this[0] = 11;
+            this.length = 1;
 
-assert.sameValue(Array.prototype.every.call(fnGlobalObject(), callbackfn), false, 'Array.prototype.every.call(fnGlobalObject(), callbackfn)');
+assert.sameValue(Array.prototype.every.call(this, callbackfn), false, 'Array.prototype.every.call(this, callbackfn)');

--- a/test/built-ins/Array/prototype/every/15.4.4.16-7-c-iii-27.js
+++ b/test/built-ins/Array/prototype/every/15.4.4.16-7-c-iii-27.js
@@ -6,14 +6,14 @@ es5id: 15.4.4.16-7-c-iii-27
 description: >
     Array.prototype.every - return value of callbackfn is the global
     object
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
         var accessed = false;
 
         function callbackfn(val, idx, obj) {
             accessed = true;
-            return fnGlobalObject();
+            return global;
         }
 
 assert([11].every(callbackfn), '[11].every(callbackfn) !== true');

--- a/test/built-ins/Array/prototype/filter/15.4.4.20-2-15.js
+++ b/test/built-ins/Array/prototype/filter/15.4.4.20-2-15.js
@@ -4,18 +4,18 @@
 /*---
 es5id: 15.4.4.20-2-15
 description: Array.prototype.filter - 'length' is property of the global object
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
         function callbackfn(val, idx, obj) {
             return  obj.length === 2;
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 12;
-            fnGlobalObject()[1] = 11;
-            fnGlobalObject()[2] = 9;
-            fnGlobalObject().length = 2;
-            var newArr = Array.prototype.filter.call(fnGlobalObject(), callbackfn);
+            var oldLen = global.length;
+            global[0] = 12;
+            global[1] = 11;
+            global[2] = 9;
+            global.length = 2;
+            var newArr = Array.prototype.filter.call(global, callbackfn);
 
 assert.sameValue(newArr.length, 2, 'newArr.length');

--- a/test/built-ins/Array/prototype/filter/15.4.4.20-2-15.js
+++ b/test/built-ins/Array/prototype/filter/15.4.4.20-2-15.js
@@ -6,16 +6,15 @@ es5id: 15.4.4.20-2-15
 description: Array.prototype.filter - 'length' is property of the global object
 ---*/
 
-var global = this;
         function callbackfn(val, idx, obj) {
             return  obj.length === 2;
         }
 
-            var oldLen = global.length;
-            global[0] = 12;
-            global[1] = 11;
-            global[2] = 9;
-            global.length = 2;
-            var newArr = Array.prototype.filter.call(global, callbackfn);
+            var oldLen = this.length;
+            this[0] = 12;
+            this[1] = 11;
+            this[2] = 9;
+            this.length = 2;
+            var newArr = Array.prototype.filter.call(this, callbackfn);
 
 assert.sameValue(newArr.length, 2, 'newArr.length');

--- a/test/built-ins/Array/prototype/filter/15.4.4.20-5-21.js
+++ b/test/built-ins/Array/prototype/filter/15.4.4.20-5-21.js
@@ -4,17 +4,18 @@
 /*---
 es5id: 15.4.4.20-5-21
 description: Array.prototype.filter - the global object can be used as thisArg
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
         var accessed = false;
 
         function callbackfn(val, idx, obj) {
             accessed = true;
-            return this === fnGlobalObject();
+            return this === global;
         }
 
-        var newArr = [11].filter(callbackfn, fnGlobalObject());
+        var newArr = [11].filter(callbackfn, global);
 
 assert.sameValue(newArr[0], 11, 'newArr[0]');
 assert(accessed, 'accessed !== true');

--- a/test/built-ins/Array/prototype/filter/15.4.4.20-9-c-i-23.js
+++ b/test/built-ins/Array/prototype/filter/15.4.4.20-9-c-i-23.js
@@ -6,17 +6,16 @@ es5id: 15.4.4.20-9-c-i-23
 description: >
     Array.prototype.filter - This object is the global object which
     contains index property
-includes: [fnGlobalObject.js]
 ---*/
 
         function callbackfn(val, idx, obj) {
             return idx === 0 && val === 11;
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 11;
-            fnGlobalObject().length = 1;
-            var newArr = Array.prototype.filter.call(fnGlobalObject(), callbackfn);
+            var oldLen = this.length;
+            this[0] = 11;
+            this.length = 1;
+            var newArr = Array.prototype.filter.call(this, callbackfn);
 
 assert.sameValue(newArr.length, 1, 'newArr.length');
 assert.sameValue(newArr[0], 11, 'newArr[0]');

--- a/test/built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-28.js
+++ b/test/built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-28.js
@@ -6,11 +6,11 @@ es5id: 15.4.4.20-9-c-iii-28
 description: >
     Array.prototype.filter - return value of callbackfn is the global
     object
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
         function callbackfn(val, idx, obj) {
-            return fnGlobalObject();
+            return global;
         }
 
         var newArr = [11].filter(callbackfn);

--- a/test/built-ins/Array/prototype/forEach/15.4.4.18-2-15.js
+++ b/test/built-ins/Array/prototype/forEach/15.4.4.18-2-15.js
@@ -4,7 +4,6 @@
 /*---
 es5id: 15.4.4.18-2-15
 description: Array.prototype.forEach - 'length' is property of the global object
-includes: [fnGlobalObject.js]
 ---*/
 
         var result = false;
@@ -12,11 +11,11 @@ includes: [fnGlobalObject.js]
             result = (obj.length === 2);
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 12;
-            fnGlobalObject()[1] = 11;
-            fnGlobalObject()[2] = 9;
-            fnGlobalObject().length = 2;
-            Array.prototype.forEach.call(fnGlobalObject(), callbackfn);
+            var oldLen = this.length;
+            this[0] = 12;
+            this[1] = 11;
+            this[2] = 9;
+            this.length = 2;
+            Array.prototype.forEach.call(this, callbackfn);
 
 assert(result, 'result !== true');

--- a/test/built-ins/Array/prototype/forEach/15.4.4.18-5-21.js
+++ b/test/built-ins/Array/prototype/forEach/15.4.4.18-5-21.js
@@ -4,14 +4,14 @@
 /*---
 es5id: 15.4.4.18-5-21
 description: Array.prototype.forEach - the global object can be used as thisArg
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
         var result = false;
         function callbackfn(val, idx, obj) {
-            result = (this === fnGlobalObject());
+            result = (this === global);
         }
 
-        [11].forEach(callbackfn, fnGlobalObject());
+        [11].forEach(callbackfn, this);
 
 assert(result, 'result !== true');

--- a/test/built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-23.js
+++ b/test/built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-23.js
@@ -6,7 +6,6 @@ es5id: 15.4.4.18-7-c-i-23
 description: >
     Array.prototype.forEach - This object is an global object which
     contains index property
-includes: [fnGlobalObject.js]
 ---*/
 
         var testResult = false;
@@ -17,10 +16,10 @@ includes: [fnGlobalObject.js]
             }
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 11;
-            fnGlobalObject().length = 1;
+            var oldLen = this.length;
+            this[0] = 11;
+            this.length = 1;
 
-            Array.prototype.forEach.call(fnGlobalObject(), callbackfn);
+            Array.prototype.forEach.call(this, callbackfn);
 
 assert(testResult, 'testResult !== true');

--- a/test/built-ins/Array/prototype/indexOf/15.4.4.14-1-17.js
+++ b/test/built-ins/Array/prototype/indexOf/15.4.4.14-1-17.js
@@ -4,11 +4,10 @@
 /*---
 es5id: 15.4.4.14-1-17
 description: Array.prototype.indexOf applied to the global object
-includes: [fnGlobalObject.js]
 ---*/
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[1] = true;
-            fnGlobalObject().length = 2;
+            var oldLen = this.length;
+            this[1] = true;
+            this.length = 2;
 
-assert.sameValue(Array.prototype.indexOf.call(fnGlobalObject(), true), 1, 'Array.prototype.indexOf.call(fnGlobalObject(), true)');
+assert.sameValue(Array.prototype.indexOf.call(this, true), 1, 'Array.prototype.indexOf.call(this, true)');

--- a/test/built-ins/Array/prototype/indexOf/15.4.4.14-2-15.js
+++ b/test/built-ins/Array/prototype/indexOf/15.4.4.14-2-15.js
@@ -4,19 +4,18 @@
 /*---
 es5id: 15.4.4.14-2-15
 description: Array.prototype.indexOf - 'length' is property of the global object
-includes: [fnGlobalObject.js]
 ---*/
 
         var targetObj = {};
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject().length = 2;
+            var oldLen = this.length;
+            this.length = 2;
 
-            fnGlobalObject()[1] = targetObj;
+            this[1] = targetObj;
 
-assert.sameValue(Array.prototype.indexOf.call(fnGlobalObject(), targetObj), 1, 'Array.prototype.indexOf.call(fnGlobalObject(), targetObj)');
+assert.sameValue(Array.prototype.indexOf.call(this, targetObj), 1, 'Array.prototype.indexOf.call(this, targetObj)');
 
-            fnGlobalObject()[1] = {};
-            fnGlobalObject()[2] = targetObj;
+            this[1] = {};
+            this[2] = targetObj;
 
-assert.sameValue(Array.prototype.indexOf.call(fnGlobalObject(), targetObj), -1, 'Array.prototype.indexOf.call(fnGlobalObject(), targetObj)');
+assert.sameValue(Array.prototype.indexOf.call(this, targetObj), -1, 'Array.prototype.indexOf.call(this, targetObj)');

--- a/test/built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-23.js
+++ b/test/built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-23.js
@@ -4,17 +4,16 @@
 /*---
 es5id: 15.4.4.14-9-b-i-23
 description: Array.prototype.indexOf - This object is the global object
-includes: [fnGlobalObject.js]
 ---*/
 
         var targetObj = {};
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = targetObj;
-            fnGlobalObject()[100] = "100";
-            fnGlobalObject()[200] = "200";
-            fnGlobalObject().length = 200;
+            var oldLen = this.length;
+            this[0] = targetObj;
+            this[100] = "100";
+            this[200] = "200";
+            this.length = 200;
 
-assert.sameValue(Array.prototype.indexOf.call(fnGlobalObject(), targetObj), 0, 'Array.prototype.indexOf.call(fnGlobalObject(), targetObj)');
-assert.sameValue(Array.prototype.indexOf.call(fnGlobalObject(), "100"), 100, 'Array.prototype.indexOf.call(fnGlobalObject(), "100")');
-assert.sameValue(Array.prototype.indexOf.call(fnGlobalObject(), "200"), -1, 'Array.prototype.indexOf.call(fnGlobalObject(), "200")');
+assert.sameValue(Array.prototype.indexOf.call(this, targetObj), 0, 'Array.prototype.indexOf.call(this, targetObj)');
+assert.sameValue(Array.prototype.indexOf.call(this, "100"), 100, 'Array.prototype.indexOf.call(this, "100")');
+assert.sameValue(Array.prototype.indexOf.call(this, "200"), -1, 'Array.prototype.indexOf.call(this, "200")');

--- a/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-17.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-17.js
@@ -4,13 +4,12 @@
 /*---
 es5id: 15.4.4.15-1-17
 description: Array.prototype.lastIndexOf applied to the global object
-includes: [fnGlobalObject.js]
 ---*/
 
         var targetObj = ["global"];
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[1] = targetObj;
-            fnGlobalObject().length = 3;
+            var oldLen = this.length;
+            this[1] = targetObj;
+            this.length = 3;
 
-assert.sameValue(Array.prototype.lastIndexOf.call(fnGlobalObject(), targetObj), 1, 'Array.prototype.lastIndexOf.call(fnGlobalObject(), targetObj)');
+assert.sameValue(Array.prototype.lastIndexOf.call(this, targetObj), 1, 'Array.prototype.lastIndexOf.call(this, targetObj)');

--- a/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-15.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-15.js
@@ -6,19 +6,18 @@ es5id: 15.4.4.15-2-15
 description: >
     Array.prototype.lastIndexOf - 'length' is property of the global
     object
-includes: [fnGlobalObject.js]
 ---*/
 
         var targetObj = {};
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject().length = 2;
+            var oldLen = this.length;
+            this.length = 2;
 
-            fnGlobalObject()[1] = targetObj;
+            this[1] = targetObj;
 
-assert.sameValue(Array.prototype.lastIndexOf.call(fnGlobalObject(), targetObj), 1);
+assert.sameValue(Array.prototype.lastIndexOf.call(this, targetObj), 1);
 
-            fnGlobalObject()[1] = {};
-            fnGlobalObject()[2] = targetObj;
+            this[1] = {};
+            this[2] = targetObj;
 
-assert.sameValue(Array.prototype.lastIndexOf.call(fnGlobalObject(), targetObj), -1);
+assert.sameValue(Array.prototype.lastIndexOf.call(this, targetObj), -1);

--- a/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-19.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-19.js
@@ -6,7 +6,6 @@ es5id: 15.4.4.15-3-19
 description: >
     Array.prototype.lastIndexOf - value of 'length' is an Object which
     has an own toString method
-includes: [fnGlobalObject.js]
 ---*/
 
         // objects inherit the default valueOf() method from Object
@@ -15,7 +14,7 @@ includes: [fnGlobalObject.js]
         // to a number by calling its toString() method and converting the
         // resulting string to a number.
 
-        var targetObj = fnGlobalObject();
+        var targetObj = this;
         var obj = {
             1: targetObj,
             2: 2,

--- a/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-23.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-23.js
@@ -4,17 +4,16 @@
 /*---
 es5id: 15.4.4.15-8-b-i-23
 description: Array.prototype.lastIndexOf - This object is the global object
-includes: [fnGlobalObject.js]
 ---*/
 
         var targetObj = {};
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = targetObj;
-            fnGlobalObject()[100] = "100";
-            fnGlobalObject()[200] = "200";
-            fnGlobalObject().length = 200;
+            var oldLen = this.length;
+            this[0] = targetObj;
+            this[100] = "100";
+            this[200] = "200";
+            this.length = 200;
 
-assert.sameValue(Array.prototype.lastIndexOf.call(fnGlobalObject(), targetObj), 0, 'Array.prototype.lastIndexOf.call(fnGlobalObject(), targetObj)');
-assert.sameValue(Array.prototype.lastIndexOf.call(fnGlobalObject(), "100"), 100, 'Array.prototype.lastIndexOf.call(fnGlobalObject(), "100")');
-assert.sameValue(Array.prototype.lastIndexOf.call(fnGlobalObject(), "200"), -1, 'Array.prototype.lastIndexOf.call(fnGlobalObject(), "200")');
+assert.sameValue(Array.prototype.lastIndexOf.call(this, targetObj), 0, 'Array.prototype.lastIndexOf.call(this, targetObj)');
+assert.sameValue(Array.prototype.lastIndexOf.call(this, "100"), 100, 'Array.prototype.lastIndexOf.call(this, "100")');
+assert.sameValue(Array.prototype.lastIndexOf.call(this, "200"), -1, 'Array.prototype.lastIndexOf.call(this, "200")');

--- a/test/built-ins/Array/prototype/map/15.4.4.19-2-15.js
+++ b/test/built-ins/Array/prototype/map/15.4.4.19-2-15.js
@@ -6,18 +6,17 @@ es5id: 15.4.4.19-2-15
 description: >
     Array.prototype.map - when 'length' is property of the global
     object
-includes: [fnGlobalObject.js]
 ---*/
 
         function callbackfn(val, idx, obj) {
             return val > 10;
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 12;
-            fnGlobalObject()[1] = 11;
-            fnGlobalObject()[2] = 9;
-            fnGlobalObject().length = 2;
-            var testResult = Array.prototype.map.call(fnGlobalObject(), callbackfn);
+            var oldLen = this.length;
+            this[0] = 12;
+            this[1] = 11;
+            this[2] = 9;
+            this.length = 2;
+            var testResult = Array.prototype.map.call(this, callbackfn);
 
 assert.sameValue(testResult.length, 2, 'testResult.length');

--- a/test/built-ins/Array/prototype/map/15.4.4.19-5-1.js
+++ b/test/built-ins/Array/prototype/map/15.4.4.19-5-1.js
@@ -5,10 +5,9 @@
 es5id: 15.4.4.19-5-1
 description: Array.prototype.map - thisArg not passed
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-    fnGlobalObject()._15_4_4_19_5_1 = true;
+    this._15_4_4_19_5_1 = true;
 
 (function() {
     var _15_4_4_19_5_1 = false;

--- a/test/built-ins/Array/prototype/map/15.4.4.19-5-21.js
+++ b/test/built-ins/Array/prototype/map/15.4.4.19-5-21.js
@@ -4,13 +4,13 @@
 /*---
 es5id: 15.4.4.19-5-21
 description: Array.prototype.map - the global object can be used as thisArg
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
         function callbackfn(val, idx, obj) {
-            return this === fnGlobalObject();
+            return this === global;
         }
 
-        var testResult = [11].map(callbackfn, fnGlobalObject());
+        var testResult = [11].map(callbackfn, this);
 
 assert.sameValue(testResult[0], true, 'testResult[0]');

--- a/test/built-ins/Array/prototype/map/15.4.4.19-8-c-i-23.js
+++ b/test/built-ins/Array/prototype/map/15.4.4.19-8-c-i-23.js
@@ -6,7 +6,6 @@ es5id: 15.4.4.19-8-c-i-23
 description: >
     Array.prototype.map - This object is the global object which
     contains index property
-includes: [fnGlobalObject.js]
 ---*/
 
         var kValue = "abc";
@@ -18,10 +17,10 @@ includes: [fnGlobalObject.js]
             return false;
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = kValue;
-            fnGlobalObject().length = 2;
+            var oldLen = this.length;
+            this[0] = kValue;
+            this.length = 2;
 
-            var testResult = Array.prototype.map.call(fnGlobalObject(), callbackfn);
+            var testResult = Array.prototype.map.call(this, callbackfn);
 
 assert.sameValue(testResult[0], true, 'testResult[0]');

--- a/test/built-ins/Array/prototype/reduce/15.4.4.21-2-15.js
+++ b/test/built-ins/Array/prototype/reduce/15.4.4.21-2-15.js
@@ -4,17 +4,16 @@
 /*---
 es5id: 15.4.4.21-2-15
 description: Array.prototype.reduce - 'length' is property of the global object
-includes: [fnGlobalObject.js]
 ---*/
 
         function callbackfn(prevVal, curVal, idx, obj) {
             return (obj.length === 2);
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 12;
-            fnGlobalObject()[1] = 11;
-            fnGlobalObject()[2] = 9;
-            fnGlobalObject().length = 2;
+            var oldLen = this.length;
+            this[0] = 12;
+            this[1] = 11;
+            this[2] = 9;
+            this.length = 2;
 
-assert.sameValue(Array.prototype.reduce.call(fnGlobalObject(), callbackfn, 1), true, 'Array.prototype.reduce.call(fnGlobalObject(), callbackfn, 1)');
+assert.sameValue(Array.prototype.reduce.call(this, callbackfn, 1), true, 'Array.prototype.reduce.call(this, callbackfn, 1)');

--- a/test/built-ins/Array/prototype/reduce/15.4.4.21-8-b-iii-1-23.js
+++ b/test/built-ins/Array/prototype/reduce/15.4.4.21-8-b-iii-1-23.js
@@ -6,7 +6,6 @@ es5id: 15.4.4.21-8-b-iii-1-23
 description: >
     Array.prototype.reduce - This object is the global object which
     contains index property
-includes: [fnGlobalObject.js]
 ---*/
 
         var testResult = false;
@@ -16,12 +15,12 @@ includes: [fnGlobalObject.js]
             }
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 0;
-            fnGlobalObject()[1] = 1;
-            fnGlobalObject()[2] = 2;
-            fnGlobalObject().length = 3;
+            var oldLen = this.length;
+            this[0] = 0;
+            this[1] = 1;
+            this[2] = 2;
+            this.length = 3;
 
-            Array.prototype.reduce.call(fnGlobalObject(), callbackfn);
+            Array.prototype.reduce.call(this, callbackfn);
 
 assert(testResult, 'testResult !== true');

--- a/test/built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-23.js
+++ b/test/built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-23.js
@@ -6,7 +6,6 @@ es5id: 15.4.4.21-9-c-i-23
 description: >
     Array.prototype.reduce - This object is the global object which
     contains index property
-includes: [fnGlobalObject.js]
 ---*/
 
         var testResult = false;
@@ -17,11 +16,11 @@ includes: [fnGlobalObject.js]
             }
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 0;
-            fnGlobalObject()[1] = 1;
-            fnGlobalObject().length = 2;
+            var oldLen = this.length;
+            this[0] = 0;
+            this[1] = 1;
+            this.length = 2;
 
-            Array.prototype.reduce.call(fnGlobalObject(), callbackfn, initialValue);
+            Array.prototype.reduce.call(this, callbackfn, initialValue);
 
 assert(testResult, 'testResult !== true');

--- a/test/built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-37.js
+++ b/test/built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-37.js
@@ -6,16 +6,16 @@ es5id: 15.4.4.21-9-c-ii-37
 description: >
     Array.prototype.reduce - the global object can be used as
     accumulator
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
         var accessed = false;
         function callbackfn(prevVal, curVal, idx, obj) {
             accessed = true;
-            return prevVal === fnGlobalObject();
+            return prevVal === global;
         }
 
         var obj = { 0: 11, length: 1 };
 
-assert.sameValue(Array.prototype.reduce.call(obj, callbackfn, fnGlobalObject()), true, 'Array.prototype.reduce.call(obj, callbackfn, fnGlobalObject())');
+assert.sameValue(Array.prototype.reduce.call(obj, callbackfn, this), true, 'Array.prototype.reduce.call(obj, callbackfn, this)');
 assert(accessed, 'accessed !== true');

--- a/test/built-ins/Array/prototype/reduceRight/15.4.4.22-2-15.js
+++ b/test/built-ins/Array/prototype/reduceRight/15.4.4.22-2-15.js
@@ -6,21 +6,21 @@ es5id: 15.4.4.22-2-15
 description: >
     Array.prototype.reduceRight - 'length' is property of the global
     object
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
         var accessed = false;
 
         function callbackfn(prevVal, curVal, idx, obj) {
             accessed = true;
-            return obj.length === fnGlobalObject().length;
+            return obj.length === global.length;
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 12;
-            fnGlobalObject()[1] = 11;
-            fnGlobalObject()[2] = 9;
-            fnGlobalObject().length = 2;
+            var oldLen = this.length;
+            this[0] = 12;
+            this[1] = 11;
+            this[2] = 9;
+            this.length = 2;
 
-assert(Array.prototype.reduceRight.call(fnGlobalObject(), callbackfn, 111), 'Array.prototype.reduceRight.call(fnGlobalObject(), callbackfn, 111) !== true');
+assert(Array.prototype.reduceRight.call(this, callbackfn, 111), 'Array.prototype.reduceRight.call(this, callbackfn, 111) !== true');
 assert(accessed, 'accessed !== true');

--- a/test/built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-23.js
+++ b/test/built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-23.js
@@ -6,7 +6,6 @@ es5id: 15.4.4.22-8-b-iii-1-23
 description: >
     Array.prototype.reduceRight - This object is the global object
     which contains index property
-includes: [fnGlobalObject.js]
 ---*/
 
         var testResult = false;
@@ -16,12 +15,12 @@ includes: [fnGlobalObject.js]
             }
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 0;
-            fnGlobalObject()[1] = 1;
-            fnGlobalObject()[2] = 2;
-            fnGlobalObject().length = 3;
+            var oldLen = this.length;
+            this[0] = 0;
+            this[1] = 1;
+            this[2] = 2;
+            this.length = 3;
 
-            Array.prototype.reduceRight.call(fnGlobalObject(), callbackfn);
+            Array.prototype.reduceRight.call(this, callbackfn);
 
 assert(testResult, 'testResult !== true');

--- a/test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-23.js
+++ b/test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-23.js
@@ -6,7 +6,6 @@ es5id: 15.4.4.22-9-c-i-23
 description: >
     Array.prototype.reduceRight - This object is an global object
     which contains index property
-includes: [fnGlobalObject.js]
 ---*/
 
         var testResult = false;
@@ -16,12 +15,12 @@ includes: [fnGlobalObject.js]
             }
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 0;
-            fnGlobalObject()[1] = 1;
-            fnGlobalObject()[2] = 2;
-            fnGlobalObject().length = 3;
+            var oldLen = this.length;
+            this[0] = 0;
+            this[1] = 1;
+            this[2] = 2;
+            this.length = 3;
 
-            Array.prototype.reduceRight.call(fnGlobalObject(), callbackfn, "initialValue");
+            Array.prototype.reduceRight.call(this, callbackfn, "initialValue");
 
 assert(testResult, 'testResult !== true');

--- a/test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-37.js
+++ b/test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-37.js
@@ -6,16 +6,16 @@ es5id: 15.4.4.22-9-c-ii-37
 description: >
     Array.prototype.reduceRight - the global object can be used as
     accumulator
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
         var accessed = false;
         function callbackfn(prevVal, curVal, idx, obj) {
             accessed = true;
-            return prevVal === fnGlobalObject();
+            return prevVal === global;
         }
 
         var obj = { 0: 11, length: 1 };
 
-assert.sameValue(Array.prototype.reduceRight.call(obj, callbackfn, fnGlobalObject()), true, 'Array.prototype.reduceRight.call(obj, callbackfn, fnGlobalObject())');
+assert.sameValue(Array.prototype.reduceRight.call(obj, callbackfn, this), true, 'Array.prototype.reduceRight.call(obj, callbackfn, this)');
 assert(accessed, 'accessed !== true');

--- a/test/built-ins/Array/prototype/some/15.4.4.17-2-15.js
+++ b/test/built-ins/Array/prototype/some/15.4.4.17-2-15.js
@@ -4,7 +4,6 @@
 /*---
 es5id: 15.4.4.17-2-15
 description: Array.prototype.some - 'length' is property of the global object
-includes: [fnGlobalObject.js]
 ---*/
 
         function callbackfn1(val, idx, obj) {
@@ -15,11 +14,11 @@ includes: [fnGlobalObject.js]
             return val > 11;
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 9;
-            fnGlobalObject()[1] = 11;
-            fnGlobalObject()[2] = 12;
-            fnGlobalObject().length = 2;
+            var oldLen = this.length;
+            this[0] = 9;
+            this[1] = 11;
+            this[2] = 12;
+            this.length = 2;
 
-assert(Array.prototype.some.call(fnGlobalObject(), callbackfn1), 'Array.prototype.some.call(fnGlobalObject(), callbackfn1) !== true');
-assert.sameValue(Array.prototype.some.call(fnGlobalObject(), callbackfn2), false, 'Array.prototype.some.call(fnGlobalObject(), callbackfn2)');
+assert(Array.prototype.some.call(this, callbackfn1), 'Array.prototype.some.call(this, callbackfn1) !== true');
+assert.sameValue(Array.prototype.some.call(this, callbackfn2), false, 'Array.prototype.some.call(this, callbackfn2)');

--- a/test/built-ins/Array/prototype/some/15.4.4.17-5-21.js
+++ b/test/built-ins/Array/prototype/some/15.4.4.17-5-21.js
@@ -4,11 +4,11 @@
 /*---
 es5id: 15.4.4.17-5-21
 description: Array.prototype.some - the global object can be used as thisArg
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
         function callbackfn(val, idx, obj) {
-            return this === fnGlobalObject();
+            return this === global;
         }
 
-assert([11].some(callbackfn, fnGlobalObject()), '[11].some(callbackfn, fnGlobalObject()) !== true');
+assert([11].some(callbackfn, this), '[11].some(callbackfn, fnGlobalObject()) !== true');

--- a/test/built-ins/Array/prototype/some/15.4.4.17-5-21.js
+++ b/test/built-ins/Array/prototype/some/15.4.4.17-5-21.js
@@ -11,4 +11,4 @@ var global = this;
             return this === global;
         }
 
-assert([11].some(callbackfn, this), '[11].some(callbackfn, fnGlobalObject()) !== true');
+assert([11].some(callbackfn, this), '[11].some(callbackfn, global) !== true');

--- a/test/built-ins/Array/prototype/some/15.4.4.17-7-c-i-23.js
+++ b/test/built-ins/Array/prototype/some/15.4.4.17-7-c-i-23.js
@@ -6,7 +6,6 @@ es5id: 15.4.4.17-7-c-i-23
 description: >
     Array.prototype.some - This object is an global object which
     contains index property
-includes: [fnGlobalObject.js]
 ---*/
 
         function callbackfn(val, idx, obj) {
@@ -16,8 +15,8 @@ includes: [fnGlobalObject.js]
             return false;
         }
 
-            var oldLen = fnGlobalObject().length;
-            fnGlobalObject()[0] = 11;
-            fnGlobalObject().length = 1;
+            var oldLen = this.length;
+            this[0] = 11;
+            this.length = 1;
 
-assert(Array.prototype.some.call(fnGlobalObject(), callbackfn), 'Array.prototype.some.call(fnGlobalObject(), callbackfn) !== true');
+assert(Array.prototype.some.call(this, callbackfn), 'Array.prototype.some.call(this, callbackfn) !== true');

--- a/test/built-ins/Array/prototype/some/15.4.4.17-7-c-iii-26.js
+++ b/test/built-ins/Array/prototype/some/15.4.4.17-7-c-iii-26.js
@@ -6,11 +6,11 @@ es5id: 15.4.4.17-7-c-iii-26
 description: >
     Array.prototype.some - return value of callbackfn is the global
     object
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
         function callbackfn(val, idx, obj) {
-            return fnGlobalObject();
+            return global;
         }
 
 assert([11].some(callbackfn), '[11].some(callbackfn) !== true');

--- a/test/built-ins/Function/15.3.5.4_2-64gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-64gs.js
@@ -8,13 +8,13 @@ description: >
     non-strict function (strict function declaration called by
     Function.prototype.apply(globalObject))
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
 function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
-    f.apply(fnGlobalObject());
+    f.apply(global);
 });
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-69gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-69gs.js
@@ -8,13 +8,13 @@ description: >
     non-strict function (strict function declaration called by
     Function.prototype.call(globalObject))
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
 function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
-    f.call(fnGlobalObject());
+    f.call(this);
 });
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-74gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-74gs.js
@@ -8,13 +8,13 @@ description: >
     non-strict function (strict function declaration called by
     Function.prototype.bind(globalObject)())
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
 function f() { "use strict"; gNonStrict();};
 
 assert.throws(TypeError, function() {
-    f.bind(fnGlobalObject())();
+    f.bind(global)();
 });
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-83gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-83gs.js
@@ -9,11 +9,11 @@ description: >
     strict Function.prototype.apply(globalObject))
 flags: [noStrict]
 features: [caller]
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
 function f() { return gNonStrict();};
-(function () {"use strict"; f.apply(fnGlobalObject()); })();
+(function () {"use strict"; f.apply(global); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-88gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-88gs.js
@@ -9,11 +9,11 @@ description: >
     strict Function.prototype.call(globalObject))
 flags: [noStrict]
 features: [caller]
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
 function f() { return gNonStrict();};
-(function () {"use strict"; f.call(fnGlobalObject()); })();
+(function () {"use strict"; f.call(global); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Function/15.3.5.4_2-93gs.js
+++ b/test/built-ins/Function/15.3.5.4_2-93gs.js
@@ -9,11 +9,11 @@ description: >
     strict Function.prototype.bind(globalObject)())
 flags: [noStrict]
 features: [caller]
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
 function f() { return gNonStrict();};
-(function () {"use strict"; f.bind(fnGlobalObject())(); })();
+(function () {"use strict"; f.bind(global)(); })();
 
 
 function gNonStrict() {

--- a/test/built-ins/Infinity/15.1.1.2-0.js
+++ b/test/built-ins/Infinity/15.1.1.2-0.js
@@ -6,10 +6,9 @@ es5id: 15.1.1.2-0
 description: >
     Global.Infinity is a data property with default attribute values
     (false)
-includes: [fnGlobalObject.js]
 ---*/
 
-    var desc = Object.getOwnPropertyDescriptor(fnGlobalObject(), 'Infinity');
+    var desc = Object.getOwnPropertyDescriptor(this, 'Infinity');
 
 assert.sameValue(desc.writable, false, 'desc.writable');
 assert.sameValue(desc.enumerable, false, 'desc.enumerable');

--- a/test/built-ins/Infinity/S15.1.1.2_A2_T1.js
+++ b/test/built-ins/Infinity/S15.1.1.2_A2_T1.js
@@ -5,11 +5,11 @@
 info: The Infinity is ReadOnly
 es5id: 15.1.1.2_A2_T1
 description: Checking typeof Functions
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
 // CHECK#1
-verifyNotWritable(fnGlobalObject(), "Infinity", null, true);
+verifyNotWritable(this, "Infinity", null, true);
 if (typeof(Infinity) === "boolean") {
 	$ERROR('#1: Infinity = true; typeof(Infinity) !== "boolean". Actual: ' + (typeof(Infinity)));
 }

--- a/test/built-ins/Infinity/S15.1.1.2_A3_T1.js
+++ b/test/built-ins/Infinity/S15.1.1.2_A3_T1.js
@@ -5,14 +5,14 @@
 info: The Infinity is DontDelete
 es5id: 15.1.1.2_A3_T1
 description: Use delete
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
 // CHECK#1
-verifyNotConfigurable(fnGlobalObject(), "Infinity");
+verifyNotConfigurable(this, "Infinity");
 
 try {
-  if (delete fnGlobalObject().Infinity !== false) {
+  if (delete this.Infinity !== false) {
     $ERROR('#1: delete Infinity === false.');
   }
 } catch (e) {

--- a/test/built-ins/NaN/15.1.1.1-0.js
+++ b/test/built-ins/NaN/15.1.1.1-0.js
@@ -4,10 +4,9 @@
 /*---
 es5id: 15.1.1.1-0
 description: Global.NaN is a data property with default attribute values (false)
-includes: [fnGlobalObject.js]
 ---*/
 
-    var desc = Object.getOwnPropertyDescriptor(fnGlobalObject(), 'NaN');
+    var desc = Object.getOwnPropertyDescriptor(this, 'NaN');
 
 assert.sameValue(desc.writable, false, 'desc.writable');
 assert.sameValue(desc.enumerable, false, 'desc.enumerable');

--- a/test/built-ins/NaN/S15.1.1.1_A2_T1.js
+++ b/test/built-ins/NaN/S15.1.1.1_A2_T1.js
@@ -5,11 +5,11 @@
 info: The NaN is ReadOnly
 es5id: 15.1.1.1_A2_T1
 description: Checking typeof Functions
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
 // CHECK#1
-verifyNotWritable(fnGlobalObject(), "NaN", null, true);
+verifyNotWritable(this, "NaN", null, true);
 if (typeof(NaN) === "boolean") {
 	$ERROR('#1: NaN = true; typeof(NaN) !== "boolean". Actual: ' + (typeof(NaN)));
 }

--- a/test/built-ins/NaN/S15.1.1.1_A3_T1.js
+++ b/test/built-ins/NaN/S15.1.1.1_A3_T1.js
@@ -5,14 +5,14 @@
 info: The NaN is DontDelete
 es5id: 15.1.1.2_A3_T1
 description: Use delete
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
 // CHECK#1
-verifyNotConfigurable(fnGlobalObject(), "NaN");
+verifyNotConfigurable(this, "NaN");
 
 try {
-  if (delete fnGlobalObject().NaN !== false) {
+  if (delete this.NaN !== false) {
     $ERROR('#1: delete NaN === false.');
   }
 } catch (e) {

--- a/test/built-ins/Object/create/15.2.3.5-4-124.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-124.js
@@ -7,13 +7,12 @@ description: >
     Object.create - one property in 'Properties' is the global object
     that uses Object's [[Get]] method to access the 'configurable'
     property (8.10.5 step 4.a)
-includes: [fnGlobalObject.js]
 ---*/
 
-            fnGlobalObject().configurable = true;
+            this.configurable = true;
 
             var newObj = Object.create({}, {
-                prop: fnGlobalObject() 
+                prop: this 
             });
 
             var result1 = newObj.hasOwnProperty("prop");

--- a/test/built-ins/Object/create/15.2.3.5-4-149.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-149.js
@@ -6,12 +6,11 @@ es5id: 15.2.3.5-4-149
 description: >
     Object.create - 'configurable' property of one property in
     'Properties' is the global object (8.10.5 step 4.b)
-includes: [fnGlobalObject.js]
 ---*/
 
         var newObj = Object.create({}, {
             prop: {
-                configurable: fnGlobalObject()
+                configurable: this
             }
         });
 

--- a/test/built-ins/Object/create/15.2.3.5-4-177.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-177.js
@@ -7,13 +7,12 @@ description: >
     Object.create - one property in 'Properties' is the global object
     that uses Object's [[Get]] method to access the 'value' property
     (8.10.5 step 5.a)
-includes: [fnGlobalObject.js]
 ---*/
 
-            fnGlobalObject().value = "GlobalValue";
+            this.value = "GlobalValue";
 
             var newObj = Object.create({}, {
-                prop: fnGlobalObject()
+                prop: this
             });
 
 assert.sameValue(newObj.prop, "GlobalValue", 'newObj.prop');

--- a/test/built-ins/Object/create/15.2.3.5-4-203.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-203.js
@@ -7,13 +7,12 @@ description: >
     Object.create - one property in 'Properties' is the global object
     that uses Object's [[Get]] method to access the 'writable'
     property (8.10.5 step 6.a)
-includes: [fnGlobalObject.js]
 ---*/
 
-            fnGlobalObject().writable = true;
+            this.writable = true;
 
             var newObj = Object.create({}, {
-                prop: fnGlobalObject() 
+                prop: this 
             });
 
             var beforeWrite = (newObj.hasOwnProperty("prop") && typeof (newObj.prop) === "undefined");

--- a/test/built-ins/Object/create/15.2.3.5-4-228.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-228.js
@@ -6,12 +6,11 @@ es5id: 15.2.3.5-4-228
 description: >
     Object.create - 'writable' property of one property in
     'Properties' is the global object (8.10.5 step 6.b)
-includes: [fnGlobalObject.js]
 ---*/
 
         var newObj = Object.create({}, {
             prop: {
-                writable: fnGlobalObject()
+                writable: this
             }
         });
         var hasProperty = newObj.hasOwnProperty("prop");

--- a/test/built-ins/Object/create/15.2.3.5-4-256.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-256.js
@@ -7,15 +7,14 @@ description: >
     Object.create - one property in 'Properties' is the global object
     that uses Object's [[Get]] method to access the 'get' property
     (8.10.5 step 7.a)
-includes: [fnGlobalObject.js]
 ---*/
 
-        fnGlobalObject().get = function () {
+        this.get = function () {
             return "VerifyGlobalObject";
         };
 
             var newObj = Object.create({}, {
-                prop: fnGlobalObject()
+                prop: this
             });
 
 assert.sameValue(newObj.prop, "VerifyGlobalObject", 'newObj.prop');

--- a/test/built-ins/Object/create/15.2.3.5-4-291.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-291.js
@@ -7,17 +7,16 @@ description: >
     Object.create - one property in 'Properties' is the global object
     that uses Object's [[Get]] method to access the 'set' property
     (8.10.5 step 8.a)
-includes: [fnGlobalObject.js]
 ---*/
 
         var data = "data";
 
-            fnGlobalObject().set = function (value) {
+            this.set = function (value) {
                 data = value;
             };
 
             var newObj = Object.create({}, {
-                prop: fnGlobalObject()
+                prop: this
             });
 
             var hasProperty = newObj.hasOwnProperty("prop");

--- a/test/built-ins/Object/create/15.2.3.5-4-300.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-300.js
@@ -6,14 +6,14 @@ es5id: 15.2.3.5-4-300
 description: >
     Object.create - 'set' property of one property in 'Properties' is
     a host object that isn't callable (8.10.5 step 8.b)
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
 
 assert.throws(TypeError, function() {
             Object.create({}, {
                 prop: {
-                    set: fnGlobalObject()
+                    set: global
                 }
             });
 });

--- a/test/built-ins/Object/create/15.2.3.5-4-71.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-71.js
@@ -7,15 +7,14 @@ description: >
     Object.create - one property in 'Properties' is the global object
     that uses Object's [[Get]] method to access the 'enumerable'
     property (8.10.5 step 3.a)
-includes: [fnGlobalObject.js]
 ---*/
 
         var accessed = false;
 
-            fnGlobalObject().enumerable = true;
+            this.enumerable = true;
 
             var newObj = Object.create({}, {
-                prop: fnGlobalObject()
+                prop: this
             });
             for (var property in newObj) {
                 if (property === "prop") {

--- a/test/built-ins/Object/create/15.2.3.5-4-96.js
+++ b/test/built-ins/Object/create/15.2.3.5-4-96.js
@@ -6,14 +6,13 @@ es5id: 15.2.3.5-4-96
 description: >
     Object.create - 'enumerable' property of one property in
     'Properties' is the global object (8.10.5 step 3.b)
-includes: [fnGlobalObject.js]
 ---*/
 
         var accessed = false;
 
         var newObj = Object.create({}, {
             prop: {
-                enumerable: fnGlobalObject()
+                enumerable: this
             }
         });
         for (var property in newObj) {

--- a/test/built-ins/Object/defineProperties/15.2.3.7-2-18.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-2-18.js
@@ -6,28 +6,28 @@ es5id: 15.2.3.7-2-18
 description: >
     Object.defineProperties - argument 'Properties' is the global
     object
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
         var obj = {};
         var result = false;
 
         try {
-            Object.defineProperty(fnGlobalObject(), "prop", {
+            Object.defineProperty(this, "prop", {
                 get: function () {
-                    result = (this === fnGlobalObject());
+                    result = (this === global);
                     return {};
                 },
                 enumerable: true,
 				configurable:true
             });
 
-            Object.defineProperties(obj, fnGlobalObject());
+            Object.defineProperties(obj, this);
         } catch (e) {
             if (!(e instanceof TypeError)) throw e;
             result = true;
         } finally {
-            delete fnGlobalObject().prop;
+            delete this.prop;
         }
 
 assert(result, 'result !== true');

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-109.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-109.js
@@ -6,14 +6,13 @@ es5id: 15.2.3.7-5-b-109
 description: >
     Object.defineProperties - value of 'configurable' property of
     'descObj' is  the global object (8.10.5 step 4.b)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
 
         Object.defineProperties(obj, {
             property: {
-                configurable: fnGlobalObject()
+                configurable: this
             }
         });
         var preCheck = obj.hasOwnProperty("property");

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-137.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-137.js
@@ -7,15 +7,14 @@ description: >
     Object.defineProperties - 'descObj' is the global object which
     implements its own [[Get]] method to get 'value' property (8.10.5
     step 5.a)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
 
-            fnGlobalObject().value = "global";
+            this.value = "global";
 
             Object.defineProperties(obj, {
-                property: fnGlobalObject()
+                property: this
             });
 
 assert.sameValue(obj.property, "global", 'obj.property');

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-163.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-163.js
@@ -7,18 +7,16 @@ description: >
     Object.defineProperties - 'descObj' is the global object which
     implements its own [[Get]] method to get 'writable' property
     (8.10.5 step 6.a)
-includes:
-    - propertyHelper.js
-    - fnGlobalObject.js
+includes: [propertyHelper.js]
 ---*/
 
 
 var obj = {};
 
-    fnGlobalObject().writable = false;
+    this.writable = false;
 
     Object.defineProperties(obj, {
-        property: fnGlobalObject()
+        property: this
     });
 
     assert(obj.hasOwnProperty("property"));

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-188.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-188.js
@@ -6,14 +6,13 @@ es5id: 15.2.3.7-5-b-188
 description: >
     Object.defineProperties - value of 'writable' property of
     'descObj' is the global object (8.10.5 step 6.b)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
 
         Object.defineProperties(obj, {
             property: {
-                writable: fnGlobalObject()
+                writable: this
             }
         });
 

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-216.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-216.js
@@ -7,17 +7,16 @@ description: >
     Object.defineProperties - 'descObj' is the global object which
     implements its own [[Get]] method to get 'get' property (8.10.5
     step 7.a)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
 
-            fnGlobalObject().get = function () {
+            this.get = function () {
                 return "global";
             };
 
             Object.defineProperties(obj, {
-                property: fnGlobalObject()
+                property: this
             });
 
 assert.sameValue(obj.property, "global", 'obj.property');

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-31.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-31.js
@@ -7,16 +7,15 @@ description: >
     Object.defineProperties - 'descObj' is the global object which
     implements its own [[Get]] method to get 'enumerable' property
     (8.10.5 step 3.a)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
         var accessed = false;
 
-            fnGlobalObject().enumerable = true;
+            this.enumerable = true;
 
             Object.defineProperties(obj, {
-                prop: fnGlobalObject()
+                prop: this
             });
             for (var property in obj) {
                 if (property === "prop") {

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-56.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-56.js
@@ -6,7 +6,6 @@ es5id: 15.2.3.7-5-b-56
 description: >
     Object.defineProperties - value of 'enumerable' property of
     'descObj' is the global object (8.10.5 step 3.b)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
@@ -14,7 +13,7 @@ includes: [fnGlobalObject.js]
 
         Object.defineProperties(obj, {
             prop: {
-                enumerable: fnGlobalObject()
+                enumerable: this
             }
         });
         for (var property in obj) {

--- a/test/built-ins/Object/defineProperties/15.2.3.7-5-b-84.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-5-b-84.js
@@ -7,15 +7,14 @@ description: >
     Object.defineProperties - 'descObj' is the global object which
     implements its own [[Get]] method to get 'configurable' property
     (8.10.5 step 4.a)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
 
-            fnGlobalObject().configurable = true;
+            this.configurable = true;
 
             Object.defineProperties(obj, {
-                prop: fnGlobalObject()
+                prop: this
             });
 
             var result1 = obj.hasOwnProperty("prop");

--- a/test/built-ins/Object/defineProperties/15.2.3.7-6-a-24.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-6-a-24.js
@@ -7,29 +7,29 @@ description: >
     Object.defineProperties - 'O' is the global object which
     implements its own [[GetOwnProperty]] method to get 'P' (8.12.9
     step 1 )
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
 
-Object.defineProperty(fnGlobalObject(), "prop", {
+Object.defineProperty(this, "prop", {
 value: 11,
 writable: true,
 enumerable: true,
 configurable: true
 });
 
-Object.defineProperties(fnGlobalObject(), {
+Object.defineProperties(this, {
     prop: {
         value: 12
     }
 });
 
-verifyEqualTo(fnGlobalObject(), "prop", 12);
+verifyEqualTo(this, "prop", 12);
 
-verifyWritable(fnGlobalObject(), "prop");
+verifyWritable(this, "prop");
 
-verifyEnumerable(fnGlobalObject(), "prop");
+verifyEnumerable(this, "prop");
 
-verifyConfigurable(fnGlobalObject(), "prop");
+verifyConfigurable(this, "prop");
 
-delete fnGlobalObject().prop;
+delete this.prop;

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-123.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-123.js
@@ -6,13 +6,12 @@ es5id: 15.2.3.6-3-123
 description: >
     Object.defineProperty - 'configurable' property in 'Attributes' is
     the global object  (8.10.5 step 4.b)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
 
         var attr = {
-            configurable: fnGlobalObject()
+            configurable: this
         };
 
         Object.defineProperty(obj, "property", attr);

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-151.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-151.js
@@ -7,13 +7,12 @@ description: >
     Object.defineProperty - 'Attributes' is the global object that
     uses Object's [[Get]] method to access the 'value' property
     (8.10.5 step 5.a)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
 
-            fnGlobalObject().value = "global";
+            this.value = "global";
 
-            Object.defineProperty(obj, "property", fnGlobalObject());
+            Object.defineProperty(obj, "property", this);
 
 assert.sameValue(obj.property, "global", 'obj.property');

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-177.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-177.js
@@ -7,14 +7,13 @@ description: >
     Object.defineProperty - 'Attributes' is the global object that
     uses Object's [[Get]] method to access the 'writable' property
     (8.10.5 step 6.a)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
 
-            fnGlobalObject().writable = true;
+            this.writable = true;
 
-            Object.defineProperty(obj, "property", fnGlobalObject());
+            Object.defineProperty(obj, "property", this);
 
             var beforeWrite = obj.hasOwnProperty("property");
 

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-202.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-202.js
@@ -6,13 +6,12 @@ es5id: 15.2.3.6-3-202
 description: >
     Object.defineProperty - 'writable' property in 'Attributes' is the
     global object (8.10.5 step 6.b)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
 
         Object.defineProperty(obj, "property", {
-            writable: fnGlobalObject()
+            writable: this
         });
 
         var beforeWrite = obj.hasOwnProperty("property");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-230.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-230.js
@@ -7,15 +7,14 @@ description: >
     Object.defineProperty - 'Attributes' is the global object that
     uses Object's [[Get]] method to access the 'get' property (8.10.5
     step 7.a)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
 
-            fnGlobalObject().get = function () {
+            this.get = function () {
                 return "globalGetProperty";
             };
 
-            Object.defineProperty(obj, "property", fnGlobalObject());
+            Object.defineProperty(obj, "property", this);
 
 assert.sameValue(obj.property, "globalGetProperty", 'obj.property');

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-260.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-260.js
@@ -7,17 +7,16 @@ description: >
     Object.defineProperty - 'Attributes' is the global object that
     uses Object's [[Get]] method to access the 'set' property (8.10.5
     step 8.a)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
         var data = "data";
 
-            fnGlobalObject().set = function (value) {
+            this.set = function (value) {
                 data = value;
             };
 
-            Object.defineProperty(obj, "property", fnGlobalObject());
+            Object.defineProperty(obj, "property", this);
             obj.property = "overrideData";
 
 assert(obj.hasOwnProperty("property"), 'obj.hasOwnProperty("property") !== true');

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-45.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-45.js
@@ -7,15 +7,14 @@ description: >
     Object.defineProperty - 'Attributes' is the global object that
     uses Object's [[Get]] method to access the 'enumerable' property
     (8.10.5 step 3.a)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
         var accessed = false;
 
-            fnGlobalObject().enumerable = true;
+            this.enumerable = true;
 
-            Object.defineProperty(obj, "property", fnGlobalObject());
+            Object.defineProperty(obj, "property", this);
 
             for (var prop in obj) {
                 if (prop === "property") {

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-70.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-70.js
@@ -6,13 +6,12 @@ es5id: 15.2.3.6-3-70
 description: >
     Object.defineProperty - value of 'enumerable' property in
     'Attributes' is the global object (8.10.5 step 3.b)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
         var accessed = false;
 
-        Object.defineProperty(obj, "property", { enumerable: fnGlobalObject() });
+        Object.defineProperty(obj, "property", { enumerable: this });
 
         for (var prop in obj) {
             if (prop === "property") {

--- a/test/built-ins/Object/defineProperty/15.2.3.6-3-98.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-3-98.js
@@ -7,14 +7,13 @@ description: >
     Object.defineProperty - 'Attributes' is the global object that
     uses Object's [[Get]] method to access the 'configurable' property
     (8.10.5 step 4.a)
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
 
-            fnGlobalObject().configurable = true;
+            this.configurable = true;
 
-            Object.defineProperty(obj, "property", fnGlobalObject());
+            Object.defineProperty(obj, "property", this);
 
             var beforeDeleted = obj.hasOwnProperty("property");
 

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-354-13.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-354-13.js
@@ -8,11 +8,11 @@ description: >
     property successfully when [[Configurable]] attribute is true and
     [[Writable]] attribute is false, 'O' is the global object (8.12.9
     - step Note)
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
 
-var obj = fnGlobalObject();
+var obj = this;
 
 try {
     Object.defineProperty(obj, "0", {

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-354-2.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-354-2.js
@@ -8,7 +8,7 @@ description: >
     property 'P' successfully when [[Configurable]] attribute is true
     and [[Writable]] attribute is false, 'A' is an Array object
     (8.12.9 step - Note)
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
 

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-354-4.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-354-4.js
@@ -7,11 +7,11 @@ description: >
     Object.defineProperty will update [[Value]] attribute successfully
     when [[Configurable]] attribute is true and [[Writable]] attribute
     is false, 'O' is the global object (8.12.9 - step Note)
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
 
-var obj = fnGlobalObject();
+var obj = this;
 
 try {
     Object.defineProperty(obj, "property", {

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-354-8.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-354-8.js
@@ -7,12 +7,10 @@ description: >
     ES5 Attributes - property 'P' with attributes [[Writable]]: false,
     [[Enumerable]]: true, [[Configurable]]: true is non-writable using
     simple assignment, 'O' is the global object
-includes:
-    - propertyHelper.js
-    - fnGlobalObject.js
+includes: [propertyHelper.js]
 ---*/
 
-var obj = fnGlobalObject();
+var obj = this;
 
     Object.defineProperty(obj, "prop", {
         value: 2010,

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-360-3.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-360-3.js
@@ -8,12 +8,10 @@ description: >
     [[Writable]]: false, [[Enumerable]]: true, [[Configurable]]: true
     to an accessor property, 'O' is the global object (8.12.9 - step
     9.b.i)
-includes:
-    - propertyHelper.js
-    - fnGlobalObject.js
+includes: [propertyHelper.js]
 ---*/
 
-var obj = fnGlobalObject();
+var obj = this;
 
     Object.defineProperty(obj, "prop", {
         value: 2010,

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-360-7.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-360-7.js
@@ -8,14 +8,14 @@ description: >
     attributes are [[Writable]]: false, [[Enumerable]]: true,
     [[Configurable]]: true to an accessor property, 'O' is the global
     object (8.12.9 - step 9.b.i)
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
 function getFunc() {
         return 20;
     }
 
-var obj = fnGlobalObject();
+var obj = this;
 try {
     Object.defineProperty(obj, "0", {
         value: 2010,

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-399.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-399.js
@@ -6,16 +6,15 @@ es5id: 15.2.3.6-4-399
 description: >
     ES5 Attributes - [[Value]] attribute of data property is the
     global object
-includes: [fnGlobalObject.js]
 ---*/
 
         var obj = {};
 
         Object.defineProperty(obj, "prop", {
-            value: fnGlobalObject()
+            value: this
         });
 
         var desc = Object.getOwnPropertyDescriptor(obj, "prop");
 
-assert.sameValue(obj.prop, fnGlobalObject(), 'obj.prop');
-assert.sameValue(desc.value, fnGlobalObject(), 'desc.value');
+assert.sameValue(obj.prop, this, 'obj.prop');
+assert.sameValue(desc.value, this, 'desc.value');

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-45.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-45.js
@@ -7,18 +7,18 @@ description: >
     Object.defineProperty - 'O' is the global object that uses
     Object's [[GetOwnProperty]] method to access the 'name' property
     (8.12.9 step 1)
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "foo", {
+Object.defineProperty(this, "foo", {
     value: 12,
     configurable: true
 });
 
-verifyEqualTo(fnGlobalObject(), "foo", 12);
+verifyEqualTo(this, "foo", 12);
 
-verifyNotWritable(fnGlobalObject(), "foo");
+verifyNotWritable(this, "foo");
 
-verifyNotEnumerable(fnGlobalObject(), "foo");
+verifyNotEnumerable(this, "foo");
 
-verifyConfigurable(fnGlobalObject(), "foo");
+verifyConfigurable(this, "foo");

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-531-13.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-531-13.js
@@ -8,11 +8,11 @@ description: >
     of indexed accessor property 'P' successfully when
     [[Configurable]] attribute is true, 'O' is the global object
     (8.12.9 step 11)
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
 
-var obj = fnGlobalObject();
+var obj = this;
 try {
     obj.verifySetFunction = "data";
     Object.defineProperty(obj, "0", {

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-531-17.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-531-17.js
@@ -7,10 +7,9 @@ description: >
     ES5 Attributes - Updating an indexed accessor property 'P' using
     simple assignment is successful, 'O' is the global object (8.12.5
     step 5.b)
-includes: [fnGlobalObject.js]
 ---*/
 
-        var obj = fnGlobalObject();
+        var obj = this;
 
             obj.verifySetFunc = "data";
             var setFunc = function (value) {

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-531-4.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-531-4.js
@@ -7,11 +7,11 @@ description: >
     Object.defineProperty will update [[Get]] and [[Set]] attributes
     of named accessor property 'P' successfully when [[Configurable]]
     attribute is true, 'O' is the global object (8.12.9 step 11)
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
 
-var obj = fnGlobalObject();
+var obj = this;
 try {
     obj.verifySetFunction = "data";
     Object.defineProperty(obj, "property", {

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-531-8.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-531-8.js
@@ -7,12 +7,10 @@ description: >
     ES5 Attributes - Updating a named accessor property 'P' without
     [[Set]] using simple assignment is failed, 'O' is the global
     object (8.12.5 step 5.b)
-includes:
-    - propertyHelper.js
-    - fnGlobalObject.js
+includes: [propertyHelper.js]
 ---*/
 
-var obj = fnGlobalObject();
+var obj = this;
 
     obj.verifySetFunc = "data";
     var getFunc = function () {

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-538-3.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-538-3.js
@@ -7,10 +7,10 @@ description: >
     ES5 Attributes - Updating a named accessor property 'P' whose
     [[Configurable]] attribute is true to a data property is
     successful, 'O' is the global object
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
-var obj = fnGlobalObject();
+var obj = this;
 
 obj.verifySetFunc = "data";
 var getFunc = function () {

--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-538-7.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-538-7.js
@@ -7,10 +7,10 @@ description: >
     ES5 Attributes - Updating an indexed accessor property 'P' whose
     [[Configurable]] attribute is true to a data property is
     successful, 'O' is the global object
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
-var obj = fnGlobalObject();
+var obj = this;
 
 obj.verifySetFunc = "data";
 var getFunc = function () {

--- a/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-10.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-10.js
@@ -6,10 +6,9 @@ es5id: 15.2.3.3-4-10
 description: >
     Object.getOwnPropertyDescriptor returns data desc for functions on
     built-ins (Global.decodeURIComponent)
-includes: [fnGlobalObject.js]
 ---*/
 
-  var global = fnGlobalObject();
+  var global = this;
   var desc = Object.getOwnPropertyDescriptor(global,  "decodeURIComponent");
 
 assert.sameValue(desc.value, global.decodeURIComponent, 'desc.value');

--- a/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-11.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-11.js
@@ -6,10 +6,9 @@ es5id: 15.2.3.3-4-11
 description: >
     Object.getOwnPropertyDescriptor returns data desc for functions on
     built-ins (Global.encodeURIComponent)
-includes: [fnGlobalObject.js]
 ---*/
 
-  var global = fnGlobalObject();
+  var global = this;
   var desc = Object.getOwnPropertyDescriptor(global,  "encodeURIComponent");
 
 assert.sameValue(desc.value, global.encodeURIComponent, 'desc.value');

--- a/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-178.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-178.js
@@ -6,11 +6,10 @@ es5id: 15.2.3.3-4-178
 description: >
     Object.getOwnPropertyDescriptor returns data desc (all false) for
     properties on built-ins (Global.NaN)
-includes: [fnGlobalObject.js]
 ---*/
 
   // in non-strict mode, 'this' is bound to the global object.
-  var desc = Object.getOwnPropertyDescriptor(fnGlobalObject(), "NaN");
+  var desc = Object.getOwnPropertyDescriptor(this, "NaN");
 
 assert.sameValue(desc.writable, false, 'desc.writable');
 assert.sameValue(desc.enumerable, false, 'desc.enumerable');

--- a/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-179.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-179.js
@@ -6,11 +6,10 @@ es5id: 15.2.3.3-4-179
 description: >
     Object.getOwnPropertyDescriptor returns data desc (all false) for
     properties on built-ins (Global.Infinity)
-includes: [fnGlobalObject.js]
 ---*/
 
   // in non-strict mode, 'this' is bound to the global object.
-  var desc = Object.getOwnPropertyDescriptor(fnGlobalObject(),  "Infinity");
+  var desc = Object.getOwnPropertyDescriptor(this,  "Infinity");
 
 assert.sameValue(desc.writable, false, 'desc.writable');
 assert.sameValue(desc.enumerable, false, 'desc.enumerable');

--- a/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-180.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-180.js
@@ -6,11 +6,10 @@ es5id: 15.2.3.3-4-180
 description: >
     Object.getOwnPropertyDescriptor returns data desc (all false) for
     properties on built-ins (Global.undefined)
-includes: [fnGlobalObject.js]
 ---*/
 
   // in non-strict mode, 'this' is bound to the global object.
-  var desc = Object.getOwnPropertyDescriptor(fnGlobalObject(),  "undefined");
+  var desc = Object.getOwnPropertyDescriptor(this,  "undefined");
 
 assert.sameValue(desc.writable, false, 'desc.writable');
 assert.sameValue(desc.enumerable, false, 'desc.enumerable');

--- a/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-4.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-4.js
@@ -6,10 +6,9 @@ es5id: 15.2.3.3-4-4
 description: >
     Object.getOwnPropertyDescriptor returns data desc for functions on
     built-ins (Global.eval)
-includes: [fnGlobalObject.js]
 ---*/
 
-  var global = fnGlobalObject();
+  var global = this;
   var desc = Object.getOwnPropertyDescriptor(global,  "eval");
 
 assert.sameValue(desc.value, global.eval, 'desc.value');

--- a/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-5.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-5.js
@@ -6,10 +6,9 @@ es5id: 15.2.3.3-4-5
 description: >
     Object.getOwnPropertyDescriptor returns data desc for functions on
     built-ins (Global.parseInt)
-includes: [fnGlobalObject.js]
 ---*/
 
-  var global = fnGlobalObject();
+  var global = this;
   var desc = Object.getOwnPropertyDescriptor(global,  "parseInt");
 
 assert.sameValue(desc.value, global.parseInt, 'desc.value');

--- a/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-6.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-6.js
@@ -6,10 +6,9 @@ es5id: 15.2.3.3-4-6
 description: >
     Object.getOwnPropertyDescriptor returns data desc for functions on
     built-ins (Global.parseFloat)
-includes: [fnGlobalObject.js]
 ---*/
 
-  var global = fnGlobalObject();
+  var global = this;
   var desc = Object.getOwnPropertyDescriptor(global, "parseFloat");
 
 assert.sameValue(desc.value, global.parseFloat, 'desc.value');

--- a/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-7.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-7.js
@@ -6,10 +6,9 @@ es5id: 15.2.3.3-4-7
 description: >
     Object.getOwnPropertyDescriptor returns data desc for functions on
     built-ins (Global.isNaN)
-includes: [fnGlobalObject.js]
 ---*/
 
-  var global = fnGlobalObject();
+  var global = this;
   var desc = Object.getOwnPropertyDescriptor(global,  "isNaN");
 
 assert.sameValue(desc.value, global.isNaN, 'desc.value');

--- a/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-8.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-8.js
@@ -6,10 +6,9 @@ es5id: 15.2.3.3-4-8
 description: >
     Object.getOwnPropertyDescriptor returns data desc for functions on
     built-ins (Global.isFinite)
-includes: [fnGlobalObject.js]
 ---*/
 
-  var global = fnGlobalObject();
+  var global = this;
   var desc = Object.getOwnPropertyDescriptor(global,  "isFinite");
 
 assert.sameValue(desc.value, global.isFinite, 'desc.value');

--- a/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-9.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-9.js
@@ -6,10 +6,9 @@ es5id: 15.2.3.3-4-9
 description: >
     Object.getOwnPropertyDescriptor returns data desc for functions on
     built-ins (Global.decodeURI)
-includes: [fnGlobalObject.js]
 ---*/
 
-  var global = fnGlobalObject();
+  var global = this;
   var desc = Object.getOwnPropertyDescriptor(global, "decodeURI");
 
 assert.sameValue(desc.value, global.decodeURI, 'desc.value');

--- a/test/built-ins/Object/getOwnPropertyDescriptors/tamper-with-global-object.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptors/tamper-with-global-object.js
@@ -6,7 +6,6 @@ description: >
     Object.getOwnPropertyDescriptors should not have its behavior impacted by modifications to the global property Object
 esid: pending
 author: Jordan Harband
-includes: [fnGlobalObject.js]
 ---*/
 
 function fakeObject() {
@@ -15,7 +14,7 @@ function fakeObject() {
 fakeObject.getOwnPropertyDescriptors = Object.getOwnPropertyDescriptors;
 fakeObject.keys = Object.keys;
 
-var global = fnGlobalObject();
+var global = this;
 global.Object = fakeObject;
 
 assert.sameValue(Object, fakeObject, 'Sanity check failed: could not modify the global Object');

--- a/test/built-ins/Object/getOwnPropertyNames/15.2.3.4-4-1.js
+++ b/test/built-ins/Object/getOwnPropertyNames/15.2.3.4-4-1.js
@@ -4,10 +4,9 @@
 /*---
 es5id: 15.2.3.4-4-1
 description: Object.getOwnPropertyNames returns array of property names (Global)
-includes: [fnGlobalObject.js]
 ---*/
 
-        var result = Object.getOwnPropertyNames(fnGlobalObject());
+        var result = Object.getOwnPropertyNames(this);
         var expResult = ["NaN", "Infinity", "undefined", "eval", "parseInt", "parseFloat", "isNaN", "isFinite", "decodeURI", "decodeURIComponent", "encodeURI", "encodeURIComponent", "Object", "Function", "Array", "String", "Boolean", "Number", "Date", "Date", "RegExp", "Error", "EvalError", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError", "Math", "JSON"];
 
         var result1 = {};

--- a/test/built-ins/Object/getPrototypeOf/15.2.3.2-2-30.js
+++ b/test/built-ins/Object/getPrototypeOf/15.2.3.2-2-30.js
@@ -6,9 +6,8 @@ es5id: 15.2.3.2-2-30
 description: >
     Object.getPrototypeOf returns the [[Prototype]] of its parameter
     (the global object)
-includes: [fnGlobalObject.js]
 ---*/
 
-        var proto = Object.getPrototypeOf(fnGlobalObject());
+        var proto = Object.getPrototypeOf(this);
 
-assert.sameValue(proto.isPrototypeOf(fnGlobalObject()), true, 'proto.isPrototypeOf(fnGlobalObject())');
+assert.sameValue(proto.isPrototypeOf(this), true, 'proto.isPrototypeOf(this)');

--- a/test/built-ins/Object/isExtensible/15.2.3.13-2-1.js
+++ b/test/built-ins/Object/isExtensible/15.2.3.13-2-1.js
@@ -4,10 +4,9 @@
 /*---
 es5id: 15.2.3.13-2-1
 description: Object.isExtensible returns true for all built-in objects (Global)
-includes: [fnGlobalObject.js]
 ---*/
 
-var global = fnGlobalObject();
+var global = this;
 
 assert(Object.isExtensible(global));
 

--- a/test/built-ins/Object/isExtensible/15.2.3.13-2-29.js
+++ b/test/built-ins/Object/isExtensible/15.2.3.13-2-29.js
@@ -4,7 +4,6 @@
 /*---
 es5id: 15.2.3.13-2-29
 description: Object.isExtensible returns true for the global object
-includes: [fnGlobalObject.js]
 ---*/
 
-assert(Object.isExtensible(fnGlobalObject()), 'Object.isExtensible(fnGlobalObject()) !== true');
+assert(Object.isExtensible(this), 'Object.isExtensible(this) !== true');

--- a/test/built-ins/Object/isFrozen/15.2.3.12-3-1.js
+++ b/test/built-ins/Object/isFrozen/15.2.3.12-3-1.js
@@ -4,7 +4,6 @@
 /*---
 es5id: 15.2.3.12-3-1
 description: Object.isFrozen returns false for all built-in objects (Global)
-includes: [fnGlobalObject.js]
 ---*/
 
-assert(!Object.isFrozen(fnGlobalObject()));
+assert(!Object.isFrozen(this));

--- a/test/built-ins/Object/isSealed/15.2.3.11-4-1.js
+++ b/test/built-ins/Object/isSealed/15.2.3.11-4-1.js
@@ -4,7 +4,6 @@
 /*---
 es5id: 15.2.3.11-4-1
 description: Object.isSealed returns false for all built-in objects (Global)
-includes: [fnGlobalObject.js]
 ---*/
 
-assert(!Object.isSealed(fnGlobalObject()));
+assert(!Object.isSealed(this));

--- a/test/built-ins/Object/keys/15.2.3.14-6-6.js
+++ b/test/built-ins/Object/keys/15.2.3.14-6-6.js
@@ -6,10 +6,9 @@ es5id: 15.2.3.14-6-6
 description: >
     Object.keys - the order of elements in returned array is the same
     with the order of properties in 'O' (global Object)
-includes: [fnGlobalObject.js]
 ---*/
 
-        var obj = fnGlobalObject();
+        var obj = this;
 
         var tempArray = [];
         for (var p in obj) {

--- a/test/built-ins/Promise/S25.4.3.1_A1.1_T1.js
+++ b/test/built-ins/Promise/S25.4.3.1_A1.1_T1.js
@@ -7,10 +7,9 @@ info: >
 es6id: S25.4.3.1_A1.1_T1
 author: Sam Mikes
 description: Promise === global.Promise
-includes: [fnGlobalObject.js]
 ---*/
 
-var global = fnGlobalObject();
+var global = this;
 
 if (Promise !== global.Promise) {
     $ERROR("Expected Promise === global.Promise.");

--- a/test/built-ins/Promise/S25.4.3.1_A5.1_T1.js
+++ b/test/built-ins/Promise/S25.4.3.1_A5.1_T1.js
@@ -10,10 +10,9 @@ es6id: S25.4.3.1_A5.1_T1
 author: Sam Mikes
 description: Promise executor gets default handling for 'this'
 flags: [async, noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-var expectedThis = fnGlobalObject();
+var expectedThis = this;
 
 var p = new Promise(function (resolve) {
     if (this !== expectedThis) {

--- a/test/built-ins/Promise/prototype/then/rxn-handler-fulfilled-invoke-nonstrict.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-fulfilled-invoke-nonstrict.js
@@ -10,10 +10,9 @@ author: Sam Mikes
 description: >
     "fulfilled" handler invoked correctly outside of strict mode
 flags: [async, noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-var expectedThis = fnGlobalObject(),
+var expectedThis = this,
     obj = {};
 
 var p = Promise.resolve(obj).then(function(arg) {

--- a/test/built-ins/Promise/prototype/then/rxn-handler-rejected-invoke-nonstrict.js
+++ b/test/built-ins/Promise/prototype/then/rxn-handler-rejected-invoke-nonstrict.js
@@ -10,10 +10,9 @@ author: Sam Mikes
 description: >
     "rejected" handler invoked correctly outside of strict mode
 flags: [async, noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-var expectedThis = fnGlobalObject(),
+var expectedThis = this,
     obj = {};
 
 var p = Promise.reject(obj).then(function () {

--- a/test/built-ins/RegExp/prototype/Symbol.replace/fn-invoke-this-no-strict.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/fn-invoke-this-no-strict.js
@@ -16,7 +16,6 @@ info: >
            iv. Let replValue be Call(replaceValue, undefined, replacerArgs).
            [...]
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 features: [Symbol.replace]
 ---*/
 
@@ -27,4 +26,4 @@ var replacer = function() {
 
 /./[Symbol.replace]('x', replacer);
 
-assert.sameValue(thisVal, fnGlobalObject());
+assert.sameValue(thisVal, this);

--- a/test/built-ins/String/prototype/match/S15.5.4.10_A1_T3.js
+++ b/test/built-ins/String/prototype/match/S15.5.4.10_A1_T3.js
@@ -5,18 +5,17 @@
 info: String.prototype.match (regexp)
 es5id: 15.5.4.10_A1_T3
 description: Checking by using eval
-includes: [fnGlobalObject.js]
 ---*/
 
-var match = String.prototype.match.bind(fnGlobalObject());
+var match = String.prototype.match.bind(this);
 
 try {
-    fnGlobalObject().toString = Object.prototype.toString;
+    this.toString = Object.prototype.toString;
 } catch (e) { ; }
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
-if ((fnGlobalObject().toString === Object.prototype.toString)  && //Ensure we could overwrite global obj's toString
+if ((this.toString === Object.prototype.toString)  && //Ensure we could overwrite global obj's toString
     (match(eval("\"bj\""))[0] !== "bj")) {
   $ERROR('#1: match = String.prototype.match.bind(this); match(eval("\\"bj\\""))[0] === "bj". Actual: '+match(eval("\"bj\""))[0] );
 }

--- a/test/built-ins/String/prototype/replace/15.5.4.11-1.js
+++ b/test/built-ins/String/prototype/replace/15.5.4.11-1.js
@@ -7,12 +7,12 @@ description: >
     'this' object used by the replaceValue function of a
     String.prototype.replace invocation
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
   var retVal = 'x'.replace(/x/, 
                            function() { 
-                               if (this===fnGlobalObject()) {
+                               if (this===global) {
                                    return 'y';
                                } else {
                                    return 'z';

--- a/test/built-ins/TypedArrays/from/mapfn-this-without-thisarg-non-strict.js
+++ b/test/built-ins/TypedArrays/from/mapfn-this-without-thisarg-non-strict.js
@@ -15,12 +15,12 @@ info: >
     c. If mapping is true, then
       i. Let mappedValue be ? Call(mapfn, T, « kValue, k »).
   ...
-includes: [testTypedArray.js, fnGlobalObject.js]
+includes: [testTypedArray.js]
 flags: [noStrict]
 ---*/
 
 var source = [42, 43];
-var global = fnGlobalObject();
+var global = this;
 
 testWithTypedArrayConstructors(function(TA) {
   var results = [];

--- a/test/built-ins/undefined/15.1.1.3-0.js
+++ b/test/built-ins/undefined/15.1.1.3-0.js
@@ -6,10 +6,9 @@ es5id: 15.1.1.3-0
 description: >
     Global.undefined is a data property with default attribute values
     (false)
-includes: [fnGlobalObject.js]
 ---*/
 
-    var desc = Object.getOwnPropertyDescriptor(fnGlobalObject(), 'undefined');
+    var desc = Object.getOwnPropertyDescriptor(this, 'undefined');
 
 assert.sameValue(desc.writable, false, 'desc.writable');
 assert.sameValue(desc.enumerable, false, 'desc.enumerable');

--- a/test/built-ins/undefined/15.1.1.3-2.js
+++ b/test/built-ins/undefined/15.1.1.3-2.js
@@ -5,10 +5,9 @@
 es5id: 15.1.1.3-2
 description: undefined is not writable, should throw TypeError in strict mode
 flags: [onlyStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-var global = fnGlobalObject();
+var global = this;
 
 assert.throws(TypeError, function() {
   global["undefined"] = 5;  // Should throw a TypeError as per 8.12.5

--- a/test/built-ins/undefined/S15.1.1.3_A3_T1.js
+++ b/test/built-ins/undefined/S15.1.1.3_A3_T1.js
@@ -5,14 +5,14 @@
 info: The undefined is DontDelete
 es5id: 15.1.1.3_A3.1
 description: Use delete
-includes: [propertyHelper.js, fnGlobalObject.js]
+includes: [propertyHelper.js]
 ---*/
 
 // CHECK#1
-verifyNotConfigurable(fnGlobalObject(), "undefined");
+verifyNotConfigurable(this, "undefined");
 
 try {
-  if (delete fnGlobalObject().undefined !== false) {
+  if (delete this.undefined !== false) {
     $ERROR('#1: delete undefined === false.');
   }
 } catch (e) {

--- a/test/intl402/Intl/8.0_L15.js
+++ b/test/intl402/Intl/8.0_L15.js
@@ -8,10 +8,8 @@ description: >
     defined by the introduction of chapter 17 of the ECMAScript
     Language Specification.
 author: Norbert Lindenberg
-includes:
-    - fnGlobalObject.js
-    - testBuiltInObject.js
+includes: [testBuiltInObject.js]
 ---*/
 
-testBuiltInObject(fnGlobalObject().Intl, false, false, []);
+testBuiltInObject(this.Intl, false, false, []);
 testBuiltInObject(Intl, false, false, ["Collator", "NumberFormat", "DateTimeFormat"]);

--- a/test/language/expressions/assignment/11.13.1-4-1.js
+++ b/test/language/expressions/assignment/11.13.1-4-1.js
@@ -8,7 +8,6 @@ description: >
     simple assignment creates property on the global object if
     LeftHandSide is an unresolvable reference
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
   function foo() {
@@ -16,7 +15,7 @@ includes: [fnGlobalObject.js]
   }
   foo();
 
-  var desc = Object.getOwnPropertyDescriptor(fnGlobalObject(), '__ES3_1_test_suite_test_11_13_1_unique_id_3__');
+  var desc = Object.getOwnPropertyDescriptor(this, '__ES3_1_test_suite_test_11_13_1_unique_id_3__');
 
 assert.sameValue(desc.value, 42, 'desc.value');
 assert.sameValue(desc.writable, true, 'desc.writable');

--- a/test/language/expressions/assignment/11.13.1-4-27-s.js
+++ b/test/language/expressions/assignment/11.13.1-4-27-s.js
@@ -7,9 +7,9 @@ description: >
     simple assignment throws TypeError if LeftHandSide is a readonly
     property in strict mode (Global.undefined)
 flags: [onlyStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
 assert.throws(TypeError, function() {
-      fnGlobalObject().undefined = 42;
+      global.undefined = 42;
 });

--- a/test/language/expressions/assignment/11.13.1-4-3-s.js
+++ b/test/language/expressions/assignment/11.13.1-4-3-s.js
@@ -7,10 +7,9 @@ description: >
     simple assignment throws TypeError if LeftHandSide is a readonly
     property in strict mode (Global.Infinity)
 flags: [onlyStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-
+var global = this;
 assert.throws(TypeError, function() {
-      fnGlobalObject().Infinity = 42;
+      global.Infinity = 42;
 });

--- a/test/language/expressions/assignment/S11.13.1_A5_T5.js
+++ b/test/language/expressions/assignment/S11.13.1_A5_T5.js
@@ -11,20 +11,19 @@ description: >
     created Reference even if the environment binding is no longer present.
     No ReferenceError is thrown when assignment is in strict-mode code and the
     original binding is no longer present.
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+var global = this;
+Object.defineProperty(this, "x", {
   configurable: true,
   value: 1
 });
 
 (function() {
   "use strict";
-  x = (delete fnGlobalObject().x, 2);
+  x = (delete global.x, 2);
 })();
 
-if (fnGlobalObject().x !== 2) {
-  $ERROR('#1: fnGlobalObject().x === 2. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 2) {
+  $ERROR('#1: this.x === 2. Actual: ' + (this.x));
 }

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.10_T5.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.10_T5.js
@@ -12,11 +12,9 @@ description: >
     No ReferenceError is thrown when 'x ^= y' is in strict-mode code and the
     original binding is no longer present.
     Check operator is "x ^= y".
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -29,6 +27,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   x ^= 3;
 })();
 
-if (fnGlobalObject().x !== 1) {
-  $ERROR('#1: fnGlobalObject().x === 1. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 1) {
+  $ERROR('#1: this.x === 1. Actual: ' + (this.x));
 }

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.11_T5.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.11_T5.js
@@ -12,11 +12,9 @@ description: >
     No ReferenceError is thrown when 'x |= y' is in strict-mode code and the
     original binding is no longer present.
     Check operator is "x |= y".
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -29,6 +27,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   x |= 4;
 })();
 
-if (fnGlobalObject().x !== 6) {
-  $ERROR('#1: fnGlobalObject().x === 6. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 6) {
+  $ERROR('#1: this.x === 6. Actual: ' + (this.x));
 }

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.1_T5.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.1_T5.js
@@ -12,11 +12,9 @@ description: >
     No ReferenceError is thrown when 'x *= y' is in strict-mode code and the
     original binding is no longer present.
     Check operator is "x *= y".
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -29,6 +27,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   x *= 3;
 })();
 
-if (fnGlobalObject().x !== 6) {
-  $ERROR('#1: fnGlobalObject().x === 6. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 6) {
+  $ERROR('#1: this.x === 6. Actual: ' + (this.x));
 }

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.2_T5.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.2_T5.js
@@ -12,11 +12,9 @@ description: >
     No ReferenceError is thrown when 'x /= y' is in strict-mode code and the
     original binding is no longer present.
     Check operator is "x /= y".
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -29,6 +27,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   x /= 3;
 })();
 
-if (fnGlobalObject().x !== 2) {
-  $ERROR('#1: fnGlobalObject().x === 2. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 2) {
+  $ERROR('#1: this.x === 2. Actual: ' + (this.x));
 }

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.3_T5.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.3_T5.js
@@ -12,11 +12,9 @@ description: >
     No ReferenceError is thrown when 'x %= y' is in strict-mode code and the
     original binding is no longer present.
     Check operator is "x %= y".
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -29,6 +27,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   x %= 3;
 })();
 
-if (fnGlobalObject().x !== 2) {
-  $ERROR('#1: fnGlobalObject().x === 2. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 2) {
+  $ERROR('#1: this.x === 2. Actual: ' + (this.x));
 }

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.4_T5.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.4_T5.js
@@ -12,11 +12,9 @@ description: >
     No ReferenceError is thrown when 'x += y' is in strict-mode code and the
     original binding is no longer present.
     Check operator is "x += y".
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -29,6 +27,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   x += 1;
 })();
 
-if (fnGlobalObject().x !== 3) {
-  $ERROR('#1: fnGlobalObject().x === 3. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 3) {
+  $ERROR('#1: this.x === 3. Actual: ' + (this.x));
 }

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.5_T5.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.5_T5.js
@@ -12,11 +12,9 @@ description: >
     No ReferenceError is thrown when 'x -= y' is in strict-mode code and the
     original binding is no longer present.
     Check operator is "x -= y".
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -29,6 +27,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   x -= 1;
 })();
 
-if (fnGlobalObject().x !== 1) {
-  $ERROR('#1: fnGlobalObject().x === 1. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 1) {
+  $ERROR('#1: this.x === 1. Actual: ' + (this.x));
 }

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.6_T5.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.6_T5.js
@@ -12,11 +12,9 @@ description: >
     No ReferenceError is thrown when 'x <<= y' is in strict-mode code and the
     original binding is no longer present.
     Check operator is "x <<= y".
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -29,6 +27,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   x <<= 3;
 })();
 
-if (fnGlobalObject().x !== 16) {
-  $ERROR('#1: fnGlobalObject().x === 16. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 16) {
+  $ERROR('#1: this.x === 16. Actual: ' + (this.x));
 }

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.7_T5.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.7_T5.js
@@ -12,11 +12,9 @@ description: >
     No ReferenceError is thrown when 'x >>= y' is in strict-mode code and the
     original binding is no longer present.
     Check operator is "x >>= y".
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -29,6 +27,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   x >>= 3;
 })();
 
-if (fnGlobalObject().x !== 2) {
-  $ERROR('#1: fnGlobalObject().x === 2. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 2) {
+  $ERROR('#1: this.x === 2. Actual: ' + (this.x));
 }

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.8_T5.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.8_T5.js
@@ -12,11 +12,9 @@ description: >
     No ReferenceError is thrown when 'x >>>= y' is in strict-mode code and the
     original binding is no longer present.
     Check operator is "x >>>= y".
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -29,6 +27,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   x >>>= 3;
 })();
 
-if (fnGlobalObject().x !== 2) {
-  $ERROR('#1: fnGlobalObject().x === 2. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 2) {
+  $ERROR('#1: this.x === 2. Actual: ' + (this.x));
 }

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.9_T5.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.9_T5.js
@@ -12,11 +12,9 @@ description: >
     No ReferenceError is thrown when 'x &= y' is in strict-mode code and the
     original binding is no longer present.
     Check operator is "x &= y".
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -29,6 +27,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   x &= 3;
 })();
 
-if (fnGlobalObject().x !== 1) {
-  $ERROR('#1: fnGlobalObject().x === 1. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 1) {
+  $ERROR('#1: this.x === 1. Actual: ' + (this.x));
 }

--- a/test/language/expressions/delete/11.4.1-4.a-8-s.js
+++ b/test/language/expressions/delete/11.4.1-4.a-8-s.js
@@ -10,10 +10,10 @@ description: >
     delete operator throws TypeError when deleting a non-configurable
     data property in strict mode
 flags: [onlyStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
   // NaN (15.1.1.1) has [[Configurable]] set to false.
 assert.throws(TypeError, function() {
-    delete fnGlobalObject().NaN;
+    delete global.NaN;
 });

--- a/test/language/expressions/postfix-decrement/S11.3.2_A5_T5.js
+++ b/test/language/expressions/postfix-decrement/S11.3.2_A5_T5.js
@@ -11,11 +11,9 @@ description: >
     created Reference even if the environment binding is no longer present.
     No ReferenceError is thrown when 'x--' is in strict-mode code and the
     original binding is no longer present.
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -28,6 +26,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   x--;
 })();
 
-if (fnGlobalObject().x !== 1) {
-  $ERROR('#1: fnGlobalObject().x === 1. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 1) {
+  $ERROR('#1: this.x === 1. Actual: ' + (this.x));
 }

--- a/test/language/expressions/postfix-increment/S11.3.1_A5_T5.js
+++ b/test/language/expressions/postfix-increment/S11.3.1_A5_T5.js
@@ -11,11 +11,9 @@ description: >
     created Reference even if the environment binding is no longer present.
     No ReferenceError is thrown when 'x++' is in strict-mode code and the
     original binding is no longer present.
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -28,6 +26,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   x++;
 })();
 
-if (fnGlobalObject().x !== 3) {
-  $ERROR('#1: fnGlobalObject().x === 3. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 3) {
+  $ERROR('#1: this.x === 3. Actual: ' + (this.x));
 }

--- a/test/language/expressions/prefix-decrement/S11.4.5_A5_T5.js
+++ b/test/language/expressions/prefix-decrement/S11.4.5_A5_T5.js
@@ -11,11 +11,9 @@ description: >
     created Reference even if the environment binding is no longer present.
     No ReferenceError is thrown when '--x' is in strict-mode code and the
     original binding is no longer present.
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -28,6 +26,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   --x;
 })();
 
-if (fnGlobalObject().x !== 1) {
-  $ERROR('#1: fnGlobalObject().x === 1. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 1) {
+  $ERROR('#1: this.x === 1. Actual: ' + (this.x));
 }

--- a/test/language/expressions/prefix-increment/S11.4.4_A5_T5.js
+++ b/test/language/expressions/prefix-increment/S11.4.4_A5_T5.js
@@ -11,11 +11,9 @@ description: >
     created Reference even if the environment binding is no longer present.
     No ReferenceError is thrown when '++x' is in strict-mode code and the
     original binding is no longer present.
-includes:
-    - fnGlobalObject.js
 ---*/
 
-Object.defineProperty(fnGlobalObject(), "x", {
+Object.defineProperty(this, "x", {
   configurable: true,
   get: function() {
     delete this.x;
@@ -28,6 +26,6 @@ Object.defineProperty(fnGlobalObject(), "x", {
   ++x;
 })();
 
-if (fnGlobalObject().x !== 3) {
-  $ERROR('#1: fnGlobalObject().x === 3. Actual: ' + (fnGlobalObject().x));
+if (this.x !== 3) {
+  $ERROR('#1: this.x === 3. Actual: ' + (this.x));
 }

--- a/test/language/function-code/10.4.3-1-101-s.js
+++ b/test/language/function-code/10.4.3-1-101-s.js
@@ -7,7 +7,6 @@ description: >
     Strict Mode - checking 'this' (non-strict function passed as arg
     to String.prototype.replace from strict context)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 var x = 3;
@@ -18,4 +17,4 @@ function f() {
 }
 
 assert.sameValue(function() {"use strict"; return "ab".replace("b", f);}(), "aa");
-assert.sameValue(x, fnGlobalObject(), 'x');
+assert.sameValue(x, this, 'x');

--- a/test/language/function-code/10.4.3-1-101gs.js
+++ b/test/language/function-code/10.4.3-1-101gs.js
@@ -7,7 +7,6 @@ description: >
     Strict Mode - checking 'this' (non-strict function passed as arg
     to String.prototype.replace from strict context)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 var x = 3;
@@ -17,6 +16,6 @@ function f() {
     return "a";
 }
 
-if ( (!(function() {"use strict"; return "ab".replace("b", f)==="aa";}())) || (x!==fnGlobalObject())) {
+if ( (!(function() {"use strict"; return "ab".replace("b", f)==="aa";}())) || (x!==this)) {
      throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-17-s.js
+++ b/test/language/function-code/10.4.3-1-17-s.js
@@ -5,11 +5,12 @@
 es5id: 10.4.3-1-17-s
 description: Strict Mode - checking 'this' (eval used within strict mode)
 flags: [onlyStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 function testcase() {
   assert.sameValue(eval("typeof this"), "undefined", 'eval("typeof this")');
-  assert.notSameValue(eval("this"), fnGlobalObject(), 'eval("this")');
+  assert.notSameValue(eval("this"), global, 'eval("this")');
 }
 testcase();

--- a/test/language/function-code/10.4.3-1-17gs.js
+++ b/test/language/function-code/10.4.3-1-17gs.js
@@ -7,9 +7,8 @@ description: >
     Strict - checking 'this' from a global scope (eval used within
     strict mode)
 flags: [onlyStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-if (eval("this") !== fnGlobalObject()) {
+if (eval("this") !== this) {
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-18gs.js
+++ b/test/language/function-code/10.4.3-1-18gs.js
@@ -7,9 +7,8 @@ description: >
     Strict - checking 'this' from a global scope (eval includes strict
     directive prologue)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-if (eval("\"use strict\";\nthis") !== fnGlobalObject()) {
+if (eval("\"use strict\";\nthis") !== this) {
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-19-s.js
+++ b/test/language/function-code/10.4.3-1-19-s.js
@@ -7,11 +7,12 @@ description: >
     Strict Mode - checking 'this' (indirect eval used within strict
     mode)
 flags: [onlyStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 function testcase() {
 var my_eval = eval;
-assert.sameValue(my_eval("this"), fnGlobalObject(), 'my_eval("this")');
+assert.sameValue(my_eval("this"), global, 'my_eval("this")');
 }
 testcase();

--- a/test/language/function-code/10.4.3-1-19gs.js
+++ b/test/language/function-code/10.4.3-1-19gs.js
@@ -7,10 +7,9 @@ description: >
     Strict - checking 'this' from a global scope (indirect eval used
     within strict mode)
 flags: [onlyStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 var my_eval = eval;
-if (my_eval("this") !== fnGlobalObject()) {
+if (my_eval("this") !== this) {
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-20-s.js
+++ b/test/language/function-code/10.4.3-1-20-s.js
@@ -7,11 +7,12 @@ description: >
     Strict Mode - checking 'this' (indirect eval includes strict
     directive prologue)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 function testcase() {
 var my_eval = eval;
-assert.sameValue(my_eval("\"use strict\";\nthis"), fnGlobalObject());
+assert.sameValue(my_eval("\"use strict\";\nthis"), this);
 }
 testcase();

--- a/test/language/function-code/10.4.3-1-20gs.js
+++ b/test/language/function-code/10.4.3-1-20gs.js
@@ -7,10 +7,9 @@ description: >
     Strict - checking 'this' from a global scope (indirect eval
     includes strict directive prologue)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 var my_eval = eval;
-if (my_eval("\"use strict\";\nthis") !== fnGlobalObject() ) {
+if (my_eval("\"use strict\";\nthis") !== this ) {
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-21-s.js
+++ b/test/language/function-code/10.4.3-1-21-s.js
@@ -7,12 +7,11 @@ description: >
     Strict Mode - checking 'this' (New'ed object from
     FunctionDeclaration defined within strict mode)
 flags: [onlyStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 function f() {
     return this;
 }
 
-assert.notSameValue((new f()), fnGlobalObject(), '(new f())');
+assert.notSameValue((new f()), this, '(new f())');
 assert.notSameValue(typeof (new f()), "undefined", 'typeof (new f())');

--- a/test/language/function-code/10.4.3-1-21gs.js
+++ b/test/language/function-code/10.4.3-1-21gs.js
@@ -7,12 +7,11 @@ description: >
     Strict - checking 'this' from a global scope (New'ed object from
     FunctionDeclaration defined within strict mode)
 flags: [onlyStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 function f() {
     return this;
 }
-if (((new f()) === fnGlobalObject()) || (typeof (new f()) === "undefined")) {
+if (((new f()) === this) || (typeof (new f()) === "undefined")) {
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-22-s.js
+++ b/test/language/function-code/10.4.3-1-22-s.js
@@ -7,7 +7,6 @@ description: >
     Strict Mode - checking 'this' (New'ed object from
     FunctionDeclaration includes strict directive prologue)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 function f() {
@@ -15,5 +14,5 @@ function f() {
     return this;
 }
 
-assert.notSameValue((new f()), fnGlobalObject(), '(new f())');
+assert.notSameValue((new f()), this, '(new f())');
 assert.notSameValue(typeof (new f()), "undefined", 'typeof (new f())');

--- a/test/language/function-code/10.4.3-1-22gs.js
+++ b/test/language/function-code/10.4.3-1-22gs.js
@@ -7,13 +7,12 @@ description: >
     Strict - checking 'this' from a global scope (New'ed object from
     FunctionDeclaration includes strict directive prologue)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 function f() {
     "use strict";
     return this;
 }
-if (((new f()) === fnGlobalObject()) || (typeof (new f()) === "undefined")) {
+if (((new f()) === this) || (typeof (new f()) === "undefined")) {
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-23-s.js
+++ b/test/language/function-code/10.4.3-1-23-s.js
@@ -7,12 +7,11 @@ description: >
     Strict Mode - checking 'this' (New'ed object from
     FunctionExpression defined within strict mode)
 flags: [onlyStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 var f = function () {
     return this;
 }
 
-assert.notSameValue((new f()), fnGlobalObject(), '(new f())');
+assert.notSameValue((new f()), this, '(new f())');
 assert.notSameValue(typeof (new f()), "undefined", 'typeof (new f())');

--- a/test/language/function-code/10.4.3-1-23gs.js
+++ b/test/language/function-code/10.4.3-1-23gs.js
@@ -7,12 +7,11 @@ description: >
     Strict - checking 'this' from a global scope (New'ed object from
     FunctionExpression defined within strict mode)
 flags: [onlyStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 var f = function () {
     return this;
 }
-if (((new f()) === fnGlobalObject()) || (typeof (new f()) === "undefined")) {
+if (((new f()) === this) || (typeof (new f()) === "undefined")) {
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-24-s.js
+++ b/test/language/function-code/10.4.3-1-24-s.js
@@ -7,7 +7,6 @@ description: >
     Strict Mode - checking 'this' (New'ed object from
     FunctionExpression includes strict directive prologue)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 var f = function () {
@@ -15,5 +14,5 @@ var f = function () {
     return this;
 }
 
-assert.notSameValue((new f()), fnGlobalObject(), '(new f())');
+assert.notSameValue((new f()), this, '(new f())');
 assert.notSameValue(typeof (new f()), "undefined", 'typeof (new f())');

--- a/test/language/function-code/10.4.3-1-24gs.js
+++ b/test/language/function-code/10.4.3-1-24gs.js
@@ -7,13 +7,12 @@ description: >
     Strict - checking 'this' from a global scope (New'ed object from
     FunctionExpression includes strict directive prologue)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 var f = function () {
     "use strict";
     return this;
 }
-if (((new f()) === fnGlobalObject()) || (typeof (new f()) === "undefined")) {
+if (((new f()) === this) || (typeof (new f()) === "undefined")) {
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-25-s.js
+++ b/test/language/function-code/10.4.3-1-25-s.js
@@ -7,12 +7,11 @@ description: >
     Strict Mode - checking 'this' (New'ed object from Anonymous
     FunctionExpression defined within strict mode)
 flags: [onlyStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 var obj = new (function () {
     return this;
 });
 
-assert.notSameValue(obj, fnGlobalObject(), 'obj');
+assert.notSameValue(obj, this, 'obj');
 assert.notSameValue((typeof obj), "undefined", '(typeof obj)');

--- a/test/language/function-code/10.4.3-1-25gs.js
+++ b/test/language/function-code/10.4.3-1-25gs.js
@@ -7,12 +7,11 @@ description: >
     Strict - checking 'this' from a global scope (New'ed object from
     Anonymous FunctionExpression defined within strict mode)
 flags: [onlyStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 var obj = new (function () {
     return this;
 });
-if ((obj === fnGlobalObject()) || (typeof obj === "undefined")) {
+if ((obj === this) || (typeof obj === "undefined")) {
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-26-s.js
+++ b/test/language/function-code/10.4.3-1-26-s.js
@@ -7,7 +7,6 @@ description: >
     Strict Mode - checking 'this' (New'ed object from Anonymous
     FunctionExpression includes strict directive prologue)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 var obj = new (function () {
@@ -15,5 +14,5 @@ var obj = new (function () {
     return this;
 });
 
-assert.notSameValue(obj, fnGlobalObject(), 'obj');
+assert.notSameValue(obj, this, 'obj');
 assert.notSameValue((typeof obj), "undefined", '(typeof obj)');

--- a/test/language/function-code/10.4.3-1-26gs.js
+++ b/test/language/function-code/10.4.3-1-26gs.js
@@ -7,13 +7,12 @@ description: >
     Strict - checking 'this' from a global scope (New'ed object from
     Anonymous FunctionExpression includes strict directive prologue)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 var obj = new (function () {
     "use strict";
     return this;
 });
-if ((obj === fnGlobalObject()) || (typeof obj === "undefined")) {
+if ((obj === this) || (typeof obj === "undefined")) {
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-45-s.js
+++ b/test/language/function-code/10.4.3-1-45-s.js
@@ -7,15 +7,16 @@ description: >
     Strict Mode - checking 'this' (FunctionDeclaration with a strict
     directive prologue defined within a FunctionDeclaration)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 function f1() {
     function f() {
         "use strict";
         return typeof this;
     }
-    return (f()==="undefined") && (this===fnGlobalObject());
+    return (f()==="undefined") && (this===global);
 }
 
 assert(f1(), 'f1() !== true');

--- a/test/language/function-code/10.4.3-1-45gs.js
+++ b/test/language/function-code/10.4.3-1-45gs.js
@@ -8,15 +8,16 @@ description: >
     with a strict directive prologue defined within a
     FunctionDeclaration)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 function f1() {
     function f() {
         "use strict";
         return typeof this;
     }
-    return (f()==="undefined") && (this===fnGlobalObject());
+    return (f()==="undefined") && (this===global);
 }
 if (! f1()) {
     throw "'this' had incorrect value!";

--- a/test/language/function-code/10.4.3-1-46-s.js
+++ b/test/language/function-code/10.4.3-1-46-s.js
@@ -7,15 +7,16 @@ description: >
     Strict Mode - checking 'this' (FunctionExpression with a strict
     directive prologue defined within a FunctionDeclaration)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 function f1() {
     var f = function () {
         "use strict";
         return typeof this;
     }
-    return (f()==="undefined") && (this===fnGlobalObject());
+    return (f()==="undefined") && (this===global);
 }
 
 assert(f1(), 'f1() !== true');

--- a/test/language/function-code/10.4.3-1-46gs.js
+++ b/test/language/function-code/10.4.3-1-46gs.js
@@ -8,15 +8,16 @@ description: >
     with a strict directive prologue defined within a
     FunctionDeclaration)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 function f1() {
     var f = function () {
         "use strict";
         return typeof this;
     }
-    return (f()==="undefined") && (this===fnGlobalObject());
+    return (f()==="undefined") && (this===global);
 }
 if (! f1()) {
     throw "'this' had incorrect value!";

--- a/test/language/function-code/10.4.3-1-47-s.js
+++ b/test/language/function-code/10.4.3-1-47-s.js
@@ -7,14 +7,15 @@ description: >
     Strict Mode - checking 'this' (Anonymous FunctionExpression with a
     strict directive prologue defined within a FunctionDeclaration)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 function f1() {
     return ((function () {
         "use strict";
         return typeof this;
-    })()==="undefined") && (this===fnGlobalObject());
+    })()==="undefined") && (this===global);
 }
 
 assert(f1(), 'f1() !== true');

--- a/test/language/function-code/10.4.3-1-47gs.js
+++ b/test/language/function-code/10.4.3-1-47gs.js
@@ -8,14 +8,15 @@ description: >
     FunctionExpression with a strict directive prologue defined within
     a FunctionDeclaration)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 function f1() {
     return ((function () {
         "use strict";
         return typeof this;
-    })()==="undefined") && (this===fnGlobalObject());
+    })()==="undefined") && (this===global);
 }
 if (! f1()) {
     throw "'this' had incorrect value!";

--- a/test/language/function-code/10.4.3-1-48-s.js
+++ b/test/language/function-code/10.4.3-1-48-s.js
@@ -7,15 +7,16 @@ description: >
     Strict Mode - checking 'this' (FunctionDeclaration with a strict
     directive prologue defined within a FunctionExpression)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 var f1 = function () {
     function f() {
         "use strict";
         return typeof this;
     }
-    return (f()==="undefined") && (this===fnGlobalObject());
+    return (f()==="undefined") && (this===global);
 }
 
 assert(f1(), 'f1() !== true');

--- a/test/language/function-code/10.4.3-1-48gs.js
+++ b/test/language/function-code/10.4.3-1-48gs.js
@@ -8,15 +8,16 @@ description: >
     with a strict directive prologue defined within a
     FunctionExpression)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 var f1 = function () {
     function f() {
         "use strict";
         return typeof this;
     }
-    return (f()==="undefined") && (this===fnGlobalObject());
+    return (f()==="undefined") && (this===global);
 }
 if (! f1()) {
     throw "'this' had incorrect value!";

--- a/test/language/function-code/10.4.3-1-49-s.js
+++ b/test/language/function-code/10.4.3-1-49-s.js
@@ -7,15 +7,16 @@ description: >
     Strict Mode - checking 'this' (FunctionExpression with a strict
     directive prologue defined within a FunctionExpression)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 var f1 = function () {
     var f = function () {
         "use strict";
         return typeof this;
     }
-    return (f()==="undefined") && (this===fnGlobalObject());
+    return (f()==="undefined") && (this===global);
 }
 
 assert(f1(), 'f1() !== true');

--- a/test/language/function-code/10.4.3-1-49gs.js
+++ b/test/language/function-code/10.4.3-1-49gs.js
@@ -8,15 +8,16 @@ description: >
     with a strict directive prologue defined within a
     FunctionExpression)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 var f1 = function () {
     var f = function () {
         "use strict";
         return typeof this;
     }
-    return (f()==="undefined") && (this===fnGlobalObject());
+    return (f()==="undefined") && (this===global);
 }
 if (! f1()) {
     throw "'this' had incorrect value!";

--- a/test/language/function-code/10.4.3-1-50-s.js
+++ b/test/language/function-code/10.4.3-1-50-s.js
@@ -7,14 +7,15 @@ description: >
     Strict Mode - checking 'this' (Anonymous FunctionExpression with a
     strict directive prologue defined within a FunctionExpression)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 var f1 = function () {
     return ((function () {
         "use strict";
         return typeof this;
-    })()==="undefined") && (this===fnGlobalObject());
+    })()==="undefined") && (this===global);
 }
 
 assert(f1(), 'f1() !== true');

--- a/test/language/function-code/10.4.3-1-50gs.js
+++ b/test/language/function-code/10.4.3-1-50gs.js
@@ -8,14 +8,15 @@ description: >
     FunctionExpression with a strict directive prologue defined within
     a FunctionExpression)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 var f1 = function () {
     return ((function () {
         "use strict";
         return typeof this;
-    })()==="undefined") && (this===fnGlobalObject());
+    })()==="undefined") && (this===global);
 }
 if (! f1()) {
     throw "'this' had incorrect value!";

--- a/test/language/function-code/10.4.3-1-51-s.js
+++ b/test/language/function-code/10.4.3-1-51-s.js
@@ -7,8 +7,9 @@ description: >
     Strict Mode - checking 'this' (FunctionDeclaration with a strict
     directive prologue defined within an Anonymous FunctionExpression)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 (function () {
     function f() {
@@ -16,5 +17,5 @@ includes: [fnGlobalObject.js]
         return typeof this;
     }
     assert.sameValue(f(), "undefined", 'f()');
-    assert.sameValue(this, fnGlobalObject(), 'this');
+    assert.sameValue(this, global, 'this');
 })();

--- a/test/language/function-code/10.4.3-1-51gs.js
+++ b/test/language/function-code/10.4.3-1-51gs.js
@@ -8,15 +8,16 @@ description: >
     with a strict directive prologue defined within an Anonymous
     FunctionExpression)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 if (! ((function () {
     function f() {
         "use strict";
         return typeof this;
     }
-    return (f()==="undefined") && (this===fnGlobalObject());
+    return (f()==="undefined") && (this===global);
 })())) {
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-52-s.js
+++ b/test/language/function-code/10.4.3-1-52-s.js
@@ -7,8 +7,9 @@ description: >
     Strict Mode - checking 'this' (FunctionExpression with a strict
     directive prologue defined within an Anonymous FunctionExpression)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global  = this;
 
 (function () {
     var f = function () {
@@ -16,5 +17,5 @@ includes: [fnGlobalObject.js]
         return typeof this;
     }
     assert.sameValue(f(), "undefined", 'f()');
-    assert.sameValue(this, fnGlobalObject(), 'this');
+    assert.sameValue(this, global, 'this');
 })();

--- a/test/language/function-code/10.4.3-1-52gs.js
+++ b/test/language/function-code/10.4.3-1-52gs.js
@@ -8,15 +8,16 @@ description: >
     with a strict directive prologue defined within an Anonymous
     FunctionExpression)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 if (! ((function () {
     var f = function () {
         "use strict";
         return typeof this;
     }
-    return (f()==="undefined") && (this===fnGlobalObject());
+    return (f()==="undefined") && (this===global);
 })())) {
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-53-s.js
+++ b/test/language/function-code/10.4.3-1-53-s.js
@@ -8,13 +8,14 @@ description: >
     strict directive prologue defined within an Anonymous
     FunctionExpression)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 (function () {
     assert.sameValue((function () {
         "use strict";
         return typeof this;
     })(), "undefined");
-    assert.sameValue(this, fnGlobalObject(), 'this');
+    assert.sameValue(this, global, 'this');
 })();

--- a/test/language/function-code/10.4.3-1-53gs.js
+++ b/test/language/function-code/10.4.3-1-53gs.js
@@ -8,14 +8,15 @@ description: >
     FunctionExpression with a strict directive prologue defined within
     an Anonymous FunctionExpression)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
+
+var global = this;
 
 if (! ((function () {
     return ((function () {
         "use strict";
         return typeof this;
-    })()==="undefined") && (this===fnGlobalObject());
+    })()==="undefined") && (this===global);
 })())) {
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-64-s.js
+++ b/test/language/function-code/10.4.3-1-64-s.js
@@ -6,8 +6,7 @@ es5id: 10.4.3-1-64-s
 description: >
     checking 'this' (strict function declaration called by non-strict Function
     constructor)
-includes: [fnGlobalObject.js]
 ---*/
 
-fnGlobalObject().f = function() { "use strict"; return this===undefined;};
+this.f = function() { "use strict"; return this===undefined;};
 assert(Function("return f();")());

--- a/test/language/function-code/10.4.3-1-65-s.js
+++ b/test/language/function-code/10.4.3-1-65-s.js
@@ -6,8 +6,7 @@ es5id: 10.4.3-1-65-s
 description: >
     checking 'this' (strict function declaration called by non-strict new'ed
     Function constructor)
-includes: [fnGlobalObject.js]
 ---*/
 
-fnGlobalObject().f = function()  { "use strict"; return this===undefined;};
+this.f = function()  { "use strict"; return this===undefined;};
 assert((new Function("return f();"))());

--- a/test/language/function-code/10.4.3-1-70-s.js
+++ b/test/language/function-code/10.4.3-1-70-s.js
@@ -6,9 +6,8 @@ es5id: 10.4.3-1-70-s
 description: >
     checking 'this' (strict function declaration called by
     Function.prototype.apply(globalObject))
-includes: [fnGlobalObject.js]
 ---*/
 
 function f() { "use strict"; return this;};
 
-assert.sameValue(f.apply(fnGlobalObject()), fnGlobalObject(), 'f.apply(fnGlobalObject())');
+assert.sameValue(f.apply(this), this, 'f.apply(this)');

--- a/test/language/function-code/10.4.3-1-70gs.js
+++ b/test/language/function-code/10.4.3-1-70gs.js
@@ -6,10 +6,9 @@ es5id: 10.4.3-1-70gs
 description: >
     checking 'this' from a global scope (strict function declaration called by
     Function.prototype.apply(globalObject))
-includes: [fnGlobalObject.js]
 ---*/
 
 function f() { "use strict"; return this;};
-if (f.apply(fnGlobalObject()) !== fnGlobalObject()){
+if (f.apply(this) !== this){
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-75-s.js
+++ b/test/language/function-code/10.4.3-1-75-s.js
@@ -6,9 +6,8 @@ es5id: 10.4.3-1-75-s
 description: >
     checking 'this' (strict function declaration called by
     Function.prototype.call(globalObject))
-includes: [fnGlobalObject.js]
 ---*/
 
 function f() { "use strict"; return this;};
 
-assert.sameValue(f.call(fnGlobalObject()), fnGlobalObject(), 'f.call(fnGlobalObject())');
+assert.sameValue(f.call(this), this, 'f.call(this)');

--- a/test/language/function-code/10.4.3-1-75gs.js
+++ b/test/language/function-code/10.4.3-1-75gs.js
@@ -6,10 +6,9 @@ es5id: 10.4.3-1-75gs
 description: >
     checking 'this' from a global scope (strict function declaration called by
     Function.prototype.call(globalObject))
-includes: [fnGlobalObject.js]
 ---*/
 
 function f() { "use strict"; return this;};
-if (f.call(fnGlobalObject()) !== fnGlobalObject()){
+if (f.call(this) !== this){
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-80-s.js
+++ b/test/language/function-code/10.4.3-1-80-s.js
@@ -7,9 +7,8 @@ description: >
     Strict Mode - checking 'this' (strict function declaration called
     by Function.prototype.bind(globalObject)())
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 function f() { "use strict"; return this;};
 
-assert.sameValue(f.bind(fnGlobalObject())(), fnGlobalObject(), 'f.bind(fnGlobalObject())()');
+assert.sameValue(f.bind(this)(), this, 'f.bind(this)()');

--- a/test/language/function-code/10.4.3-1-80gs.js
+++ b/test/language/function-code/10.4.3-1-80gs.js
@@ -7,10 +7,9 @@ description: >
     Strict - checking 'this' from a global scope (strict function
     declaration called by Function.prototype.bind(globalObject)())
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
 function f() { "use strict"; return this;};
-if (f.bind(fnGlobalObject())() !== fnGlobalObject()){
+if (f.bind(this)() !== this){
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-83-s.js
+++ b/test/language/function-code/10.4.3-1-83-s.js
@@ -7,8 +7,7 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function constructor)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-fnGlobalObject().f = function() {return this!==undefined;};
+this.f = function() {return this!==undefined;};
 assert((function () {return Function("\"use strict\";return f();")();})());

--- a/test/language/function-code/10.4.3-1-84-s.js
+++ b/test/language/function-code/10.4.3-1-84-s.js
@@ -7,8 +7,7 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict new'ed Function constructor)
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-fnGlobalObject().f = function()  { return this!==undefined;};
+this.f = function()  { return this!==undefined;};
 assert((function () {return new Function("\"use strict\";return f();")();})());

--- a/test/language/function-code/10.4.3-1-86-s.js
+++ b/test/language/function-code/10.4.3-1-86-s.js
@@ -7,8 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.apply(null))
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 assert((function () {"use strict"; return f.apply(null);})());

--- a/test/language/function-code/10.4.3-1-86gs.js
+++ b/test/language/function-code/10.4.3-1-86gs.js
@@ -7,10 +7,10 @@ description: >
     Strict - checking 'this' from a global scope (non-strict function
     declaration called by strict Function.prototype.apply(null))
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 if (! ((function () {"use strict"; return f.apply(null);})())){
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-87-s.js
+++ b/test/language/function-code/10.4.3-1-87-s.js
@@ -7,8 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.apply(undefined))
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject()};
+var global = this;
+function f() { return this===global};
 assert((function () {"use strict"; return f.apply(undefined);})());

--- a/test/language/function-code/10.4.3-1-87gs.js
+++ b/test/language/function-code/10.4.3-1-87gs.js
@@ -7,10 +7,10 @@ description: >
     Strict - checking 'this' from a global scope (non-strict function
     declaration called by strict Function.prototype.apply(undefined))
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 if (! ((function () {"use strict"; return f.apply(undefined);})())){
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-89-s.js
+++ b/test/language/function-code/10.4.3-1-89-s.js
@@ -7,8 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.apply(globalObject))
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
 function f() { return this;};
-assert.sameValue((function () {"use strict"; return f.apply(fnGlobalObject()); })(), fnGlobalObject());
+assert.sameValue((function () {"use strict"; return f.apply(global); })(), global);

--- a/test/language/function-code/10.4.3-1-89gs.js
+++ b/test/language/function-code/10.4.3-1-89gs.js
@@ -8,10 +8,10 @@ description: >
     declaration called by strict
     Function.prototype.apply(globalObject))
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
+var global = this;
 function f() { return this;};
-if ((function () {"use strict"; return f.apply(fnGlobalObject());})() !== fnGlobalObject()){
+if ((function () {"use strict"; return f.apply(global);})() !== global){
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-90-s.js
+++ b/test/language/function-code/10.4.3-1-90-s.js
@@ -7,8 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.call())
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 assert((function () {"use strict"; return f.call(); })());

--- a/test/language/function-code/10.4.3-1-90gs.js
+++ b/test/language/function-code/10.4.3-1-90gs.js
@@ -7,10 +7,10 @@ description: >
     Strict - checking 'this' from a global scope (non-strict function
     declaration called by strict Function.prototype.call())
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 if (! ((function () {"use strict"; return f.call();})())){
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-91-s.js
+++ b/test/language/function-code/10.4.3-1-91-s.js
@@ -7,8 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.call(null))
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 assert((function () {"use strict"; return f.call(null); })());

--- a/test/language/function-code/10.4.3-1-91gs.js
+++ b/test/language/function-code/10.4.3-1-91gs.js
@@ -7,10 +7,10 @@ description: >
     Strict - checking 'this' from a global scope (non-strict function
     declaration called by strict Function.prototype.call(null))
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 if (! ((function () {"use strict"; return f.call(null); })())){
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-92-s.js
+++ b/test/language/function-code/10.4.3-1-92-s.js
@@ -7,8 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.call(undefined))
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 assert((function () {"use strict"; return f.call(undefined);})());

--- a/test/language/function-code/10.4.3-1-92gs.js
+++ b/test/language/function-code/10.4.3-1-92gs.js
@@ -7,10 +7,10 @@ description: >
     Strict - checking 'this' from a global scope (non-strict function
     declaration called by strict Function.prototype.call(undefined))
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 if (! ((function () {"use strict"; return f.call(undefined);})())){
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-94-s.js
+++ b/test/language/function-code/10.4.3-1-94-s.js
@@ -7,8 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.call(globalObject))
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
-assert((function () {"use strict"; return f.call(fnGlobalObject());})());
+var global = this;
+function f() { return this===global;};
+assert((function () {"use strict"; return f.call(global);})());

--- a/test/language/function-code/10.4.3-1-94gs.js
+++ b/test/language/function-code/10.4.3-1-94gs.js
@@ -7,10 +7,10 @@ description: >
     Strict - checking 'this' from a global scope (non-strict function
     declaration called by strict Function.prototype.call(globalObject))
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
-if (! ((function () {"use strict"; return f.call(fnGlobalObject());})())){
+var global = this;
+function f() { return this===global;};
+if (! ((function () {"use strict"; return f.call(global);})())){
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-95-s.js
+++ b/test/language/function-code/10.4.3-1-95-s.js
@@ -7,8 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.bind()())
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 assert((function () {"use strict"; return f.bind()(); })());

--- a/test/language/function-code/10.4.3-1-95gs.js
+++ b/test/language/function-code/10.4.3-1-95gs.js
@@ -7,10 +7,10 @@ description: >
     Strict - checking 'this' from a global scope (non-strict function
     declaration called by strict Function.prototype.bind()())
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 if (! ((function () {"use strict"; return f.bind()(); })())){
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-96-s.js
+++ b/test/language/function-code/10.4.3-1-96-s.js
@@ -7,8 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.bind(null)())
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 assert((function () {"use strict"; return f.bind(null)(); })());

--- a/test/language/function-code/10.4.3-1-96gs.js
+++ b/test/language/function-code/10.4.3-1-96gs.js
@@ -7,10 +7,10 @@ description: >
     Strict - checking 'this' from a global scope (non-strict function
     declaration called by strict Function.prototype.bind(null)())
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 if (! ((function () {"use strict"; return f.bind(null)(); })())){
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-97-s.js
+++ b/test/language/function-code/10.4.3-1-97-s.js
@@ -7,8 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.bind(undefined)())
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 assert((function () {"use strict"; return f.bind(undefined)();})());

--- a/test/language/function-code/10.4.3-1-97gs.js
+++ b/test/language/function-code/10.4.3-1-97gs.js
@@ -7,10 +7,10 @@ description: >
     Strict - checking 'this' from a global scope (non-strict function
     declaration called by strict Function.prototype.bind(undefined)())
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
+var global = this;
+function f() { return this===global;};
 if (! ((function () {"use strict"; return f.bind(undefined)(); })())){
     throw "'this' had incorrect value!";
 }

--- a/test/language/function-code/10.4.3-1-99-s.js
+++ b/test/language/function-code/10.4.3-1-99-s.js
@@ -7,8 +7,8 @@ description: >
     Strict Mode - checking 'this' (non-strict function declaration
     called by strict Function.prototype.bind(globalObject)())
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
-assert((function () {"use strict"; return f.bind(fnGlobalObject())();})());
+var global = this;
+function f() { return this===global;};
+assert((function () {"use strict"; return f.bind(global)();})());

--- a/test/language/function-code/10.4.3-1-99gs.js
+++ b/test/language/function-code/10.4.3-1-99gs.js
@@ -8,10 +8,10 @@ description: >
     declaration called by strict
     Function.prototype.bind(globalObject)())
 flags: [noStrict]
-includes: [fnGlobalObject.js]
 ---*/
 
-function f() { return this===fnGlobalObject();};
-if (! ((function () {"use strict"; return f.bind(fnGlobalObject())();})())){
+var global = this;
+function f() { return this===global;};
+if (! ((function () {"use strict"; return f.bind(global)();})())){
     throw "'this' had incorrect value!";
 }

--- a/test/language/identifier-resolution/unscopables.js
+++ b/test/language/identifier-resolution/unscopables.js
@@ -3,7 +3,6 @@
 
 /*---
 es6id: 8.1.1.4.1
-includes: [fnGlobalObject.js]
 description: >
     `Symbol.unscopables` is not referenced when finding bindings in global scope
 info: >
@@ -17,7 +16,7 @@ features: [Symbol.unscopables]
 ---*/
 
 var x = 86;
-fnGlobalObject()[Symbol.unscopables] = {
+this[Symbol.unscopables] = {
   x: true
 };
 assert.sameValue(x, 86);

--- a/test/language/statements/try/12.14-14.js
+++ b/test/language/statements/try/12.14-14.js
@@ -7,10 +7,10 @@ description: >
     Exception object is a function, when an exception parameter is
     called as a function in catch block, global object is passed as
     the this value
-includes: [fnGlobalObject.js]
 flags: [noStrict]
 ---*/
 
+var global = this;
 var result;
 
 (function() {
@@ -20,7 +20,7 @@ var result;
             };
         } catch (e) {
             e();
-            result = fnGlobalObject()._12_14_14_foo;
+            result = global._12_14_14_foo;
         }
 })();
 

--- a/test/language/statements/try/12.14-15.js
+++ b/test/language/statements/try/12.14-15.js
@@ -7,10 +7,10 @@ description: >
     Exception object is a function which is a property of an object,
     when an exception parameter is called as a function in catch
     block, global object is passed as the this value
-includes: [fnGlobalObject.js]
 flags: [noStrict]
 ---*/
 
+var global = this;
 var result;
 
 (function() {
@@ -22,7 +22,7 @@ var result;
             throw obj.test;
         } catch (e) {
             e();
-            result = fnGlobalObject()._12_14_15_foo;
+            result = global._12_14_15_foo;
         }
 })();
 

--- a/test/language/statements/try/12.14-16.js
+++ b/test/language/statements/try/12.14-16.js
@@ -7,10 +7,10 @@ description: >
     Exception object is a function which update in catch block, when
     an exception parameter is called as a function in catch block,
     global object is passed as the this value
-includes: [fnGlobalObject.js]
 flags: [noStrict]
 ---*/
 
+var global = this;
 var result;
 
 (function() {
@@ -25,7 +25,7 @@ var result;
             };
             e = obj.test;
             e();
-            result = fnGlobalObject()._12_14_16_foo;
+            result = global._12_14_16_foo;
         }
 })();
 


### PR DESCRIPTION
This harness function is not necessary in the majority of cases in which
it is used. Remove its usage to simplify tests and decrease the amount
of domain-specific knowledge necessary to contribute to the test suite.

Persist the harness function itself for use by future tests for ES2015
modules (such a helper is necessary for tests that are interpreted as
module code).

This resolves gh-568