### PR TITLE
Add tests for ArraySpeciesCreate

### DIFF
--- a/test/built-ins/Array/prototype/concat/create-ctor-non-object.js
+++ b/test/built-ins/Array/prototype/concat/create-ctor-non-object.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+esid: sec-array.prototype.concat
+description: >
+    Behavior when `constructor` property is neither an Object nor undefined
+info: |
+    1. Let O be ? ToObject(this value).
+    2. Let A be ? ArraySpeciesCreate(O, 0).
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    9. If IsConstructor(C) is false, throw a TypeError exception.
+---*/
+
+var a = [];
+
+a.constructor = null;
+assert.throws(TypeError, function() {
+  a.concat();
+}, 'null value');
+
+a = [];
+a.constructor = 1;
+assert.throws(TypeError, function() {
+  a.concat();
+}, 'number value');
+
+a = [];
+a.constructor = 'string';
+assert.throws(TypeError, function() {
+  a.concat();
+}, 'string value');
+
+a = [];
+a.constructor = true;
+assert.throws(TypeError, function() {
+  a.concat();
+}, 'boolean value');

--- a/test/built-ins/Array/prototype/concat/create-ctor-poisoned.js
+++ b/test/built-ins/Array/prototype/concat/create-ctor-poisoned.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+esid: sec-array.prototype.concat
+description: Abrupt completion from `constructor` property access
+info: |
+    1. Let O be ? ToObject(this value).
+    2. Let A be ? ArraySpeciesCreate(O, 0).
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+---*/
+
+var a = [];
+
+Object.defineProperty(a, 'constructor', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  a.concat();
+});

--- a/test/built-ins/Array/prototype/concat/create-non-array.js
+++ b/test/built-ins/Array/prototype/concat/create-non-array.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+esid: sec-array.prototype.concat
+description: Constructor is ignored for non-Array values
+info: |
+    1. Let O be ? ToObject(this value).
+    2. Let A be ? ArraySpeciesCreate(O, 0).
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    3. Let isArray be ? IsArray(originalArray).
+    4. If isArray is false, return ? ArrayCreate(length).
+---*/
+
+var obj = { length: 0 };
+var callCount = 0;
+var result;
+Object.defineProperty(obj, 'constructor', {
+  get: function() {
+    callCount += 1;
+  }
+});
+
+result = Array.prototype.concat.call(obj);
+
+assert.sameValue(callCount, 0, '`constructor` property not accessed');
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');
+assert.sameValue(result.length, 1, 'array created with appropriate length');
+assert.sameValue(result[0], obj);

--- a/test/built-ins/Array/prototype/concat/create-revoked-proxy.js
+++ b/test/built-ins/Array/prototype/concat/create-revoked-proxy.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+esid: sec-array.prototype.concat
+description: Abrupt completion from constructor that is a revoked Proxy object
+info: |
+    1. Let O be ? ToObject(this value).
+    2. Let A be ? ArraySpeciesCreate(O, 0).
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    3. Let isArray be ? IsArray(originalArray).
+
+    7.2.2 IsArray
+
+    [...]
+    3. If argument is a Proxy exotic object, then
+       a. If the value of the [[ProxyHandler]] internal slot of argument is
+          null, throw a TypeError exception.
+features: [Proxy]
+---*/
+
+var o = Proxy.revocable([], {});
+var callCount = 0;
+
+Object.defineProperty(o.proxy, 'constructor', {
+  get: function() {
+    callCount += 1;
+  }
+});
+o.revoke();
+
+assert.throws(TypeError, function() {
+  Array.prototype.concat.call(o.proxy);
+});
+
+assert.sameValue(callCount, 0, '`constructor` property not accessed');

--- a/test/built-ins/Array/prototype/concat/create-species-abrupt.js
+++ b/test/built-ins/Array/prototype/concat/create-species-abrupt.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+esid: sec-array.prototype.concat
+description: Species constructor returns an abrupt completion
+info: |
+    1. Let O be ? ToObject(this value).
+    2. Let A be ? ArraySpeciesCreate(O, 0).
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    10. Return ? Construct(C, « length »).
+features: [Symbol.species]
+---*/
+
+var Ctor = function() {
+  throw new Test262Error();
+};
+var a = [];
+a.constructor = {};
+a.constructor[Symbol.species] = Ctor;
+
+assert.throws(Test262Error, function() {
+  a.concat();
+});

--- a/test/built-ins/Array/prototype/concat/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/concat/create-species-non-ctor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+esid: sec-array.prototype.concat
+description: >
+    Behavior when the @@species attribute is a non-constructor object
+info: |
+    1. Let O be ? ToObject(this value).
+    2. Let A be ? ArraySpeciesCreate(O, 0).
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    9. If IsConstructor(C) is false, throw a TypeError exception.
+features: [Symbol.species]
+---*/
+
+var a = [];
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = parseInt;
+
+assert.throws(TypeError, function() {
+  a.concat();
+});

--- a/test/built-ins/Array/prototype/concat/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/concat/create-species-non-ctor.js
@@ -23,7 +23,6 @@ features: [Symbol.species]
 ---*/
 
 var a = [];
-var result;
 
 a.constructor = {};
 a.constructor[Symbol.species] = parseInt;

--- a/test/built-ins/Array/prototype/concat/create-species-null.js
+++ b/test/built-ins/Array/prototype/concat/create-species-null.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+esid: sec-array.prototype.concat
+description: >
+    A null value for the @@species constructor is interpreted as `undefined`
+info: |
+    1. Let O be ? ToObject(this value).
+    2. Let A be ? ArraySpeciesCreate(O, 0).
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    8. If C is undefined, return ? ArrayCreate(length).
+features: [Symbol.species]
+---*/
+
+var a = [];
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = null;
+
+result = a.concat();
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');

--- a/test/built-ins/Array/prototype/concat/create-species-poisoned.js
+++ b/test/built-ins/Array/prototype/concat/create-species-poisoned.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+esid: sec-array.prototype.concat
+description: Abrupt completion from `@@species` property access
+info: |
+    1. Let O be ? ToObject(this value).
+    2. Let A be ? ArraySpeciesCreate(O, 0).
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+features: [Symbol.species]
+---*/
+
+var a = [];
+a.constructor = {};
+
+Object.defineProperty(a.constructor, Symbol.species, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  a.concat();
+});

--- a/test/built-ins/Array/prototype/concat/create-species-undef.js
+++ b/test/built-ins/Array/prototype/concat/create-species-undef.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+esid: sec-array.prototype.concat
+description: >
+    An undefined value for the @@species constructor triggers the creation  of
+    an Array exotic object
+info: |
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    8. If C is undefined, return ? ArrayCreate(length).
+features: [Symbol.species]
+---*/
+
+var a = [];
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = undefined;
+
+result = a.concat();
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');

--- a/test/built-ins/Array/prototype/concat/create-species.js
+++ b/test/built-ins/Array/prototype/concat/create-species.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+esid: sec-array.prototype.concat
+description: Species constructor is used to create a new instance
+info: |
+    1. Let O be ? ToObject(this value).
+    2. Let A be ? ArraySpeciesCreate(O, 0).
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    10. Return ? Construct(C, « length »).
+features: [Symbol.species]
+---*/
+
+var thisValue, args, result;
+var callCount = 0;
+var instance = [];
+var Ctor = function() {
+  callCount += 1;
+  thisValue = this;
+  args = arguments;
+  return instance;
+};
+var a = [];
+a.constructor = {};
+a.constructor[Symbol.species] = Ctor;
+
+result = a.concat();
+
+assert.sameValue(callCount, 1, 'Constructor invoked exactly once');
+assert.sameValue(Object.getPrototypeOf(thisValue), Ctor.prototype);
+assert.sameValue(args.length, 1, 'Constructor invoked with a single argument');
+assert.sameValue(args[0], 0);
+assert.sameValue(result, instance);

--- a/test/built-ins/Array/prototype/filter/create-ctor-non-object.js
+++ b/test/built-ins/Array/prototype/filter/create-ctor-non-object.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.7
+esid: sec-array.prototype.filter
+description: >
+    Behavior when `constructor` property is neither an Object nor undefined
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, 0).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    9. If IsConstructor(C) is false, throw a TypeError exception.
+---*/
+
+var a = [];
+var callCount = 0;
+var cb = function() { callCount += 0; };
+
+a.constructor = null;
+assert.throws(TypeError, function() {
+  a.filter(cb);
+}, 'null value');
+assert.sameValue(callCount, 0, 'callback not invoked (null value)');
+
+a = [];
+a.constructor = 1;
+assert.throws(TypeError, function() {
+  a.filter(cb);
+}, 'number value');
+assert.sameValue(callCount, 0, 'callback not invoked (number value)');
+
+a = [];
+a.constructor = 'string';
+assert.throws(TypeError, function() {
+  a.filter(cb);
+}, 'string value');
+assert.sameValue(callCount, 0, 'callback not invoked (string value)');
+
+a = [];
+a.constructor = true;
+assert.throws(TypeError, function() {
+  a.filter(cb);
+}, 'boolean value');
+assert.sameValue(callCount, 0, 'callback not invoked (boolean value)');

--- a/test/built-ins/Array/prototype/filter/create-ctor-poisoned.js
+++ b/test/built-ins/Array/prototype/filter/create-ctor-poisoned.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.7
+esid: sec-array.prototype.filter
+description: Abrupt completion from `constructor` property access
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, 0).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+---*/
+
+var a = [];
+var callCount = 0;
+var cb = function() { callCount += 1; };
+
+Object.defineProperty(a, 'constructor', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  a.filter(cb);
+});
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Array/prototype/filter/create-non-array.js
+++ b/test/built-ins/Array/prototype/filter/create-non-array.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.7
+esid: sec-array.prototype.filter
+description: Constructor is ignored for non-Array values
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, 0).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    3. Let isArray be ? IsArray(originalArray).
+    4. If isArray is false, return ? ArrayCreate(length).
+---*/
+
+var obj = { length: 0 };
+var callCount = 0;
+var result;
+Object.defineProperty(obj, 'constructor', {
+  get: function() {
+    callCount += 1;
+  }
+});
+
+result = Array.prototype.filter.call(obj, function() {});
+
+assert.sameValue(callCount, 0, '`constructor` property not accessed');
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');
+assert.sameValue(result.length, 0, 'array created with appropriate length');

--- a/test/built-ins/Array/prototype/filter/create-revoked-proxy.js
+++ b/test/built-ins/Array/prototype/filter/create-revoked-proxy.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.7
+esid: sec-array.prototype.filter
+description: Abrupt completion from constructor that is a revoked Proxy object
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, 0).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    3. Let isArray be ? IsArray(originalArray).
+
+    7.2.2 IsArray
+
+    [...]
+    3. If argument is a Proxy exotic object, then
+       a. If the value of the [[ProxyHandler]] internal slot of argument is
+          null, throw a TypeError exception.
+features: [Proxy]
+---*/
+
+var o = Proxy.revocable([], {});
+var ctorCount = 0;
+var cbCount = 0;
+var cb = function() { cbCount += 1; };
+
+Object.defineProperty(o.proxy, 'constructor', {
+  get: function() {
+    ctorCount += 1;
+  }
+});
+o.revoke();
+
+assert.throws(TypeError, function() {
+  Array.prototype.filter.call(o.proxy, cb);
+});
+
+assert.sameValue(ctorCount, 0, '`constructor` property not accessed');
+assert.sameValue(cbCount, 0, 'callback not invoked');

--- a/test/built-ins/Array/prototype/filter/create-species-abrupt.js
+++ b/test/built-ins/Array/prototype/filter/create-species-abrupt.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.7
+esid: sec-array.prototype.filter
+description: Species constructor returns an abrupt completion
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, 0).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    10. Return ? Construct(C, « length »).
+features: [Symbol.species]
+---*/
+
+var Ctor = function() {
+  throw new Test262Error();
+};
+var callCount = 0;
+var cb = function() { callCount += 1; };
+var a = [];
+a.constructor = {};
+a.constructor[Symbol.species] = Ctor;
+
+assert.throws(Test262Error, function() {
+  a.filter(cb);
+});
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Array/prototype/filter/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/filter/create-species-non-ctor.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.7
+esid: sec-array.prototype.filter
+description: >
+    Behavior when the @@species attribute is a non-constructor object
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, 0).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    9. If IsConstructor(C) is false, throw a TypeError exception.
+features: [Symbol.species]
+---*/
+
+var a = [];
+var callCount = 0;
+var cb = function() { callCount += 1; };
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = parseInt;
+
+assert.throws(TypeError, function() {
+  a.filter(cb);
+});
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Array/prototype/filter/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/filter/create-species-non-ctor.js
@@ -26,7 +26,6 @@ features: [Symbol.species]
 var a = [];
 var callCount = 0;
 var cb = function() { callCount += 1; };
-var result;
 
 a.constructor = {};
 a.constructor[Symbol.species] = parseInt;

--- a/test/built-ins/Array/prototype/filter/create-species-null.js
+++ b/test/built-ins/Array/prototype/filter/create-species-null.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.7
+esid: sec-array.prototype.filter
+description: >
+    A null value for the @@species constructor is interpreted as `undefined`
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, 0).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    8. If C is undefined, return ? ArrayCreate(length).
+features: [Symbol.species]
+---*/
+
+var a = [];
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = null;
+
+result = a.filter(function() {});
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');

--- a/test/built-ins/Array/prototype/filter/create-species-poisoned.js
+++ b/test/built-ins/Array/prototype/filter/create-species-poisoned.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.7
+esid: sec-array.prototype.filter
+description: Abrupt completion from `@@species` property access
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, 0).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+features: [Symbol.species]
+---*/
+
+var a = [];
+var callCount = 0;
+var cb = function() { callCount += 1; };
+a.constructor = {};
+
+Object.defineProperty(a.constructor, Symbol.species, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  a.filter(cb);
+});
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Array/prototype/filter/create-species-undef.js
+++ b/test/built-ins/Array/prototype/filter/create-species-undef.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.7
+esid: sec-array.prototype.filter
+description: >
+    An undefined value for the @@species constructor triggers the creation  of
+    an Array exotic object
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, 0).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    8. If C is undefined, return ? ArrayCreate(length).
+features: [Symbol.species]
+---*/
+
+var a = [];
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = undefined;
+
+result = a.filter(function() {});
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');

--- a/test/built-ins/Array/prototype/filter/create-species.js
+++ b/test/built-ins/Array/prototype/filter/create-species.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.7
+esid: sec-array.prototype.filter
+description: Species constructor is used to create a new instance
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, 0).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    10. Return ? Construct(C, « length »).
+features: [Symbol.species]
+---*/
+
+var thisValue, args, result;
+var callCount = 0;
+var instance = [];
+var Ctor = function() {
+  callCount += 1;
+  thisValue = this;
+  args = arguments;
+  return instance;
+};
+var a = [1, 2, 3, 4, 5, 6, 7];
+a.constructor = {};
+a.constructor[Symbol.species] = Ctor;
+
+result = a.filter(function() {});
+
+assert.sameValue(callCount, 1, 'Constructor invoked exactly once');
+assert.sameValue(Object.getPrototypeOf(thisValue), Ctor.prototype);
+assert.sameValue(args.length, 1, 'Constructor invoked with a single argument');
+assert.sameValue(args[0], 0);
+assert.sameValue(result, instance);

--- a/test/built-ins/Array/prototype/map/create-ctor-non-object.js
+++ b/test/built-ins/Array/prototype/map/create-ctor-non-object.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.16
+esid: sec-array.prototype.map
+description: >
+    Behavior when `constructor` property is neither an Object nor undefined
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, len).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    9. If IsConstructor(C) is false, throw a TypeError exception.
+---*/
+
+var a = [];
+var callCount = 0;
+var cb = function() { callCount += 0; };
+
+a.constructor = null;
+assert.throws(TypeError, function() {
+  a.map(cb);
+}, 'null value');
+assert.sameValue(callCount, 0, 'callback not invoked (null value)');
+
+a = [];
+a.constructor = 1;
+assert.throws(TypeError, function() {
+  a.map(cb);
+}, 'number value');
+assert.sameValue(callCount, 0, 'callback not invoked (number value)');
+
+a = [];
+a.constructor = 'string';
+assert.throws(TypeError, function() {
+  a.map(cb);
+}, 'string value');
+assert.sameValue(callCount, 0, 'callback not invoked (string value)');
+
+a = [];
+a.constructor = true;
+assert.throws(TypeError, function() {
+  a.map(cb);
+}, 'boolean value');
+assert.sameValue(callCount, 0, 'callback not invoked (boolean value)');

--- a/test/built-ins/Array/prototype/map/create-ctor-poisoned.js
+++ b/test/built-ins/Array/prototype/map/create-ctor-poisoned.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.16
+esid: sec-array.prototype.map
+description: Abrupt completion from `constructor` property access
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, len).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+---*/
+
+var a = [];
+var callCount = 0;
+var cb = function() { callCount += 1; };
+
+Object.defineProperty(a, 'constructor', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  a.map(cb);
+});
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Array/prototype/map/create-non-array-invalid-len.js
+++ b/test/built-ins/Array/prototype/map/create-non-array-invalid-len.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.16
+esid: sec-array.prototype.map
+description: Abrupt completion from creating a new array
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, len).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    3. Let isArray be ? IsArray(originalArray).
+    4. If isArray is false, return ? ArrayCreate(length).
+
+    9.4.2.2 ArrayCreate
+
+    [...]
+    3. If length>232-1, throw a RangeError exception.
+---*/
+
+var callCount = 0;
+var obj = { length: Math.pow(2, 32) };
+var cb = function() {
+  callCount += 1;
+};
+
+assert.throws(RangeError, function() {
+  Array.prototype.map.call(obj, cb);
+});
+
+assert.sameValue(
+  callCount,
+  0,
+  'RangeError thrown during array creation, not property modification'
+);

--- a/test/built-ins/Array/prototype/map/create-non-array.js
+++ b/test/built-ins/Array/prototype/map/create-non-array.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.16
+esid: sec-array.prototype.map
+description: Constructor is ignored for non-Array values
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, len).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    3. Let isArray be ? IsArray(originalArray).
+    4. If isArray is false, return ? ArrayCreate(length).
+---*/
+
+var obj = { length: 0 };
+var callCount = 0;
+var result;
+Object.defineProperty(obj, 'constructor', {
+  get: function() {
+    callCount += 1;
+  }
+});
+
+result = Array.prototype.map.call(obj, function() {});
+
+assert.sameValue(callCount, 0, '`constructor` property not accessed');
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');

--- a/test/built-ins/Array/prototype/map/create-revoked-proxy.js
+++ b/test/built-ins/Array/prototype/map/create-revoked-proxy.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.16
+esid: sec-array.prototype.map
+description: Abrupt completion from constructor that is a revoked Proxy object
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, len).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    3. Let isArray be ? IsArray(originalArray).
+
+    7.2.2 IsArray
+
+    [...]
+    3. If argument is a Proxy exotic object, then
+       a. If the value of the [[ProxyHandler]] internal slot of argument is
+          null, throw a TypeError exception.
+features: [Proxy]
+---*/
+
+var o = Proxy.revocable([], {});
+var ctorCount = 0;
+var cbCount = 0;
+var cb = function() { cbCount += 1; };
+
+Object.defineProperty(o.proxy, 'constructor', {
+  get: function() {
+    ctorCount += 1;
+  }
+});
+o.revoke();
+
+assert.throws(TypeError, function() {
+  Array.prototype.map.call(o.proxy, cb);
+});
+
+assert.sameValue(ctorCount, 0, '`constructor` property not accessed');
+assert.sameValue(cbCount, 0, 'callback not invoked');

--- a/test/built-ins/Array/prototype/map/create-species-abrupt.js
+++ b/test/built-ins/Array/prototype/map/create-species-abrupt.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.16
+esid: sec-array.prototype.map
+description: Species constructor returns an abrupt completion
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, len).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    10. Return ? Construct(C, « length »).
+features: [Symbol.species]
+---*/
+
+var Ctor = function() {
+  throw new Test262Error();
+};
+var callCount = 0;
+var cb = function() { callCount += 1; };
+var a = [];
+a.constructor = {};
+a.constructor[Symbol.species] = Ctor;
+
+assert.throws(Test262Error, function() {
+  a.map(cb);
+});
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Array/prototype/map/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/map/create-species-non-ctor.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.16
+esid: sec-array.prototype.map
+description: >
+    Behavior when the @@species attribute is a non-constructor object
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, len).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    9. If IsConstructor(C) is false, throw a TypeError exception.
+features: [Symbol.species]
+---*/
+
+var a = [];
+var callCount = 0;
+var cb = function() { callCount += 1; };
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = parseInt;
+
+assert.throws(TypeError, function() {
+  a.map(cb);
+});
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Array/prototype/map/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/map/create-species-non-ctor.js
@@ -26,7 +26,6 @@ features: [Symbol.species]
 var a = [];
 var callCount = 0;
 var cb = function() { callCount += 1; };
-var result;
 
 a.constructor = {};
 a.constructor[Symbol.species] = parseInt;

--- a/test/built-ins/Array/prototype/map/create-species-null.js
+++ b/test/built-ins/Array/prototype/map/create-species-null.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.16
+esid: sec-array.prototype.map
+description: >
+    A null value for the @@species constructor is interpreted as `undefined`
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, len).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    8. If C is undefined, return ? ArrayCreate(length).
+features: [Symbol.species]
+---*/
+
+var a = [];
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = null;
+
+result = a.map(function() {});
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');

--- a/test/built-ins/Array/prototype/map/create-species-poisoned.js
+++ b/test/built-ins/Array/prototype/map/create-species-poisoned.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.16
+esid: sec-array.prototype.map
+description: Abrupt completion from `@@species` property access
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, len).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+features: [Symbol.species]
+---*/
+
+var a = [];
+var callCount = 0;
+var cb = function() { callCount += 1; };
+a.constructor = {};
+
+Object.defineProperty(a.constructor, Symbol.species, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  a.map(cb);
+});
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Array/prototype/map/create-species-undef-invalid-len.js
+++ b/test/built-ins/Array/prototype/map/create-species-undef-invalid-len.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.16
+esid: sec-array.prototype.map
+description: >
+    An undefined value for the @@species constructor triggers the creation  of
+    an Array exotic object
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, len).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    8. If C is undefined, return ? ArrayCreate(length).
+
+    9.4.2.2 ArrayCreate
+
+    [...]
+    3. If length>232-1, throw a RangeError exception.
+features: [Proxy]
+---*/
+
+var array = [];
+var maxLength = Math.pow(2, 32);
+var cbCount = 0;
+var setCount = 0;
+var cb = function() { cbCount += 1; };
+var proxy = new Proxy(array, {
+  get: function(_, name) {
+    if (name === 'length') {
+      return maxLength;
+    }
+    return array[name];
+  },
+  set: function(_, name, value) {
+    setCount += 1;
+    return true;
+  }
+});
+
+assert.throws(RangeError, function() {
+  Array.prototype.map.call(proxy, cb);
+});
+
+assert.sameValue(
+  setCount,
+  0,
+  'RangeError thrown during array creation, not property modification'
+);
+assert.sameValue(cbCount, 0, 'callback function not invoked');

--- a/test/built-ins/Array/prototype/map/create-species-undef-invalid-len.js
+++ b/test/built-ins/Array/prototype/map/create-species-undef-invalid-len.js
@@ -40,7 +40,7 @@ var proxy = new Proxy(array, {
     }
     return array[name];
   },
-  set: function(_, name, value) {
+  set: function() {
     setCount += 1;
     return true;
   }

--- a/test/built-ins/Array/prototype/map/create-species-undef.js
+++ b/test/built-ins/Array/prototype/map/create-species-undef.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.16
+esid: sec-array.prototype.map
+description: >
+    An undefined value for the @@species constructor triggers the creation  of
+    an Array exotic object
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, len).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    8. If C is undefined, return ? ArrayCreate(length).
+features: [Symbol.species]
+---*/
+
+var a = [];
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = undefined;
+
+result = a.map(function() {});
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');

--- a/test/built-ins/Array/prototype/map/create-species.js
+++ b/test/built-ins/Array/prototype/map/create-species.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.16
+esid: sec-array.prototype.map
+description: Species constructor is used to create a new instance
+info: |
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, len).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    10. Return ? Construct(C, « length »).
+features: [Symbol.species]
+---*/
+
+var thisValue, args, result;
+var callCount = 0;
+var instance = [];
+var Ctor = function() {
+  callCount += 1;
+  thisValue = this;
+  args = arguments;
+  return instance;
+};
+var a = [1, 2, 3, 4, 5];
+a.constructor = {};
+a.constructor[Symbol.species] = Ctor;
+
+result = a.map(function() {});
+
+assert.sameValue(callCount, 1, 'Constructor invoked exactly once');
+assert.sameValue(Object.getPrototypeOf(thisValue), Ctor.prototype);
+assert.sameValue(args.length, 1, 'Constructor invoked with a single argument');
+assert.sameValue(args[0], 5);
+assert.sameValue(result, instance);

--- a/test/built-ins/Array/prototype/slice/create-ctor-non-object.js
+++ b/test/built-ins/Array/prototype/slice/create-ctor-non-object.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.23
+esid: sec-array.prototype.slice
+description: >
+    Behavior when `constructor` property is neither an Object nor undefined
+info: |
+    [...]
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    9. If IsConstructor(C) is false, throw a TypeError exception.
+---*/
+
+var a = [];
+
+a.constructor = null;
+assert.throws(TypeError, function() {
+  a.slice();
+}, 'null value');
+
+a = [];
+a.constructor = 1;
+assert.throws(TypeError, function() {
+  a.slice();
+}, 'number value');
+
+a = [];
+a.constructor = 'string';
+assert.throws(TypeError, function() {
+  a.slice();
+}, 'string value');
+
+a = [];
+a.constructor = true;
+assert.throws(TypeError, function() {
+  a.slice();
+}, 'boolean value');

--- a/test/built-ins/Array/prototype/slice/create-ctor-poisoned.js
+++ b/test/built-ins/Array/prototype/slice/create-ctor-poisoned.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.23
+esid: sec-array.prototype.slice
+description: Abrupt completion from `constructor` property access
+info: |
+    [...]
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+---*/
+
+var a = [];
+
+Object.defineProperty(a, 'constructor', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  a.slice();
+});

--- a/test/built-ins/Array/prototype/slice/create-non-array-invalid-len.js
+++ b/test/built-ins/Array/prototype/slice/create-non-array-invalid-len.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.23
+esid: sec-array.prototype.slice
+description: Abrupt completion from creating a new array
+info: |
+    [...]
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    3. Let isArray be ? IsArray(originalArray).
+    4. If isArray is false, return ? ArrayCreate(length).
+
+    9.4.2.2 ArrayCreate
+
+    [...]
+    3. If length>232-1, throw a RangeError exception.
+---*/
+
+var callCount = 0;
+var maxLength = Math.pow(2, 32);
+var obj = Object.defineProperty({}, 'length', {
+  get: function() {
+    return maxLength;
+  },
+  set: function() {
+    callCount += 1;
+  }
+});
+
+assert.throws(RangeError, function() {
+  Array.prototype.slice.call(obj);
+});
+
+assert.sameValue(
+  callCount,
+  0,
+  'RangeError thrown during array creation, not property modification'
+);

--- a/test/built-ins/Array/prototype/slice/create-non-array.js
+++ b/test/built-ins/Array/prototype/slice/create-non-array.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.23
+esid: sec-array.prototype.slice
+description: Constructor is ignored for non-Array values
+info: |
+    [...]
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    3. Let isArray be ? IsArray(originalArray).
+    4. If isArray is false, return ? ArrayCreate(length).
+---*/
+
+var obj = { length: 0 };
+var callCount = 0;
+var result;
+Object.defineProperty(obj, 'constructor', {
+  get: function() {
+    callCount += 1;
+  }
+});
+
+result = Array.prototype.slice.call(obj);
+
+assert.sameValue(callCount, 0, '`constructor` property not accessed');
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');

--- a/test/built-ins/Array/prototype/slice/create-revoked-proxy.js
+++ b/test/built-ins/Array/prototype/slice/create-revoked-proxy.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.23
+esid: sec-array.prototype.slice
+description: Abrupt completion from constructor that is a revoked Proxy object
+info: |
+    [...]
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    3. Let isArray be ? IsArray(originalArray).
+
+    7.2.2 IsArray
+
+    [...]
+    3. If argument is a Proxy exotic object, then
+       a. If the value of the [[ProxyHandler]] internal slot of argument is
+          null, throw a TypeError exception.
+features: [Proxy]
+---*/
+
+var o = Proxy.revocable([], {});
+var callCount = 0;
+
+Object.defineProperty(o.proxy, 'constructor', {
+  get: function() {
+    callCount += 1;
+  }
+});
+o.revoke();
+
+assert.throws(TypeError, function() {
+  Array.prototype.slice.call(o.proxy);
+});
+
+assert.sameValue(callCount, 0, '`constructor` property not accessed');

--- a/test/built-ins/Array/prototype/slice/create-species-abrupt.js
+++ b/test/built-ins/Array/prototype/slice/create-species-abrupt.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.23
+esid: sec-array.prototype.slice
+description: Species constructor returns an abrupt completion
+info: |
+    [...]
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    10. Return ? Construct(C, « length »).
+features: [Symbol.species]
+---*/
+
+var Ctor = function() {
+  throw new Test262Error();
+};
+var a = [];
+a.constructor = {};
+a.constructor[Symbol.species] = Ctor;
+
+assert.throws(Test262Error, function() {
+  a.slice();
+});

--- a/test/built-ins/Array/prototype/slice/create-species-neg-zero.js
+++ b/test/built-ins/Array/prototype/slice/create-species-neg-zero.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.23
+esid: sec-array.prototype.slice
+description: The value `-0` is converted to `0`
+info: |
+    [...]
+    3. Let relativeStart be ? ToInteger(start).
+    4. If relativeStart < 0, let k be max((len + relativeStart), 0); else let k
+       be min(relativeStart, len).
+    5. If end is undefined, let relativeEnd be len; else let relativeEnd be ?
+       ToInteger(end).
+    6. If relativeEnd < 0, let final be max((len + relativeEnd), 0); else let
+       final be min(relativeEnd, len).
+    7. Let count be max(final - k, 0).
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    2. If length is -0, let length be +0.
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    10. Return ? Construct(C, « length »).
+features: [Symbol.species]
+---*/
+
+var args;
+var Ctor = function() {
+  args = arguments;
+};
+var a = [];
+a.constructor = {};
+a.constructor[Symbol.species] = Ctor;
+
+a.slice(0, -0);
+
+assert.sameValue(args.length, 1);
+assert.sameValue(args[0], 0);

--- a/test/built-ins/Array/prototype/slice/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/slice/create-species-non-ctor.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.23
+esid: sec-array.prototype.slice
+description: >
+    Behavior when the @@species attribute is a non-constructor object
+info: |
+    [...]
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    9. If IsConstructor(C) is false, throw a TypeError exception.
+features: [Symbol.species]
+---*/
+
+var a = [];
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = parseInt;
+
+assert.throws(TypeError, function() {
+  a.slice();
+});

--- a/test/built-ins/Array/prototype/slice/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/slice/create-species-non-ctor.js
@@ -24,7 +24,6 @@ features: [Symbol.species]
 ---*/
 
 var a = [];
-var result;
 
 a.constructor = {};
 a.constructor[Symbol.species] = parseInt;

--- a/test/built-ins/Array/prototype/slice/create-species-null.js
+++ b/test/built-ins/Array/prototype/slice/create-species-null.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.23
+esid: sec-array.prototype.slice
+description: >
+    A null value for the @@species constructor is interpreted as `undefined`
+info: |
+    [...]
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    8. If C is undefined, return ? ArrayCreate(length).
+features: [Symbol.species]
+---*/
+
+var a = [];
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = null;
+
+result = a.slice();
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');

--- a/test/built-ins/Array/prototype/slice/create-species-poisoned.js
+++ b/test/built-ins/Array/prototype/slice/create-species-poisoned.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.23
+esid: sec-array.prototype.slice
+description: Abrupt completion from `@@species` property access
+info: |
+    [...]
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+features: [Symbol.species]
+---*/
+
+var a = [];
+a.constructor = {};
+
+Object.defineProperty(a.constructor, Symbol.species, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  a.slice();
+});

--- a/test/built-ins/Array/prototype/slice/create-species-undef-invalid-len.js
+++ b/test/built-ins/Array/prototype/slice/create-species-undef-invalid-len.js
@@ -38,7 +38,7 @@ var proxy = new Proxy(array, {
     }
     return array[name];
   },
-  set: function(_, name, value) {
+  set: function() {
     callCount += 1;
     return true;
   }

--- a/test/built-ins/Array/prototype/slice/create-species-undef-invalid-len.js
+++ b/test/built-ins/Array/prototype/slice/create-species-undef-invalid-len.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.23
+esid: sec-array.prototype.slice
+description: >
+    An undefined value for the @@species constructor triggers the creation  of
+    an Array exotic object
+info: |
+    [...]
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    8. If C is undefined, return ? ArrayCreate(length).
+
+    9.4.2.2 ArrayCreate
+
+    [...]
+    3. If length>232-1, throw a RangeError exception.
+features: [Proxy]
+---*/
+
+var array = [];
+var maxLength = Math.pow(2, 32);
+var callCount = 0;
+var proxy = new Proxy(array, {
+  get: function(_, name) {
+    if (name === 'length') {
+      return maxLength;
+    }
+    return array[name];
+  },
+  set: function(_, name, value) {
+    callCount += 1;
+    return true;
+  }
+});
+
+assert.throws(RangeError, function() {
+  Array.prototype.slice.call(proxy);
+});
+
+assert.sameValue(
+  callCount,
+  0,
+  'RangeError thrown during array creation, not property modification'
+);

--- a/test/built-ins/Array/prototype/slice/create-species-undef.js
+++ b/test/built-ins/Array/prototype/slice/create-species-undef.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.23
+esid: sec-array.prototype.slice
+description: >
+    An undefined value for the @@species constructor triggers the creation  of
+    an Array exotic object
+info: |
+    [...]
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    8. If C is undefined, return ? ArrayCreate(length).
+features: [Symbol.species]
+---*/
+
+var a = [];
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = undefined;
+
+result = a.slice();
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');

--- a/test/built-ins/Array/prototype/slice/create-species.js
+++ b/test/built-ins/Array/prototype/slice/create-species.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.23
+esid: sec-array.prototype.slice
+description: Species constructor is used to create a new instance
+info: |
+    [...]
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    10. Return ? Construct(C, « length »).
+features: [Symbol.species]
+---*/
+
+var thisValue, args, result;
+var callCount = 0;
+var instance = [];
+var Ctor = function() {
+  callCount += 1;
+  thisValue = this;
+  args = arguments;
+  return instance;
+};
+var a = [1, 2, 3, 4, 5];
+a.constructor = {};
+a.constructor[Symbol.species] = Ctor;
+
+result = a.slice(1, -1);
+
+assert.sameValue(callCount, 1, 'Constructor invoked exactly once');
+assert.sameValue(Object.getPrototypeOf(thisValue), Ctor.prototype);
+assert.sameValue(args.length, 1, 'Constructor invoked with a single argument');
+assert.sameValue(args[0], 3);
+assert.sameValue(result, instance);

--- a/test/built-ins/Array/prototype/splice/create-ctor-non-object.js
+++ b/test/built-ins/Array/prototype/splice/create-ctor-non-object.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.26
+esid: sec-array.prototype.splice
+description: >
+    Behavior when `constructor` property is neither an Object nor undefined
+info: |
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    9. If IsConstructor(C) is false, throw a TypeError exception.
+---*/
+
+var a = [];
+
+a.constructor = null;
+assert.throws(TypeError, function() {
+  a.splice();
+}, 'null value');
+
+a = [];
+a.constructor = 1;
+assert.throws(TypeError, function() {
+  a.splice();
+}, 'number value');
+
+a = [];
+a.constructor = 'string';
+assert.throws(TypeError, function() {
+  a.splice();
+}, 'string value');
+
+a = [];
+a.constructor = true;
+assert.throws(TypeError, function() {
+  a.splice();
+}, 'boolean value');

--- a/test/built-ins/Array/prototype/splice/create-ctor-poisoned.js
+++ b/test/built-ins/Array/prototype/splice/create-ctor-poisoned.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.26
+esid: sec-array.prototype.splice
+description: Abrupt completion from `constructor` property access
+info: |
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+---*/
+
+var a = [];
+
+Object.defineProperty(a, 'constructor', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  a.splice();
+});

--- a/test/built-ins/Array/prototype/splice/create-non-array-invalid-len.js
+++ b/test/built-ins/Array/prototype/splice/create-non-array-invalid-len.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.26
+esid: sec-array.prototype.splice
+description: Abrupt completion from creating a new array
+info: |
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    3. Let isArray be ? IsArray(originalArray).
+    4. If isArray is false, return ? ArrayCreate(length).
+
+    9.4.2.2 ArrayCreate
+
+    [...]
+    3. If length>232-1, throw a RangeError exception.
+---*/
+
+var callCount = 0;
+var maxLength = Math.pow(2, 32);
+var obj = Object.defineProperty({}, 'length', {
+  get: function() {
+    return maxLength;
+  },
+  set: function() {
+    callCount += 1;
+  }
+});
+
+assert.throws(RangeError, function() {
+  Array.prototype.splice.call(obj, 0);
+});
+
+assert.sameValue(
+  callCount,
+  0,
+  'RangeError thrown during array creation, not property modification'
+);

--- a/test/built-ins/Array/prototype/splice/create-non-array.js
+++ b/test/built-ins/Array/prototype/splice/create-non-array.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.26
+esid: sec-array.prototype.splice
+description: Constructor is ignored for non-Array values
+info: |
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    3. Let isArray be ? IsArray(originalArray).
+    4. If isArray is false, return ? ArrayCreate(length).
+---*/
+
+var obj = { length: 0 };
+var callCount = 0;
+var result;
+Object.defineProperty(obj, 'constructor', {
+  get: function() {
+    callCount += 1;
+  }
+});
+
+result = Array.prototype.splice.call(obj);
+
+assert.sameValue(callCount, 0, '`constructor` property not accessed');
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');
+assert.sameValue(result.length, 0, 'array created with appropriate length');

--- a/test/built-ins/Array/prototype/splice/create-revoked-proxy.js
+++ b/test/built-ins/Array/prototype/splice/create-revoked-proxy.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.26
+esid: sec-array.prototype.splice
+description: Abrupt completion from constructor that is a revoked Proxy object
+info: |
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    3. Let isArray be ? IsArray(originalArray).
+
+    7.2.2 IsArray
+
+    [...]
+    3. If argument is a Proxy exotic object, then
+       a. If the value of the [[ProxyHandler]] internal slot of argument is
+          null, throw a TypeError exception.
+features: [Proxy]
+---*/
+
+var o = Proxy.revocable([], {});
+var callCount = 0;
+
+Object.defineProperty(o.proxy, 'constructor', {
+  get: function() {
+    callCount += 1;
+  }
+});
+o.revoke();
+
+assert.throws(TypeError, function() {
+  Array.prototype.splice.call(o.proxy);
+});
+
+assert.sameValue(callCount, 0, '`constructor` property not accessed');

--- a/test/built-ins/Array/prototype/splice/create-species-abrupt.js
+++ b/test/built-ins/Array/prototype/splice/create-species-abrupt.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.26
+esid: sec-array.prototype.splice
+description: Species constructor returns an abrupt completion
+info: |
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    10. Return ? Construct(C, « length »).
+features: [Symbol.species]
+---*/
+
+var Ctor = function() {
+  throw new Test262Error();
+};
+var a = [];
+a.constructor = {};
+a.constructor[Symbol.species] = Ctor;
+
+assert.throws(Test262Error, function() {
+  a.splice();
+});

--- a/test/built-ins/Array/prototype/splice/create-species-neg-zero.js
+++ b/test/built-ins/Array/prototype/splice/create-species-neg-zero.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.26
+esid: sec-array.prototype.splice
+description: The value `-0` is converted to `0`
+info: |
+    [...]
+    3. Let relativeStart be ? ToInteger(start).
+    4. If relativeStart < 0, let actualStart be max((len + relativeStart), 0);
+       else let actualStart be min(relativeStart, len).
+    5. If the number of actual arguments is 0, then
+       [...]
+    6. Else if the number of actual arguments is 1, then
+       [...]
+    7. Else,
+       a. Let insertCount be the number of actual arguments minus 2.
+       b. Let dc be ? ToInteger(deleteCount).
+       c. Let actualDeleteCount be min(max(dc, 0), len - actualStart).
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    2. If length is -0, let length be +0.
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    10. Return ? Construct(C, « length »).
+features: [Symbol.species]
+---*/
+
+var args;
+var Ctor = function() {
+  args = arguments;
+};
+var a = [];
+a.constructor = {};
+a.constructor[Symbol.species] = Ctor;
+
+a.splice(0, -0);
+
+assert.sameValue(args.length, 1);
+assert.sameValue(args[0], 0);

--- a/test/built-ins/Array/prototype/splice/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/splice/create-species-non-ctor.js
@@ -24,7 +24,6 @@ features: [Symbol.species]
 ---*/
 
 var a = [];
-var result;
 
 a.constructor = {};
 a.constructor[Symbol.species] = parseInt;

--- a/test/built-ins/Array/prototype/splice/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/splice/create-species-non-ctor.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.26
+esid: sec-array.prototype.splice
+description: >
+    Behavior when the @@species attribute is a non-constructor object
+info: |
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    9. If IsConstructor(C) is false, throw a TypeError exception.
+features: [Symbol.species]
+---*/
+
+var a = [];
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = parseInt;
+
+assert.throws(TypeError, function() {
+  a.splice();
+});

--- a/test/built-ins/Array/prototype/splice/create-species-null.js
+++ b/test/built-ins/Array/prototype/splice/create-species-null.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.26
+esid: sec-array.prototype.splice
+description: >
+    A null value for the @@species constructor is interpreted as `undefined`
+info: |
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    8. If C is undefined, return ? ArrayCreate(length).
+features: [Symbol.species]
+---*/
+
+var a = [];
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = null;
+
+result = a.splice();
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');

--- a/test/built-ins/Array/prototype/splice/create-species-poisoned.js
+++ b/test/built-ins/Array/prototype/splice/create-species-poisoned.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.26
+esid: sec-array.prototype.splice
+description: Abrupt completion from `@@species` property access
+info: |
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+features: [Symbol.species]
+---*/
+
+var a = [];
+a.constructor = {};
+
+Object.defineProperty(a.constructor, Symbol.species, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  a.splice();
+});

--- a/test/built-ins/Array/prototype/splice/create-species-undef-invalid-len.js
+++ b/test/built-ins/Array/prototype/splice/create-species-undef-invalid-len.js
@@ -38,7 +38,7 @@ var proxy = new Proxy(array, {
     }
     return array[name];
   },
-  set: function(_, name, value) {
+  set: function() {
     callCount += 1;
     return true;
   }

--- a/test/built-ins/Array/prototype/splice/create-species-undef-invalid-len.js
+++ b/test/built-ins/Array/prototype/splice/create-species-undef-invalid-len.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.26
+esid: sec-array.prototype.splice
+description: >
+    An undefined value for the @@species constructor triggers the creation  of
+    an Array exotic object
+info: |
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    8. If C is undefined, return ? ArrayCreate(length).
+
+    9.4.2.2 ArrayCreate
+
+    [...]
+    3. If length>232-1, throw a RangeError exception.
+features: [Proxy]
+---*/
+
+var array = [];
+var maxLength = Math.pow(2, 32);
+var callCount = 0;
+var proxy = new Proxy(array, {
+  get: function(_, name) {
+    if (name === 'length') {
+      return maxLength;
+    }
+    return array[name];
+  },
+  set: function(_, name, value) {
+    callCount += 1;
+    return true;
+  }
+});
+
+assert.throws(RangeError, function() {
+  Array.prototype.splice.call(proxy, 0);
+});
+
+assert.sameValue(
+  callCount,
+  0,
+  'RangeError thrown during array creation, not property modification'
+);

--- a/test/built-ins/Array/prototype/splice/create-species-undef.js
+++ b/test/built-ins/Array/prototype/splice/create-species-undef.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.26
+esid: sec-array.prototype.splice
+description: >
+    An undefined value for the @@species constructor triggers the creation  of
+    an Array exotic object
+info: |
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    8. If C is undefined, return ? ArrayCreate(length).
+features: [Symbol.species]
+---*/
+
+var a = [];
+var result;
+
+a.constructor = {};
+a.constructor[Symbol.species] = undefined;
+
+result = a.splice();
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert(Array.isArray(result), 'result is an Array exotic object');

--- a/test/built-ins/Array/prototype/splice/create-species.js
+++ b/test/built-ins/Array/prototype/splice/create-species.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.26
+esid: sec-array.prototype.splice
+description: Species constructor is used to create a new instance
+info: |
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    [...]
+    7. If Type(C) is Object, then
+       a. Let C be ? Get(C, @@species).
+       b. If C is null, let C be undefined.
+    [...]
+    10. Return ? Construct(C, « length »).
+features: [Symbol.species]
+---*/
+
+var thisValue, args, result;
+var callCount = 0;
+var instance = [];
+var Ctor = function() {
+  callCount += 1;
+  thisValue = this;
+  args = arguments;
+  return instance;
+};
+var a = [1, 2, 3, 4, 5];
+a.constructor = {};
+a.constructor[Symbol.species] = Ctor;
+
+result = a.splice(2);
+
+assert.sameValue(callCount, 1, 'Constructor invoked exactly once');
+assert.sameValue(Object.getPrototypeOf(thisValue), Ctor.prototype);
+assert.sameValue(args.length, 1, 'Constructor invoked with a single argument');
+assert.sameValue(args[0], 3);
+assert.sameValue(result, instance);


### PR DESCRIPTION
Assert the expected behavior of the ArraySpeciesCreate abstract
operation in the 5 Array instance methods from which it is invoked.

This change set does not include tests for ECMAScript realm
considerations because Test262 does not currently expose a mechanism for
interfacing with realms.