### PR TITLE
Reduce noise in output of test generation tool

### DIFF
--- a/test/language/expressions/arrow-function/dstr-ary-name-iter-val.js
+++ b/test/language/expressions/arrow-function/dstr-ary-name-iter-val.js
@@ -5,26 +5,26 @@
 description: SingleNameBinding with normal value iteration (arrow function expression)
 es6id: 14.2.16
 flags: [generated]
-info: >
+info: |
     ArrowFunction : ArrowParameters => ConciseBody
-    
+
     [...]
     4. Let closure be FunctionCreate(Arrow, parameters, ConciseBody, scope, strict).
     [...]
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -36,9 +36,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/expressions/call/spread-err-sngl-err-expr-throws.js
+++ b/test/language/expressions/call/spread-err-sngl-err-expr-throws.js
@@ -5,25 +5,24 @@
 description: Spread operator applied to the only argument when evaluation throws (CallExpression)
 es6id: 12.3.4.1
 features: [generators]
-
 flags: [generated]
-info: >
+info: |
     CallExpression : MemberExpression Arguments
-    
+
     [...]
     9. Return EvaluateDirectCall(func, thisValue, Arguments, tailCall).
-    
+
     12.3.4.3 Runtime Semantics: EvaluateDirectCall
-    
+
     1. Let argList be ArgumentListEvaluation(arguments).
     [...]
     6. Let result be Call(func, thisValue, argList).
     [...]
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
-    
+
     ArgumentList : ... AssignmentExpression
-    
+
     1. Let list be an empty List.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
     3. Let spreadObj be GetValue(spreadRef).

--- a/test/language/expressions/call/spread-sngl-iter.js
+++ b/test/language/expressions/call/spread-sngl-iter.js
@@ -5,25 +5,24 @@
 description: Spread operator applied to the only argument with a valid iterator (CallExpression)
 es6id: 12.3.4.1
 features: [Symbol.iterator]
-
 flags: [generated]
-info: >
+info: |
     CallExpression : MemberExpression Arguments
-    
+
     [...]
     9. Return EvaluateDirectCall(func, thisValue, Arguments, tailCall).
-    
+
     12.3.4.3 Runtime Semantics: EvaluateDirectCall
-    
+
     1. Let argList be ArgumentListEvaluation(arguments).
     [...]
     6. Let result be Call(func, thisValue, argList).
     [...]
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
-    
+
     ArgumentList : ... AssignmentExpression
-    
+
     1. Let list be an empty List.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
     3. Let spreadObj be GetValue(spreadRef).

--- a/test/language/expressions/class/dstr-gen-meth-ary-name-iter-val.js
+++ b/test/language/expressions/class/dstr-gen-meth-ary-name-iter-val.js
@@ -5,29 +5,29 @@
 description: SingleNameBinding with normal value iteration (class expression method)
 es6id: 14.5.16
 flags: [generated]
-info: >
+info: |
     ClassExpression : class BindingIdentifieropt ClassTail
-    
+
     1. If BindingIdentifieropt is not present, let className be undefined.
     2. Else, let className be StringValue of BindingIdentifier.
     3. Let value be the result of ClassDefinitionEvaluation of ClassTail
        with argument className.
     [...]
-    
+
     14.5.14 Runtime Semantics: ClassDefinitionEvaluation
-    
+
     21. For each ClassElement m in order from methods
         a. If IsStatic of m is false, then
            i. Let status be the result of performing
               PropertyDefinitionEvaluation for m with arguments proto and
               false.
         [...]
-    
+
     14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
-    
+
     GeneratorMethod :
         * PropertyName ( StrictFormalParameters ) { GeneratorBody }
-    
+
     1. Let propKey be the result of evaluating PropertyName.
     2. ReturnIfAbrupt(propKey).
     3. If the function code for this GeneratorMethod is strict mode code,
@@ -35,20 +35,20 @@ info: >
     4. Let scope be the running execution context's LexicalEnvironment.
     5. Let closure be GeneratorFunctionCreate(Method,
        StrictFormalParameters, GeneratorBody, scope, strict).
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -60,9 +60,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/expressions/class/dstr-gen-meth-static-ary-name-iter-val.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-ary-name-iter-val.js
@@ -5,29 +5,29 @@
 description: SingleNameBinding with normal value iteration (static class expression generator method)
 es6id: 14.5.16
 flags: [generated]
-info: >
+info: |
     ClassExpression : class BindingIdentifieropt ClassTail
-    
+
     1. If BindingIdentifieropt is not present, let className be undefined.
     2. Else, let className be StringValue of BindingIdentifier.
     3. Let value be the result of ClassDefinitionEvaluation of ClassTail
        with argument className.
     [...]
-    
+
     14.5.14 Runtime Semantics: ClassDefinitionEvaluation
-    
+
     21. For each ClassElement m in order from methods
         a. If IsStatic of m is false, then
         b. Else,
            Let status be the result of performing PropertyDefinitionEvaluation
            for m with arguments F and false.
     [...]
-    
+
     14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
-    
+
     GeneratorMethod :
         * PropertyName ( StrictFormalParameters ) { GeneratorBody }
-    
+
     1. Let propKey be the result of evaluating PropertyName.
     2. ReturnIfAbrupt(propKey).
     3. If the function code for this GeneratorMethod is strict mode code,
@@ -35,20 +35,20 @@ info: >
     4. Let scope be the running execution context's LexicalEnvironment.
     5. Let closure be GeneratorFunctionCreate(Method,
        StrictFormalParameters, GeneratorBody, scope, strict).
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -60,9 +60,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/expressions/class/dstr-meth-ary-name-iter-val.js
+++ b/test/language/expressions/class/dstr-meth-ary-name-iter-val.js
@@ -5,47 +5,47 @@
 description: SingleNameBinding with normal value iteration (class expression method)
 es6id: 14.5.16
 flags: [generated]
-info: >
+info: |
     ClassExpression : class BindingIdentifieropt ClassTail
-    
+
     1. If BindingIdentifieropt is not present, let className be undefined.
     2. Else, let className be StringValue of BindingIdentifier.
     3. Let value be the result of ClassDefinitionEvaluation of ClassTail
        with argument className.
     [...]
-    
+
     14.5.14 Runtime Semantics: ClassDefinitionEvaluation
-    
+
     21. For each ClassElement m in order from methods
         a. If IsStatic of m is false, then
            i. Let status be the result of performing
               PropertyDefinitionEvaluation for m with arguments proto and
               false.
         [...]
-    
+
     14.3.8 Runtime Semantics: DefineMethod
-    
+
     MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
-    
+
     [...]
     6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
        scope, strict). If functionPrototype was passed as a parameter then pass its
        value as the functionPrototype optional argument of FunctionCreate.
     [...]
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -57,9 +57,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/expressions/class/dstr-meth-static-ary-name-iter-val.js
+++ b/test/language/expressions/class/dstr-meth-static-ary-name-iter-val.js
@@ -5,47 +5,47 @@
 description: SingleNameBinding with normal value iteration (static class expression method)
 es6id: 14.5.16
 flags: [generated]
-info: >
+info: |
     ClassExpression : class BindingIdentifieropt ClassTail
-    
+
     1. If BindingIdentifieropt is not present, let className be undefined.
     2. Else, let className be StringValue of BindingIdentifier.
     3. Let value be the result of ClassDefinitionEvaluation of ClassTail
        with argument className.
     [...]
-    
+
     14.5.14 Runtime Semantics: ClassDefinitionEvaluation
-    
+
     21. For each ClassElement m in order from methods
         a. If IsStatic of m is false, then
         b. Else,
            Let status be the result of performing PropertyDefinitionEvaluation for
            m with arguments F and false.
     [...]
-    
+
     14.3.8 Runtime Semantics: DefineMethod
-    
+
     MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
-    
+
     [...]
     6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
        scope, strict). If functionPrototype was passed as a parameter then pass its
        value as the functionPrototype optional argument of FunctionCreate.
     [...]
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -57,9 +57,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/expressions/function/dstr-ary-name-iter-val.js
+++ b/test/language/expressions/function/dstr-ary-name-iter-val.js
@@ -5,27 +5,27 @@
 description: SingleNameBinding with normal value iteration (function expression)
 es6id: 14.1.20
 flags: [generated]
-info: >
+info: |
     FunctionExpression : function ( FormalParameters ) { FunctionBody }
-    
+
         [...]
         3. Let closure be FunctionCreate(Normal, FormalParameters, FunctionBody,
            scope, strict).
         [...]
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -37,9 +37,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/expressions/generators/dstr-ary-name-iter-val.js
+++ b/test/language/expressions/generators/dstr-ary-name-iter-val.js
@@ -5,27 +5,27 @@
 description: SingleNameBinding with normal value iteration (generator function expression)
 es6id: 14.4.14
 flags: [generated]
-info: >
+info: |
     GeneratorExpression : function * ( FormalParameters ) { GeneratorBody }
-    
+
         [...]
         3. Let closure be GeneratorFunctionCreate(Normal, FormalParameters,
            GeneratorBody, scope, strict).
         [...]
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -37,9 +37,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/expressions/new/spread-err-sngl-err-expr-throws.js
+++ b/test/language/expressions/new/spread-err-sngl-err-expr-throws.js
@@ -5,24 +5,23 @@
 description: Spread operator applied to the only argument when evaluation throws (`new` operator)
 es6id: 12.3.3.1
 features: [generators]
-
 flags: [generated]
-info: >
+info: |
     MemberExpression : new MemberExpression Arguments
-    
+
     1. Return EvaluateNew(MemberExpression, Arguments).
-    
+
     12.3.3.1.1 Runtime Semantics: EvaluateNew
-    
+
     6. If arguments is empty, let argList be an empty List.
     7. Else,
        a. Let argList be ArgumentListEvaluation of arguments.
        [...]
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
-    
+
     ArgumentList : ... AssignmentExpression
-    
+
     1. Let list be an empty List.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
     3. Let spreadObj be GetValue(spreadRef).

--- a/test/language/expressions/new/spread-sngl-iter.js
+++ b/test/language/expressions/new/spread-sngl-iter.js
@@ -5,24 +5,23 @@
 description: Spread operator applied to the only argument with a valid iterator (`new` operator)
 es6id: 12.3.3.1
 features: [Symbol.iterator]
-
 flags: [generated]
-info: >
+info: |
     MemberExpression : new MemberExpression Arguments
-    
+
     1. Return EvaluateNew(MemberExpression, Arguments).
-    
+
     12.3.3.1.1 Runtime Semantics: EvaluateNew
-    
+
     6. If arguments is empty, let argList be an empty List.
     7. Else,
        a. Let argList be ArgumentListEvaluation of arguments.
        [...]
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
-    
+
     ArgumentList : ... AssignmentExpression
-    
+
     1. Let list be an empty List.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
     3. Let spreadObj be GetValue(spreadRef).

--- a/test/language/expressions/object/dstr-gen-meth-ary-name-iter-val.js
+++ b/test/language/expressions/object/dstr-gen-meth-ary-name-iter-val.js
@@ -5,10 +5,10 @@
 description: SingleNameBinding with normal value iteration (generator method)
 es6id: 14.4.13
 flags: [generated]
-info: >
+info: |
     GeneratorMethod :
         * PropertyName ( StrictFormalParameters ) { GeneratorBody }
-    
+
     1. Let propKey be the result of evaluating PropertyName.
     2. ReturnIfAbrupt(propKey).
     3. If the function code for this GeneratorMethod is strict mode code,
@@ -17,20 +17,20 @@ info: >
     5. Let closure be GeneratorFunctionCreate(Method,
        StrictFormalParameters, GeneratorBody, scope, strict).
     [...]
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -42,9 +42,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/expressions/object/dstr-meth-ary-name-iter-val.js
+++ b/test/language/expressions/object/dstr-meth-ary-name-iter-val.js
@@ -5,29 +5,29 @@
 description: SingleNameBinding with normal value iteration (method)
 es6id: 14.3.8
 flags: [generated]
-info: >
+info: |
     MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
-    
+
     [...]
     6. Let closure be FunctionCreate(kind, StrictFormalParameters,
        FunctionBody, scope, strict). If functionPrototype was passed as a
        parameter then pass its value as the functionPrototype optional argument
        of FunctionCreate.
     [...]
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -39,9 +39,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/expressions/super/spread-err-sngl-err-expr-throws.js
+++ b/test/language/expressions/super/spread-err-sngl-err-expr-throws.js
@@ -5,11 +5,10 @@
 description: Spread operator applied to the only argument when evaluation throws (SuperCall)
 es6id: 12.3.5.1
 features: [generators]
-
 flags: [generated]
-info: >
+info: |
     SuperCall : super Arguments
-    
+
     1. Let newTarget be GetNewTarget().
     2. If newTarget is undefined, throw a ReferenceError exception.
     3. Let func be GetSuperConstructor().
@@ -18,9 +17,9 @@ info: >
     [...]
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
-    
+
     ArgumentList : ... AssignmentExpression
-    
+
     1. Let list be an empty List.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
     3. Let spreadObj be GetValue(spreadRef).

--- a/test/language/expressions/super/spread-sngl-iter.js
+++ b/test/language/expressions/super/spread-sngl-iter.js
@@ -5,11 +5,10 @@
 description: Spread operator applied to the only argument with a valid iterator (SuperCall)
 es6id: 12.3.5.1
 features: [Symbol.iterator]
-
 flags: [generated]
-info: >
+info: |
     SuperCall : super Arguments
-    
+
     1. Let newTarget be GetNewTarget().
     2. If newTarget is undefined, throw a ReferenceError exception.
     3. Let func be GetSuperConstructor().
@@ -18,9 +17,9 @@ info: >
     [...]
 
     12.3.6.1 Runtime Semantics: ArgumentListEvaluation
-    
+
     ArgumentList : ... AssignmentExpression
-    
+
     1. Let list be an empty List.
     2. Let spreadRef be the result of evaluating AssignmentExpression.
     3. Let spreadObj be GetValue(spreadRef).

--- a/test/language/statements/class/dstr-gen-meth-ary-name-iter-val.js
+++ b/test/language/statements/class/dstr-gen-meth-ary-name-iter-val.js
@@ -5,27 +5,27 @@
 description: SingleNameBinding with normal value iteration (class expression method)
 es6id: 14.5.16
 flags: [generated]
-info: >
+info: |
     ClassDeclaration : class BindingIdentifier ClassTail
-    
+
     1. Let className be StringValue of BindingIdentifier.
     2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
        argument className.
     [...]
-    
+
     14.5.14 Runtime Semantics: ClassDefinitionEvaluation
-    
+
     21. For each ClassElement m in order from methods
         a. If IsStatic of m is false, then
            i. Let status be the result of performing
               PropertyDefinitionEvaluation for m with arguments proto and
               false.
         [...]
-    
+
     14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
-    
+
     GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
-    
+
     1. Let propKey be the result of evaluating PropertyName.
     2. ReturnIfAbrupt(propKey).
     3. If the function code for this GeneratorMethod is strict mode code,
@@ -33,20 +33,20 @@ info: >
     4. Let scope be the running execution context's LexicalEnvironment.
     5. Let closure be GeneratorFunctionCreate(Method,
        StrictFormalParameters, GeneratorBody, scope, strict).
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -58,9 +58,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/statements/class/dstr-gen-meth-static-ary-name-iter-val.js
+++ b/test/language/statements/class/dstr-gen-meth-static-ary-name-iter-val.js
@@ -5,27 +5,27 @@
 description: SingleNameBinding with normal value iteration (static class expression generator method)
 es6id: 14.5.15
 flags: [generated]
-info: >
+info: |
     ClassDeclaration : class BindingIdentifier ClassTail
-    
+
     1. Let className be StringValue of BindingIdentifier.
     2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
        argument className.
     [...]
-    
+
     14.5.14 Runtime Semantics: ClassDefinitionEvaluation
-    
+
     21. For each ClassElement m in order from methods
         a. If IsStatic of m is false, then
         b. Else,
            Let status be the result of performing PropertyDefinitionEvaluation for
            m with arguments F and false.
     [...]
-    
+
     14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
-    
+
     GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
-    
+
     1. Let propKey be the result of evaluating PropertyName.
     2. ReturnIfAbrupt(propKey).
     3. If the function code for this GeneratorMethod is strict mode code,
@@ -33,20 +33,20 @@ info: >
     4. Let scope be the running execution context's LexicalEnvironment.
     5. Let closure be GeneratorFunctionCreate(Method,
        StrictFormalParameters, GeneratorBody, scope, strict).
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -58,9 +58,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/statements/class/dstr-meth-ary-name-iter-val.js
+++ b/test/language/statements/class/dstr-meth-ary-name-iter-val.js
@@ -5,46 +5,46 @@
 description: SingleNameBinding with normal value iteration (class expression method)
 es6id: 14.5.15
 flags: [generated]
-info: >
+info: |
     ClassDeclaration : class BindingIdentifier ClassTail
-    
+
     1. Let className be StringValue of BindingIdentifier.
     2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
        argument className.
     [...]
-    
+
     14.5.14 Runtime Semantics: ClassDefinitionEvaluation
-    
+
     21. For each ClassElement m in order from methods
         a. If IsStatic of m is false, then
            i. Let status be the result of performing
               PropertyDefinitionEvaluation for m with arguments proto and
               false.
         [...]
-    
+
     14.3.8 Runtime Semantics: DefineMethod
-    
+
     MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
-    
+
     [...]
     6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
        scope, strict). If functionPrototype was passed as a parameter then pass its
        value as the functionPrototype optional argument of FunctionCreate.
     [...]
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -56,9 +56,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/statements/class/dstr-meth-static-ary-name-iter-val.js
+++ b/test/language/statements/class/dstr-meth-static-ary-name-iter-val.js
@@ -5,46 +5,46 @@
 description: SingleNameBinding with normal value iteration (static class expression method)
 es6id: 14.5.15
 flags: [generated]
-info: >
+info: |
     ClassDeclaration : class BindingIdentifier ClassTail
-    
+
     1. Let className be StringValue of BindingIdentifier.
     2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
        argument className.
     [...]
-    
+
     14.5.14 Runtime Semantics: ClassDefinitionEvaluation
-    
+
     21. For each ClassElement m in order from methods
         a. If IsStatic of m is false, then
         b. Else,
            Let status be the result of performing PropertyDefinitionEvaluation for
            m with arguments F and false.
     [...]
-    
+
     14.3.8 Runtime Semantics: DefineMethod
-    
+
     MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
-    
+
     [...]
     6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
        scope, strict). If functionPrototype was passed as a parameter then pass its
        value as the functionPrototype optional argument of FunctionCreate.
     [...]
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -56,9 +56,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/statements/const/dstr-ary-name-iter-val.js
+++ b/test/language/statements/const/dstr-ary-name-iter-val.js
@@ -5,9 +5,9 @@
 description: SingleNameBinding with normal value iteration (`const` statement)
 es6id: 13.3.1.4
 flags: [generated]
-info: >
+info: |
     LexicalBinding : BindingPattern Initializer
-    
+
     1. Let rhs be the result of evaluating Initializer.
     2. Let value be GetValue(rhs).
     3. ReturnIfAbrupt(value).
@@ -16,9 +16,9 @@ info: >
        using value and env as the arguments.
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/statements/function/dstr-ary-name-iter-val.js
+++ b/test/language/statements/function/dstr-ary-name-iter-val.js
@@ -5,28 +5,28 @@
 description: SingleNameBinding with normal value iteration (function declaration)
 es6id: 14.1.19
 flags: [generated]
-info: >
+info: |
     FunctionDeclaration :
         function BindingIdentifier ( FormalParameters ) { FunctionBody }
-    
+
         [...]
         3. Let F be FunctionCreate(Normal, FormalParameters, FunctionBody,
            scope, strict).
         [...]
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -38,9 +38,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/statements/generators/dstr-ary-name-iter-val.js
+++ b/test/language/statements/generators/dstr-ary-name-iter-val.js
@@ -5,27 +5,27 @@
 description: SingleNameBinding with normal value iteration (generator function declaration)
 es6id: 14.4.12
 flags: [generated]
-info: >
+info: |
     GeneratorDeclaration : function * ( FormalParameters ) { GeneratorBody }
-    
+
         [...]
         2. Let F be GeneratorFunctionCreate(Normal, FormalParameters,
            GeneratorBody, scope, strict).
         [...]
-    
+
     9.2.1 [[Call]] ( thisArgument, argumentsList)
-    
+
     [...]
     7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
     [...]
-    
+
     9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
-    
+
     1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
     [...]
-    
+
     9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
-    
+
     [...]
     23. Let iteratorRecord be Record {[[iterator]]:
         CreateListIterator(argumentsList), [[done]]: false}.
@@ -37,9 +37,9 @@ info: >
     [...]
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/statements/let/dstr-ary-name-iter-val.js
+++ b/test/language/statements/let/dstr-ary-name-iter-val.js
@@ -5,9 +5,9 @@
 description: SingleNameBinding with normal value iteration (`let` statement)
 es6id: 13.3.1.4
 flags: [generated]
-info: >
+info: |
     LexicalBinding : BindingPattern Initializer
-    
+
     1. Let rhs be the result of evaluating Initializer.
     2. Let value be GetValue(rhs).
     3. ReturnIfAbrupt(value).
@@ -16,9 +16,9 @@ info: >
        using value and env as the arguments.
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/test/language/statements/variable/dstr-ary-name-iter-val.js
+++ b/test/language/statements/variable/dstr-ary-name-iter-val.js
@@ -5,9 +5,9 @@
 description: SingleNameBinding with normal value iteration (`var` statement)
 es6id: 13.3.2.4
 flags: [generated]
-info: >
+info: |
     VariableDeclaration : BindingPattern Initializer
-    
+
     1. Let rhs be the result of evaluating Initializer.
     2. Let rval be GetValue(rhs).
     3. ReturnIfAbrupt(rval).
@@ -15,9 +15,9 @@ info: >
        BindingPattern passing rval and undefined as arguments.
 
     13.3.3.6 Runtime Semantics: IteratorBindingInitialization
-    
+
     SingleNameBinding : BindingIdentifier Initializeropt
-    
+
     [...]
     4. If iteratorRecord.[[done]] is false, then
        a. Let next be IteratorStep(iteratorRecord.[[iterator]]).

--- a/tools/generation/lib/template.py
+++ b/tools/generation/lib/template.py
@@ -20,7 +20,11 @@ def indent(text, prefix = '    '):
     else:
         lines = text.split('\n')
 
-    return prefix + ('\n' + prefix).join(lines)
+    indented = map(
+        lambda line: line if len(line) == 0 else prefix + line,
+        lines)
+
+    return '\n'.join(indented)
 
 class Template:
     def __init__(self, filename):

--- a/tools/generation/lib/template.py
+++ b/tools/generation/lib/template.py
@@ -119,7 +119,7 @@ class Template:
         features += case_values['meta'].get('features', [])
         features += self.attribs['meta'].get('features', [])
         if len(features):
-            lines += ['features: ' + yaml.dump(features)]
+            lines += ['features: ' + yaml.dump(features).strip()]
 
         flags = ['generated']
         flags += case_values['meta'].get('flags', [])

--- a/tools/generation/lib/template.py
+++ b/tools/generation/lib/template.py
@@ -149,7 +149,7 @@ class Template:
             info.append(indent(case_values['meta']['info']))
 
         if len(info):
-            lines.append('info: >')
+            lines.append('info: |')
             lines += info
 
         lines.append('---*/')

--- a/tools/generation/test/expected/normal/features-normal.js
+++ b/tools/generation/test/expected/normal/features-normal.js
@@ -7,7 +7,7 @@ es6id: 1.2.3
 features: [f1]
 flags: [generated, a, b]
 includes: [foo.js]
-info: >
+info: |
     case info
 ---*/
 

--- a/tools/generation/test/expected/normal/features-normal.js
+++ b/tools/generation/test/expected/normal/features-normal.js
@@ -1,0 +1,14 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/normal.case
+// - tools/generation/test/fixtures/normal/features.template
+/*---
+description: foobar (First template name)
+es6id: 1.2.3
+features: [f1]
+flags: [generated, a, b]
+includes: [foo.js]
+info: >
+    case info
+---*/
+
+'This is "teardown" code.';

--- a/tools/generation/test/expected/normal/info-multiline-folding-normal.js
+++ b/tools/generation/test/expected/normal/info-multiline-folding-normal.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/normal.case
+// - tools/generation/test/fixtures/normal/info-multiline-folding.template
+/*---
+description: foobar (First template name)
+es6id: 1.2.3
+flags: [generated, a, b]
+includes: [foo.js]
+info: >
+    This is an "info" field with an
+
+    empty line
+    Trailing white space in the template: 
+    should be preserved:	
+     
+      
+       
+        
+    	
+    		
+    	 	  
+
+    case info
+---*/
+
+// Trailing white space in the test body: 
+// should be preserved:	
+ 
+  
+   
+    
+	
+		
+	 	  
+
+'This is "teardown" code.';

--- a/tools/generation/test/expected/normal/info-multiline-folding-normal.js
+++ b/tools/generation/test/expected/normal/info-multiline-folding-normal.js
@@ -6,7 +6,7 @@ description: foobar (First template name)
 es6id: 1.2.3
 flags: [generated, a, b]
 includes: [foo.js]
-info: >
+info: |
     This is an "info" field with an
 
     empty line

--- a/tools/generation/test/expected/normal/nested/path2-normal.js
+++ b/tools/generation/test/expected/normal/nested/path2-normal.js
@@ -6,7 +6,7 @@ description: foobar (Second template name)
 esid: sec-a-generic-id
 flags: [generated, a, b]
 includes: [foo.js, bar.js]
-info: >
+info: |
     template info
 
     case info

--- a/tools/generation/test/expected/normal/no-info-normal.js
+++ b/tools/generation/test/expected/normal/no-info-normal.js
@@ -6,7 +6,7 @@ description: foobar (First template name)
 es6id: 1.2.3
 flags: [generated, a, b]
 includes: [foo.js]
-info: >
+info: |
     case info
 ---*/
 

--- a/tools/generation/test/expected/normal/path1-normal.js
+++ b/tools/generation/test/expected/normal/path1-normal.js
@@ -6,7 +6,7 @@ description: foobar (First template name)
 es6id: 1.2.3
 flags: [generated, a, b, c, d]
 includes: [foo.js]
-info: >
+info: |
     template info
 
     case info

--- a/tools/generation/test/fixtures/normal/features.template
+++ b/tools/generation/test/fixtures/normal/features.template
@@ -1,0 +1,8 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+name: First template name
+path: normal/features-
+es6id: 1.2.3
+features: [f1]
+---*/

--- a/tools/generation/test/fixtures/normal/info-multiline-folding.template
+++ b/tools/generation/test/fixtures/normal/info-multiline-folding.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+name: First template name
+path: normal/info-multiline-folding-
+es6id: 1.2.3
+info: |
+    This is an "info" field with an
+
+    empty line
+    Trailing white space in the template: 
+    should be preserved:	
+     
+      
+       
+        
+    	
+    		
+    	 	  
+---*/
+
+// Trailing white space in the test body: 
+// should be preserved:	
+ 
+  
+   
+    
+	
+		
+	 	  


### PR DESCRIPTION
This patch corrects a number of errors in the test generation tool which led to
undesirable artifacts in the output files, as identified by @leobalter in the
review of gh-584.

