### PR TITLE
[TypedArrays] Apply code consistency fixes after checks with JSHint

### DIFF
--- a/test/built-ins/TypedArray/from/mapfn-is-not-callable.js
+++ b/test/built-ins/TypedArray/from/mapfn-is-not-callable.js
@@ -46,7 +46,7 @@ assert.throws(TypeError, function() {
   TypedArray.from(arrayLike, true);
 }, "mapfn is a boolean");
 
-var s = Symbol("1")
+var s = Symbol("1");
 assert.throws(TypeError, function() {
   TypedArray.from(arrayLike, s);
 }, "mapfn is a symbol");

--- a/test/built-ins/TypedArray/prototype/byteOffset/return-byteoffset.js
+++ b/test/built-ins/TypedArray/prototype/byteOffset/return-byteoffset.js
@@ -24,7 +24,7 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(ta2.byteOffset, offset, "TA(buffer, offset)");
 
   var buffer2 = new ArrayBuffer(8 * TA.BYTES_PER_ELEMENT);
-  var sample = new TA(buffer2, offset)
+  var sample = new TA(buffer2, offset);
   var ta3 = new TA(sample);
   assert.sameValue(ta3.byteOffset, 0, "TA(typedArray)");
 });

--- a/test/built-ins/TypedArray/prototype/every/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/every/values-are-not-cached.js
@@ -27,7 +27,6 @@ includes: [testTypedArray.js]
 
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA([42, 43, 44]);
-  var calls = 0;
 
   sample.every(function(v, i) {
     if (i < sample.length - 1) {

--- a/test/built-ins/TypedArray/prototype/fill/fill-values-symbol-throws.js
+++ b/test/built-ins/TypedArray/prototype/fill/fill-values-symbol-throws.js
@@ -44,5 +44,5 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.throws(TypeError, function() {
     sample.fill(s);
-  })
+  });
 });

--- a/test/built-ins/TypedArray/prototype/find/return-undefined-if-predicate-returns-false-value.js
+++ b/test/built-ins/TypedArray/prototype/find/return-undefined-if-predicate-returns-false-value.js
@@ -33,7 +33,7 @@ testWithTypedArrayConstructors(function(TA) {
   var sample = new TA(3);
   var called = 0;
 
-  var result = sample.find(function(val) {
+  var result = sample.find(function() {
     called++;
     return false;
   });
@@ -41,21 +41,21 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(called, 3, "predicate was called three times");
   assert.sameValue(result, undefined);
 
-  result = sample.find(function(val) { return ""; });
+  result = sample.find(function() { return ""; });
   assert.sameValue(result, undefined, "ToBoolean(empty string)");
 
-  result = sample.find(function(val) { return undefined; });
+  result = sample.find(function() { return undefined; });
   assert.sameValue(result, undefined, "ToBoolean(undefined)");
 
-  result = sample.find(function(val) { return null; });
+  result = sample.find(function() { return null; });
   assert.sameValue(result, undefined, "ToBoolean(null)");
 
-  result = sample.find(function(val) { return 0; });
+  result = sample.find(function() { return 0; });
   assert.sameValue(result, undefined, "ToBoolean(0)");
 
-  result = sample.find(function(val) { return -0; });
+  result = sample.find(function() { return -0; });
   assert.sameValue(result, undefined, "ToBoolean(-0)");
 
-  result = sample.find(function(val) { return NaN; });
+  result = sample.find(function() { return NaN; });
   assert.sameValue(result, undefined, "ToBoolean(NaN)");
 });

--- a/test/built-ins/TypedArray/prototype/findIndex/return-negative-one-if-predicate-returns-false-value.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/return-negative-one-if-predicate-returns-false-value.js
@@ -30,7 +30,7 @@ testWithTypedArrayConstructors(function(TA) {
   var sample = new TA([1, 2, 3]);
   var called = 0;
 
-  var result = sample.findIndex(function(val) {
+  var result = sample.findIndex(function() {
     called++;
     return false;
   });
@@ -38,21 +38,21 @@ testWithTypedArrayConstructors(function(TA) {
   assert.sameValue(called, 3, "predicate was called three times");
   assert.sameValue(result, -1, "result is -1 when predicate returns are false");
 
-  result = sample.findIndex(function(val) { return ""; });
+  result = sample.findIndex(function() { return ""; });
   assert.sameValue(result, -1, "ToBoolean(string)");
 
-  result = sample.findIndex(function(val) { return undefined; });
+  result = sample.findIndex(function() { return undefined; });
   assert.sameValue(result, -1, "ToBoolean(undefined)");
 
-  result = sample.findIndex(function(val) { return null; });
+  result = sample.findIndex(function() { return null; });
   assert.sameValue(result, -1, "ToBoolean(null)");
 
-  result = sample.findIndex(function(val) { return 0; });
+  result = sample.findIndex(function() { return 0; });
   assert.sameValue(result, -1, "ToBoolean(0)");
 
-  result = sample.findIndex(function(val) { return -0; });
+  result = sample.findIndex(function() { return -0; });
   assert.sameValue(result, -1, "ToBoolean(-0)");
 
-  result = sample.findIndex(function(val) { return NaN; });
+  result = sample.findIndex(function() { return NaN; });
   assert.sameValue(result, -1, "ToBoolean(NaN)");
 });

--- a/test/built-ins/TypedArray/prototype/forEach/callbackfn-not-called-on-empty.js
+++ b/test/built-ins/TypedArray/prototype/forEach/callbackfn-not-called-on-empty.js
@@ -27,7 +27,7 @@ includes: [testTypedArray.js]
 testWithTypedArrayConstructors(function(TA) {
   var called = 0;
 
-  var result1 = new TA().forEach(function() {
+  new TA().forEach(function() {
     called++;
   });
 

--- a/test/built-ins/TypedArray/prototype/indexOf/return-abrupt-tointeger-fromindex-symbol.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/return-abrupt-tointeger-fromindex-symbol.js
@@ -28,5 +28,5 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.throws(TypeError, function() {
     sample.indexOf(7, fromIndex);
-  })
+  });
 });

--- a/test/built-ins/TypedArray/prototype/indexOf/return-abrupt-tointeger-fromindex.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/return-abrupt-tointeger-fromindex.js
@@ -31,5 +31,5 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.throws(Test262Error, function() {
     sample.indexOf(7, fromIndex);
-  })
+  });
 });

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/return-abrupt-tointeger-fromindex-symbol.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/return-abrupt-tointeger-fromindex-symbol.js
@@ -28,5 +28,5 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.throws(TypeError, function() {
     sample.lastIndexOf(7, fromIndex);
-  })
+  });
 });

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/return-abrupt-tointeger-fromindex.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/return-abrupt-tointeger-fromindex.js
@@ -31,5 +31,5 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.throws(Test262Error, function() {
     sample.lastIndexOf(7, fromIndex);
-  })
+  });
 });

--- a/test/built-ins/TypedArray/prototype/map/callbackfn-return-does-not-copy-non-integer-properties.js
+++ b/test/built-ins/TypedArray/prototype/map/callbackfn-return-does-not-copy-non-integer-properties.js
@@ -22,7 +22,7 @@ testWithTypedArrayConstructors(function(TA) {
   var bar = Symbol("1");
 
   sample.foo = 42;
-  sample[bar]
+  sample[bar] = 1;
 
   var result = sample.map(function() {
     return 0;

--- a/test/built-ins/TypedArray/prototype/some/returns-true-if-any-cb-returns-true.js
+++ b/test/built-ins/TypedArray/prototype/some/returns-true-if-any-cb-returns-true.js
@@ -29,9 +29,8 @@ features: [Symbol]
 var s = Symbol("1");
 
 testWithTypedArrayConstructors(function(TA) {
-  var called = 0;
   var sample = new TA(42);
-  var values = [
+  [
     true,
     1,
     "test262",

--- a/test/built-ins/TypedArray/prototype/some/values-are-not-cached.js
+++ b/test/built-ins/TypedArray/prototype/some/values-are-not-cached.js
@@ -26,7 +26,6 @@ includes: [testTypedArray.js]
 
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA([42, 43, 44]);
-  var calls = 0;
 
   sample.some(function(v, i) {
     if (i < sample.length - 1) {

--- a/test/built-ins/TypedArray/prototype/subarray/detached-buffer.js
+++ b/test/built-ins/TypedArray/prototype/subarray/detached-buffer.js
@@ -47,7 +47,7 @@ var o2 = {
     end = true;
     return 2;
   }
-}
+};
 
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA(2);

--- a/test/built-ins/TypedArray/prototype/subarray/speciesctor-get-species-custom-ctor-invocation.js
+++ b/test/built-ins/TypedArray/prototype/subarray/speciesctor-get-species-custom-ctor-invocation.js
@@ -37,7 +37,6 @@ features: [Symbol.species]
 
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA([40, 41, 42]);
-  var calls = 0;
   var expectedOffset = TA.BYTES_PER_ELEMENT;
   var result, ctorThis;
 
@@ -46,7 +45,7 @@ testWithTypedArrayConstructors(function(TA) {
     result = arguments;
     ctorThis = this;
     return new TA(buffer, offset, length);
-  };;
+  };
 
   sample.subarray(1);
 

--- a/test/built-ins/TypedArray/prototype/subarray/speciesctor-get-species-custom-ctor.js
+++ b/test/built-ins/TypedArray/prototype/subarray/speciesctor-get-species-custom-ctor.js
@@ -44,7 +44,7 @@ testWithTypedArrayConstructors(function(TA) {
   sample.constructor[Symbol.species] = function(buffer, offset, length) {
     calls++;
     return new TA(buffer, offset, length);
-  };;
+  };
 
   result = sample.subarray(1);
 

--- a/test/built-ins/TypedArrays/buffer-arg-length-access-throws.js
+++ b/test/built-ins/TypedArrays/buffer-arg-length-access-throws.js
@@ -23,7 +23,7 @@ var length = {
   valueOf() {
     throw new Test262Error();
   }
-}
+};
 
 testWithTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {

--- a/test/built-ins/TypedArrays/from/mapfn-is-not-callable.js
+++ b/test/built-ins/TypedArrays/from/mapfn-is-not-callable.js
@@ -47,7 +47,7 @@ testWithTypedArrayConstructors(function(TA) {
     TA.from(arrayLike, true);
   }, "mapfn is a boolean");
 
-  var s = Symbol("1")
+  var s = Symbol("1");
   assert.throws(TypeError, function() {
     TA.from(arrayLike, s);
   }, "mapfn is a symbol");

--- a/test/built-ins/TypedArrays/from/mapfn-this-with-thisarg.js
+++ b/test/built-ins/TypedArrays/from/mapfn-this-with-thisarg.js
@@ -23,7 +23,7 @@ var thisArg = {};
 
 testWithTypedArrayConstructors(function(TA) {
   var results = [];
-  var mapfn = function(kValue, k) {
+  var mapfn = function() {
     results.push(this);
   };
 

--- a/test/built-ins/TypedArrays/from/mapfn-this-without-thisarg-non-strict.js
+++ b/test/built-ins/TypedArrays/from/mapfn-this-without-thisarg-non-strict.js
@@ -24,7 +24,7 @@ var global = this;
 
 testWithTypedArrayConstructors(function(TA) {
   var results = [];
-  var mapfn = function(kValue, k) {
+  var mapfn = function() {
     results.push(this);
   };
 

--- a/test/built-ins/TypedArrays/from/mapfn-this-without-thisarg-strict.js
+++ b/test/built-ins/TypedArrays/from/mapfn-this-without-thisarg-strict.js
@@ -23,7 +23,7 @@ var source = [42, 43];
 
 testWithTypedArrayConstructors(function(TA) {
   var results = [];
-  var mapfn = function(kValue, k) {
+  var mapfn = function() {
     results.push(this);
   };
 

--- a/test/built-ins/TypedArrays/from/new-instance-using-custom-ctor.js
+++ b/test/built-ins/TypedArrays/from/new-instance-using-custom-ctor.js
@@ -15,7 +15,7 @@ testWithTypedArrayConstructors(function(TA) {
   var ctor = function(len) {
     assert.sameValue(arguments.length, 1);
     called++;
-    return new TA(len)
+    return new TA(len);
   };
 
   var result = TA.from.call(ctor, source);

--- a/test/built-ins/TypedArrays/from/new-instance-with-mapfn.js
+++ b/test/built-ins/TypedArrays/from/new-instance-with-mapfn.js
@@ -10,7 +10,6 @@ includes: [testTypedArray.js]
 var source = [42, 43, 42];
 
 testWithTypedArrayConstructors(function(TA) {
-  var lastValue;
   var mapfn = function(kValue) {
     return kValue * 2;
   };

--- a/test/built-ins/TypedArrays/internals/DefineOwnProperty/detached-buffer.js
+++ b/test/built-ins/TypedArrays/internals/DefineOwnProperty/detached-buffer.js
@@ -37,7 +37,7 @@ var obj = {
   valueOf: function() {
     throw new Test262Error();
   }
-}
+};
 
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA(42);

--- a/test/built-ins/TypedArrays/internals/Set/detached-buffer-key-is-not-numeric-index.js
+++ b/test/built-ins/TypedArrays/internals/Set/detached-buffer-key-is-not-numeric-index.js
@@ -22,5 +22,5 @@ testWithTypedArrayConstructors(function(TA) {
   $DETACHBUFFER(sample.buffer);
 
   assert.sameValue(Reflect.set(sample, "foo", "test262"), true);
-  assert.sameValue(sample["foo"], "test262");
+  assert.sameValue(sample.foo, "test262");
 });

--- a/test/built-ins/TypedArrays/length-arg-is-not-valid-buffer-size-throws-rangeerror.js
+++ b/test/built-ins/TypedArrays/length-arg-is-not-valid-buffer-size-throws-rangeerror.js
@@ -49,5 +49,5 @@ var length = Math.pow(2, 53);
 testWithTypedArrayConstructors(function(TA) {
   assert.throws(RangeError, function() {
     new TA(length);
-  })
+  });
 });

--- a/test/built-ins/TypedArrays/object-arg-iterator-not-callable-throws.js
+++ b/test/built-ins/TypedArrays/object-arg-iterator-not-callable-throws.js
@@ -19,7 +19,7 @@ includes: [testTypedArray.js]
 features: [Symbol.iterator]
 ---*/
 
-var obj = function () {}
+var obj = function () {};
 
 testWithTypedArrayConstructors(function(TA) {
   obj[Symbol.iterator] = {};

--- a/test/built-ins/TypedArrays/object-arg-iterator-throws.js
+++ b/test/built-ins/TypedArrays/object-arg-iterator-throws.js
@@ -19,7 +19,7 @@ includes: [testTypedArray.js]
 features: [Symbol.iterator]
 ---*/
 
-var obj = function () {}
+var obj = function () {};
 
 Object.defineProperty(obj, Symbol.iterator, {
   get() {

--- a/test/built-ins/TypedArrays/of/argument-is-symbol-throws.js
+++ b/test/built-ins/TypedArrays/of/argument-is-symbol-throws.js
@@ -18,6 +18,6 @@ var s = Symbol("1");
 
 testWithTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
-    var result = TA.of(s);
+    TA.of(s);
   });
 });

--- a/test/built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-access-throws.js
+++ b/test/built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-access-throws.js
@@ -25,9 +25,8 @@ includes: [testTypedArray.js]
 ---*/
 
 testWithTypedArrayConstructors(function(TA) {
-  var sample1 = Int8Array;
-  var sample2 = Int16Array;
-  var sample = new (TA === Int8Array ? sample2 : sample1);
+  var OtherCtor = TA === Int8Array ? Int16Array : Int8Array;
+  var sample = new OtherCtor();
 
   Object.defineProperty(sample.buffer, "constructor", {
     get() {

--- a/test/built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-species-null.js
+++ b/test/built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-species-null.js
@@ -26,12 +26,10 @@ includes: [testTypedArray.js]
 features: [Symbol.species]
 ---*/
 
-var sample1 = new Int8Array();
-var sample2 = new Int16Array();
-
 testWithTypedArrayConstructors(function(TA) {
-  var sample = TA === Int8Array ? sample2 : sample1;
-  var ctor = {}
+  var OtherCtor = TA === Int8Array ? Int16Array : Int8Array;
+  var sample = new OtherCtor();
+  var ctor = {};
 
   sample.buffer.constructor = ctor;
 

--- a/test/built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-species-undefined.js
+++ b/test/built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-species-undefined.js
@@ -26,12 +26,10 @@ includes: [testTypedArray.js]
 features: [Symbol.species]
 ---*/
 
-var sample1 = new Int8Array();
-var sample2 = new Int16Array();
-
 testWithTypedArrayConstructors(function(TA) {
-  var sample = TA === Int8Array ? sample2 : sample1;
-  var ctor = {}
+  var OtherCtor = TA === Int8Array ? Int16Array : Int8Array;
+  var sample = new OtherCtor();
+  var ctor = {};
 
   sample.buffer.constructor = ctor;
 

--- a/test/built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-null.js
+++ b/test/built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-null.js
@@ -35,7 +35,7 @@ features: [Symbol.species]
 
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA(4);
-  var ctor = {}
+  var ctor = {};
 
   sample.buffer.constructor = ctor;
 

--- a/test/built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-undefined.js
+++ b/test/built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-undefined.js
@@ -35,7 +35,7 @@ features: [Symbol.species]
 
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA(4);
-  var ctor = {}
+  var ctor = {};
 
   sample.buffer.constructor = ctor;
 


### PR DESCRIPTION
I used JSHint to find some unused variables, missing semi-colons, etc on the tests for TypedArrays. The test results are not affected by these changes, verified each changed file on es6draft, v8 and SpiderMonkey, before and after the changes.

