### PR TITLE
Add tests for Annex B `Object.prototype` methods

### DIFF
--- a/test/annexB/built-ins/Object/prototype/__defineGetter__/define-abrupt.js
+++ b/test/annexB/built-ins/Object/prototype/__defineGetter__/define-abrupt.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when [[DefineOwnProperty]] returns an abrupt completion
+info: |
+    [...]
+    5. Perform ? DefinePropertyOrThrow(O, key, desc).
+features: [Proxy]
+---*/
+
+var noop = function() {};
+var thrower = function() {
+  throw new Test262Error();
+};
+var subject = new Proxy({}, { defineProperty: thrower });
+
+assert.throws(Test262Error, function() {
+  subject.__defineGetter__('attr', noop);
+});

--- a/test/annexB/built-ins/Object/prototype/__defineGetter__/define-existing.js
+++ b/test/annexB/built-ins/Object/prototype/__defineGetter__/define-existing.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when property exists and is configurable
+info: |
+    [...]
+    3. Let desc be PropertyDescriptor{[[Get]]: getter, [[Enumerable]]: true,
+       [[Configurable]]: true}.
+    4. Let key be ? ToPropertyKey(P).
+    5. Perform ? DefinePropertyOrThrow(O, key, desc).
+    6. Return undefined.
+includes: [propertyHelper.js]
+---*/
+
+var subject = {};
+var originalGet = function() {};
+var originalSet = function() {};
+var newGet = function() {};
+var desc, result;
+
+Object.defineProperty(subject, 'stringAcsr', {
+  get: originalGet,
+  set: originalSet,
+  enumerable: false,
+  configurable: true
+});
+
+result = subject.__defineGetter__('stringAcsr', newGet);
+
+desc = Object.getOwnPropertyDescriptor(subject, 'stringAcsr');
+verifyEnumerable(subject, 'stringAcsr');
+verifyConfigurable(subject, 'stringAcsr');
+
+assert.sameValue(desc.get, newGet, 'descriptor `get` method');
+assert.sameValue(desc.set, originalSet, 'descriptor `set` method');
+assert.sameValue(desc.value, undefined, 'descriptor `value` property');
+
+assert.sameValue(result, undefined, 'method return value');

--- a/test/annexB/built-ins/Object/prototype/__defineGetter__/define-new.js
+++ b/test/annexB/built-ins/Object/prototype/__defineGetter__/define-new.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when property does not exist
+info: |
+    [...]
+    3. Let desc be PropertyDescriptor{[[Get]]: getter, [[Enumerable]]: true,
+       [[Configurable]]: true}.
+    4. Let key be ? ToPropertyKey(P).
+    5. Perform ? DefinePropertyOrThrow(O, key, desc).
+    6. Return undefined.
+includes: [propertyHelper.js]
+---*/
+
+var subject = {};
+var get = function() {};
+var desc, result;
+
+result = subject.__defineGetter__('stringAcsr', get);
+
+desc = Object.getOwnPropertyDescriptor(subject, 'stringAcsr');
+verifyEnumerable(subject, 'stringAcsr');
+verifyConfigurable(subject, 'stringAcsr');
+
+assert.sameValue(desc.get, get, 'descriptor `get` method');
+assert.sameValue(desc.set, undefined, 'descriptor `set` method');
+assert.sameValue(desc.value, undefined, 'descriptor `value` property');
+
+assert.sameValue(result, undefined, 'method return value');

--- a/test/annexB/built-ins/Object/prototype/__defineGetter__/define-non-configurable.js
+++ b/test/annexB/built-ins/Object/prototype/__defineGetter__/define-non-configurable.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when property exists and is not configurable
+info: |
+    [...]
+    5. Perform ? DefinePropertyOrThrow(O, key, desc).
+---*/
+
+var noop = function() {};
+var subject = Object.defineProperty(
+  {}, 'attr', { value: 1, configurable: false }
+);
+
+assert.sameValue(typeof Object.prototype.__defineGetter__, 'function');
+
+assert.throws(TypeError, function() {
+  subject.__defineGetter__('attr', noop);
+});

--- a/test/annexB/built-ins/Object/prototype/__defineGetter__/define-non-extensible.js
+++ b/test/annexB/built-ins/Object/prototype/__defineGetter__/define-non-extensible.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when "this" value is not extensible
+info: |
+    [...]
+    5. Perform ? DefinePropertyOrThrow(O, key, desc).
+---*/
+
+var noop = function() {};
+var thrower = function() {
+  throw new Test262Error();
+};
+var subject = Object.preventExtensions({ existing: null });
+
+subject.__defineGetter__('existing', noop);
+
+assert.throws(TypeError, function() {
+  subject.__defineGetter__('brand new', noop);
+});

--- a/test/annexB/built-ins/Object/prototype/__defineGetter__/define-non-extensible.js
+++ b/test/annexB/built-ins/Object/prototype/__defineGetter__/define-non-extensible.js
@@ -9,9 +9,6 @@ info: |
 ---*/
 
 var noop = function() {};
-var thrower = function() {
-  throw new Test262Error();
-};
 var subject = Object.preventExtensions({ existing: null });
 
 subject.__defineGetter__('existing', noop);

--- a/test/annexB/built-ins/Object/prototype/__defineGetter__/getter-non-callable.js
+++ b/test/annexB/built-ins/Object/prototype/__defineGetter__/getter-non-callable.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when getter is not callable
+info: |
+    [...]
+    2. If IsCallable(getter) is false, throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var subject = {};
+var symbol = Symbol('');
+var toStringCount = 0;
+var key = {
+  toString: function() {
+    toStringCount += 1;
+  }
+};
+
+assert.sameValue(typeof Object.prototype.__defineGetter__, 'function');
+
+assert.throws(TypeError, function() {
+  subject.__defineGetter__(key, '');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  subject.__defineGetter__(key, 23);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  subject.__defineGetter__(key, true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  subject.__defineGetter__(key, symbol);
+}, 'symbol');
+
+assert.throws(TypeError, function() {
+  subject.__defineGetter__(key, {});
+}, 'object');
+
+assert.sameValue(toStringCount, 0);

--- a/test/annexB/built-ins/Object/prototype/__defineGetter__/key-invalid.js
+++ b/test/annexB/built-ins/Object/prototype/__defineGetter__/key-invalid.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when property key cannot be derived
+info: |
+    [...]
+    4. Let key be ? ToPropertyKey(P).
+---*/
+
+var noop = function() {};
+var subject = {};
+var key = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  subject.__defineGetter__(key, noop);
+});

--- a/test/annexB/built-ins/Object/prototype/__defineGetter__/length.js
+++ b/test/annexB/built-ins/Object/prototype/__defineGetter__/length.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Object.prototype.__defineGetter__ `length` property
+info: >
+    ES6 Section 17:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this value
+    is equal to the largest number of named arguments shown in the subclause
+    headings for the function description, including optional parameters.
+
+    [...]
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Object.prototype.__defineGetter__.length, 2);
+
+verifyNotEnumerable(Object.prototype.__defineGetter__, 'length');
+verifyNotWritable(Object.prototype.__defineGetter__, 'length');
+verifyConfigurable(Object.prototype.__defineGetter__, 'length');

--- a/test/annexB/built-ins/Object/prototype/__defineGetter__/name.js
+++ b/test/annexB/built-ins/Object/prototype/__defineGetter__/name.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Object.prototype.__defineGetter__ `name` property
+info: >
+    ES6 Section 17:
+
+    Every built-in Function object, including constructors, that is not
+    identified as an anonymous function has a name property whose value is a
+    String. Unless otherwise specified, this value is the name that is given to
+    the function in this specification.
+
+    [...]
+
+    Unless otherwise specified, the name property of a built-in Function
+    object, if it exists, has the attributes { [[Writable]]: false,
+    [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Object.prototype.__defineGetter__.name, '__defineGetter__');
+
+verifyNotEnumerable(Object.prototype.__defineGetter__, 'name');
+verifyNotWritable(Object.prototype.__defineGetter__, 'name');
+verifyConfigurable(Object.prototype.__defineGetter__, 'name');

--- a/test/annexB/built-ins/Object/prototype/__defineGetter__/prop-desc.js
+++ b/test/annexB/built-ins/Object/prototype/__defineGetter__/prop-desc.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Property descriptor for Object.prototype.__defineGetter__
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Object.prototype, '__defineGetter__');
+verifyWritable(Object.prototype, '__defineGetter__');
+verifyConfigurable(Object.prototype, '__defineGetter__');

--- a/test/annexB/built-ins/Object/prototype/__defineGetter__/this-non-obj.js
+++ b/test/annexB/built-ins/Object/prototype/__defineGetter__/this-non-obj.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when "this" value is not Object-coercible
+info: |
+    1. Let O be ? ToObject(this value).
+---*/
+
+var __defineGetter__ = Object.prototype.__defineGetter__;
+var noop = function() {};
+var toStringCount = 0;
+var key = {
+  toString: function() {
+    toStringCount += 1;
+  }
+};
+
+assert.sameValue(typeof __defineGetter__, 'function');
+
+assert.throws(TypeError, function() {
+  __defineGetter__.call(undefined, key, noop);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  __defineGetter__.call(null, key, noop);
+}, 'null');
+
+assert.sameValue(toStringCount, 0);

--- a/test/annexB/built-ins/Object/prototype/__defineSetter__/define-abrupt.js
+++ b/test/annexB/built-ins/Object/prototype/__defineSetter__/define-abrupt.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when [[DefineOwnProperty]] returns an abrupt completion
+info: |
+    [...]
+    5. Perform ? DefinePropertyOrThrow(O, key, desc).
+features: [Proxy]
+---*/
+
+var noop = function() {};
+var thrower = function() {
+  throw new Test262Error();
+};
+var subject = new Proxy({}, { defineProperty: thrower });
+
+assert.throws(Test262Error, function() {
+  subject.__defineSetter__('attr', noop);
+});

--- a/test/annexB/built-ins/Object/prototype/__defineSetter__/define-existing.js
+++ b/test/annexB/built-ins/Object/prototype/__defineSetter__/define-existing.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when property exists and is configurable
+info: |
+    [...]
+    3. Let desc be PropertyDescriptor{[[Set]]: setter, [[Enumerable]]: true,
+       [[Configurable]]: true}.
+    4. Let key be ? ToPropertyKey(P).
+    5. Perform ? DefinePropertyOrThrow(O, key, desc).
+    6. Return undefined.
+includes: [propertyHelper.js]
+---*/
+
+var subject = {};
+var originalGet = function() {};
+var originalSet = function() {};
+var newSet = function() {};
+var desc, result;
+
+Object.defineProperty(subject, 'stringAcsr', {
+  get: originalGet,
+  set: originalSet,
+  enumerable: false,
+  configurable: true
+});
+
+result = subject.__defineSetter__('stringAcsr', newSet);
+
+desc = Object.getOwnPropertyDescriptor(subject, 'stringAcsr');
+verifyEnumerable(subject, 'stringAcsr');
+verifyConfigurable(subject, 'stringAcsr');
+
+assert.sameValue(desc.get, originalGet, 'descriptor `get` method');
+assert.sameValue(desc.set, newSet, 'descriptor `set` method');
+assert.sameValue(desc.value, undefined, 'descriptor `value` property');
+
+assert.sameValue(result, undefined, 'method return value');

--- a/test/annexB/built-ins/Object/prototype/__defineSetter__/define-new.js
+++ b/test/annexB/built-ins/Object/prototype/__defineSetter__/define-new.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when property does not exist
+info: |
+    [...]
+    3. Let desc be PropertyDescriptor{[[Set]]: setter, [[Enumerable]]: true,
+       [[Configurable]]: true}.
+    4. Let key be ? ToPropertyKey(P).
+    5. Perform ? DefinePropertyOrThrow(O, key, desc).
+    6. Return undefined.
+includes: [propertyHelper.js]
+---*/
+
+var subject = {};
+var set = function() {};
+var desc, result;
+
+result = subject.__defineSetter__('stringAcsr', set);
+
+desc = Object.getOwnPropertyDescriptor(subject, 'stringAcsr');
+verifyEnumerable(subject, 'stringAcsr');
+verifyConfigurable(subject, 'stringAcsr');
+
+assert.sameValue(desc.get, undefined, 'descriptor `get` method');
+assert.sameValue(desc.set, set, 'descriptor `set` method');
+assert.sameValue(desc.value, undefined, 'descriptor `value` property');
+
+assert.sameValue(result, undefined, 'method return value');

--- a/test/annexB/built-ins/Object/prototype/__defineSetter__/define-non-configurable.js
+++ b/test/annexB/built-ins/Object/prototype/__defineSetter__/define-non-configurable.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when property exists and is not configurable
+info: |
+    [...]
+    5. Perform ? DefinePropertyOrThrow(O, key, desc).
+---*/
+
+var noop = function() {};
+var subject = Object.defineProperty(
+  {}, 'attr', { value: 1, configurable: false }
+);
+
+assert.sameValue(typeof Object.prototype.__defineSetter__, 'function');
+
+assert.throws(TypeError, function() {
+  subject.__defineSetter__('attr', noop);
+});

--- a/test/annexB/built-ins/Object/prototype/__defineSetter__/define-non-extensible.js
+++ b/test/annexB/built-ins/Object/prototype/__defineSetter__/define-non-extensible.js
@@ -9,9 +9,6 @@ info: |
 ---*/
 
 var noop = function() {};
-var thrower = function() {
-  throw new Test262Error();
-};
 var subject = Object.preventExtensions({ existing: null });
 
 subject.__defineSetter__('existing', noop);

--- a/test/annexB/built-ins/Object/prototype/__defineSetter__/define-non-extensible.js
+++ b/test/annexB/built-ins/Object/prototype/__defineSetter__/define-non-extensible.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when "this" value is not extensible
+info: |
+    [...]
+    5. Perform ? DefinePropertyOrThrow(O, key, desc).
+---*/
+
+var noop = function() {};
+var thrower = function() {
+  throw new Test262Error();
+};
+var subject = Object.preventExtensions({ existing: null });
+
+subject.__defineSetter__('existing', noop);
+
+assert.throws(TypeError, function() {
+  subject.__defineSetter__('brand new', noop);
+});

--- a/test/annexB/built-ins/Object/prototype/__defineSetter__/key-invalid.js
+++ b/test/annexB/built-ins/Object/prototype/__defineSetter__/key-invalid.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when property key cannot be derived
+info: |
+    [...]
+    4. Let key be ? ToPropertyKey(P).
+---*/
+
+var noop = function() {};
+var subject = {};
+var key = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  subject.__defineSetter__(key, noop);
+});

--- a/test/annexB/built-ins/Object/prototype/__defineSetter__/length.js
+++ b/test/annexB/built-ins/Object/prototype/__defineSetter__/length.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Object.prototype.__defineSetter__ `length` property
+info: >
+    ES6 Section 17:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this value
+    is equal to the largest number of named arguments shown in the subclause
+    headings for the function description, including optional parameters.
+
+    [...]
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Object.prototype.__defineSetter__.length, 2);
+
+verifyNotEnumerable(Object.prototype.__defineSetter__, 'length');
+verifyNotWritable(Object.prototype.__defineSetter__, 'length');
+verifyConfigurable(Object.prototype.__defineSetter__, 'length');

--- a/test/annexB/built-ins/Object/prototype/__defineSetter__/name.js
+++ b/test/annexB/built-ins/Object/prototype/__defineSetter__/name.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Object.prototype.__defineSetter__ `name` property
+info: >
+    ES6 Section 17:
+
+    Every built-in Function object, including constructors, that is not
+    identified as an anonymous function has a name property whose value is a
+    String. Unless otherwise specified, this value is the name that is given to
+    the function in this specification.
+
+    [...]
+
+    Unless otherwise specified, the name property of a built-in Function
+    object, if it exists, has the attributes { [[Writable]]: false,
+    [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Object.prototype.__defineSetter__.name, '__defineSetter__');
+
+verifyNotEnumerable(Object.prototype.__defineSetter__, 'name');
+verifyNotWritable(Object.prototype.__defineSetter__, 'name');
+verifyConfigurable(Object.prototype.__defineSetter__, 'name');

--- a/test/annexB/built-ins/Object/prototype/__defineSetter__/prop-desc.js
+++ b/test/annexB/built-ins/Object/prototype/__defineSetter__/prop-desc.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Property descriptor for Object.prototype.__defineSetter__
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Object.prototype, '__defineSetter__');
+verifyWritable(Object.prototype, '__defineSetter__');
+verifyConfigurable(Object.prototype, '__defineSetter__');

--- a/test/annexB/built-ins/Object/prototype/__defineSetter__/setter-non-callable.js
+++ b/test/annexB/built-ins/Object/prototype/__defineSetter__/setter-non-callable.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when getter is not callable
+info: |
+    [...]
+    2. If IsCallable(setter) is false, throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var subject = {};
+var symbol = Symbol('');
+var toStringCount = 0;
+var key = {
+  toString: function() {
+    toStringCount += 1;
+  }
+};
+
+assert.sameValue(typeof Object.prototype.__defineSetter__, 'function');
+
+assert.throws(TypeError, function() {
+  subject.__defineSetter__(key, '');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  subject.__defineSetter__(key, 23);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  subject.__defineSetter__(key, true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  subject.__defineSetter__(key, symbol);
+}, 'symbol');
+
+assert.throws(TypeError, function() {
+  subject.__defineSetter__(key, {});
+}, 'object');
+
+assert.sameValue(toStringCount, 0);

--- a/test/annexB/built-ins/Object/prototype/__defineSetter__/this-non-obj.js
+++ b/test/annexB/built-ins/Object/prototype/__defineSetter__/this-non-obj.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when "this" value is not Object-coercible
+info: |
+    1. Let O be ? ToObject(this value).
+---*/
+
+var __defineSetter__ = Object.prototype.__defineSetter__;
+var noop = function() {};
+var toStringCount = 0;
+var key = {
+  toString: function() {
+    toStringCount += 1;
+  }
+};
+
+assert.sameValue(typeof __defineSetter__, 'function');
+
+assert.throws(TypeError, function() {
+  __defineSetter__.call(undefined, key, noop);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  __defineSetter__.call(null, key, noop);
+}, 'null');
+
+assert.sameValue(toStringCount, 0);

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/key-invalid.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/key-invalid.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when property key cannot be derived
+info: |
+    [...]
+    2. Let key be ? ToPropertyKey(P).
+---*/
+
+var subject = {};
+var key = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  subject.__lookupGetter__(key);
+});

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/length.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/length.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Object.prototype.__lookupGetter__ `length` property
+info: >
+    ES6 Section 17:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this value
+    is equal to the largest number of named arguments shown in the subclause
+    headings for the function description, including optional parameters.
+
+    [...]
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Object.prototype.__lookupGetter__.length, 1);
+
+verifyNotEnumerable(Object.prototype.__lookupGetter__, 'length');
+verifyNotWritable(Object.prototype.__lookupGetter__, 'length');
+verifyConfigurable(Object.prototype.__lookupGetter__, 'length');

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-not-found.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-not-found.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when property does not exist in prototype chain
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+---*/
+
+var root = {};
+var intermediary = Object.create(root);
+var subject = Object.create(intermediary);
+
+assert.sameValue(subject.__lookupGetter__('target'), undefined);

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-own-acsr-w-getter.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-own-acsr-w-getter.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when "this" value defines a like-named accessor property with a
+    `get` method
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+---*/
+
+var root = Object.defineProperty({}, 'target', { get: function() {} });
+var desc = { get: function() {} };
+var subject = Object.create(root, { target: desc });
+
+assert.sameValue(subject.__lookupGetter__('target'), desc.get);

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-own-acsr-wo-getter.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-own-acsr-wo-getter.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when "this" value defines a like-named accessor property without a
+    `get` method
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+---*/
+
+var root = Object.defineProperty({}, 'target', { get: function() {} });
+var desc = { set: function() {} };
+var subject = Object.create(root, { target: desc });
+
+assert.sameValue(subject.__lookupGetter__('target'), undefined);

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-own-data.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-own-data.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when "this" value defines a like-named data property
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+---*/
+
+var root = Object.defineProperty({}, 'target', { get: function() {} });
+var desc = { value: null };
+var subject = Object.create(root, { target: desc });
+
+assert.sameValue(subject.__lookupGetter__('target'), undefined);

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-own-get-err.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-own-get-err.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when [[GetOwnProperty]] of "this" value returns an abrupt
+    completion
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+features: [Proxy]
+---*/
+
+var root = Object.defineProperty({}, 'target', { get: function() {} });
+var thrower = function() { throw new Test262Error(); };
+var subject = new Proxy(root, { getOwnPropertyDescriptor: thrower });
+
+assert.throws(Test262Error, function() {
+  subject.__lookupGetter__('target');
+});

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-own-proto-err.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-own-proto-err.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when [[GetPrototypeOf]] of "this" value returns an abrupt
+    completion
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+features: [Proxy]
+---*/
+
+var root = Object.defineProperty({}, 'target', { get: function() {} });
+var thrower = function() { throw new Test262Error(); };
+var subject = new Proxy(Object.create(root), { getPrototypeOf: thrower });
+
+assert.throws(Test262Error, function() {
+  subject.__lookupGetter__('target');
+});

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-proto-acsr-w-getter.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-proto-acsr-w-getter.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when prototype defines a like-named accessor property with a `get`
+    method
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+---*/
+
+var root = Object.defineProperty({}, 'target', { get: function() {} });
+var desc = { get: function() {} };
+var intermediary = Object.create(root, { target: desc });
+var subject = Object.create(intermediary);
+
+assert.sameValue(subject.__lookupGetter__('target'), desc.get);

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-proto-acsr-wo-getter.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-proto-acsr-wo-getter.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when prototype defines a like-named accessor property without a
+    `get` method
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+---*/
+
+var root = Object.defineProperty({}, 'target', { get: function() {} });
+var desc = { set: function() {} };
+var intermediary = Object.create(root, { target: desc });
+var subject = Object.create(intermediary);
+
+assert.sameValue(subject.__lookupGetter__('target'), undefined);

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-proto-data.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-proto-data.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when prototype defines a like-named data property
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+---*/
+
+var root = Object.defineProperty({}, 'target', { get: function() {} });
+var desc = { value: null };
+var intermediary = Object.create(root, { target: desc });
+var subject = Object.create(intermediary);
+
+assert.sameValue(subject.__lookupGetter__('target'), undefined);

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-proto-get-err.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-proto-get-err.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when [[GetOwnProperty]] of prototype returns an abrupt completion
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+features: [Proxy]
+---*/
+
+var root = Object.defineProperty({}, 'target', { get: function() {} });
+var thrower = function() { throw new Test262Error(); };
+var intermediary = new Proxy(
+  Object.create(root), { getOwnPropertyDescriptor: thrower }
+);
+var subject = Object.create(intermediary);
+
+assert.throws(Test262Error, function() {
+  subject.__lookupGetter__('target');
+});

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-proto-proto-err.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/lookup-proto-proto-err.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when [[GetPrototypeOf]] of prototype returns an abrupt completion
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+features: [Proxy]
+---*/
+
+var root = Object.defineProperty({}, 'target', { get: function() {} });
+var thrower = function() { throw new Test262Error(); };
+var intermediary = new Proxy(Object.create(root), { getPrototypeOf: thrower });
+var subject = Object.create(intermediary);
+
+assert.throws(Test262Error, function() {
+  subject.__lookupGetter__('target');
+});

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/name.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/name.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Object.prototype.__lookupGetter__ `name` property
+info: >
+    ES6 Section 17:
+
+    Every built-in Function object, including constructors, that is not
+    identified as an anonymous function has a name property whose value is a
+    String. Unless otherwise specified, this value is the name that is given to
+    the function in this specification.
+
+    [...]
+
+    Unless otherwise specified, the name property of a built-in Function
+    object, if it exists, has the attributes { [[Writable]]: false,
+    [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Object.prototype.__lookupGetter__.name, '__lookupGetter__');
+
+verifyNotEnumerable(Object.prototype.__lookupGetter__, 'name');
+verifyNotWritable(Object.prototype.__lookupGetter__, 'name');
+verifyConfigurable(Object.prototype.__lookupGetter__, 'name');

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/prop-desc.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/prop-desc.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Property descriptor for Object.prototype.__lookupGetter__
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Object.prototype, '__lookupGetter__');
+verifyWritable(Object.prototype, '__lookupGetter__');
+verifyConfigurable(Object.prototype, '__lookupGetter__');

--- a/test/annexB/built-ins/Object/prototype/__lookupGetter__/this-non-obj.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupGetter__/this-non-obj.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when "this" value is not Object-coercible
+info: |
+    1. Let O be ? ToObject(this value).
+---*/
+
+var __lookupGetter__ = Object.prototype.__lookupGetter__;
+var toStringCount = 0;
+var key = {
+  toString: function() {
+    toStringCount += 1;
+  }
+};
+
+assert.sameValue(typeof __lookupGetter__, 'function');
+
+assert.throws(TypeError, function() {
+  __lookupGetter__.call(undefined, key);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  __lookupGetter__.call(null, key);
+}, 'null');
+
+assert.sameValue(toStringCount, 0);

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/key-invalid.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/key-invalid.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when property key cannot be derived
+info: |
+    [...]
+    2. Let key be ? ToPropertyKey(P).
+---*/
+
+var subject = {};
+var key = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  subject.__lookupSetter__(key);
+});

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/length.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/length.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Object.prototype.__lookupSetter__ `length` property
+info: >
+    ES6 Section 17:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this value
+    is equal to the largest number of named arguments shown in the subclause
+    headings for the function description, including optional parameters.
+
+    [...]
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Object.prototype.__lookupSetter__.length, 1);
+
+verifyNotEnumerable(Object.prototype.__lookupSetter__, 'length');
+verifyNotWritable(Object.prototype.__lookupSetter__, 'length');
+verifyConfigurable(Object.prototype.__lookupSetter__, 'length');

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-not-found.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-not-found.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when property does not exist in prototype chain
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+---*/
+
+var root = {};
+var intermediary = Object.create(root);
+var subject = Object.create(intermediary);
+
+assert.sameValue(subject.__lookupSetter__('target'), undefined);

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-own-acsr-w-setter.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-own-acsr-w-setter.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when "this" value defines a like-named accessor property with a
+    `set` method
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Set]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+---*/
+
+var root = Object.defineProperty({}, 'target', { set: function() {} });
+var desc = { set: function() {} };
+var subject = Object.create(root, { target: desc });
+
+assert.sameValue(subject.__lookupSetter__('target'), desc.set);

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-own-acsr-wo-setter.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-own-acsr-wo-setter.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when "this" value defines a like-named accessor property without a
+    `set` method
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Set]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+---*/
+
+var root = Object.defineProperty({}, 'target', { set: function() {} });
+var desc = { get: function() {} };
+var subject = Object.create(root, { target: desc });
+
+assert.sameValue(subject.__lookupSetter__('target'), undefined);

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-own-data.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-own-data.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when "this" value defines a like-named data property
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+---*/
+
+var root = Object.defineProperty({}, 'target', { set: function() {} });
+var desc = { value: null };
+var subject = Object.create(root, { target: desc });
+
+assert.sameValue(subject.__lookupSetter__('target'), undefined);

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-own-get-err.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-own-get-err.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when [[GetOwnProperty]] of "this" value returns an abrupt
+    completion
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Set]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+features: [Proxy]
+---*/
+
+var root = Object.defineProperty({}, 'target', { set: function() {} });
+var thrower = function() { throw new Test262Error(); };
+var subject = new Proxy(root, { getOwnPropertyDescriptor: thrower });
+
+assert.throws(Test262Error, function() {
+  subject.__lookupSetter__('target');
+});

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-own-proto-err.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-own-proto-err.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when [[GetPrototypeOf]] of "this" value returns an abrupt
+    completion
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+features: [Proxy]
+---*/
+
+var root = Object.defineProperty({}, 'target', { set: function() {} });
+var thrower = function() { throw new Test262Error(); };
+var subject = new Proxy(Object.create(root), { getPrototypeOf: thrower });
+
+assert.throws(Test262Error, function() {
+  subject.__lookupSetter__('target');
+});

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-proto-acsr-w-setter.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-proto-acsr-w-setter.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when prototype defines a like-named accessor property with a `get`
+    method
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Set]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+---*/
+
+var root = Object.defineProperty({}, 'target', { set: function() {} });
+var desc = { set: function() {} };
+var intermediary = Object.create(root, { target: desc });
+var subject = Object.create(intermediary);
+
+assert.sameValue(subject.__lookupSetter__('target'), desc.set);

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-proto-acsr-wo-setter.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-proto-acsr-wo-setter.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when prototype defines a like-named accessor property without a
+    `get` method
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Set]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+---*/
+
+var root = Object.defineProperty({}, 'target', { set: function() {} });
+var desc = { get: function() {} };
+var intermediary = Object.create(root, { target: desc });
+var subject = Object.create(intermediary);
+
+assert.sameValue(subject.__lookupSetter__('target'), undefined);

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-proto-data.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-proto-data.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when prototype defines a like-named data property
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+---*/
+
+var root = Object.defineProperty({}, 'target', { set: function() {} });
+var desc = { value: null };
+var intermediary = Object.create(root, { target: desc });
+var subject = Object.create(intermediary);
+
+assert.sameValue(subject.__lookupSetter__('target'), undefined);

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-proto-get-err.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-proto-get-err.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when [[GetOwnProperty]] of prototype returns an abrupt completion
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Set]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+features: [Proxy]
+---*/
+
+var root = Object.defineProperty({}, 'target', { set: function() {} });
+var thrower = function() { throw new Test262Error(); };
+var intermediary = new Proxy(
+  Object.create(root), { getOwnPropertyDescriptor: thrower }
+);
+var subject = Object.create(intermediary);
+
+assert.throws(Test262Error, function() {
+  subject.__lookupSetter__('target');
+});

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-proto-proto-err.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/lookup-proto-proto-err.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: >
+    Behavior when [[GetPrototypeOf]] of prototype returns an abrupt completion
+info: |
+    [...]
+    4. Repeat
+       a. Let desc be ? O.[[GetOwnProperty]](key).
+       b. If desc is not undefined, then
+          i. If IsAccessorDescriptor(desc) is true, return desc.[[Set]].
+          ii. Return undefined.
+       c. Let O be ? O.[[GetPrototypeOf]]().
+       d. If O is null, return undefined. 
+features: [Proxy]
+---*/
+
+var root = Object.defineProperty({}, 'target', { set: function() {} });
+var thrower = function() { throw new Test262Error(); };
+var intermediary = new Proxy(Object.create(root), { getPrototypeOf: thrower });
+var subject = Object.create(intermediary);
+
+assert.throws(Test262Error, function() {
+  subject.__lookupSetter__('target');
+});

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/name.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/name.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Object.prototype.__lookupSetter__ `name` property
+info: >
+    ES6 Section 17:
+
+    Every built-in Function object, including constructors, that is not
+    identified as an anonymous function has a name property whose value is a
+    String. Unless otherwise specified, this value is the name that is given to
+    the function in this specification.
+
+    [...]
+
+    Unless otherwise specified, the name property of a built-in Function
+    object, if it exists, has the attributes { [[Writable]]: false,
+    [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Object.prototype.__lookupSetter__.name, '__lookupSetter__');
+
+verifyNotEnumerable(Object.prototype.__lookupSetter__, 'name');
+verifyNotWritable(Object.prototype.__lookupSetter__, 'name');
+verifyConfigurable(Object.prototype.__lookupSetter__, 'name');

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/prop-desc.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/prop-desc.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Property descriptor for Object.prototype.__lookupSetter__
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Object.prototype, '__lookupSetter__');
+verifyWritable(Object.prototype, '__lookupSetter__');
+verifyConfigurable(Object.prototype, '__lookupSetter__');

--- a/test/annexB/built-ins/Object/prototype/__lookupSetter__/this-non-obj.js
+++ b/test/annexB/built-ins/Object/prototype/__lookupSetter__/this-non-obj.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-additional-properties-of-the-object.prototype-object
+description: Behavior when "this" value is not Object-coercible
+info: |
+    1. Let O be ? ToObject(this value).
+---*/
+
+var __lookupSetter__ = Object.prototype.__lookupSetter__;
+var toStringCount = 0;
+var key = {
+  toString: function() {
+    toStringCount += 1;
+  }
+};
+
+assert.sameValue(typeof __lookupSetter__, 'function');
+
+assert.throws(TypeError, function() {
+  __lookupSetter__.call(undefined, key);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  __lookupSetter__.call(null, key);
+}, 'null');
+
+assert.sameValue(toStringCount, 0);


### PR DESCRIPTION
This patch has a large number of files, but there is a good deal of symmetry in
the tests (just like the specification text they exercise).