### PR TITLE
Extend tests for Annex B String HTML methods

### DIFF
--- a/test/annexB/built-ins/String/prototype/anchor/B.2.3.2.js
+++ b/test/annexB/built-ins/String/prototype/anchor/B.2.3.2.js
@@ -24,4 +24,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   String.prototype.anchor.call(null);
 });
-assert.sameValue(String.prototype.anchor.length, 1);

--- a/test/annexB/built-ins/String/prototype/anchor/attr-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/anchor/attr-tostring-err.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.anchor
+es6id: B.2.3.2
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    [...]
+    4. If attribute is not the empty String, then
+       a. Let V be ? ToString(value).
+---*/
+
+var attr = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  ''.anchor(attr);
+});

--- a/test/annexB/built-ins/String/prototype/anchor/prop-desc.js
+++ b/test/annexB/built-ins/String/prototype/anchor/prop-desc.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.anchor
+es6id: B.2.3.2
+description: Property descriptor for String.prototype.anchor
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(String.prototype, 'anchor');
+verifyWritable(String.prototype, 'anchor');
+verifyConfigurable(String.prototype, 'anchor');

--- a/test/annexB/built-ins/String/prototype/anchor/this-val-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/anchor/this-val-tostring-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.anchor
+es6id: B.2.3.2
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    1. Let str be ? RequireObjectCoercible(string).
+    2. Let S be ? ToString(str).
+---*/
+
+var thisVal = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  String.prototype.anchor.call(thisVal);
+});

--- a/test/annexB/built-ins/String/prototype/big/B.2.3.3.js
+++ b/test/annexB/built-ins/String/prototype/big/B.2.3.3.js
@@ -21,4 +21,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   String.prototype.big.call(null);
 });
-assert.sameValue(String.prototype.big.length, 0);

--- a/test/annexB/built-ins/String/prototype/big/prop-desc.js
+++ b/test/annexB/built-ins/String/prototype/big/prop-desc.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.big
+es6id: B.2.3.3
+description: Property descriptor for String.prototype.big
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(String.prototype, 'big');
+verifyWritable(String.prototype, 'big');
+verifyConfigurable(String.prototype, 'big');

--- a/test/annexB/built-ins/String/prototype/big/this-val-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/big/this-val-tostring-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.big
+es6id: B.2.3.3
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    1. Let str be ? RequireObjectCoercible(string).
+    2. Let S be ? ToString(str).
+---*/
+
+var thisVal = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  String.prototype.big.call(thisVal);
+});

--- a/test/annexB/built-ins/String/prototype/blink/B.2.3.4.js
+++ b/test/annexB/built-ins/String/prototype/blink/B.2.3.4.js
@@ -21,4 +21,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   String.prototype.blink.call(null);
 });
-assert.sameValue(String.prototype.blink.length, 0);

--- a/test/annexB/built-ins/String/prototype/blink/prop-desc.js
+++ b/test/annexB/built-ins/String/prototype/blink/prop-desc.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.blink
+es6id: B.2.3.4
+description: Property descriptor for String.prototype.blink
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(String.prototype, 'blink');
+verifyWritable(String.prototype, 'blink');
+verifyConfigurable(String.prototype, 'blink');

--- a/test/annexB/built-ins/String/prototype/blink/this-val-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/blink/this-val-tostring-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.blink
+es6id: B.2.3.4
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    1. Let str be ? RequireObjectCoercible(string).
+    2. Let S be ? ToString(str).
+---*/
+
+var thisVal = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  String.prototype.blink.call(thisVal);
+});

--- a/test/annexB/built-ins/String/prototype/bold/B.2.3.5.js
+++ b/test/annexB/built-ins/String/prototype/bold/B.2.3.5.js
@@ -21,4 +21,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   String.prototype.bold.call(null);
 });
-assert.sameValue(String.prototype.bold.length, 0);

--- a/test/annexB/built-ins/String/prototype/bold/prop-desc.js
+++ b/test/annexB/built-ins/String/prototype/bold/prop-desc.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.bold
+es6id: B.2.3.5
+description: Property descriptor for String.prototype.bold
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(String.prototype, 'bold');
+verifyWritable(String.prototype, 'bold');
+verifyConfigurable(String.prototype, 'bold');

--- a/test/annexB/built-ins/String/prototype/bold/this-val-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/bold/this-val-tostring-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.bold
+es6id: B.2.3.5
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    1. Let str be ? RequireObjectCoercible(string).
+    2. Let S be ? ToString(str).
+---*/
+
+var thisVal = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  String.prototype.bold.call(thisVal);
+});

--- a/test/annexB/built-ins/String/prototype/fixed/B.2.3.6.js
+++ b/test/annexB/built-ins/String/prototype/fixed/B.2.3.6.js
@@ -21,4 +21,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   String.prototype.fixed.call(null);
 });
-assert.sameValue(String.prototype.fixed.length, 0);

--- a/test/annexB/built-ins/String/prototype/fixed/prop-desc.js
+++ b/test/annexB/built-ins/String/prototype/fixed/prop-desc.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.fixed
+es6id: B.2.3.6
+description: Property descriptor for String.prototype.fixed
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(String.prototype, 'fixed');
+verifyWritable(String.prototype, 'fixed');
+verifyConfigurable(String.prototype, 'fixed');

--- a/test/annexB/built-ins/String/prototype/fixed/this-val-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/fixed/this-val-tostring-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.fixed
+es6id: B.2.3.6
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    1. Let str be ? RequireObjectCoercible(string).
+    2. Let S be ? ToString(str).
+---*/
+
+var thisVal = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  String.prototype.fixed.call(thisVal);
+});

--- a/test/annexB/built-ins/String/prototype/fontcolor/B.2.3.7.js
+++ b/test/annexB/built-ins/String/prototype/fontcolor/B.2.3.7.js
@@ -26,4 +26,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   String.prototype.fontcolor.call(null);
 });
-assert.sameValue(String.prototype.fontcolor.length, 1);

--- a/test/annexB/built-ins/String/prototype/fontcolor/attr-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/fontcolor/attr-tostring-err.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.fontcolor
+es6id: B.2.3.7
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    [...]
+    4. If attribute is not the empty String, then
+       a. Let V be ? ToString(value).
+---*/
+
+var attr = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  ''.fontcolor(attr);
+});

--- a/test/annexB/built-ins/String/prototype/fontcolor/prop-desc.js
+++ b/test/annexB/built-ins/String/prototype/fontcolor/prop-desc.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.fontcolor
+es6id: B.2.3.7
+description: Property descriptor for String.prototype.fontcolor
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(String.prototype, 'fontcolor');
+verifyWritable(String.prototype, 'fontcolor');
+verifyConfigurable(String.prototype, 'fontcolor');

--- a/test/annexB/built-ins/String/prototype/fontcolor/this-val-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/fontcolor/this-val-tostring-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.fontcolor
+es6id: B.2.3.7
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    1. Let str be ? RequireObjectCoercible(string).
+    2. Let S be ? ToString(str).
+---*/
+
+var thisVal = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  String.prototype.fontcolor.call(thisVal);
+});

--- a/test/annexB/built-ins/String/prototype/fontsize/B.2.3.8.js
+++ b/test/annexB/built-ins/String/prototype/fontsize/B.2.3.8.js
@@ -26,4 +26,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   String.prototype.fontsize.call(null);
 });
-assert.sameValue(String.prototype.fontsize.length, 1);

--- a/test/annexB/built-ins/String/prototype/fontsize/attr-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/fontsize/attr-tostring-err.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.fontsize
+es6id: B.2.3.8
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    [...]
+    4. If attribute is not the empty String, then
+       a. Let V be ? ToString(value).
+---*/
+
+var attr = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  ''.fontsize(attr);
+});

--- a/test/annexB/built-ins/String/prototype/fontsize/prop-desc.js
+++ b/test/annexB/built-ins/String/prototype/fontsize/prop-desc.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.fontsize
+es6id: B.2.3.8
+description: Property descriptor for String.prototype.fontsize
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(String.prototype, 'fontsize');
+verifyWritable(String.prototype, 'fontsize');
+verifyConfigurable(String.prototype, 'fontsize');

--- a/test/annexB/built-ins/String/prototype/fontsize/this-val-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/fontsize/this-val-tostring-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.fontsize
+es6id: B.2.3.8
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    1. Let str be ? RequireObjectCoercible(string).
+    2. Let S be ? ToString(str).
+---*/
+
+var thisVal = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  String.prototype.fontsize.call(thisVal);
+});

--- a/test/annexB/built-ins/String/prototype/italics/B.2.3.9.js
+++ b/test/annexB/built-ins/String/prototype/italics/B.2.3.9.js
@@ -21,4 +21,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   String.prototype.italics.call(null);
 });
-assert.sameValue(String.prototype.italics.length, 0);

--- a/test/annexB/built-ins/String/prototype/italics/prop-desc.js
+++ b/test/annexB/built-ins/String/prototype/italics/prop-desc.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.italics
+es6id: B.2.3.9
+description: Property descriptor for String.prototype.italics
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(String.prototype, 'italics');
+verifyWritable(String.prototype, 'italics');
+verifyConfigurable(String.prototype, 'italics');

--- a/test/annexB/built-ins/String/prototype/italics/this-val-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/italics/this-val-tostring-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.italics
+es6id: B.2.3.9
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    1. Let str be ? RequireObjectCoercible(string).
+    2. Let S be ? ToString(str).
+---*/
+
+var thisVal = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  String.prototype.italics.call(thisVal);
+});

--- a/test/annexB/built-ins/String/prototype/link/B.2.3.10.js
+++ b/test/annexB/built-ins/String/prototype/link/B.2.3.10.js
@@ -7,7 +7,7 @@
 /*---
  description: >
      String.prototype.link returns a string of HTML describing a single HTML
-     anchor element. The element's content is the `this` value of the function
+     link element. The element's content is the `this` value of the function
      invocation, coerced to a string. If specified, the first argument will be
      coerced to a string, escaped, and set as the element's `href` attribute.
  es6id: B.2.3.10
@@ -24,4 +24,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   String.prototype.link.call(null);
 });
-assert.sameValue(String.prototype.link.length, 1);

--- a/test/annexB/built-ins/String/prototype/link/attr-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/link/attr-tostring-err.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.link
+es6id: B.2.3.10
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    [...]
+    4. If attribute is not the empty String, then
+       a. Let V be ? ToString(value).
+---*/
+
+var attr = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  ''.link(attr);
+});

--- a/test/annexB/built-ins/String/prototype/link/prop-desc.js
+++ b/test/annexB/built-ins/String/prototype/link/prop-desc.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.link
+es6id: B.2.3.10
+description: Property descriptor for String.prototype.link
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(String.prototype, 'link');
+verifyWritable(String.prototype, 'link');
+verifyConfigurable(String.prototype, 'link');

--- a/test/annexB/built-ins/String/prototype/link/this-val-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/link/this-val-tostring-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.link
+es6id: B.2.3.10
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    1. Let str be ? RequireObjectCoercible(string).
+    2. Let S be ? ToString(str).
+---*/
+
+var thisVal = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  String.prototype.link.call(thisVal);
+});

--- a/test/annexB/built-ins/String/prototype/small/B.2.3.11.js
+++ b/test/annexB/built-ins/String/prototype/small/B.2.3.11.js
@@ -21,4 +21,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   String.prototype.small.call(null);
 });
-assert.sameValue(String.prototype.small.length, 0);

--- a/test/annexB/built-ins/String/prototype/small/prop-desc.js
+++ b/test/annexB/built-ins/String/prototype/small/prop-desc.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.small
+es6id: B.2.3.11
+description: Property descriptor for String.prototype.small
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(String.prototype, 'small');
+verifyWritable(String.prototype, 'small');
+verifyConfigurable(String.prototype, 'small');

--- a/test/annexB/built-ins/String/prototype/small/this-val-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/small/this-val-tostring-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.small
+es6id: B.2.3.11
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    1. Let str be ? RequireObjectCoercible(string).
+    2. Let S be ? ToString(str).
+---*/
+
+var thisVal = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  String.prototype.small.call(thisVal);
+});

--- a/test/annexB/built-ins/String/prototype/strike/B.2.3.12.js
+++ b/test/annexB/built-ins/String/prototype/strike/B.2.3.12.js
@@ -21,4 +21,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   String.prototype.strike.call(null);
 });
-assert.sameValue(String.prototype.strike.length, 0);

--- a/test/annexB/built-ins/String/prototype/strike/prop-desc.js
+++ b/test/annexB/built-ins/String/prototype/strike/prop-desc.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.strike
+es6id: B.2.3.12
+description: Property descriptor for String.prototype.strike
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(String.prototype, 'strike');
+verifyWritable(String.prototype, 'strike');
+verifyConfigurable(String.prototype, 'strike');

--- a/test/annexB/built-ins/String/prototype/strike/this-val-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/strike/this-val-tostring-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.strike
+es6id: B.2.3.12
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    1. Let str be ? RequireObjectCoercible(string).
+    2. Let S be ? ToString(str).
+---*/
+
+var thisVal = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  String.prototype.strike.call(thisVal);
+});

--- a/test/annexB/built-ins/String/prototype/sub/B.2.3.13.js
+++ b/test/annexB/built-ins/String/prototype/sub/B.2.3.13.js
@@ -21,4 +21,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   String.prototype.sub.call(null);
 });
-assert.sameValue(String.prototype.sub.length, 0);

--- a/test/annexB/built-ins/String/prototype/sub/prop-desc.js
+++ b/test/annexB/built-ins/String/prototype/sub/prop-desc.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.sub
+es6id: B.2.3.13
+description: Property descriptor for String.prototype.sub
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(String.prototype, 'sub');
+verifyWritable(String.prototype, 'sub');
+verifyConfigurable(String.prototype, 'sub');

--- a/test/annexB/built-ins/String/prototype/sub/this-val-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/sub/this-val-tostring-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.sub
+es6id: B.2.3.13
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    1. Let str be ? RequireObjectCoercible(string).
+    2. Let S be ? ToString(str).
+---*/
+
+var thisVal = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  String.prototype.sub.call(thisVal);
+});

--- a/test/annexB/built-ins/String/prototype/sup/B.2.3.14.js
+++ b/test/annexB/built-ins/String/prototype/sup/B.2.3.14.js
@@ -21,4 +21,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   String.prototype.sup.call(null);
 });
-assert.sameValue(String.prototype.sup.length, 0);

--- a/test/annexB/built-ins/String/prototype/sup/prop-desc.js
+++ b/test/annexB/built-ins/String/prototype/sup/prop-desc.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.sup
+es6id: B.2.3.14
+description: Property descriptor for String.prototype.sup
+info: >
+    Every other data property described in clauses 18 through 26 and in Annex
+    B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(String.prototype, 'sup');
+verifyWritable(String.prototype, 'sup');
+verifyConfigurable(String.prototype, 'sup');

--- a/test/annexB/built-ins/String/prototype/sup/this-val-tostring-err.js
+++ b/test/annexB/built-ins/String/prototype/sup/this-val-tostring-err.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.sup
+es6id: B.2.3.14
+description: Abrupt completion when coercing "this" value to string
+info: |
+    B.2.3.2.1 Runtime Semantics: CreateHTML
+
+    1. Let str be ? RequireObjectCoercible(string).
+    2. Let S be ? ToString(str).
+---*/
+
+var thisVal = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  String.prototype.sup.call(thisVal);
+});


### PR DESCRIPTION
- Add tests for abrupt completion handling from ToString operations
- Add tests for method property descriptors
- Remove redundant assertion