### PR TITLE
Add tests for DataView.prototype.getFloat32

### DIFF
--- a/test/built-ins/DataView/prototype/getFloat32/byteoffset-is-different-integer-throws.js
+++ b/test/built-ins/DataView/prototype/getFloat32/byteoffset-is-different-integer-throws.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Throws a RangeError if numberIndex ≠ getIndex
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  4. Let numberIndex be ? ToNumber(requestIndex).
+  5. Let getIndex be ToInteger(numberIndex).
+  6. If numberIndex ≠ getIndex or getIndex < 0, throw a RangeError exception.
+  ...
+---*/
+
+var buffer = new ArrayBuffer(12);
+var sample = new DataView(buffer, 0);
+
+assert.throws(RangeError, function() {
+  sample.getFloat32();
+}, "no args");
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(undefined);
+}, "undefined");
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(1.1);
+}, "floating number");
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(0.1);
+}, "0.1");
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(NaN);
+}, "NaN");
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(-0.1);
+}, "-0.1");
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(-1.1);
+}, "-1.1");

--- a/test/built-ins/DataView/prototype/getFloat32/byteoffset-is-negative-throws.js
+++ b/test/built-ins/DataView/prototype/getFloat32/byteoffset-is-negative-throws.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Throws a RangeError if getIndex < 0
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  4. Let numberIndex be ? ToNumber(requestIndex).
+  5. Let getIndex be ToInteger(numberIndex).
+  6. If numberIndex ≠ getIndex or getIndex < 0, throw a RangeError exception.
+  ...
+---*/
+
+var buffer = new ArrayBuffer(12);
+var sample = new DataView(buffer, 0);
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(-1);
+}, "-1");
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(-Infinity);
+}, "-Infinity");

--- a/test/built-ins/DataView/prototype/getFloat32/detached-buffer-after-integer-byteoffset.js
+++ b/test/built-ins/DataView/prototype/getFloat32/detached-buffer-after-integer-byteoffset.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Detached buffer is checked after checking If numberIndex ≠ getIndex or
+  getIndex < 0,
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  6. If numberIndex ≠ getIndex or getIndex < 0, throw a RangeError exception.
+  ...
+  8. Let buffer be the value of view's [[ViewedArrayBuffer]] internal slot.
+  9. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [detachArrayBuffer.js]
+---*/
+
+var buffer = new ArrayBuffer(1);
+var sample = new DataView(buffer, 0);
+
+$DETACHBUFFER(buffer);
+assert.throws(RangeError, function() {
+  sample.getFloat32(1.1);
+});
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(-1);
+});

--- a/test/built-ins/DataView/prototype/getFloat32/detached-buffer-after-integer-byteoffset.js
+++ b/test/built-ins/DataView/prototype/getFloat32/detached-buffer-after-integer-byteoffset.js
@@ -25,7 +25,7 @@ info: |
 includes: [detachArrayBuffer.js]
 ---*/
 
-var buffer = new ArrayBuffer(1);
+var buffer = new ArrayBuffer(6);
 var sample = new DataView(buffer, 0);
 
 $DETACHBUFFER(buffer);

--- a/test/built-ins/DataView/prototype/getFloat32/detached-buffer-before-outofrange-byteoffset.js
+++ b/test/built-ins/DataView/prototype/getFloat32/detached-buffer-before-outofrange-byteoffset.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Detached buffer is checked before out of range byteOffset's value
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  8. Let buffer be the value of view's [[ViewedArrayBuffer]] internal slot.
+  9. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+  13. If getIndex + elementSize > viewSize, throw a RangeError exception.
+  ...
+includes: [detachArrayBuffer.js]
+---*/
+
+var sample;
+var buffer = new ArrayBuffer(12);
+
+sample = new DataView(buffer, 0);
+
+$DETACHBUFFER(buffer);
+
+assert.throws(TypeError, function() {
+  sample.getFloat32(Infinity);
+}, "Infinity");
+
+assert.throws(TypeError, function() {
+  sample.getFloat32(13);
+}, "13");

--- a/test/built-ins/DataView/prototype/getFloat32/detached-buffer.js
+++ b/test/built-ins/DataView/prototype/getFloat32/detached-buffer.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Throws a TypeError if buffer is detached
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  8. Let buffer be the value of view's [[ViewedArrayBuffer]] internal slot.
+  9. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [detachArrayBuffer.js]
+---*/
+
+var buffer = new ArrayBuffer(1);
+var sample = new DataView(buffer, 0);
+
+$DETACHBUFFER(buffer);
+assert.throws(TypeError, function() {
+  sample.getFloat32(0);
+});

--- a/test/built-ins/DataView/prototype/getFloat32/index-is-out-of-range.js
+++ b/test/built-ins/DataView/prototype/getFloat32/index-is-out-of-range.js
@@ -1,0 +1,84 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Throws a RangeError if getIndex + elementSize > viewSize
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  10. Let viewOffset be the value of view's [[ByteOffset]] internal slot.
+  11. Let viewSize be the value of view's [[ByteLength]] internal slot.
+  12. Let elementSize be the Number value of the Element Size value specified in
+  Table 50 for Element Type type.
+  13. If getIndex + elementSize > viewSize, throw a RangeError exception.
+  ...
+---*/
+
+var sample;
+var buffer = new ArrayBuffer(12);
+
+sample = new DataView(buffer, 0);
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(Infinity);
+}, "getIndex == Infinity");
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(13);
+}, "13 + 4 > 12");
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(12);
+}, "12 + 4 > 12");
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(11);
+}, "11 + 4 > 12");
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(10);
+}, "10 + 4 > 12");
+
+assert.throws(RangeError, function() {
+  sample.getFloat32(9);
+}, "9 + 4 > 12");
+
+sample = new DataView(buffer, 8);
+assert.throws(RangeError, function() {
+  sample.getFloat32(1);
+}, "1 + 4 > 4 (offset)");
+
+sample = new DataView(buffer, 9);
+assert.throws(RangeError, function() {
+  sample.getFloat32(0);
+}, "0 + 4 > 3 (offset)");
+
+sample = new DataView(buffer, 0, 4);
+assert.throws(RangeError, function() {
+  sample.getFloat32(1);
+}, "1 + 4 > 4 (length)");
+
+sample = new DataView(buffer, 0, 3);
+assert.throws(RangeError, function() {
+  sample.getFloat32(0);
+}, "0 + 4 > 3 (length)");
+
+sample = new DataView(buffer, 4, 4);
+assert.throws(RangeError, function() {
+  sample.getFloat32(1);
+}, "1 + 4 > 4 (offset+length)");
+
+sample = new DataView(buffer, 4, 3);
+assert.throws(RangeError, function() {
+  sample.getFloat32(0);
+}, "0 + 4 > 3 (offset+length)");

--- a/test/built-ins/DataView/prototype/getFloat32/minus-zero.js
+++ b/test/built-ins/DataView/prototype/getFloat32/minus-zero.js
@@ -38,5 +38,4 @@ sample.setUint8(2, 0);
 sample.setUint8(3, 0);
 
 var result = sample.getFloat32(0);
-assert.sameValue(result, 0);
-assert.sameValue(1 / result, -Infinity);
+assert.sameValue(result, -0);

--- a/test/built-ins/DataView/prototype/getFloat32/minus-zero.js
+++ b/test/built-ins/DataView/prototype/getFloat32/minus-zero.js
@@ -37,6 +37,6 @@ sample.setUint8(1, 0);
 sample.setUint8(2, 0);
 sample.setUint8(3, 0);
 
-var result = sample.getFloat64(0);
+var result = sample.getFloat32(0);
 assert.sameValue(result, 0);
 assert.sameValue(1 / result, -Infinity);

--- a/test/built-ins/DataView/prototype/getFloat32/minus-zero.js
+++ b/test/built-ins/DataView/prototype/getFloat32/minus-zero.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Return -0
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  14. Let bufferIndex be getIndex + viewOffset.
+  15. Return GetValueFromBuffer(buffer, bufferIndex, type, isLittleEndian).
+  ...
+
+  24.1.1.5 GetValueFromBuffer ( arrayBuffer, byteIndex, type [ , isLittleEndian
+  ] )
+
+  ...
+  8. If isLittleEndian is false, reverse the order of the elements of rawValue.
+  ...
+features: [DataView.prototype.setUint8]
+---*/
+
+var buffer = new ArrayBuffer(8);
+var sample = new DataView(buffer, 0);
+
+sample.setUint8(0, 128);
+sample.setUint8(1, 0);
+sample.setUint8(2, 0);
+sample.setUint8(3, 0);
+
+var result = sample.getFloat64(0);
+assert.sameValue(result, 0);
+assert.sameValue(1 / result, -Infinity);

--- a/test/built-ins/DataView/prototype/getFloat32/return-abrupt-from-tonumber-byteoffset-symbol.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-abrupt-from-tonumber-byteoffset-symbol.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Return abrupt from ToNumber(symbol byteOffset)
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  4. Let numberIndex be ? ToNumber(requestIndex).
+  ...
+features: [Symbol]
+---*/
+
+var buffer = new ArrayBuffer(1);
+var sample = new DataView(buffer, 0);
+
+var s = Symbol("1");
+
+assert.throws(TypeError, function() {
+  sample.getFloat32(s);
+});

--- a/test/built-ins/DataView/prototype/getFloat32/return-abrupt-from-tonumber-byteoffset.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-abrupt-from-tonumber-byteoffset.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Return abrupt from ToNumber(byteOffset)
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  4. Let numberIndex be ? ToNumber(requestIndex).
+  ...
+---*/
+
+var buffer = new ArrayBuffer(1);
+var sample = new DataView(buffer, 0);
+
+var bo1 = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+
+var bo2 = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  sample.getFloat32(bo1);
+}, "valueOf");
+
+assert.throws(Test262Error, function() {
+  sample.getFloat32(bo2);
+}, "toString");

--- a/test/built-ins/DataView/prototype/getFloat32/return-infinity.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-infinity.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Return Infinity values
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  14. Let bufferIndex be getIndex + viewOffset.
+  15. Return GetValueFromBuffer(buffer, bufferIndex, type, isLittleEndian).
+  ...
+
+  24.1.1.5 GetValueFromBuffer ( arrayBuffer, byteIndex, type [ , isLittleEndian
+  ] )
+
+  ...
+  7. If isLittleEndian is not present, set isLittleEndian to either true or
+  false. The choice is implementation dependent and should be the alternative
+  that is most efficient for the implementation. An implementation must use the
+  same value each time this step is executed and the same value must be used for
+  the corresponding step in the SetValueInBuffer abstract operation.
+  8. If isLittleEndian is false, reverse the order of the elements of rawValue.
+  ...
+features: [DataView.prototype.setFloat32]
+---*/
+
+var buffer = new ArrayBuffer(8);
+var sample = new DataView(buffer, 0);
+
+sample.setFloat32(0, Infinity);
+sample.setFloat32(4, -Infinity);
+
+assert.sameValue(sample.getFloat32(0), Infinity);
+assert.sameValue(sample.getFloat32(0, false), Infinity);
+assert.sameValue(sample.getFloat32(4), -Infinity);
+assert.sameValue(sample.getFloat32(4, false), -Infinity);

--- a/test/built-ins/DataView/prototype/getFloat32/return-infinity.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-infinity.js
@@ -26,16 +26,20 @@ info: |
   ...
   8. If isLittleEndian is false, reverse the order of the elements of rawValue.
   ...
-features: [DataView.prototype.setFloat32]
+features: [DataView.prototype.setUint8]
 ---*/
 
 var buffer = new ArrayBuffer(8);
 var sample = new DataView(buffer, 0);
 
-sample.setFloat32(0, Infinity);
-sample.setFloat32(4, -Infinity);
+sample.setUint8(0, 127);
+sample.setUint8(1, 128);
+sample.setUint8(2, 0);
+sample.setUint8(3, 0);
+sample.setUint8(4, 255);
+sample.setUint8(5, 128);
+sample.setUint8(6, 0);
+sample.setUint8(7, 0);
 
 assert.sameValue(sample.getFloat32(0), Infinity);
-assert.sameValue(sample.getFloat32(0, false), Infinity);
 assert.sameValue(sample.getFloat32(4), -Infinity);
-assert.sameValue(sample.getFloat32(4, false), -Infinity);

--- a/test/built-ins/DataView/prototype/getFloat32/return-infinity.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-infinity.js
@@ -24,11 +24,6 @@ info: |
   ] )
 
   ...
-  7. If isLittleEndian is not present, set isLittleEndian to either true or
-  false. The choice is implementation dependent and should be the alternative
-  that is most efficient for the implementation. An implementation must use the
-  same value each time this step is executed and the same value must be used for
-  the corresponding step in the SetValueInBuffer abstract operation.
   8. If isLittleEndian is false, reverse the order of the elements of rawValue.
   ...
 features: [DataView.prototype.setFloat32]

--- a/test/built-ins/DataView/prototype/getFloat32/return-nan.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-nan.js
@@ -26,21 +26,20 @@ info: |
   ...
   8. If isLittleEndian is false, reverse the order of the elements of rawValue.
   ...
-features: [DataView.prototype.setFloat32]
+features: [DataView.prototype.setUint8]
 ---*/
 
-var buffer = new ArrayBuffer(12);
+var buffer = new ArrayBuffer(8);
 var sample = new DataView(buffer, 0);
 
-sample.setFloat32(0, 39);
-sample.setFloat32(4, NaN);
-sample.setFloat32(8, 42);
+sample.setUint8(0, 127);
+sample.setUint8(1, 192);
+sample.setUint8(2, 0);
+sample.setUint8(3, 0);
+sample.setUint8(4, 255);
+sample.setUint8(5, 192);
+sample.setUint8(6, 0);
+sample.setUint8(7, 0);
 
-assert.sameValue(sample.getFloat32(0), 39);
-assert.sameValue(sample.getFloat32(0, false), 39);
-
+assert.sameValue(sample.getFloat32(0), NaN);
 assert.sameValue(sample.getFloat32(4), NaN);
-assert.sameValue(sample.getFloat32(4, false), NaN);
-
-assert.sameValue(sample.getFloat32(8), 42);
-assert.sameValue(sample.getFloat32(8, false), 42);

--- a/test/built-ins/DataView/prototype/getFloat32/return-nan.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-nan.js
@@ -29,10 +29,18 @@ info: |
 features: [DataView.prototype.setFloat32]
 ---*/
 
-var buffer = new ArrayBuffer(4);
+var buffer = new ArrayBuffer(12);
 var sample = new DataView(buffer, 0);
 
-sample.setFloat32(0, NaN);
+sample.setFloat32(0, 39);
+sample.setFloat32(4, NaN);
+sample.setFloat32(8, 42);
 
-assert.sameValue(sample.getFloat32(0), NaN);
-assert.sameValue(sample.getFloat32(0, false), NaN);
+assert.sameValue(sample.getFloat32(0), 39);
+assert.sameValue(sample.getFloat32(0, false), 39);
+
+assert.sameValue(sample.getFloat32(4), NaN);
+assert.sameValue(sample.getFloat32(4, false), NaN);
+
+assert.sameValue(sample.getFloat32(8), 42);
+assert.sameValue(sample.getFloat32(8, false), 42);

--- a/test/built-ins/DataView/prototype/getFloat32/return-nan.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-nan.js
@@ -24,11 +24,6 @@ info: |
   ] )
 
   ...
-  7. If isLittleEndian is not present, set isLittleEndian to either true or
-  false. The choice is implementation dependent and should be the alternative
-  that is most efficient for the implementation. An implementation must use the
-  same value each time this step is executed and the same value must be used for
-  the corresponding step in the SetValueInBuffer abstract operation.
   8. If isLittleEndian is false, reverse the order of the elements of rawValue.
   ...
 features: [DataView.prototype.setFloat32]

--- a/test/built-ins/DataView/prototype/getFloat32/return-nan.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-nan.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Return NaN values
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  14. Let bufferIndex be getIndex + viewOffset.
+  15. Return GetValueFromBuffer(buffer, bufferIndex, type, isLittleEndian).
+  ...
+
+  24.1.1.5 GetValueFromBuffer ( arrayBuffer, byteIndex, type [ , isLittleEndian
+  ] )
+
+  ...
+  7. If isLittleEndian is not present, set isLittleEndian to either true or
+  false. The choice is implementation dependent and should be the alternative
+  that is most efficient for the implementation. An implementation must use the
+  same value each time this step is executed and the same value must be used for
+  the corresponding step in the SetValueInBuffer abstract operation.
+  8. If isLittleEndian is false, reverse the order of the elements of rawValue.
+  ...
+features: [DataView.prototype.setFloat32]
+---*/
+
+var buffer = new ArrayBuffer(4);
+var sample = new DataView(buffer, 0);
+
+sample.setFloat32(0, NaN);
+
+assert.sameValue(sample.getFloat32(0), NaN);
+assert.sameValue(sample.getFloat32(0, false), NaN);

--- a/test/built-ins/DataView/prototype/getFloat32/return-value-clean-arraybuffer.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-value-clean-arraybuffer.js
@@ -24,11 +24,6 @@ info: |
   ] )
 
   ...
-  7. If isLittleEndian is not present, set isLittleEndian to either true or
-  false. The choice is implementation dependent and should be the alternative
-  that is most efficient for the implementation. An implementation must use the
-  same value each time this step is executed and the same value must be used for
-  the corresponding step in the SetValueInBuffer abstract operation.
   8. If isLittleEndian is false, reverse the order of the elements of rawValue.
   ...
 ---*/

--- a/test/built-ins/DataView/prototype/getFloat32/return-value-clean-arraybuffer.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-value-clean-arraybuffer.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Return value from Buffer using a clean ArrayBuffer
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  14. Let bufferIndex be getIndex + viewOffset.
+  15. Return GetValueFromBuffer(buffer, bufferIndex, type, isLittleEndian).
+  ...
+
+  24.1.1.5 GetValueFromBuffer ( arrayBuffer, byteIndex, type [ , isLittleEndian
+  ] )
+
+  ...
+  7. If isLittleEndian is not present, set isLittleEndian to either true or
+  false. The choice is implementation dependent and should be the alternative
+  that is most efficient for the implementation. An implementation must use the
+  same value each time this step is executed and the same value must be used for
+  the corresponding step in the SetValueInBuffer abstract operation.
+  8. If isLittleEndian is false, reverse the order of the elements of rawValue.
+  ...
+---*/
+
+var buffer = new ArrayBuffer(8);
+var sample = new DataView(buffer, 0);
+
+assert.sameValue(sample.getFloat32(0, true), 0, "sample.getFloat32(0, true)");
+assert.sameValue(sample.getFloat32(1, true), 0, "sample.getFloat32(1, true)");
+assert.sameValue(sample.getFloat32(2, true), 0, "sample.getFloat32(2, true)");
+assert.sameValue(sample.getFloat32(3, true), 0, "sample.getFloat32(3, true)");
+assert.sameValue(sample.getFloat32(4, true), 0, "sample.getFloat32(4, true)");
+assert.sameValue(sample.getFloat32(0, false), 0, "sample.getFloat32(0, false)");
+assert.sameValue(sample.getFloat32(1, false), 0, "sample.getFloat32(1, false)");
+assert.sameValue(sample.getFloat32(2, false), 0, "sample.getFloat32(2, false)");
+assert.sameValue(sample.getFloat32(3, false), 0, "sample.getFloat32(3, false)");
+assert.sameValue(sample.getFloat32(4, false), 0, "sample.getFloat32(4, false)");

--- a/test/built-ins/DataView/prototype/getFloat32/return-values-coerced-byteoffset.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-values-coerced-byteoffset.js
@@ -24,11 +24,6 @@ info: |
   ] )
 
   ...
-  7. If isLittleEndian is not present, set isLittleEndian to either true or
-  false. The choice is implementation dependent and should be the alternative
-  that is most efficient for the implementation. An implementation must use the
-  same value each time this step is executed and the same value must be used for
-  the corresponding step in the SetValueInBuffer abstract operation.
   8. If isLittleEndian is false, reverse the order of the elements of rawValue.
   ...
 features: [DataView.prototype.setUint8]

--- a/test/built-ins/DataView/prototype/getFloat32/return-values-coerced-byteoffset.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-values-coerced-byteoffset.js
@@ -1,0 +1,86 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Return values using coerced ToInteger byteOffset values
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  14. Let bufferIndex be getIndex + viewOffset.
+  15. Return GetValueFromBuffer(buffer, bufferIndex, type, isLittleEndian).
+  ...
+
+  24.1.1.5 GetValueFromBuffer ( arrayBuffer, byteIndex, type [ , isLittleEndian
+  ] )
+
+  ...
+  7. If isLittleEndian is not present, set isLittleEndian to either true or
+  false. The choice is implementation dependent and should be the alternative
+  that is most efficient for the implementation. An implementation must use the
+  same value each time this step is executed and the same value must be used for
+  the corresponding step in the SetValueInBuffer abstract operation.
+  8. If isLittleEndian is false, reverse the order of the elements of rawValue.
+  ...
+features: [DataView.prototype.setUint8]
+---*/
+
+var buffer = new ArrayBuffer(8);
+var sample = new DataView(buffer, 0);
+
+sample.setUint8(0, 75);
+sample.setUint8(1, 75);
+sample.setUint8(2, 76);
+sample.setUint8(3, 76);
+sample.setUint8(4, 75);
+sample.setUint8(5, 75);
+sample.setUint8(6, 76);
+sample.setUint8(7, 76);
+
+assert.sameValue(sample.getFloat32(0, false), 13323340, "0, false");
+assert.sameValue(sample.getFloat32(1, false), 13388875, "1, false");
+assert.sameValue(sample.getFloat32(0, true), 53554476, "0, true");
+assert.sameValue(sample.getFloat32(1, true), 13388875, "1, true");
+
+assert.sameValue(sample.getFloat32("", false), 13323340, "'', false");
+assert.sameValue(sample.getFloat32("", true), 53554476, "'', true");
+
+assert.sameValue(sample.getFloat32("0", false), 13323340, "'0', false");
+assert.sameValue(sample.getFloat32("0", true), 53554476, "'0', true");
+
+assert.sameValue(sample.getFloat32("1", false), 13388875, "'1', false");
+assert.sameValue(sample.getFloat32("1", true), 13388875, "'1', true");
+
+var obj1 = {
+  valueOf: function() {
+    return 1;
+  }
+};
+assert.sameValue(sample.getFloat32(obj1, false), 13388875, "{}.valueOf, false");
+assert.sameValue(sample.getFloat32(obj1, true), 13388875, "{}.valueOf, true");
+
+var obj2 = {
+  toString: function() {
+    return 1;
+  }
+};
+assert.sameValue(sample.getFloat32(obj2, false), 13388875, "{}.toString, false");
+assert.sameValue(sample.getFloat32(obj2, true), 13388875, "{}.toString, true");
+
+assert.sameValue(sample.getFloat32(true, false), 13388875, "true, false");
+assert.sameValue(sample.getFloat32(true, true), 13388875, "true, true");
+
+assert.sameValue(sample.getFloat32(false, false), 13323340, "false, false");
+assert.sameValue(sample.getFloat32(false, true), 53554476, "false, true");
+
+assert.sameValue(sample.getFloat32(null, false), 13323340, "null, false");
+assert.sameValue(sample.getFloat32(null, true), 53554476, "null, true");

--- a/test/built-ins/DataView/prototype/getFloat32/return-values-coerced-byteoffset.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-values-coerced-byteoffset.js
@@ -41,11 +41,6 @@ sample.setUint8(5, 75);
 sample.setUint8(6, 76);
 sample.setUint8(7, 76);
 
-assert.sameValue(sample.getFloat32(0, false), 13323340, "0, false");
-assert.sameValue(sample.getFloat32(1, false), 13388875, "1, false");
-assert.sameValue(sample.getFloat32(0, true), 53554476, "0, true");
-assert.sameValue(sample.getFloat32(1, true), 13388875, "1, true");
-
 assert.sameValue(sample.getFloat32("", false), 13323340, "'', false");
 assert.sameValue(sample.getFloat32("", true), 53554476, "'', true");
 

--- a/test/built-ins/DataView/prototype/getFloat32/return-values-custom-offset.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-values-custom-offset.js
@@ -24,11 +24,6 @@ info: |
   ] )
 
   ...
-  7. If isLittleEndian is not present, set isLittleEndian to either true or
-  false. The choice is implementation dependent and should be the alternative
-  that is most efficient for the implementation. An implementation must use the
-  same value each time this step is executed and the same value must be used for
-  the corresponding step in the SetValueInBuffer abstract operation.
   8. If isLittleEndian is false, reverse the order of the elements of rawValue.
   ...
 features: [DataView.prototype.setUint8]

--- a/test/built-ins/DataView/prototype/getFloat32/return-values-custom-offset.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-values-custom-offset.js
@@ -1,0 +1,60 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Return values from Buffer using a custom offset
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  14. Let bufferIndex be getIndex + viewOffset.
+  15. Return GetValueFromBuffer(buffer, bufferIndex, type, isLittleEndian).
+  ...
+
+  24.1.1.5 GetValueFromBuffer ( arrayBuffer, byteIndex, type [ , isLittleEndian
+  ] )
+
+  ...
+  7. If isLittleEndian is not present, set isLittleEndian to either true or
+  false. The choice is implementation dependent and should be the alternative
+  that is most efficient for the implementation. An implementation must use the
+  same value each time this step is executed and the same value must be used for
+  the corresponding step in the SetValueInBuffer abstract operation.
+  8. If isLittleEndian is false, reverse the order of the elements of rawValue.
+  ...
+features: [DataView.prototype.setUint8]
+---*/
+
+var buffer = new ArrayBuffer(12);
+var sample = new DataView(buffer, 0);
+
+sample.setUint8(4, 75);
+sample.setUint8(5, 75);
+sample.setUint8(6, 75);
+sample.setUint8(7, 75);
+sample.setUint8(8, 76);
+sample.setUint8(9, 76);
+sample.setUint8(10, 77);
+sample.setUint8(11, 77);
+
+sample = new DataView(buffer, 4);
+
+assert.sameValue(sample.getFloat32(0, false), 13323083, "0, false");
+assert.sameValue(sample.getFloat32(1, false), 13323084, "1, false");
+assert.sameValue(sample.getFloat32(2, false), 13323340, "2, false");
+assert.sameValue(sample.getFloat32(3, false), 13388877, "3, false");
+assert.sameValue(sample.getFloat32(4, false), 53556532, "4, false");
+assert.sameValue(sample.getFloat32(0, true), 13323083, "0, true");
+assert.sameValue(sample.getFloat32(1, true), 53292332, "1, true");
+assert.sameValue(sample.getFloat32(2, true), 53554476, "2, true");
+assert.sameValue(sample.getFloat32(3, true), 214222000, "3, true");
+assert.sameValue(sample.getFloat32(4, true), 215270592, "4, true");

--- a/test/built-ins/DataView/prototype/getFloat32/return-values.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-values.js
@@ -24,11 +24,6 @@ info: |
   ] )
 
   ...
-  7. If isLittleEndian is not present, set isLittleEndian to either true or
-  false. The choice is implementation dependent and should be the alternative
-  that is most efficient for the implementation. An implementation must use the
-  same value each time this step is executed and the same value must be used for
-  the corresponding step in the SetValueInBuffer abstract operation.
   8. If isLittleEndian is false, reverse the order of the elements of rawValue.
   ...
 features: [DataView.prototype.setUint8]

--- a/test/built-ins/DataView/prototype/getFloat32/return-values.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-values.js
@@ -1,0 +1,85 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Return values from Buffer
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  14. Let bufferIndex be getIndex + viewOffset.
+  15. Return GetValueFromBuffer(buffer, bufferIndex, type, isLittleEndian).
+  ...
+
+  24.1.1.5 GetValueFromBuffer ( arrayBuffer, byteIndex, type [ , isLittleEndian
+  ] )
+
+  ...
+  7. If isLittleEndian is not present, set isLittleEndian to either true or
+  false. The choice is implementation dependent and should be the alternative
+  that is most efficient for the implementation. An implementation must use the
+  same value each time this step is executed and the same value must be used for
+  the corresponding step in the SetValueInBuffer abstract operation.
+  8. If isLittleEndian is false, reverse the order of the elements of rawValue.
+  ...
+features: [DataView.prototype.setUint8]
+---*/
+
+var buffer = new ArrayBuffer(8);
+var sample = new DataView(buffer, 0);
+
+sample.setUint8(0, 66);
+sample.setUint8(1, 40);
+sample.setUint8(2, 0);
+sample.setUint8(3, 0);
+sample.setUint8(4, 64);
+sample.setUint8(5, 224);
+sample.setUint8(6, 0);
+sample.setUint8(7, 0);
+
+assert.sameValue(sample.getFloat32(0), 42, "0");
+assert.sameValue(sample.getFloat32(1), 7.105481567709626e-15, "1");
+assert.sameValue(sample.getFloat32(2), 2.327276489550656e-41, "2");
+assert.sameValue(sample.getFloat32(3), 5.95782781324968e-39, "3");
+assert.sameValue(sample.getFloat32(4), 7, "4");
+
+assert.sameValue(sample.getFloat32(0, false), 42, "0, false");
+assert.sameValue(sample.getFloat32(1, false), 7.105481567709626e-15, "1, false");
+assert.sameValue(sample.getFloat32(2, false), 2.327276489550656e-41, "2, false");
+assert.sameValue(sample.getFloat32(3, false), 5.95782781324968e-39, "3, false");
+assert.sameValue(sample.getFloat32(4, false), 7, "4, false");
+
+assert.sameValue(sample.getFloat32(0, true), 1.4441781973331565e-41, "0, true");
+assert.sameValue(sample.getFloat32(1, true), 2.000009536743164, "1, true");
+assert.sameValue(sample.getFloat32(2, true), -55340232221128655000, "2, true");
+assert.sameValue(sample.getFloat32(3, true), 2.059411001342953e-38, "3, true");
+assert.sameValue(sample.getFloat32(4, true), 8.04457422399591e-41, "4, true");
+
+sample.setUint8(0, 75);
+sample.setUint8(1, 75);
+sample.setUint8(2, 76);
+sample.setUint8(3, 76);
+sample.setUint8(4, 75);
+sample.setUint8(5, 75);
+sample.setUint8(6, 76);
+sample.setUint8(7, 76);
+
+assert.sameValue(sample.getFloat32(0, false), 13323340, "0, false");
+assert.sameValue(sample.getFloat32(1, false), 13388875, "1, false");
+assert.sameValue(sample.getFloat32(2, false), 53554476, "2, false");
+assert.sameValue(sample.getFloat32(3, false), 53292336, "3, false");
+assert.sameValue(sample.getFloat32(4, false), 13323340, "4, false");
+assert.sameValue(sample.getFloat32(0, true), 53554476, "0, true");
+assert.sameValue(sample.getFloat32(1, true), 13388875, "1, true");
+assert.sameValue(sample.getFloat32(2, true), 13323340, "2, true");
+assert.sameValue(sample.getFloat32(3, true), 53292336, "3, true");
+assert.sameValue(sample.getFloat32(4, true), 53554476, "4, true");

--- a/test/built-ins/DataView/prototype/getFloat32/return-values.js
+++ b/test/built-ins/DataView/prototype/getFloat32/return-values.js
@@ -41,12 +41,6 @@ sample.setUint8(5, 224);
 sample.setUint8(6, 0);
 sample.setUint8(7, 0);
 
-assert.sameValue(sample.getFloat32(0), 42, "0");
-assert.sameValue(sample.getFloat32(1), 7.105481567709626e-15, "1");
-assert.sameValue(sample.getFloat32(2), 2.327276489550656e-41, "2");
-assert.sameValue(sample.getFloat32(3), 5.95782781324968e-39, "3");
-assert.sameValue(sample.getFloat32(4), 7, "4");
-
 assert.sameValue(sample.getFloat32(0, false), 42, "0, false");
 assert.sameValue(sample.getFloat32(1, false), 7.105481567709626e-15, "1, false");
 assert.sameValue(sample.getFloat32(2, false), 2.327276489550656e-41, "2, false");

--- a/test/built-ins/DataView/prototype/getFloat32/this-has-no-dataview-internal.js
+++ b/test/built-ins/DataView/prototype/getFloat32/this-has-no-dataview-internal.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Throws a TypeError if this does not have a [[DataView]] internal slot
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  1. If Type(view) is not Object, throw a TypeError exception.
+  2. If view does not have a [[DataView]] internal slot, throw a TypeError
+  exception.
+  ...
+features: [Int8Array]
+---*/
+
+var getFloat32 = DataView.prototype.getFloat32;
+
+assert.throws(TypeError, function() {
+  getFloat32.call({});
+}, "{}");
+
+assert.throws(TypeError, function() {
+  getFloat32.call([]);
+}, "[]");
+
+var ab = new ArrayBuffer(1);
+assert.throws(TypeError, function() {
+  getFloat32.call(ab);
+}, "ArrayBuffer");
+
+var ta = new Int8Array();
+assert.throws(TypeError, function() {
+  getFloat32.call(ta);
+}, "TypedArray");

--- a/test/built-ins/DataView/prototype/getFloat32/this-is-not-object.js
+++ b/test/built-ins/DataView/prototype/getFloat32/this-is-not-object.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: Throws a TypeError if this is not Object
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  1. If Type(view) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol]
+---*/
+
+var getFloat32 = DataView.prototype.getFloat32;
+
+assert.throws(TypeError, function() {
+  getFloat32.call(undefined);
+}, "undefined");
+
+assert.throws(TypeError, function() {
+  getFloat32.call(null);
+}, "null");
+
+assert.throws(TypeError, function() {
+  getFloat32.call(1);
+}, "1");
+
+assert.throws(TypeError, function() {
+  getFloat32.call("string");
+}, "string");
+
+assert.throws(TypeError, function() {
+  getFloat32.call(true);
+}, "true");
+
+assert.throws(TypeError, function() {
+  getFloat32.call(false);
+}, "false");
+
+var s = Symbol("1");
+assert.throws(TypeError, function() {
+  getFloat32.call(s);
+}, "symbol");

--- a/test/built-ins/DataView/prototype/getFloat32/to-boolean-littleendian.js
+++ b/test/built-ins/DataView/prototype/getFloat32/to-boolean-littleendian.js
@@ -24,11 +24,6 @@ info: |
   ] )
 
   ...
-  7. If isLittleEndian is not present, set isLittleEndian to either true or
-  false. The choice is implementation dependent and should be the alternative
-  that is most efficient for the implementation. An implementation must use the
-  same value each time this step is executed and the same value must be used for
-  the corresponding step in the SetValueInBuffer abstract operation.
   8. If isLittleEndian is false, reverse the order of the elements of rawValue.
   ...
 features: [DataView.prototype.setUint8, Symbol]

--- a/test/built-ins/DataView/prototype/getFloat32/to-boolean-littleendian.js
+++ b/test/built-ins/DataView/prototype/getFloat32/to-boolean-littleendian.js
@@ -38,6 +38,7 @@ sample.setUint8(2, 76);
 sample.setUint8(3, 76);
 
 // False
+assert.sameValue(sample.getFloat32(0), 13323340, "no arg");
 assert.sameValue(sample.getFloat32(0, undefined), 13323340, "undefined");
 assert.sameValue(sample.getFloat32(0, null), 13323340, "null");
 assert.sameValue(sample.getFloat32(0, 0), 13323340, "0");

--- a/test/built-ins/DataView/prototype/getFloat32/to-boolean-littleendian.js
+++ b/test/built-ins/DataView/prototype/getFloat32/to-boolean-littleendian.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview.prototype.getfloat32
+es6id: 24.2.4.5
+description: >
+  Boolean littleEndian argument coerced in ToBoolean
+info: |
+  24.2.4.5 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be false.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Float32").
+
+  24.2.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  14. Let bufferIndex be getIndex + viewOffset.
+  15. Return GetValueFromBuffer(buffer, bufferIndex, type, isLittleEndian).
+  ...
+
+  24.1.1.5 GetValueFromBuffer ( arrayBuffer, byteIndex, type [ , isLittleEndian
+  ] )
+
+  ...
+  7. If isLittleEndian is not present, set isLittleEndian to either true or
+  false. The choice is implementation dependent and should be the alternative
+  that is most efficient for the implementation. An implementation must use the
+  same value each time this step is executed and the same value must be used for
+  the corresponding step in the SetValueInBuffer abstract operation.
+  8. If isLittleEndian is false, reverse the order of the elements of rawValue.
+  ...
+features: [DataView.prototype.setUint8, Symbol]
+---*/
+
+var buffer = new ArrayBuffer(4);
+var sample = new DataView(buffer, 0);
+
+sample.setUint8(0, 75);
+sample.setUint8(1, 75);
+sample.setUint8(2, 76);
+sample.setUint8(3, 76);
+
+// False
+assert.sameValue(sample.getFloat32(0, undefined), 13323340, "undefined");
+assert.sameValue(sample.getFloat32(0, null), 13323340, "null");
+assert.sameValue(sample.getFloat32(0, 0), 13323340, "0");
+assert.sameValue(sample.getFloat32(0, ""), 13323340, "the empty string");
+
+// True
+assert.sameValue(sample.getFloat32(0, {}), 53554476, "{}");
+assert.sameValue(sample.getFloat32(0, Symbol("1")), 53554476, "symbol");
+assert.sameValue(sample.getFloat32(0, 1), 53554476, "1");
+assert.sameValue(sample.getFloat32(0, "string"), 53554476, "string");


### PR DESCRIPTION
These tests will be similar to on the other `DataView#get*` methods. I'm opening this to reuse any feedback on the following tests (new PRs).

I'm not so happy with the tests returning a NaN. Have you got any ideas to improve it, @jugglinmike?