### PR TITLE
Correct test for NaN canonicalization

### DIFF
--- a/test/built-ins/TypedArray/prototype/map/return-new-typedarray-conversion-operation-consistent-nan.js
+++ b/test/built-ins/TypedArray/prototype/map/return-new-typedarray-conversion-operation-consistent-nan.js
@@ -46,9 +46,10 @@ includes: [nans.js, testTypedArray.js, compareArray.js]
 function body(FloatArray) {
   var sample = new FloatArray(distinctNaNs);
   var sampleBytes, resultBytes;
+  var i = 0;
 
-  var result = sample.map(function(value) {
-    return value;
+  var result = sample.map(function() {
+    return distinctNaNs[i++];
   });
 
   sampleBytes = new Uint8Array(sample.buffer);


### PR DESCRIPTION
Because implementations are free to select any valid NaN value during
GetValueFromBuffer, tests concerning semantics for consistent NaN value
encoding cannot rely on values returned from that abstract operation.

Update the test for `%TypedArray%.prototype.map` to set the same NaN
values via `map` as set in the "control" array.

This problem was [originally reported](https://github.com/tc39/test262/pull/623#discussion_r63443319) by @littledan. Dan: what do you think of this approach?