### PR TITLE
Add tests for Intl.getCanonicalLocales

### DIFF
--- a/test/intl402/Intl/getCanonicalLocales/duplicates.js
+++ b/test/intl402/Intl/getCanonicalLocales/duplicates.js
@@ -1,0 +1,19 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: Tests the getCanonicalLocales function for duplicate locales scenario.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+  1. Let ll be ? CanonicalizeLocaleList(locales).
+  2. Return CreateArrayFromList(ll).
+includes: [compareArray.js]
+---*/
+
+assert(compareArray(
+  Intl.getCanonicalLocales(
+    ['ab-cd', 'ff', 'de-rt', 'ab-Cd']), ['ab-CD', 'ff', 'de-RT']));
+
+var locales = Intl.getCanonicalLocales(["en-US", "en-US"]);
+assert(compareArray(locales, ['en-US']), 'en-US');

--- a/test/intl402/Intl/getCanonicalLocales/error-cases.js
+++ b/test/intl402/Intl/getCanonicalLocales/error-cases.js
@@ -1,0 +1,46 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: Tests the getCanonicalLocales function for error tags.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+  1. Let ll be ? CanonicalizeLocaleList(locales).
+  2. Return CreateArrayFromList(ll).
+includes: [compareArray.js]
+features: [Symbol]
+---*/
+
+var rangeErrorCases =
+  [
+   "en-us-",
+   "-en-us",
+   "en-us-en-us",
+   "--",
+   "-",
+   "",
+   "-e-"
+  ];
+
+rangeErrorCases.forEach(function(re) {
+  assert.throws(RangeError, function() {
+    Intl.getCanonicalLocales(re);
+  });
+});
+
+var typeErrorCases =
+  [
+    null,
+    [null],
+    [true],
+    [NaN],
+    [2],
+    [Symbol('foo')]
+  ];
+
+typeErrorCases.forEach(function(te) {
+  assert.throws(TypeError, function() {
+    Intl.getCanonicalLocales(te);
+  });
+});

--- a/test/intl402/Intl/getCanonicalLocales/get-locale.js
+++ b/test/intl402/Intl/getCanonicalLocales/get-locale.js
@@ -1,0 +1,25 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: Test Intl.getCanonicalLocales for step 7.c.i. 
+info: |
+  9.2.1 CanonicalizeLocaleList (locales)
+    7. Repeat, while k < len.
+      c. If kPresent is true, then
+        i. Let kValue be ? Get(O, Pk).
+---*/
+
+var locales = {
+  '0': 'en-US',
+  length: 2
+};
+
+Object.defineProperty(locales, "1", {
+  get: function() { throw new Test262Error() }
+});
+
+assert.throws(Test262Error, function() {
+  Intl.getCanonicalLocales(locales);
+});

--- a/test/intl402/Intl/getCanonicalLocales/getCanonicalLocales.js
+++ b/test/intl402/Intl/getCanonicalLocales/getCanonicalLocales.js
@@ -1,0 +1,22 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: Property type and descriptor. 
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+  1. Let ll be ? CanonicalizeLocaleList(locales).
+  2. Return CreateArrayFromList(ll).
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  typeof Intl.getCanonicalLocales,
+  'function',
+  '`typeof Intl.getCanonicalLocales` is `function`'
+);
+
+verifyNotEnumerable(Intl, 'getCanonicalLocales');
+verifyWritable(Intl, 'getCanonicalLocales');
+verifyConfigurable(Intl, 'getCanonicalLocales');

--- a/test/intl402/Intl/getCanonicalLocales/has-property.js
+++ b/test/intl402/Intl/getCanonicalLocales/has-property.js
@@ -1,0 +1,30 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: Test Intl.getCanonicalLocales.name for step 7.b. 
+info: |
+  9.2.1 CanonicalizeLocaleList (locales)
+    7. Repeat, while k < len.
+      b. Let kPresent be HasProperty(O, Pk).
+features: [Proxy]
+---*/
+
+var locales = {
+  '0': 'en-US',
+  '1': 'pt-BR',
+  length: 2
+};
+
+var p = new Proxy(locales, {
+  has: function(_, prop) {
+    if (prop === '0') {
+      throw new Test262Error();
+    }
+  }
+});
+
+assert.throws(Test262Error, function() {
+  Intl.getCanonicalLocales(p);
+});

--- a/test/intl402/Intl/getCanonicalLocales/length.js
+++ b/test/intl402/Intl/getCanonicalLocales/length.js
@@ -1,0 +1,18 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: Intl.getCanonicalLocales.length. 
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+  1. Let ll be ? CanonicalizeLocaleList(locales).
+  2. Return CreateArrayFromList(ll).
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Intl.getCanonicalLocales.length, 1);
+
+verifyNotEnumerable(Intl.getCanonicalLocales, "length");
+verifyNotWritable(Intl.getCanonicalLocales, "length");
+verifyConfigurable(Intl.getCanonicalLocales, "length");

--- a/test/intl402/Intl/getCanonicalLocales/locales-is-not-a-string.js
+++ b/test/intl402/Intl/getCanonicalLocales/locales-is-not-a-string.js
@@ -1,0 +1,30 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: Tests for scenario where locales is not a string
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+  1. Let ll be ? CanonicalizeLocaleList(locales).
+  2. Return CreateArrayFromList(ll).
+includes: [compareArray.js]
+features: [Symbol]
+---*/
+
+var gCL = Intl.getCanonicalLocales;
+
+function assertArray(l, r) {
+  assert(compareArray(l, r), r);
+}
+
+assertArray(gCL(), []);
+assertArray(gCL(false), []);
+assertArray(gCL(true), []);
+assertArray(gCL(Symbol("foo")), []);
+assertArray(gCL(NaN), []);
+assertArray(gCL(1), []);
+
+Number.prototype[0] = "en-US";
+Number.prototype.length = 1;
+assertArray(gCL(NaN), ["en-US"]);

--- a/test/intl402/Intl/getCanonicalLocales/main.js
+++ b/test/intl402/Intl/getCanonicalLocales/main.js
@@ -1,0 +1,34 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: Tests for existance and behavior of Intl.getCanonicalLocales
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+  1. Let ll be ? CanonicalizeLocaleList(locales).
+  2. Return CreateArrayFromList(ll).
+includes: [compareArray.js]
+---*/
+
+var gCL = Intl.getCanonicalLocales;
+
+function assertArray(l, r) {
+  assert(compareArray(l, r), r);
+}
+
+assertArray(gCL(), []);
+
+assertArray(gCL('ab-cd'), ['ab-CD']);
+
+assertArray(gCL(['ab-cd']), ['ab-CD']);
+
+assertArray(gCL(['ab-cd', 'FF']), ['ab-CD', 'ff']);
+
+assertArray(gCL({'a': 0}), []);
+
+assertArray(gCL({}), []);
+
+assertArray(gCL(['ar-ma-u-ca-islamicc']), ['ar-MA-u-ca-islamicc']);
+
+assertArray(gCL(['th-th-u-nu-thai']), ['th-TH-u-nu-thai']);

--- a/test/intl402/Intl/getCanonicalLocales/name.js
+++ b/test/intl402/Intl/getCanonicalLocales/name.js
@@ -1,0 +1,20 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: Intl.getCanonicalLocales.name value and descriptor. 
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+  1. Let ll be ? CanonicalizeLocaleList(locales).
+  2. Return CreateArrayFromList(ll).
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Intl.getCanonicalLocales.name, 'getCanonicalLocales',
+  'The value of `Intl.getCanonicalLocales.name` is `"getCanonicalLocales"`'
+);
+
+verifyNotEnumerable(Intl.getCanonicalLocales, 'name');
+verifyNotWritable(Intl.getCanonicalLocales, 'name');
+verifyConfigurable(Intl.getCanonicalLocales, 'name');

--- a/test/intl402/Intl/getCanonicalLocales/overriden-arg-length.js
+++ b/test/intl402/Intl/getCanonicalLocales/overriden-arg-length.js
@@ -1,0 +1,89 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: Test Intl.getCanonicalLocales for step 5. 
+info: |
+  9.2.1 CanonicalizeLocaleList (locales)
+    5. Let len be ? ToLength(? Get(O, "length")).
+includes: [compareArray.js]
+features: [Symbol]
+---*/
+
+var locales = {
+  '0': 'en-US',
+};
+
+Object.defineProperty(locales, "length", {
+  get: function() { throw new Test262Error() }
+});
+
+assert.throws(Test262Error, function() {
+  Intl.getCanonicalLocales(locales);
+}, "should throw if locales.length throws");
+
+var locales = {
+  '0': 'en-US',
+  '1': 'pt-BR',
+};
+
+Object.defineProperty(locales, "length", {
+  get: function() { return "1" }
+});
+
+assert(compareArray(Intl.getCanonicalLocales(locales), ['en-US']),
+  "should return one element if locales.length is '1'");
+
+var locales = {
+  '0': 'en-US',
+  '1': 'pt-BR',
+};
+
+Object.defineProperty(locales, "length", {
+  get: function() { return 1.3 }
+});
+
+assert(compareArray(Intl.getCanonicalLocales(locales), ['en-US']),
+  "should return one element if locales.length is 1.3");
+
+var locales = {
+  '0': 'en-US',
+  '1': 'pt-BR',
+};
+
+Object.defineProperty(locales, "length", {
+  get: function() { return Symbol("1.8") }
+});
+
+assert.throws(TypeError, function() {
+  Intl.getCanonicalLocales(locales);
+}, "should throw if locales.length is a Symbol");
+
+var locales = {
+  '0': 'en-US',
+  '1': 'pt-BR',
+};
+
+Object.defineProperty(locales, "length", {
+  get: function() { return -Infinity }
+});
+
+assert(compareArray(Intl.getCanonicalLocales(locales), []),
+  "should return empty array if locales.length is -Infinity");
+
+var locales = {
+  length: -Math.pow(2, 32) + 1
+};
+
+Object.defineProperty(locales, "0", {
+  get: function() { throw new Error("must not be gotten!"); }
+})
+
+assert(compareArray(Intl.getCanonicalLocales(locales), []),
+  "should return empty array if locales.length is a negative value");
+
+var count = 0;
+var locs = { get length() { if (count++ > 0) throw 42; return 0; } };
+var locales = Intl.getCanonicalLocales(locs); // shouldn't throw 42
+assert.sameValue(locales.length, 0);

--- a/test/intl402/Intl/getCanonicalLocales/overriden-push.js
+++ b/test/intl402/Intl/getCanonicalLocales/overriden-push.js
@@ -1,0 +1,19 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: Tests the getCanonicalLocales function for overridden Array.push().
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+  1. Let ll be ? CanonicalizeLocaleList(locales).
+  2. Return CreateArrayFromList(ll).
+includes: [compareArray.js]
+---*/
+
+Array.prototype.push = function() { throw 42; };
+
+// must not throw 42, might if push is used
+var arr = Intl.getCanonicalLocales(["en-US"]);
+
+assert(compareArray(arr, ["en-US"]));

--- a/test/intl402/Intl/getCanonicalLocales/returned-object-is-an-array.js
+++ b/test/intl402/Intl/getCanonicalLocales/returned-object-is-an-array.js
@@ -1,0 +1,20 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: Tests that the value returned by getCanonicalLocales is an Array.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+  1. Let ll be ? CanonicalizeLocaleList(locales).
+  2. Return CreateArrayFromList(ll).
+includes: [compareArray.js]
+---*/
+
+var locales = ['en-US'];
+var result = Intl.getCanonicalLocales(['en-US']);
+
+assert.notSameValue(result, locales, "result is a new array instance");
+assert.sameValue(result.length, 1, "result.length");
+assert(result.hasOwnProperty("0"), "result an own property `0`");
+assert.sameValue(result[0], "en-US", "result[0]");

--- a/test/intl402/Intl/getCanonicalLocales/to-string.js
+++ b/test/intl402/Intl/getCanonicalLocales/to-string.js
@@ -1,0 +1,20 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: Test Intl.getCanonicalLocales.name for step 7.c.iii 
+info: |
+  9.2.1 CanonicalizeLocaleList (locales)
+    7. Repeat, while k < len.
+      c. If kPresent is true, then
+        iii. Let tag be ? ToString(kValue).
+includes: [compareArray.js]
+---*/
+
+var locales = {
+  '0': { toString: function() { locales[1] = 'pt-BR'; return 'en-US'; }},
+  length: 2
+};
+
+assert(compareArray(Intl.getCanonicalLocales(locales), [ "en-US", "pt-BR" ]));

--- a/test/intl402/Intl/getCanonicalLocales/weird-cases.js
+++ b/test/intl402/Intl/getCanonicalLocales/weird-cases.js
@@ -1,0 +1,25 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: Tests the getCanonicalLocales function for weird tags.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+  1. Let ll be ? CanonicalizeLocaleList(locales).
+  2. Return CreateArrayFromList(ll).
+includes: [compareArray.js]
+---*/
+
+var weirdCases =
+  [
+   "x-u-foo",
+   "en-x-u-foo",
+   "en-a-bar-x-u-foo",
+   "en-x-u-foo-a-bar",
+   "en-a-bar-u-baz-x-u-foo",
+  ];
+
+weirdCases.forEach(function (weird) {
+  assert(compareArray(Intl.getCanonicalLocales(weird), [weird]));
+});


### PR DESCRIPTION
This ports a bunch of tests we wrote for SpiderMonkey implementation into test262 suite - https://dxr.mozilla.org/mozilla-central/source/js/src/tests/Intl

You can see background story of why those tests have been chosen here: https://bugzilla.mozilla.org/show_bug.cgi?id=1263040