### PR TITLE
Document host-defined realm/script API

### DIFF
--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -36,15 +36,15 @@ properties of the global scope prior to test execution.
   tests (via the `async` flag, described below).
 - **`$`** An ordinary object with the following properties:
   - **`createRealm`** - a function which creates a new [ECMAScript
-    Realm](http://www.ecma-international.org/ecma-262/6.0/#sec-code-realms),
+    Realm](https://tc39.github.io/ecma262/2016/#sec-code-realms),
     defines this API on the new realm's global `this` value, and returns the
     `$` property of the new realm's global `this` value
   - **`detachArrayBuffer`** - a function which implements [the
     DetachArrayBuffer abstract
-    operation](http://www.ecma-international.org/ecma-262/6.0/#sec-detacharraybuffer)
+    operation](https://tc39.github.io/ecma262/2016/#sec-detacharraybuffer)
   - **`evalScript`** - a function which accepts a string value as its first
     argument and performs
-    [ScriptEvaluation](http://www.ecma-international.org/ecma-262/6.0/#sec-runtime-semantics-scriptevaluation)
+    [ScriptEvaluation](https://tc39.github.io/ecma262/2016/#sec-runtime-semantics-scriptevaluation)
     on that value, using the current Realm as the argument.
   - **`global`** - a reference to the global `this` value on which `$` was
     initially defined

--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -43,9 +43,21 @@ properties of the global scope prior to test execution.
     DetachArrayBuffer abstract
     operation](https://tc39.github.io/ecma262/2016/#sec-detacharraybuffer)
   - **`evalScript`** - a function which accepts a string value as its first
-    argument and performs
-    [ScriptEvaluation](https://tc39.github.io/ecma262/2016/#sec-runtime-semantics-scriptevaluation)
-    on that value, using the current Realm as the argument.
+    argument and executes is as [an ECMAScript
+    script](https://tc39.github.io/ecma262/2016/#sec-scripts) according to the
+    following algorithm:
+
+        1. Let hostDefined be any host-defined values for the provided
+           sourceText (obtained in an implementation dependent manner)
+        2. Let realm be the current Realm Record.
+        3. Let s be ParseScript(sourceText, realm, hostDefined).
+        4. If s is a List of errors, then
+           a. Let error be the first element of s.
+           b. Return
+              Completion{[[Type]]: throw, [[Value]]: error, [[Target]]: empty}.
+        5. Let status be ScriptEvaluation(s).
+        6. Return Completion(status).
+
   - **`global`** - a reference to the global `this` value on which `$` was
     initially defined
 

--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -34,6 +34,20 @@ properties of the global scope prior to test execution.
 - **`print`** A function that exposes the string value of its first argument to
   the test runner. This is used as a communication mechanism for asynchronous
   tests (via the `async` flag, described below).
+- **`$`** An ordinary object with the following properties:
+  - **`createRealm`** - a function which creates a new [ECMAScript
+    Realm](http://www.ecma-international.org/ecma-262/6.0/#sec-code-realms),
+    defines this API on the new realm's global `this` value, and returns the
+    `$` property of the new realm's global `this` value
+  - **`detachArrayBuffer`** - a function which implements [the
+    DetachArrayBuffer abstract
+    operation](http://www.ecma-international.org/ecma-262/6.0/#sec-detacharraybuffer)
+  - **`evalScript`** - a function which accepts a string value as its first
+    argument and performs
+    [ScriptEvaluation](http://www.ecma-international.org/ecma-262/6.0/#sec-runtime-semantics-scriptevaluation)
+    on that value, using the current Realm as the argument.
+  - **`global`** - a reference to the global `this` value on which `$` was
+    initially defined
 
 ### Strict Mode
 

--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -37,8 +37,8 @@ properties of the global scope prior to test execution.
 - **`$`** An ordinary object with the following properties:
   - **`createRealm`** - a function which creates a new [ECMAScript
     Realm](https://tc39.github.io/ecma262/2016/#sec-code-realms),
-    defines this API on the new realm's global `this` value, and returns the
-    `$` property of the new realm's global `this` value
+    defines this API on the new realm's global object, and returns the `$`
+    property of the new realm's global object
   - **`detachArrayBuffer`** - a function which implements [the
     DetachArrayBuffer abstract
     operation](https://tc39.github.io/ecma262/2016/#sec-detacharraybuffer)
@@ -58,8 +58,8 @@ properties of the global scope prior to test execution.
         5. Let status be ScriptEvaluation(s).
         6. Return Completion(status).
 
-  - **`global`** - a reference to the global `this` value on which `$` was
-    initially defined
+  - **`global`** - a reference to the global object on which `$` was initially
+    defined
 
 ### Strict Mode
 


### PR DESCRIPTION
@bterlson @domenic @littledan @caridy @dherman Between my fumbling with ECMA262
references, my (mis)use of [eshost's current API](https://github.com/bterlson/eshost#runtime-library), and my negligence of [the Realms proposal](https://github.com/caridy/proposal-realms), I expect I have stepped on *all* of your toes, collectively.  I'm submitting this naive draft to serve as a concrete basis for discussion.

Background: I am currently writing tests for cross-realm semantics, and either @leobalter or I will soon be writing tests for cross-script semantics as well. I'd like to define an API to enable this, and my goals are (1) ease of implementation (to encourage consumers to actually run those new tests), and (2) harmony with the Realms proposal (to limit friction when/if that is standardized).

From tips on improving the presentation (do you think we need full-blown ECMArkup for this?), to improving the language, to fixing the fundamental API design, I'm really interested in what you all have to say!

Commit message:

> Define the expected behavior of new host-defined utilities. These will
> facilitate forthcoming tests that concern cross-realm and cross-script
> semantics (which are currently untestable using standard ECMAScript
> alone).