### PR TITLE
Add tests for known violations of invariants

### DIFF
--- a/test/built-ins/Object/internals/DefineOwnProperty/consistent-value-regexp-$1.js
+++ b/test/built-ins/Object/internals/DefineOwnProperty/consistent-value-regexp-$1.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-invariants-of-the-essential-internal-methods
+es6id: 6.1.7.3
+author: Claude Pache
+description: >
+  Value of non-writable, non-configurable data property does not change
+  ("$1" property of RegExp constructor)
+info: |
+  [[GetOwnProperty]] (P)
+
+  [...]
+  - If a property P is described as a data property with Desc.[[Value]] equal
+    to v and Desc.[[Writable]] and Desc.[[Configurable]] are both false, then
+    the SameValue must be returned for the Desc.[[Value]] attribute of the
+    property on all future calls to [[GetOwnProperty]] ( P ).
+  [...]
+
+  (This invariant was violated for the specific property under test by a number
+  of implementations as of May 2016.)
+---*/
+
+var before, after;
+
+try {
+  Object.defineProperty(RegExp, '$1', { writable: false, configurable: false });
+} catch (err) {}
+
+before = Object.getOwnPropertyDescriptor(RegExp, '$1');
+
+if (before.writable === false && before.configurable === false) {
+  /(.)/.test('.');
+
+  after = Object.getOwnPropertyDescriptor(RegExp, '$1');
+
+  assert.sameValue(before.value, after.value);
+}

--- a/test/language/arguments-object/internals/GetOwnProperty/consistent-value-arguments.js
+++ b/test/language/arguments-object/internals/GetOwnProperty/consistent-value-arguments.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-invariants-of-the-essential-internal-methods
+es6id: 6.1.7.3
+author: Claude Pache
+description: >
+  Value of non-writable, non-configurable data property does not change
+  ("arguments" property)
+info: |
+  [[GetOwnProperty]] (P)
+
+  [...]
+  - If a property P is described as a data property with Desc.[[Value]] equal
+    to v and Desc.[[Writable]] and Desc.[[Configurable]] are both false, then
+    the SameValue must be returned for the Desc.[[Value]] attribute of the
+    property on all future calls to [[GetOwnProperty]] ( P ).
+  [...]
+
+  (This invariant was violated for the specific property under test by a number
+  of implementations as of May 2016.)
+---*/
+
+var outside, inside;
+
+function f() { return Object.getOwnPropertyDescriptor(f, 'arguments'); }
+
+try {
+  Object.defineProperty(f, 'arguments', { writable: false, configurable: false });
+} catch (err) {}
+
+outside = Object.getOwnPropertyDescriptor(f, 'arguments');
+
+if (outside.writable === false && outside.configurable === false) {
+  inside = f();
+
+  assert.sameValue(outside.value, inside.value);
+}

--- a/test/language/arguments-object/internals/GetOwnProperty/consistent-value-caller.js
+++ b/test/language/arguments-object/internals/GetOwnProperty/consistent-value-caller.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-invariants-of-the-essential-internal-methods
+es6id: 6.1.7.3
+author: Claude Pache
+description: >
+  Value of non-writable, non-configurable data property does not change
+  ("caller" property)
+info: |
+  [[GetOwnProperty]] (P)
+
+  [...]
+  - If a property P is described as a data property with Desc.[[Value]] equal
+    to v and Desc.[[Writable]] and Desc.[[Configurable]] are both false, then
+    the SameValue must be returned for the Desc.[[Value]] attribute of the
+    property on all future calls to [[GetOwnProperty]] ( P ).
+  [...]
+
+  (This invariant was violated for the specific property under test by a number
+  of implementations as of May 2016.)
+---*/
+
+var outside, inside;
+
+function f() { return Object.getOwnPropertyDescriptor(f, 'caller'); }
+
+try {
+  Object.defineProperty(f, 'caller', { writable: false, configurable: false });
+} catch (err) {}
+
+outside = Object.getOwnPropertyDescriptor(f, 'caller');
+
+if (outside.writable === false && outside.configurable === false) {
+  (function() {
+    inside = f();
+  }());
+
+  assert.sameValue(outside.value, inside.value);
+}


### PR DESCRIPTION
JavaScriptCore and V8 have both been shown to violate an invariant of
the [[GetOwnProperty]] internal method in a number of cases. Add tests
asserting that the invariants are honored consistently.

Resolves gh-649. @claudepache I've listed your name in the tests' "author"
field. Please let me know if you're happy with that level of attribution!
