### PR TITLE
[runner] Add support for "folding" block delimiter

### DIFF
--- a/tools/packaging/monkeyYaml.py
+++ b/tools/packaging/monkeyYaml.py
@@ -43,7 +43,7 @@ def load(str):
     return dict
 
 def myReadValue(lines, value):
-    if value == ">":
+    if value == ">" or value == "|":
         (lines, value) = myMultiline(lines, value)
         value = value + "\n"
         return (lines, value)

--- a/tools/packaging/test/test_monkeyYaml.py
+++ b/tools/packaging/test/test_monkeyYaml.py
@@ -81,6 +81,11 @@ class TestMonkeyYAMLParsing(unittest.TestCase):
         self.assertEqual(lines, ["  other: 42"])
         self.assertEqual(value, "foo bar")
 
+    def test_Multiline_5(self):
+        lines = ["info: |", "  attr: this is a string (not nested yaml)", ""]
+        y = "\n".join(lines)
+        self.assertEqual(monkeyYaml.load(y), yaml.load(y))
+
     def test_myLeading(self):
         self.assertEqual(2, monkeyYaml.myLeadingSpaces("  foo"))
         self.assertEqual(2, monkeyYaml.myLeadingSpaces("  "))


### PR DESCRIPTION
We recently began using the `|` character as a delimiter for YAML blocks in test files. The content of these blocks can confuse the custom YAML parser, disrupting test runs.

[It looks like TC-39 has reached consensus](https://github.com/tc39/agendas/commit/a2fa5e1444552954c06e76d5cc6f120a5fd8d32c) on gh-647 ("Definitive decision for Test262 console runner"), but I'm not sure what that decision was.

In any case, the code is still in use, and this is a blocking bug (no pun intended--honest). The fix was simple enough; we can either merge it to `master` here, or allow consumers to apply the patch to their forks of the runner.