### PR TITLE
Update tests concerning null-extending classes

### DIFF
--- a/test/language/statements/class/subclass/class-definition-null-proto-contains-return-override.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto-contains-return-override.js
@@ -1,6 +1,7 @@
 // Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
+esid: sec-runtime-semantics-classdefinitionevaluation
 es6id: 14.5.14
 description: >
     Runtime Semantics: ClassDefinitionEvaluation
@@ -8,8 +9,6 @@ description: >
     If superclass is null, then
       Let protoParent be null.
       Let constructorParent be the intrinsic object %FunctionPrototype%.
-
-    `extends null` requires return override in the constructor
 ---*/
 class Foo extends null {
   constructor() {

--- a/test/language/statements/class/subclass/class-definition-null-proto-super.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto-super.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-runtime-semantics-classdefinitionevaluation

--- a/test/language/statements/class/subclass/class-definition-null-proto-this.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto-this.js
@@ -3,8 +3,7 @@
 /*---
 esid: sec-runtime-semantics-classdefinitionevaluation
 description: >
-  The `this` value of a null-extending class is automatically initialized,
-  obviating the need for an explicit return value in the constructor.
+  The `this` value of a null-extending class is automatically initialized
 info: |
   The behavior under test was introduced in the "ES2017" revision of the
   specification and conflicts with prior editions.
@@ -31,13 +30,17 @@ info: |
      a. Let thisArgument be ? OrdinaryCreateFromConstructor(newTarget,
         "%ObjectPrototype%").
   [...]
-  15. Return ? envRec.GetThisBinding().
 ---*/
 
-class Foo extends null {
-  constructor() {}
+var thisVal, instance;
+
+class C extends null {
+  constructor() {
+    thisVal = this;
+  }
 }
 
-var foo = new Foo();
+instance = new C();
 
-assert.sameValue(Object.getPrototypeOf(foo), Foo);
+assert.sameValue(instance instanceof C, true);
+assert.sameValue(instance, thisVal);

--- a/test/language/statements/class/subclass/class-definition-null-proto.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 the V8 project authors. All rights reserved.
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-runtime-semantics-classdefinitionevaluation

--- a/test/language/statements/class/subclass/class-definition-null-proto.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto.js
@@ -1,19 +1,41 @@
 // Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-es6id: 14.5.14_S6.e
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
 description: >
-    Runtime Semantics: ClassDefinitionEvaluation
+  When a null-extending class does not specify a `constructor` method
+  definition, a method with zero parameters and an empty body is used
+info: |
+  The behavior under test was introduced in the "ES2017" revision of the
+  specification and conflicts with prior editions.
 
-    If superclass is null, then
-      Let protoParent be null.
-      Let constructorParent be the intrinsic object %FunctionPrototype%.
+  Runtime Semantics: ClassDefinitionEvaluation
+
+  5. If ClassHeritageopt is not present, then
+     [...]
+  6. Else,
+     [...]
+     e. If superclass is null, then
+        i. Let protoParent be null.
+        ii. Let constructorParent be the intrinsic object %FunctionPrototype%.
+     [...]
+  7. Let proto be ObjectCreate(protoParent).
+  8. If ClassBodyopt is not present, let constructor be empty.
+  9. Else, let constructor be ConstructorMethod of ClassBody.
+  10. If constructor is empty, then
+      a. If ClassHeritageopt is present and protoParent is not null, then
+         [...]
+      b. Else,
+         i. Let constructor be the result of parsing the source text
+
+              constructor( ){ }
+
+            using the syntactic grammar with the goal symbol MethodDefinition.
+  [...]
 ---*/
-class Foo extends null {
-  constructor() {
-    return {};
-  }
-}
+
+class Foo extends null {}
 
 assert.sameValue(Object.getPrototypeOf(Foo.prototype), null);
 assert.sameValue(Object.getPrototypeOf(Foo.prototype.constructor), Function.prototype);


### PR DESCRIPTION
The latest revision of ECMA262 makes special provisions for classes
which extend the `null` value [1]. Update the relevant tests
accordingly.

[1] https://github.com/tc39/ecma262/issues/543

@bterlson I believe this fully addresses gh-588. As far as I can tell, there
are two observable difference for that change in the spec:

- There is no requirement for the constructor to return a value (ES2016
  required a return value in this case, and I've updated the relevant test)
- `this` may be referenced from within the constructor (ES2016 does not allow
  such a reference, but we previously had no test for that)

SuperCall continues to be invalid for the same reason. Despite the fact that
there was no change to that behavior, I added a test for good measure.

I'm reasonably confident that there are no lingering tests for the outdated
semantics. (My heuristic is manually inspecting all files that contain the
strings "extends" and "null" but not necessarily on the same line.)

    $ grep -E 'extends' test/ -r -l --null | xargs -0 grep null -l

This should resolve gh-588.