### PR TITLE
Add tests for Number#toPrecision

### DIFF
--- a/test/built-ins/Number/prototype/toPrecision/exponential.js
+++ b/test/built-ins/Number/prototype/toPrecision/exponential.js
@@ -5,7 +5,7 @@
 es6id: 20.1.3.5
 esid: sec-number.prototype.toprecision
 description: >
-  Return string values using 0x0065
+  Return string values using exponential character
 info: |
   Number.prototype.toPrecision ( precision )
 

--- a/test/built-ins/Number/prototype/toPrecision/infinity.js
+++ b/test/built-ins/Number/prototype/toPrecision/infinity.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 The V8 Project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.3.5
+esid: sec-number.prototype.toprecision
+description: >
+  Return "NaN" if this is NaN
+info: |
+  Number.prototype.toPrecision ( precision )
+
+  1. Let x be ? thisNumberValue(this value).
+  [...]
+  5. Let s be the empty String.
+  6. If x < 0, then
+    a. Let s be code unit 0x002D (HYPHEN-MINUS).
+    b. Let x be -x.
+  7. If x = +∞, then
+    a. Return the String that is the concatenation of s and "Infinity".
+  [...]
+---*/
+
+var p = {
+  valueOf: function() {
+    calls++;
+    return 1;
+  }
+};
+
+var calls = 0;
+assert.sameValue((+Infinity).toPrecision(p), "Infinity", "Infinity value");
+assert.sameValue(calls, 1, "Infinity is checked after ToInteger(precision)");
+
+calls = 0;
+var n = new Number(+Infinity);
+assert.sameValue(n.toPrecision(p), "Infinity", "Number Infinity");
+assert.sameValue(
+  calls,
+  1,
+  "Number Infinity is checked after ToInteger(precision)"
+);
+
+calls = 0;
+assert.sameValue((-Infinity).toPrecision(p), "-Infinity", "-Infinity value");
+assert.sameValue(calls, 1, "-Infinity is checked after ToInteger(precision)");
+
+calls = 0;
+var n = new Number(-Infinity);
+assert.sameValue(n.toPrecision(p), "-Infinity", "Number -Infinity");
+assert.sameValue(
+  calls,
+  1,
+  "Number -Infinity is checked after ToInteger(precision)"
+);

--- a/test/built-ins/Number/prototype/toPrecision/infinity.js
+++ b/test/built-ins/Number/prototype/toPrecision/infinity.js
@@ -20,35 +20,10 @@ info: |
   [...]
 ---*/
 
-var p = {
-  valueOf: function() {
-    calls++;
-    return 1;
-  }
-};
-
-var calls = 0;
-assert.sameValue((+Infinity).toPrecision(p), "Infinity", "Infinity value");
-assert.sameValue(calls, 1, "Infinity is checked after ToInteger(precision)");
-
-calls = 0;
+assert.sameValue((+Infinity).toPrecision(1000), "Infinity", "Infinity value");
 var n = new Number(+Infinity);
-assert.sameValue(n.toPrecision(p), "Infinity", "Number Infinity");
-assert.sameValue(
-  calls,
-  1,
-  "Number Infinity is checked after ToInteger(precision)"
-);
+assert.sameValue(n.toPrecision(1000), "Infinity", "Number Infinity");
 
-calls = 0;
-assert.sameValue((-Infinity).toPrecision(p), "-Infinity", "-Infinity value");
-assert.sameValue(calls, 1, "-Infinity is checked after ToInteger(precision)");
-
-calls = 0;
+assert.sameValue((-Infinity).toPrecision(1000), "-Infinity", "-Infinity value");
 var n = new Number(-Infinity);
-assert.sameValue(n.toPrecision(p), "-Infinity", "Number -Infinity");
-assert.sameValue(
-  calls,
-  1,
-  "Number -Infinity is checked after ToInteger(precision)"
-);
+assert.sameValue(n.toPrecision(1000), "-Infinity", "Number -Infinity");

--- a/test/built-ins/Number/prototype/toPrecision/latin-small-letter-e.js
+++ b/test/built-ins/Number/prototype/toPrecision/latin-small-letter-e.js
@@ -1,0 +1,109 @@
+// Copyright (C) 2016 The V8 Project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.3.5
+esid: sec-number.prototype.toprecision
+description: >
+  Return string values using 0x0065
+info: |
+  Number.prototype.toPrecision ( precision )
+
+  1. Let x be ? thisNumberValue(this value).
+  [...]
+  5. Let s be the empty String.
+  [...]
+  9. If x = 0, then
+    [...]
+  10. Else x ≠ 0,
+    [...]
+    c. If e < -6 or e ≥ p, then
+      [...]
+      vii. Return the concatenation of s, m, code unit 0x0065 (LATIN SMALL
+      LETTER E), c, and d.
+  [...]
+---*/
+
+assert.sameValue((10).toPrecision(1), "1e+1");
+assert.sameValue((11).toPrecision(1), "1e+1");
+assert.sameValue((17).toPrecision(1), "2e+1");
+assert.sameValue((19).toPrecision(1), "2e+1");
+assert.sameValue((20).toPrecision(1), "2e+1");
+
+assert.sameValue((100).toPrecision(1), "1e+2");
+assert.sameValue((1000).toPrecision(1), "1e+3");
+assert.sameValue((10000).toPrecision(1), "1e+4");
+assert.sameValue((100000).toPrecision(1), "1e+5");
+
+assert.sameValue((100).toPrecision(2), "1.0e+2");
+assert.sameValue((1000).toPrecision(2), "1.0e+3");
+assert.sameValue((10000).toPrecision(2), "1.0e+4");
+assert.sameValue((100000).toPrecision(2), "1.0e+5");
+
+assert.sameValue((1000).toPrecision(3), "1.00e+3");
+assert.sameValue((10000).toPrecision(3), "1.00e+4");
+assert.sameValue((100000).toPrecision(3), "1.00e+5");
+
+assert.sameValue((42).toPrecision(1), "4e+1");
+assert.sameValue((-42).toPrecision(1), "-4e+1");
+
+assert.sameValue((1.2345e+27).toPrecision(1), "1e+27");
+assert.sameValue((1.2345e+27).toPrecision(2), "1.2e+27");
+assert.sameValue((1.2345e+27).toPrecision(3), "1.23e+27");
+assert.sameValue((1.2345e+27).toPrecision(4), "1.234e+27");
+assert.sameValue((1.2345e+27).toPrecision(5), "1.2345e+27");
+assert.sameValue((1.2345e+27).toPrecision(6), "1.23450e+27");
+assert.sameValue((1.2345e+27).toPrecision(7), "1.234500e+27");
+assert.sameValue((1.2345e+27).toPrecision(16), "1.234500000000000e+27");
+assert.sameValue((1.2345e+27).toPrecision(17), "1.2345000000000000e+27");
+assert.sameValue((1.2345e+27).toPrecision(18), "1.23449999999999996e+27");
+assert.sameValue((1.2345e+27).toPrecision(19), "1.234499999999999962e+27");
+assert.sameValue((1.2345e+27).toPrecision(20), "1.2344999999999999618e+27");
+assert.sameValue((1.2345e+27).toPrecision(21), "1.23449999999999996184e+27");
+
+assert.sameValue((-1.2345e+27).toPrecision(1), "-1e+27");
+assert.sameValue((-1.2345e+27).toPrecision(2), "-1.2e+27");
+assert.sameValue((-1.2345e+27).toPrecision(3), "-1.23e+27");
+assert.sameValue((-1.2345e+27).toPrecision(4), "-1.234e+27");
+assert.sameValue((-1.2345e+27).toPrecision(5), "-1.2345e+27");
+assert.sameValue((-1.2345e+27).toPrecision(6), "-1.23450e+27");
+assert.sameValue((-1.2345e+27).toPrecision(7), "-1.234500e+27");
+assert.sameValue((-1.2345e+27).toPrecision(16), "-1.234500000000000e+27");
+assert.sameValue((-1.2345e+27).toPrecision(17), "-1.2345000000000000e+27");
+assert.sameValue((-1.2345e+27).toPrecision(18), "-1.23449999999999996e+27");
+assert.sameValue((-1.2345e+27).toPrecision(19), "-1.234499999999999962e+27");
+assert.sameValue((-1.2345e+27).toPrecision(20), "-1.2344999999999999618e+27");
+assert.sameValue((-1.2345e+27).toPrecision(21), "-1.23449999999999996184e+27");
+
+var n = new Number("1000000000000000000000"); // 1e+21
+assert.sameValue((n).toPrecision(1), "1e+21");
+assert.sameValue((n).toPrecision(2), "1.0e+21");
+assert.sameValue((n).toPrecision(3), "1.00e+21");
+assert.sameValue((n).toPrecision(4), "1.000e+21");
+assert.sameValue((n).toPrecision(5), "1.0000e+21");
+assert.sameValue((n).toPrecision(6), "1.00000e+21");
+assert.sameValue((n).toPrecision(7), "1.000000e+21");
+assert.sameValue((n).toPrecision(16), "1.000000000000000e+21");
+assert.sameValue((n).toPrecision(17), "1.0000000000000000e+21");
+assert.sameValue((n).toPrecision(18), "1.00000000000000000e+21");
+assert.sameValue((n).toPrecision(19), "1.000000000000000000e+21");
+assert.sameValue((n).toPrecision(20), "1.0000000000000000000e+21");
+assert.sameValue((n).toPrecision(21), "1.00000000000000000000e+21");
+
+var n = new Number("0.000000000000000000001"); // 1e-21
+assert.sameValue((n).toPrecision(1), "1e-21");
+assert.sameValue((n).toPrecision(2), "1.0e-21");
+assert.sameValue((n).toPrecision(3), "1.00e-21");
+assert.sameValue((n).toPrecision(4), "1.000e-21");
+assert.sameValue((n).toPrecision(5), "1.0000e-21");
+assert.sameValue((n).toPrecision(6), "1.00000e-21");
+assert.sameValue((n).toPrecision(7), "1.000000e-21");
+assert.sameValue((n).toPrecision(16), "9.999999999999999e-22");
+assert.sameValue((n).toPrecision(17), "9.9999999999999991e-22");
+assert.sameValue((n).toPrecision(18), "9.99999999999999908e-22");
+assert.sameValue((n).toPrecision(19), "9.999999999999999075e-22");
+assert.sameValue((n).toPrecision(20), "9.9999999999999990754e-22");
+assert.sameValue((n).toPrecision(21), "9.99999999999999907537e-22");
+
+assert.sameValue((0.00000001).toPrecision(1), "1e-8");
+assert.sameValue((-0.00000001).toPrecision(1), "-1e-8");

--- a/test/built-ins/Number/prototype/toPrecision/nan.js
+++ b/test/built-ins/Number/prototype/toPrecision/nan.js
@@ -31,18 +31,20 @@ info: |
   [...]
 ---*/
 
+assert.sameValue(
+  NaN.toPrecision(undefined),
+  "NaN",
+  "step 2: If precision is undefined, return ! ToString(x)"
+);
+
+var calls = 0;
+
 var p = {
   valueOf: function() {
     calls++;
     return Infinity;
   }
 };
-
-assert.sameValue(
-  NaN.toPrecision(undefined),
-  "NaN",
-  "step 2: If precision is undefined, return ! ToString(x)"
-);
 
 assert.sameValue(NaN.toPrecision(p), "NaN", "value");
 assert.sameValue(calls, 1, "NaN is checked after ToInteger(precision)");

--- a/test/built-ins/Number/prototype/toPrecision/nan.js
+++ b/test/built-ins/Number/prototype/toPrecision/nan.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2016 The V8 Project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.3.5
+esid: sec-number.prototype.toprecision
+description: >
+  Return "NaN" if this is NaN
+info: |
+  20.1.3 Properties of the Number Prototype Object
+
+  The Number prototype object is the intrinsic object %NumberPrototype%. The
+  Number prototype object is an ordinary object. The Number prototype is itself
+  a Number object; it has a [[NumberData]] internal slot with the value +0.
+
+  [...]
+  The abstract operation thisNumberValue(value) performs the following steps:
+
+  1. If Type(value) is Number, return value.
+  2. If Type(value) is Object and value has a [[NumberData]] internal slot, then
+    a. Assert: value's [[NumberData]] internal slot is a Number value.
+    b. Return the value of value's [[NumberData]] internal slot.
+  3. Throw a TypeError exception.
+
+  Number.prototype.toPrecision ( precision )
+
+  1. Let x be ? thisNumberValue(this value).
+  2. If precision is undefined, return ! ToString(x).
+  3. Let p be ? ToInteger(precision).
+  4. If x is NaN, return the String "NaN".
+  [...]
+---*/
+
+var p = {
+  valueOf: function() {
+    calls++;
+    return 1;
+  }
+};
+
+var calls = 0;
+assert.sameValue(NaN.toPrecision(p), "NaN", "NaN value");
+assert.sameValue(calls, 1, "NaN is checked after ToInteger(precision)");
+
+var n = new Number(NaN);
+calls = 0;
+assert.sameValue(n.toPrecision(p), "NaN", "Number NaN");
+assert.sameValue(calls, 1, "Number NaN is checked after ToInteger(precision)");
+
+calls = 0;
+assert.sameValue(NaN.toPrecision(undefined), "NaN");
+assert.sameValue(
+  calls,
+  0,
+  "returned before ToInteger(precision) if precision is undefined"
+);

--- a/test/built-ins/Number/prototype/toPrecision/nan.js
+++ b/test/built-ins/Number/prototype/toPrecision/nan.js
@@ -34,23 +34,20 @@ info: |
 var p = {
   valueOf: function() {
     calls++;
-    return 1;
+    return Infinity;
   }
 };
 
-var calls = 0;
-assert.sameValue(NaN.toPrecision(p), "NaN", "NaN value");
+assert.sameValue(
+  NaN.toPrecision(undefined),
+  "NaN",
+  "step 2: If precision is undefined, return ! ToString(x)"
+);
+
+assert.sameValue(NaN.toPrecision(p), "NaN", "value");
 assert.sameValue(calls, 1, "NaN is checked after ToInteger(precision)");
 
 var n = new Number(NaN);
 calls = 0;
-assert.sameValue(n.toPrecision(p), "NaN", "Number NaN");
+assert.sameValue(n.toPrecision(p), "NaN", "object");
 assert.sameValue(calls, 1, "Number NaN is checked after ToInteger(precision)");
-
-calls = 0;
-assert.sameValue(NaN.toPrecision(undefined), "NaN");
-assert.sameValue(
-  calls,
-  0,
-  "returned before ToInteger(precision) if precision is undefined"
-);

--- a/test/built-ins/Number/prototype/toPrecision/prop-desc.js
+++ b/test/built-ins/Number/prototype/toPrecision/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2016 The V8 Project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.3.5
+esid: sec-number.prototype.toprecision
+description: >
+  "toPrecision" property of Number.prototype
+info: >
+  ES6 section 17: Every other data property described in clauses 18 through 26
+  and in Annex B.2 has the attributes { [[Writable]]: true,
+  [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Number.prototype, "toPrecision");
+verifyWritable(Number.prototype, "toPrecision");
+verifyConfigurable(Number.prototype, "toPrecision");

--- a/test/built-ins/Number/prototype/toPrecision/return-abrupt-tointeger-precision-symbol.js
+++ b/test/built-ins/Number/prototype/toPrecision/return-abrupt-tointeger-precision-symbol.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2016 The V8 Project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.3.5
+esid: sec-number.prototype.toprecision
+description: >
+  Return abrupt completion from ToInteger(symbol precision)
+info: |
+  20.1.3 Properties of the Number Prototype Object
+
+  The Number prototype object is the intrinsic object %NumberPrototype%. The
+  Number prototype object is an ordinary object. The Number prototype is itself
+  a Number object; it has a [[NumberData]] internal slot with the value +0.
+
+  [...]
+  The abstract operation thisNumberValue(value) performs the following steps:
+
+  1. If Type(value) is Number, return value.
+  2. If Type(value) is Object and value has a [[NumberData]] internal slot, then
+    a. Assert: value's [[NumberData]] internal slot is a Number value.
+    b. Return the value of value's [[NumberData]] internal slot.
+  3. Throw a TypeError exception.
+
+  Number.prototype.toPrecision ( precision )
+
+  1. Let x be ? thisNumberValue(this value).
+  2. If precision is undefined, return ! ToString(x).
+  3. Let p be ? ToInteger(precision).
+  [...]
+features: [Symbol]
+---*/
+
+var p = Symbol("1");
+
+assert.throws(TypeError, function() {
+  Number.prototype.toPrecision(p);
+});

--- a/test/built-ins/Number/prototype/toPrecision/return-abrupt-tointeger-precision.js
+++ b/test/built-ins/Number/prototype/toPrecision/return-abrupt-tointeger-precision.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2016 The V8 Project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.3.5
+esid: sec-number.prototype.toprecision
+description: >
+  Return abrupt completion from ToInteger(precision)
+info: |
+  20.1.3 Properties of the Number Prototype Object
+
+  The Number prototype object is the intrinsic object %NumberPrototype%. The
+  Number prototype object is an ordinary object. The Number prototype is itself
+  a Number object; it has a [[NumberData]] internal slot with the value +0.
+
+  [...]
+  The abstract operation thisNumberValue(value) performs the following steps:
+
+  1. If Type(value) is Number, return value.
+  2. If Type(value) is Object and value has a [[NumberData]] internal slot, then
+    a. Assert: value's [[NumberData]] internal slot is a Number value.
+    b. Return the value of value's [[NumberData]] internal slot.
+  3. Throw a TypeError exception.
+
+  Number.prototype.toPrecision ( precision )
+
+  1. Let x be ? thisNumberValue(this value).
+  2. If precision is undefined, return ! ToString(x).
+  3. Let p be ? ToInteger(precision).
+  [...]
+---*/
+
+var p1 = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+
+var p2 = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  Number.prototype.toPrecision(p1);
+}, "valueOf");
+
+assert.throws(Test262Error, function() {
+  Number.prototype.toPrecision(p2);
+}, "toString");

--- a/test/built-ins/Number/prototype/toPrecision/return-values.js
+++ b/test/built-ins/Number/prototype/toPrecision/return-values.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2016 The V8 Project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.3.5
+esid: sec-number.prototype.toprecision
+description: >
+  Return regular string values
+info: |
+  Number.prototype.toPrecision ( precision )
+
+  1. Let x be ? thisNumberValue(this value).
+  [...]
+  5. Let s be the empty String.
+  [...]
+  11. If e = p-1, return the concatenation of the Strings s and m.
+  12. If e ≥ 0, then
+    a. Let m be the concatenation of the first e+1 elements of m, the code unit
+    0x002E (FULL STOP), and the remaining p- (e+1) elements of m.
+  13. Else e < 0,
+    a. Let m be the String formed by the concatenation of code unit 0x0030
+    (DIGIT ZERO), code unit 0x002E (FULL STOP), -(e+1) occurrences of code unit
+    0x0030 (DIGIT ZERO), and the String m.
+  14. Return the String that is the concatenation of s and m. 
+---*/
+
+assert.sameValue((7).toPrecision(1), "7");
+assert.sameValue((7).toPrecision(2), "7.0");
+assert.sameValue((7).toPrecision(3), "7.00");
+assert.sameValue((7).toPrecision(19), "7.000000000000000000");
+assert.sameValue((7).toPrecision(20), "7.0000000000000000000");
+assert.sameValue((7).toPrecision(21), "7.00000000000000000000");
+
+assert.sameValue((-7).toPrecision(1), "-7");
+assert.sameValue((-7).toPrecision(2), "-7.0");
+assert.sameValue((-7).toPrecision(3), "-7.00");
+assert.sameValue((-7).toPrecision(19), "-7.000000000000000000");
+assert.sameValue((-7).toPrecision(20), "-7.0000000000000000000");
+assert.sameValue((-7).toPrecision(21), "-7.00000000000000000000");
+
+assert.sameValue((10).toPrecision(2), "10");
+assert.sameValue((11).toPrecision(2), "11");
+assert.sameValue((17).toPrecision(2), "17");
+assert.sameValue((19).toPrecision(2), "19");
+assert.sameValue((20).toPrecision(2), "20");
+
+assert.sameValue((-10).toPrecision(2), "-10");
+assert.sameValue((-11).toPrecision(2), "-11");
+assert.sameValue((-17).toPrecision(2), "-17");
+assert.sameValue((-19).toPrecision(2), "-19");
+assert.sameValue((-20).toPrecision(2), "-20");
+
+assert.sameValue((42).toPrecision(2), "42");
+assert.sameValue((-42).toPrecision(2), "-42");
+
+assert.sameValue((100).toPrecision(3), "100");
+assert.sameValue((100).toPrecision(7), "100.0000");
+assert.sameValue((1000).toPrecision(7), "1000.000");
+assert.sameValue((10000).toPrecision(7), "10000.00");
+assert.sameValue((100000).toPrecision(7), "100000.0");
+
+assert.sameValue((0.000001).toPrecision(1), "0.000001");
+assert.sameValue((0.000001).toPrecision(2), "0.0000010");
+assert.sameValue((0.000001).toPrecision(3), "0.00000100");

--- a/test/built-ins/Number/prototype/toPrecision/this-is-0-precision-is-1.js
+++ b/test/built-ins/Number/prototype/toPrecision/this-is-0-precision-is-1.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 The V8 Project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.3.5
+esid: sec-number.prototype.toprecision
+description: >
+  Return "0" if this value is 0 and precision is 1
+info: |
+  Number.prototype.toPrecision ( precision )
+
+  1. Let x be ? thisNumberValue(this value).
+  [...]
+  5. Let s be the empty String.
+  [...]
+  9. If x = 0, then
+    a. Let m be the String consisting of p occurrences of the code unit 0x0030
+    (DIGIT ZERO).
+    b. Let e be 0.
+  [...]
+  11. If e = p-1, return the concatenation of the Strings s and m.
+---*/
+
+assert.sameValue(Number.prototype.toPrecision(1), "0", "Number.prototype is 0");
+
+assert.sameValue((-0).toPrecision(1), "0", "-0");

--- a/test/built-ins/Number/prototype/toPrecision/this-is-0-precision-is-gter-than-1.js
+++ b/test/built-ins/Number/prototype/toPrecision/this-is-0-precision-is-gter-than-1.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2016 The V8 Project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.3.5
+esid: sec-number.prototype.toprecision
+description: >
+  Return string value for this value = 0 and precision is > 1
+info: |
+  Number.prototype.toPrecision ( precision )
+
+  1. Let x be ? thisNumberValue(this value).
+  [...]
+  5. Let s be the empty String.
+  [...]
+  9. If x = 0, then
+    a. Let m be the String consisting of p occurrences of the code unit 0x0030
+    (DIGIT ZERO).
+    b. Let e be 0.
+  [...]
+  11. If e = p-1, return the concatenation of the Strings s and m.
+  12. If e ≥ 0, then
+    a. Let m be the concatenation of the first e+1 elements of m, the code unit
+    0x002E (FULL STOP), and the remaining p- (e+1) elements of m.
+  [...]
+  14. Return the String that is the concatenation of s and m.
+---*/
+
+assert.sameValue(
+  (0).toPrecision(2),
+  "0.0",
+  "(0).toPrecision(2)"
+);
+
+assert.sameValue(
+  (0).toPrecision(7),
+  "0.000000",
+  "(0).toPrecision(7)"
+);
+
+assert.sameValue(
+  (0).toPrecision(21),
+  "0.00000000000000000000",
+  "(0).toPrecision(21)"
+);
+
+assert.sameValue(
+  (-0).toPrecision(2),
+  "0.0",
+  "(-0).toPrecision(2)"
+);
+
+assert.sameValue(
+  (-0).toPrecision(7),
+  "0.000000",
+  "(-0).toPrecision(7)"
+);
+
+assert.sameValue(
+  (-0).toPrecision(21),
+  "0.00000000000000000000",
+  "(-0).toPrecision(21)"
+);

--- a/test/built-ins/Number/prototype/toPrecision/this-type-not-number-or-number-object.js
+++ b/test/built-ins/Number/prototype/toPrecision/this-type-not-number-or-number-object.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2016 The V8 Project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.3.5
+esid: sec-number.prototype.toprecision
+description: >
+  Throws a TypeError if this value is not a number object or value
+info: |
+  20.1.3 Properties of the Number Prototype Object
+
+  The Number prototype object is the intrinsic object %NumberPrototype%. The
+  Number prototype object is an ordinary object. The Number prototype is itself
+  a Number object; it has a [[NumberData]] internal slot with the value +0.
+
+  [...]
+  The abstract operation thisNumberValue(value) performs the following steps:
+
+  1. If Type(value) is Number, return value.
+  2. If Type(value) is Object and value has a [[NumberData]] internal slot, then
+    a. Assert: value's [[NumberData]] internal slot is a Number value.
+    b. Return the value of value's [[NumberData]] internal slot.
+  3. Throw a TypeError exception.
+
+  Number.prototype.toPrecision ( precision )
+
+  1. Let x be ? thisNumberValue(this value).
+  [...]
+features: [Symbol]
+---*/
+
+var toPrecision = Number.prototype.toPrecision;
+
+assert.throws(TypeError, function() {
+  toPrecision.call({}, 1);
+}, "{}");
+
+assert.throws(TypeError, function() {
+  toPrecision.call("1", 1);
+}, "string");
+
+assert.throws(TypeError, function() {
+  toPrecision.call(Number, 1);
+}, "Number");
+
+assert.throws(TypeError, function() {
+  toPrecision.call(true, 1);
+}, "true");
+
+assert.throws(TypeError, function() {
+  toPrecision.call(false, 1);
+}, "false");
+
+assert.throws(TypeError, function() {
+  toPrecision.call(null, 1);
+}, "null");
+
+assert.throws(TypeError, function() {
+  toPrecision.call(undefined, 1);
+}, "undefined");
+
+assert.throws(TypeError, function() {
+  toPrecision.call(Symbol("1"), 1);
+}, "symbol");
+
+assert.throws(TypeError, function() {
+  toPrecision.call([], 1);
+}, "[]");

--- a/test/built-ins/Number/prototype/toPrecision/tointeger-precision.js
+++ b/test/built-ins/Number/prototype/toPrecision/tointeger-precision.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 The V8 Project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.3.5
+esid: sec-number.prototype.toprecision
+description: >
+  ToInteger(precision) operations
+info: |
+  Number.prototype.toPrecision ( precision )
+
+  [...]
+  3. Let p be ? ToInteger(precision).
+  [...]
+---*/
+
+assert.sameValue((123.456).toPrecision(1.1), "1e+2", "1.1");
+assert.sameValue((123.456).toPrecision(1.9), "1e+2", "1.9");
+
+assert.sameValue((123.456).toPrecision(true), "1e+2", "true");
+
+assert.sameValue((123.456).toPrecision("2"), "1.2e+2", "string");
+
+assert.sameValue((123.456).toPrecision([2]), "1.2e+2", "[2]");

--- a/test/built-ins/Number/prototype/toPrecision/undefined-precision-arg.js
+++ b/test/built-ins/Number/prototype/toPrecision/undefined-precision-arg.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 The V8 Project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 20.1.3.5
+esid: sec-number.prototype.toprecision
+description: >
+  Return a string containing the the number value of this if precision is
+  undefined
+info: |
+  20.1.3 Properties of the Number Prototype Object
+
+  The Number prototype object is the intrinsic object %NumberPrototype%. The
+  Number prototype object is an ordinary object. The Number prototype is itself
+  a Number object; it has a [[NumberData]] internal slot with the value +0.
+
+  [...]
+  The abstract operation thisNumberValue(value) performs the following steps:
+
+  1. If Type(value) is Number, return value.
+  2. If Type(value) is Object and value has a [[NumberData]] internal slot, then
+    a. Assert: value's [[NumberData]] internal slot is a Number value.
+    b. Return the value of value's [[NumberData]] internal slot.
+  3. Throw a TypeError exception.
+
+  Number.prototype.toPrecision ( precision )
+
+  1. Let x be ? thisNumberValue(this value).
+  2. If precision is undefined, return ! ToString(x).
+  [...]
+---*/
+
+var n = new Number(7);
+
+assert.sameValue(n.toPrecision(undefined), "7");
+assert.sameValue((39).toPrecision(undefined), "39");
+
+assert.sameValue(Number.prototype.toPrecision(), "0");
+assert.sameValue((42).toPrecision(), "42");


### PR DESCRIPTION
I'm not happy with the lack of separation for the tests on return-values.js, but it sounded less confusing this way.