### PR TITLE
`Object.getOwnPropertyDescriptors`: add test to ensure undefined descriptors are not added

### DIFF
--- a/test/built-ins/Object/getOwnPropertyDescriptors/duplicate-keys.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptors/duplicate-keys.js
@@ -27,5 +27,12 @@ var proxy = new Proxy({}, {
 
 var result = Object.getOwnPropertyDescriptors(proxy);
 assert.sameValue(result.hasOwnProperty('DUPLICATE'), true);
-assert.sameValue(result.DUPLICATE, undefined);
+
+var lastDescriptor = descriptors[descriptors.length - 1];
+assert.notSameValue(result.DUPLICATE, lastDescriptor);
+assert.sameValue(result.DUPLICATE.enumerable, lastDescriptor.enumerable);
+assert.sameValue(result.DUPLICATE.configurable, lastDescriptor.configurable);
+assert.sameValue(result.DUPLICATE.value, lastDescriptor.value);
+assert.sameValue(result.DUPLICATE.writable, lastDescriptor.writable);
+
 assert.sameValue(log, 'ownKeys|getOwnPropertyDescriptor:DUPLICATE|getOwnPropertyDescriptor:DUPLICATE|getOwnPropertyDescriptor:DUPLICATE|');

--- a/test/built-ins/Object/getOwnPropertyDescriptors/proxy-undefined-descriptor.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptors/proxy-undefined-descriptor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 Jordan Harband. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Object.getOwnPropertyDescriptors should filter out undefined OwnPropertyDescriptors
+esid: sec-object.getownpropertydescriptors
+author: Jordan Harband
+features: [Proxy]
+includes: [proxyTrapsHelper.js]
+---*/
+
+var key = "a";
+var ownKeys = [key];
+var badProxyHandlers = allowProxyTraps({
+  getOwnPropertyDescriptor: function () {},
+  ownKeys: function () {
+	return ownKeys;
+  }
+});
+var proxy = new Proxy({}, badProxyHandlers);
+
+var keys = Reflect.ownKeys(proxy);
+assert.notSameValue(keys, ownKeys, 'Object.keys returns a new Array');
+assert.sameValue(Array.isArray(keys), true, 'Object.keys returns an Array');
+assert.sameValue(keys.length, ownKeys.length, 'keys and ownKeys have the same length');
+assert.sameValue(keys[0], ownKeys[0], 'keys and ownKeys have the same contents');
+
+var descriptor = Object.getOwnPropertyDescriptor(proxy, key);
+assert.sameValue(descriptor, undefined, "Descriptor matches result of [[GetOwnPropertyDescriptor]] trap");
+
+var result = Object.getOwnPropertyDescriptors(proxy);
+assert.sameValue(key in result, false, "key is not present in result");


### PR DESCRIPTION
Per https://github.com/tc39/ecma262/pull/593

**NOTE**: do not merge yet, until TC39 consensus is reached and the above PR is also merged.