### PR TITLE
Improve coverage for "spread" operator

### DIFF
--- a/src/spread/default/array.template
+++ b/src/spread/default/array.template
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/array/spread-
+name: Array initializer
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+info: |
+  SpreadElement : ...AssignmentExpression
+
+  1. Let spreadRef be the result of evaluating AssignmentExpression.
+  2. Let spreadObj be ? GetValue(spreadRef).
+  3. Let iterator be ? GetIterator(spreadObj).
+  4. Repeat
+     a. Let next be ? IteratorStep(iterator).
+     b. If next is false, return nextIndex.
+     c. Let nextValue be ? IteratorValue(next).
+     d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+        nextValue).
+     e. Assert: status is true.
+     f. Let nextIndex be nextIndex + 1.
+---*/
+
+var callCount = 0;
+
+(function(/*{ params }*/) {
+  /*{ body }*/
+  callCount += 1;
+}.apply(null, [/*{ args }*/]));
+
+assert.sameValue(callCount, 1);

--- a/src/spread/error/array.template
+++ b/src/spread/error/array.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/array/spread-err-
+name: Array initializer
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+info: |
+  SpreadElement : ...AssignmentExpression
+
+  1. Let spreadRef be the result of evaluating AssignmentExpression.
+  2. Let spreadObj be ? GetValue(spreadRef).
+  3. Let iterator be ? GetIterator(spreadObj).
+  4. Repeat
+     a. Let next be ? IteratorStep(iterator).
+     b. If next is false, return nextIndex.
+     c. Let nextValue be ? IteratorValue(next).
+     d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+        nextValue).
+     e. Assert: status is true.
+     f. Let nextIndex be nextIndex + 1.
+---*/
+
+assert.throws(/*{ error }*/, function() {
+  [/*{ args }*/];
+});

--- a/src/spread/mult-expr.case
+++ b/src/spread/mult-expr.case
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Spread operator applied to AssignmentExpression following other elements
+template: default
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return precedingArgs.
+---*/
+
+//- setup
+var source = [3, 4, 5];
+var target;
+//- args
+1, 2, ...target = source
+//- body
+assert.sameValue(arguments.length, 5);
+assert.sameValue(arguments[0], 1);
+assert.sameValue(arguments[1], 2);
+assert.sameValue(arguments[2], 3);
+assert.sameValue(arguments[3], 4);
+assert.sameValue(arguments[4], 5);
+assert.sameValue(target, source);

--- a/src/spread/mult-literal.case
+++ b/src/spread/mult-literal.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Spread operator applied to AssignmentExpression following other elements
+template: default
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return precedingArgs.
+---*/
+
+//- args
+5, ...[6, 7, 8], 9
+//- body
+assert.sameValue(arguments.length, 5);
+assert.sameValue(arguments[0], 5);
+assert.sameValue(arguments[1], 6);
+assert.sameValue(arguments[2], 7);
+assert.sameValue(arguments[3], 8);
+assert.sameValue(arguments[4], 9);

--- a/src/spread/sngl-expr.case
+++ b/src/spread/sngl-expr.case
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Spread operator applied to AssignmentExpression as only element
+template: default
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+       f. Append nextArg as the last element of list.
+---*/
+
+//- setup
+var source = [2, 3, 4];
+var target;
+//- args
+...target = source
+//- body
+assert.sameValue(arguments.length, 3);
+assert.sameValue(arguments[0], 2);
+assert.sameValue(arguments[1], 3);
+assert.sameValue(arguments[2], 4);
+assert.sameValue(target, source);

--- a/src/spread/sngl-literal.case
+++ b/src/spread/sngl-literal.case
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Spread operator applied to array literal as only element
+template: default
+info: |
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+       f. Append nextArg as the last element of list.
+---*/
+
+//- args
+...[3, 4, 5]
+//- body
+assert.sameValue(arguments.length, 3);
+assert.sameValue(arguments[0], 3);
+assert.sameValue(arguments[1], 4);
+assert.sameValue(arguments[2], 5);

--- a/test/language/expressions/array/spread-err-mult-err-expr-throws.js
+++ b/test/language/expressions/array/spread-err-mult-err-expr-throws.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-err-expr-throws.case
+// - src/spread/error/array.template
+/*---
+description: Spread operator following other arguments when evaluation throws (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+---*/
+
+assert.throws(Test262Error, function() {
+  [0, ...function*() { throw new Test262Error(); }()];
+});

--- a/test/language/expressions/array/spread-err-mult-err-iter-get-value.js
+++ b/test/language/expressions/array/spread-err-mult-err-iter-get-value.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-err-iter-get-value.case
+// - src/spread/error/array.template
+/*---
+description: Spread operator following other arguments when GetIterator fails (@@iterator function return value) (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    2. Let iterator be ? Call(method, obj).
+    3. If Type(iterator) is not Object, throw a TypeError exception.
+---*/
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    return null;
+  }
+});
+
+assert.throws(TypeError, function() {
+  [0, ...iter];
+});

--- a/test/language/expressions/array/spread-err-mult-err-itr-get-call.js
+++ b/test/language/expressions/array/spread-err-mult-err-itr-get-call.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-err-itr-get-call.case
+// - src/spread/error/array.template
+/*---
+description: Spread operator following other arguments when GetIterator fails (@@iterator function invocation) (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    3. Let iterator be Call(method,obj).
+    4. ReturnIfAbrupt(iterator).
+---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  throw new Test262Error();
+};
+
+assert.throws(Test262Error, function() {
+  [0, ...iter];
+});

--- a/test/language/expressions/array/spread-err-mult-err-itr-get-get.js
+++ b/test/language/expressions/array/spread-err-mult-err-itr-get-get.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-err-itr-get-get.case
+// - src/spread/error/array.template
+/*---
+description: Spread operator following other arguments when GetIterator fails (@@iterator property access) (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    1. If method was not passed, then
+       a. Let method be ? GetMethod(obj, @@iterator).
+---*/
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  [0, ...iter];
+});

--- a/test/language/expressions/array/spread-err-mult-err-itr-step.js
+++ b/test/language/expressions/array/spread-err-mult-err-itr-step.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-err-itr-step.case
+// - src/spread/error/array.template
+/*---
+description: Spread operator following other arguments when IteratorStep fails (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.5 IteratorStep ( iterator )
+
+    1. Let result be IteratorNext(iterator).
+    2. ReturnIfAbrupt(result).
+
+    7.4.2 IteratorNext ( iterator, value )
+
+    1. If value was not passed, then
+       a. Let result be Invoke(iterator, "next", « »).
+    [...]
+    3. ReturnIfAbrupt(result).
+---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      throw new Test262Error();
+    }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  [0, ...iter];
+});

--- a/test/language/expressions/array/spread-err-mult-err-itr-value.js
+++ b/test/language/expressions/array/spread-err-mult-err-itr-value.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-err-itr-value.case
+// - src/spread/error/array.template
+/*---
+description: Spread operator following other arguments when IteratorValue fails (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    7.4.4 IteratorValue ( iterResult )
+
+    1. Assert: Type(iterResult) is Object.
+    2. Return Get(iterResult, "value").
+
+    7.3.1 Get (O, P)
+
+    [...]
+    3. Return O.[[Get]](P, O).
+---*/
+var iter = {};
+var poisonedValue = Object.defineProperty({}, 'value', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return poisonedValue;
+    }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  [0, ...iter];
+});

--- a/test/language/expressions/array/spread-err-mult-err-unresolvable.js
+++ b/test/language/expressions/array/spread-err-mult-err-unresolvable.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-err-unresolvable.case
+// - src/spread/error/array.template
+/*---
+description: Spread operator following other arguments when reference is unresolvable (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+
+    6.2.3.1 GetValue (V)
+
+    1. ReturnIfAbrupt(V).
+    2. If Type(V) is not Reference, return V.
+    3. Let base be GetBase(V).
+    4. If IsUnresolvableReference(V), throw a ReferenceError exception.
+---*/
+
+assert.throws(ReferenceError, function() {
+  [0, ...unresolvableReference];
+});

--- a/test/language/expressions/array/spread-err-sngl-err-expr-throws.js
+++ b/test/language/expressions/array/spread-err-sngl-err-expr-throws.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-err-expr-throws.case
+// - src/spread/error/array.template
+/*---
+description: Spread operator applied to the only argument when evaluation throws (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+features: [generators]
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+---*/
+
+assert.throws(Test262Error, function() {
+  [...function*() { throw new Test262Error(); }()];
+});

--- a/test/language/expressions/array/spread-err-sngl-err-itr-get-call.js
+++ b/test/language/expressions/array/spread-err-sngl-err-itr-get-call.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-err-itr-get-call.case
+// - src/spread/error/array.template
+/*---
+description: Spread operator applied to the only argument when GetIterator fails (@@iterator function invocation) (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    3. Let iterator be Call(method,obj).
+    4. ReturnIfAbrupt(iterator).
+---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  throw new Test262Error();
+};
+
+assert.throws(Test262Error, function() {
+  [...iter];
+});

--- a/test/language/expressions/array/spread-err-sngl-err-itr-get-get.js
+++ b/test/language/expressions/array/spread-err-sngl-err-itr-get-get.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-err-itr-get-get.case
+// - src/spread/error/array.template
+/*---
+description: Spread operator applied to the only argument when GetIterator fails (@@iterator property access) (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    1. If method was not passed, then
+       a. Let method be ? GetMethod(obj, @@iterator).
+---*/
+var iter = {};
+Object.defineProperty(iter, Symbol.iterator, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  [...iter];
+});

--- a/test/language/expressions/array/spread-err-sngl-err-itr-get-value.js
+++ b/test/language/expressions/array/spread-err-sngl-err-itr-get-value.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-err-itr-get-value.case
+// - src/spread/error/array.template
+/*---
+description: Spread operator applied to the only argument when GetIterator fails (@@iterator function return value) (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+
+    7.4.1 GetIterator ( obj, method )
+
+    [...]
+    2. Let iterator be ? Call(method, obj).
+    3. If Type(iterator) is not Object, throw a TypeError exception.
+---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return null;
+};
+
+assert.throws(TypeError, function() {
+  [...iter];
+});

--- a/test/language/expressions/array/spread-err-sngl-err-itr-step.js
+++ b/test/language/expressions/array/spread-err-sngl-err-itr-step.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-err-itr-step.case
+// - src/spread/error/array.template
+/*---
+description: Spread operator applied to the only argument when IteratorStep fails (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+
+    7.4.5 IteratorStep ( iterator )
+
+    1. Let result be IteratorNext(iterator).
+    2. ReturnIfAbrupt(result).
+
+    7.4.2 IteratorNext ( iterator, value )
+
+    1. If value was not passed, then
+       a. Let result be Invoke(iterator, "next", « »).
+    [...]
+    3. ReturnIfAbrupt(result).
+---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      throw new Test262Error();
+    }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  [...iter];
+});

--- a/test/language/expressions/array/spread-err-sngl-err-itr-value.js
+++ b/test/language/expressions/array/spread-err-sngl-err-itr-value.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-err-itr-value.case
+// - src/spread/error/array.template
+/*---
+description: Spread operator applied to the only argument when IteratorValue fails (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+
+    7.4.4 IteratorValue ( iterResult )
+
+    1. Assert: Type(iterResult) is Object.
+    2. Return Get(iterResult, "value").
+
+    7.3.1 Get (O, P)
+
+    [...]
+    3. Return O.[[Get]](P, O).
+---*/
+var iter = {};
+var poisonedValue = Object.defineProperty({}, 'value', {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return poisonedValue;
+    }
+  };
+};
+
+assert.throws(Test262Error, function() {
+  [...iter];
+});

--- a/test/language/expressions/array/spread-err-sngl-err-unresolvable.js
+++ b/test/language/expressions/array/spread-err-sngl-err-unresolvable.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-err-unresolvable.case
+// - src/spread/error/array.template
+/*---
+description: Spread operator applied to the only argument when reference is unresolvable (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+
+    6.2.3.1 GetValue (V)
+
+    1. ReturnIfAbrupt(V).
+    2. If Type(V) is not Reference, return V.
+    3. Let base be GetBase(V).
+    4. If IsUnresolvableReference(V), throw a ReferenceError exception.
+---*/
+
+assert.throws(ReferenceError, function() {
+  [...unresolvableReference];
+});

--- a/test/language/expressions/array/spread-mult-empty.js
+++ b/test/language/expressions/array/spread-mult-empty.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-empty.case
+// - src/spread/default/array.template
+/*---
+description: Spread operator following other arguments when no iteration occurs (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return precedingArgs.
+---*/
+
+var callCount = 0;
+
+(function() {
+  assert.sameValue(arguments.length, 3);
+  assert.sameValue(arguments[0], 1);
+  assert.sameValue(arguments[1], 2);
+  assert.sameValue(arguments[2], 3);
+  callCount += 1;
+}.apply(null, [1, 2, 3, ...[]]));
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/array/spread-mult-expr.js
+++ b/test/language/expressions/array/spread-mult-expr.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-expr.case
+// - src/spread/default/array.template
+/*---
+description: Spread operator applied to AssignmentExpression following other elements (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return precedingArgs.
+---*/
+var source = [3, 4, 5];
+var target;
+
+var callCount = 0;
+
+(function() {
+  assert.sameValue(arguments.length, 5);
+  assert.sameValue(arguments[0], 1);
+  assert.sameValue(arguments[1], 2);
+  assert.sameValue(arguments[2], 3);
+  assert.sameValue(arguments[3], 4);
+  assert.sameValue(arguments[4], 5);
+  assert.sameValue(target, source);
+  callCount += 1;
+}.apply(null, [1, 2, ...target = source]));
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/array/spread-mult-iter.js
+++ b/test/language/expressions/array/spread-mult-iter.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-iter.case
+// - src/spread/default/array.template
+/*---
+description: Spread operator following other arguments with a valid iterator (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+       f. Append nextArg as the last element of list.
+---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  var nextCount = 3;
+  return {
+    next: function() {
+      nextCount += 1;
+      return { done: nextCount === 6, value: nextCount };
+    }
+  };
+};
+
+var callCount = 0;
+
+(function() {
+  assert.sameValue(arguments.length, 5);
+  assert.sameValue(arguments[0], 1);
+  assert.sameValue(arguments[1], 2);
+  assert.sameValue(arguments[2], 3);
+  assert.sameValue(arguments[3], 4);
+  assert.sameValue(arguments[4], 5);
+  callCount += 1;
+}.apply(null, [1, 2, 3, ...iter]));
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/array/spread-mult-literal.js
+++ b/test/language/expressions/array/spread-mult-literal.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-literal.case
+// - src/spread/default/array.template
+/*---
+description: Spread operator applied to AssignmentExpression following other elements (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return precedingArgs.
+---*/
+
+var callCount = 0;
+
+(function() {
+  assert.sameValue(arguments.length, 5);
+  assert.sameValue(arguments[0], 5);
+  assert.sameValue(arguments[1], 6);
+  assert.sameValue(arguments[2], 7);
+  assert.sameValue(arguments[3], 8);
+  assert.sameValue(arguments[4], 9);
+  callCount += 1;
+}.apply(null, [5, ...[6, 7, 8], 9]));
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/array/spread-sngl-empty.js
+++ b/test/language/expressions/array/spread-sngl-empty.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-empty.case
+// - src/spread/default/array.template
+/*---
+description: Spread operator applied to the only argument when no iteration occurs (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       [...]
+---*/
+
+var callCount = 0;
+
+(function() {
+  assert.sameValue(arguments.length, 0);
+  callCount += 1;
+}.apply(null, [...[]]));
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/array/spread-sngl-expr.js
+++ b/test/language/expressions/array/spread-sngl-expr.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-expr.case
+// - src/spread/default/array.template
+/*---
+description: Spread operator applied to AssignmentExpression as only element (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+       f. Append nextArg as the last element of list.
+---*/
+var source = [2, 3, 4];
+var target;
+
+var callCount = 0;
+
+(function() {
+  assert.sameValue(arguments.length, 3);
+  assert.sameValue(arguments[0], 2);
+  assert.sameValue(arguments[1], 3);
+  assert.sameValue(arguments[2], 4);
+  assert.sameValue(target, source);
+  callCount += 1;
+}.apply(null, [...target = source]));
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/array/spread-sngl-iter.js
+++ b/test/language/expressions/array/spread-sngl-iter.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-iter.case
+// - src/spread/default/array.template
+/*---
+description: Spread operator applied to the only argument with a valid iterator (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+features: [Symbol.iterator]
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+       f. Append nextArg as the last element of list.
+---*/
+var iter = {};
+iter[Symbol.iterator] = function() {
+  var nextCount = 0;
+  return {
+    next: function() {
+      nextCount += 1;
+      return { done: nextCount === 3, value: nextCount };
+    }
+  };
+};
+
+var callCount = 0;
+
+(function() {
+  assert.sameValue(arguments.length, 2);
+  assert.sameValue(arguments[0], 1);
+  assert.sameValue(arguments[1], 2);
+  callCount += 1;
+}.apply(null, [...iter]));
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/array/spread-sngl-literal.js
+++ b/test/language/expressions/array/spread-sngl-literal.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-literal.case
+// - src/spread/default/array.template
+/*---
+description: Spread operator applied to array literal as only element (Array initializer)
+esid: sec-runtime-semantics-arrayaccumulation
+es6id: 12.2.5.2
+flags: [generated]
+info: |
+    SpreadElement : ...AssignmentExpression
+
+    1. Let spreadRef be the result of evaluating AssignmentExpression.
+    2. Let spreadObj be ? GetValue(spreadRef).
+    3. Let iterator be ? GetIterator(spreadObj).
+    4. Repeat
+       a. Let next be ? IteratorStep(iterator).
+       b. If next is false, return nextIndex.
+       c. Let nextValue be ? IteratorValue(next).
+       d. Let status be CreateDataProperty(array, ToString(ToUint32(nextIndex)),
+          nextValue).
+       e. Assert: status is true.
+       f. Let nextIndex be nextIndex + 1.
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+       f. Append nextArg as the last element of list.
+---*/
+
+var callCount = 0;
+
+(function() {
+  assert.sameValue(arguments.length, 3);
+  assert.sameValue(arguments[0], 3);
+  assert.sameValue(arguments[1], 4);
+  assert.sameValue(arguments[2], 5);
+  callCount += 1;
+}.apply(null, [...[3, 4, 5]]));
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/call/spread-mult-expr.js
+++ b/test/language/expressions/call/spread-mult-expr.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-expr.case
+// - src/spread/default/call-expr.template
+/*---
+description: Spread operator applied to AssignmentExpression following other elements (CallExpression)
+esid: sec-function-calls-runtime-semantics-evaluation
+es6id: 12.3.4.1
+flags: [generated]
+info: |
+    CallExpression : MemberExpression Arguments
+
+    [...]
+    9. Return EvaluateDirectCall(func, thisValue, Arguments, tailCall).
+
+    12.3.4.3 Runtime Semantics: EvaluateDirectCall
+
+    1. Let argList be ArgumentListEvaluation(arguments).
+    [...]
+    6. Let result be Call(func, thisValue, argList).
+    [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return precedingArgs.
+---*/
+var source = [3, 4, 5];
+var target;
+
+var callCount = 0;
+
+(function() {
+  assert.sameValue(arguments.length, 5);
+  assert.sameValue(arguments[0], 1);
+  assert.sameValue(arguments[1], 2);
+  assert.sameValue(arguments[2], 3);
+  assert.sameValue(arguments[3], 4);
+  assert.sameValue(arguments[4], 5);
+  assert.sameValue(target, source);
+  callCount += 1;
+}(1, 2, ...target = source));
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/call/spread-mult-literal.js
+++ b/test/language/expressions/call/spread-mult-literal.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-literal.case
+// - src/spread/default/call-expr.template
+/*---
+description: Spread operator applied to AssignmentExpression following other elements (CallExpression)
+esid: sec-function-calls-runtime-semantics-evaluation
+es6id: 12.3.4.1
+flags: [generated]
+info: |
+    CallExpression : MemberExpression Arguments
+
+    [...]
+    9. Return EvaluateDirectCall(func, thisValue, Arguments, tailCall).
+
+    12.3.4.3 Runtime Semantics: EvaluateDirectCall
+
+    1. Let argList be ArgumentListEvaluation(arguments).
+    [...]
+    6. Let result be Call(func, thisValue, argList).
+    [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return precedingArgs.
+---*/
+
+var callCount = 0;
+
+(function() {
+  assert.sameValue(arguments.length, 5);
+  assert.sameValue(arguments[0], 5);
+  assert.sameValue(arguments[1], 6);
+  assert.sameValue(arguments[2], 7);
+  assert.sameValue(arguments[3], 8);
+  assert.sameValue(arguments[4], 9);
+  callCount += 1;
+}(5, ...[6, 7, 8], 9));
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/call/spread-sngl-expr.js
+++ b/test/language/expressions/call/spread-sngl-expr.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-expr.case
+// - src/spread/default/call-expr.template
+/*---
+description: Spread operator applied to AssignmentExpression as only element (CallExpression)
+esid: sec-function-calls-runtime-semantics-evaluation
+es6id: 12.3.4.1
+flags: [generated]
+info: |
+    CallExpression : MemberExpression Arguments
+
+    [...]
+    9. Return EvaluateDirectCall(func, thisValue, Arguments, tailCall).
+
+    12.3.4.3 Runtime Semantics: EvaluateDirectCall
+
+    1. Let argList be ArgumentListEvaluation(arguments).
+    [...]
+    6. Let result be Call(func, thisValue, argList).
+    [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+       f. Append nextArg as the last element of list.
+---*/
+var source = [2, 3, 4];
+var target;
+
+var callCount = 0;
+
+(function() {
+  assert.sameValue(arguments.length, 3);
+  assert.sameValue(arguments[0], 2);
+  assert.sameValue(arguments[1], 3);
+  assert.sameValue(arguments[2], 4);
+  assert.sameValue(target, source);
+  callCount += 1;
+}(...target = source));
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/call/spread-sngl-literal.js
+++ b/test/language/expressions/call/spread-sngl-literal.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-literal.case
+// - src/spread/default/call-expr.template
+/*---
+description: Spread operator applied to array literal as only element (CallExpression)
+esid: sec-function-calls-runtime-semantics-evaluation
+es6id: 12.3.4.1
+flags: [generated]
+info: |
+    CallExpression : MemberExpression Arguments
+
+    [...]
+    9. Return EvaluateDirectCall(func, thisValue, Arguments, tailCall).
+
+    12.3.4.3 Runtime Semantics: EvaluateDirectCall
+
+    1. Let argList be ArgumentListEvaluation(arguments).
+    [...]
+    6. Let result be Call(func, thisValue, argList).
+    [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+       f. Append nextArg as the last element of list.
+---*/
+
+var callCount = 0;
+
+(function() {
+  assert.sameValue(arguments.length, 3);
+  assert.sameValue(arguments[0], 3);
+  assert.sameValue(arguments[1], 4);
+  assert.sameValue(arguments[2], 5);
+  callCount += 1;
+}(...[3, 4, 5]));
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/new/spread-mult-expr.js
+++ b/test/language/expressions/new/spread-mult-expr.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-expr.case
+// - src/spread/default/member-expr.template
+/*---
+description: Spread operator applied to AssignmentExpression following other elements (`new` operator)
+esid: sec-new-operator-runtime-semantics-evaluation
+es6id: 12.3.3.1
+flags: [generated]
+info: |
+    MemberExpression : new MemberExpression Arguments
+
+    1. Return EvaluateNew(MemberExpression, Arguments).
+
+    12.3.3.1.1 Runtime Semantics: EvaluateNew
+
+    6. If arguments is empty, let argList be an empty List.
+    7. Else,
+       a. Let argList be ArgumentListEvaluation of arguments.
+       [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return precedingArgs.
+---*/
+var source = [3, 4, 5];
+var target;
+
+var callCount = 0;
+
+new function() {
+  assert.sameValue(arguments.length, 5);
+  assert.sameValue(arguments[0], 1);
+  assert.sameValue(arguments[1], 2);
+  assert.sameValue(arguments[2], 3);
+  assert.sameValue(arguments[3], 4);
+  assert.sameValue(arguments[4], 5);
+  assert.sameValue(target, source);
+  callCount += 1;
+}(1, 2, ...target = source);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/new/spread-mult-literal.js
+++ b/test/language/expressions/new/spread-mult-literal.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-literal.case
+// - src/spread/default/member-expr.template
+/*---
+description: Spread operator applied to AssignmentExpression following other elements (`new` operator)
+esid: sec-new-operator-runtime-semantics-evaluation
+es6id: 12.3.3.1
+flags: [generated]
+info: |
+    MemberExpression : new MemberExpression Arguments
+
+    1. Return EvaluateNew(MemberExpression, Arguments).
+
+    12.3.3.1.1 Runtime Semantics: EvaluateNew
+
+    6. If arguments is empty, let argList be an empty List.
+    7. Else,
+       a. Let argList be ArgumentListEvaluation of arguments.
+       [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return precedingArgs.
+---*/
+
+var callCount = 0;
+
+new function() {
+  assert.sameValue(arguments.length, 5);
+  assert.sameValue(arguments[0], 5);
+  assert.sameValue(arguments[1], 6);
+  assert.sameValue(arguments[2], 7);
+  assert.sameValue(arguments[3], 8);
+  assert.sameValue(arguments[4], 9);
+  callCount += 1;
+}(5, ...[6, 7, 8], 9);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/new/spread-sngl-expr.js
+++ b/test/language/expressions/new/spread-sngl-expr.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-expr.case
+// - src/spread/default/member-expr.template
+/*---
+description: Spread operator applied to AssignmentExpression as only element (`new` operator)
+esid: sec-new-operator-runtime-semantics-evaluation
+es6id: 12.3.3.1
+flags: [generated]
+info: |
+    MemberExpression : new MemberExpression Arguments
+
+    1. Return EvaluateNew(MemberExpression, Arguments).
+
+    12.3.3.1.1 Runtime Semantics: EvaluateNew
+
+    6. If arguments is empty, let argList be an empty List.
+    7. Else,
+       a. Let argList be ArgumentListEvaluation of arguments.
+       [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+       f. Append nextArg as the last element of list.
+---*/
+var source = [2, 3, 4];
+var target;
+
+var callCount = 0;
+
+new function() {
+  assert.sameValue(arguments.length, 3);
+  assert.sameValue(arguments[0], 2);
+  assert.sameValue(arguments[1], 3);
+  assert.sameValue(arguments[2], 4);
+  assert.sameValue(target, source);
+  callCount += 1;
+}(...target = source);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/new/spread-sngl-literal.js
+++ b/test/language/expressions/new/spread-sngl-literal.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-literal.case
+// - src/spread/default/member-expr.template
+/*---
+description: Spread operator applied to array literal as only element (`new` operator)
+esid: sec-new-operator-runtime-semantics-evaluation
+es6id: 12.3.3.1
+flags: [generated]
+info: |
+    MemberExpression : new MemberExpression Arguments
+
+    1. Return EvaluateNew(MemberExpression, Arguments).
+
+    12.3.3.1.1 Runtime Semantics: EvaluateNew
+
+    6. If arguments is empty, let argList be an empty List.
+    7. Else,
+       a. Let argList be ArgumentListEvaluation of arguments.
+       [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+       f. Append nextArg as the last element of list.
+---*/
+
+var callCount = 0;
+
+new function() {
+  assert.sameValue(arguments.length, 3);
+  assert.sameValue(arguments[0], 3);
+  assert.sameValue(arguments[1], 4);
+  assert.sameValue(arguments[2], 5);
+  callCount += 1;
+}(...[3, 4, 5]);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/super/spread-mult-expr.js
+++ b/test/language/expressions/super/spread-mult-expr.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-expr.case
+// - src/spread/default/super-call.template
+/*---
+description: Spread operator applied to AssignmentExpression following other elements (SuperCall)
+esid: sec-super-keyword-runtime-semantics-evaluation
+es6id: 12.3.5.1
+flags: [generated]
+info: |
+    SuperCall : super Arguments
+
+    1. Let newTarget be GetNewTarget().
+    2. If newTarget is undefined, throw a ReferenceError exception.
+    3. Let func be GetSuperConstructor().
+    4. ReturnIfAbrupt(func).
+    5. Let argList be ArgumentListEvaluation of Arguments.
+    [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return precedingArgs.
+---*/
+var source = [3, 4, 5];
+var target;
+
+var callCount = 0;
+
+class Test262ParentClass {
+  constructor() {
+    assert.sameValue(arguments.length, 5);
+    assert.sameValue(arguments[0], 1);
+    assert.sameValue(arguments[1], 2);
+    assert.sameValue(arguments[2], 3);
+    assert.sameValue(arguments[3], 4);
+    assert.sameValue(arguments[4], 5);
+    assert.sameValue(target, source);
+    callCount += 1;
+  }
+}
+
+class Test262ChildClass extends Test262ParentClass {
+  constructor() {
+    super(1, 2, ...target = source);
+  }
+}
+
+new Test262ChildClass();
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/super/spread-mult-literal.js
+++ b/test/language/expressions/super/spread-mult-literal.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/mult-literal.case
+// - src/spread/default/super-call.template
+/*---
+description: Spread operator applied to AssignmentExpression following other elements (SuperCall)
+esid: sec-super-keyword-runtime-semantics-evaluation
+es6id: 12.3.5.1
+flags: [generated]
+info: |
+    SuperCall : super Arguments
+
+    1. Let newTarget be GetNewTarget().
+    2. If newTarget is undefined, throw a ReferenceError exception.
+    3. Let func be GetSuperConstructor().
+    4. ReturnIfAbrupt(func).
+    5. Let argList be ArgumentListEvaluation of Arguments.
+    [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ArgumentList , ... AssignmentExpression
+
+    1. Let precedingArgs be the result of evaluating ArgumentList.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let iterator be GetIterator(GetValue(spreadRef) ).
+    4. ReturnIfAbrupt(iterator).
+    5. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return precedingArgs.
+---*/
+
+var callCount = 0;
+
+class Test262ParentClass {
+  constructor() {
+    assert.sameValue(arguments.length, 5);
+    assert.sameValue(arguments[0], 5);
+    assert.sameValue(arguments[1], 6);
+    assert.sameValue(arguments[2], 7);
+    assert.sameValue(arguments[3], 8);
+    assert.sameValue(arguments[4], 9);
+    callCount += 1;
+  }
+}
+
+class Test262ChildClass extends Test262ParentClass {
+  constructor() {
+    super(5, ...[6, 7, 8], 9);
+  }
+}
+
+new Test262ChildClass();
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/super/spread-sngl-expr.js
+++ b/test/language/expressions/super/spread-sngl-expr.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-expr.case
+// - src/spread/default/super-call.template
+/*---
+description: Spread operator applied to AssignmentExpression as only element (SuperCall)
+esid: sec-super-keyword-runtime-semantics-evaluation
+es6id: 12.3.5.1
+flags: [generated]
+info: |
+    SuperCall : super Arguments
+
+    1. Let newTarget be GetNewTarget().
+    2. If newTarget is undefined, throw a ReferenceError exception.
+    3. Let func be GetSuperConstructor().
+    4. ReturnIfAbrupt(func).
+    5. Let argList be ArgumentListEvaluation of Arguments.
+    [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+       f. Append nextArg as the last element of list.
+---*/
+var source = [2, 3, 4];
+var target;
+
+var callCount = 0;
+
+class Test262ParentClass {
+  constructor() {
+    assert.sameValue(arguments.length, 3);
+    assert.sameValue(arguments[0], 2);
+    assert.sameValue(arguments[1], 3);
+    assert.sameValue(arguments[2], 4);
+    assert.sameValue(target, source);
+    callCount += 1;
+  }
+}
+
+class Test262ChildClass extends Test262ParentClass {
+  constructor() {
+    super(...target = source);
+  }
+}
+
+new Test262ChildClass();
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/super/spread-sngl-literal.js
+++ b/test/language/expressions/super/spread-sngl-literal.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/spread/sngl-literal.case
+// - src/spread/default/super-call.template
+/*---
+description: Spread operator applied to array literal as only element (SuperCall)
+esid: sec-super-keyword-runtime-semantics-evaluation
+es6id: 12.3.5.1
+flags: [generated]
+info: |
+    SuperCall : super Arguments
+
+    1. Let newTarget be GetNewTarget().
+    2. If newTarget is undefined, throw a ReferenceError exception.
+    3. Let func be GetSuperConstructor().
+    4. ReturnIfAbrupt(func).
+    5. Let argList be ArgumentListEvaluation of Arguments.
+    [...]
+
+    12.3.6.1 Runtime Semantics: ArgumentListEvaluation
+
+    ArgumentList : ... AssignmentExpression
+
+    1. Let list be an empty List.
+    2. Let spreadRef be the result of evaluating AssignmentExpression.
+    3. Let spreadObj be GetValue(spreadRef).
+    4. Let iterator be GetIterator(spreadObj).
+    5. ReturnIfAbrupt(iterator).
+    6. Repeat
+       a. Let next be IteratorStep(iterator).
+       b. ReturnIfAbrupt(next).
+       c. If next is false, return list.
+       d. Let nextArg be IteratorValue(next).
+       e. ReturnIfAbrupt(nextArg).
+       f. Append nextArg as the last element of list.
+---*/
+
+var callCount = 0;
+
+class Test262ParentClass {
+  constructor() {
+    assert.sameValue(arguments.length, 3);
+    assert.sameValue(arguments[0], 3);
+    assert.sameValue(arguments[1], 4);
+    assert.sameValue(arguments[2], 5);
+    callCount += 1;
+  }
+}
+
+class Test262ChildClass extends Test262ParentClass {
+  constructor() {
+    super(...[3, 4, 5]);
+  }
+}
+
+new Test262ChildClass();
+assert.sameValue(callCount, 1);


### PR DESCRIPTION
As reported in gh-671, Test262's coverage of the spread operator is lacking in
the following respects:

- It does not include the use of the operator within array initializers
- It does not include the application of the operator to expressions other than
  Identifiers

This patch introduces coverage for both cases.

Existing coverage of the operator is provided by the test generation tool, and
I wanted to draw attention to that here. In order to re-use the same test
cases, the formulation of these new tests is a little indirect. For instance:

```js
(function() {
  assert.sameValue(arguments.length, 3);
  assert.sameValue(arguments[0], 3);
  assert.sameValue(arguments[1], 4);
  assert.sameValue(arguments[2], 5);
}.apply(null, [...[3, 4, 5]]));
```

Referencing the array instance would be more direct, but it would not
generalize for re-use with the existing tests for MemberExpression,
CallExpression, and SuperCall.

