### PR TITLE
Relax test for forbidden extension

### DIFF
--- a/test/built-ins/Function/StrictFunction_restricted-properties.js
+++ b/test/built-ins/Function/StrictFunction_restricted-properties.js
@@ -5,15 +5,13 @@
 description: >
     ECMAScript Function objects defined using syntactic constructors
     in strict mode code do not have own properties "caller" or
-    "arguments", but inherit them from %FunctionPrototype%.
+    "arguments" other than those that are created by applying the
+    AddRestrictedFunctionProperties abstract operation to the function.
 flags: [onlyStrict]
 es6id: 16.1
 ---*/
 
 function func() {}
-
-assert.sameValue(func.hasOwnProperty('caller'), false, 'Functions defined using syntactic constructors in strict mode code do not have own property "caller"');
-assert.sameValue(func.hasOwnProperty('arguments'), false, 'Functions defined using syntactic constructors in strict mode code do not have own property "arguments"');
 
 assert.throws(TypeError, function() {
   return func.caller;


### PR DESCRIPTION
According to ES2015, functions created using the FunctionDeclaration
syntax may define "own" properties named "caller" and "arguments" as
long as this is done using the AddRestrictedFunctionProperties abstract
operation.

Remove the assertions that prohibit this extension.

@caitp Does this look okay to you?