### PR TITLE
Document requirements for module tests

### DIFF
--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -49,6 +49,30 @@ semicolon (`;`) and newline character (`\n`):
 
 This must precede any additional text modifications described by test metadata.
 
+### Modules
+
+Test262 includes tests for ECMAScript 2015 module code, denoted by the "module"
+metadata flag. Files bearing a name ending in `_FIXTURE.js` should not be
+interpreted as standalone tests; they are intended to be referenced by test
+files.
+
+All module specifiers used by Test262 begin with the character sequence `./`.
+The remaining characters should be interpreted as the name of a file within the
+same directory as the file under test. The contents of this file must be
+interpreted as UTF-8-encoded text and supplied to the Source Text Module
+Record's ParseModule abstract operation. The result of that operation must be
+returned by the implementation-defined HostResolveImportedModule directly.
+
+For example, consider a test file located at
+`test/language/import/nested/index.js` with the following contents:
+
+```js
+import * as ns from './dep.js';
+```
+
+Implementers should attempt to resolve this module specifier by loading a file
+located at `test/language/import/nested/dep.js`.
+
 ## Test Results
 
 By default, tests signal failure by generating an uncaught exception. If
@@ -141,7 +165,8 @@ following strings:
   In addition, this flag negates the default requirement to execute the test
   both in strict mode and in non-strict mode. In other words, the
   transformation described by the section titled "Strict Mode" must **not** be
-  applied to these tests.
+  applied to these tests. Refer to the section titled "Modules" for more
+  information on interpreting these tests.
 
   *Example*
 


### PR DESCRIPTION
These instructions were mistakenly omitted from the recent patches that extended
coverage of ECMAScript modules (gh-560, gh-561, gh-562, gh-563, and gh-565).
The text was drafted and subsequently revised through the discussion in gh-519.