### PR TITLE
Switch to non-positional argument.

### DIFF
--- a/tools/packaging/packager.py
+++ b/tools/packaging/packager.py
@@ -27,7 +27,7 @@ from packagerConfig import *
 
 __parser = argparse.ArgumentParser(description= \
                                    'Tool used to generate the test262 website')
-__parser.add_argument('version', action='store',
+__parser.add_argument('--version', action='store', required=True,
                       help='Version of the test suite.')
 __parser.add_argument('--type', action='store', default=DEFAULT_TESTCASE_TEMPLATE,
                       help='Type of test case runner to generate.')


### PR DESCRIPTION
Since the argument is required, we mark it as so. Using this approach
gives the user a much nicer error message, as compared to just the "not
enough args" message.