### PR TITLE
Add tests for realm interactions

### DIFF
--- a/test/built-ins/Array/define-own-prop-length-overflow-realm.js
+++ b/test/built-ins/Array/define-own-prop-length-overflow-realm.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array-exotic-objects-defineownproperty-p-desc
+es6id: 9.4.2.1
+description: >
+  Error when setting a length larger than 2**32 (honoring the Realm of the
+  current execution context)
+info: |
+  [...]
+  2. If P is "length", then
+     a. Return ? ArraySetLength(A, Desc).
+---*/
+
+var OArray = $.createRealm().global.Array;
+var array = new OArray();
+
+assert.throws(RangeError, function() {
+  array.length = 4294967296;
+});

--- a/test/built-ins/Array/from/proto-from-ctor-realm.js
+++ b/test/built-ins/Array/from/proto-from-ctor-realm.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.from
+es6id: 22.1.2.1
+description: Default [[Prototype]] value derived from realm of the constructor
+info: |
+    [...]
+    5. If usingIterator is not undefined, then
+       a. If IsConstructor(C) is true, then
+          i. Let A be ? Construct(C).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var a = Array.from.call(C, []);
+
+assert.sameValue(Object.getPrototypeOf(a), other.Object.prototype);

--- a/test/built-ins/Array/of/proto-from-ctor-realm.js
+++ b/test/built-ins/Array/of/proto-from-ctor-realm.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.of
+es6id: 22.1.2.3
+description: Default [[Prototype]] value derived from realm of the constructor
+info: |
+    [...]
+    4. If IsConstructor(C) is true, then
+       a. Let A be ? Construct(C, « len »).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var a = Array.of.call(C, 1, 2, 3);
+
+assert.sameValue(Object.getPrototypeOf(a), other.Object.prototype);

--- a/test/built-ins/Array/proto-from-ctor-realm.js
+++ b/test/built-ins/Array/proto-from-ctor-realm.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array-constructor-array
+es6id: 21.1.1.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    4. Let proto be ? GetPrototypeFromConstructor(newTarget,
+       "%ArrayPrototype%").
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(Array, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.Array.prototype);

--- a/test/built-ins/Array/prototype/concat/create-proto-from-ctor-realm-array.js
+++ b/test/built-ins/Array/prototype/concat/create-proto-from-ctor-realm-array.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+esid: sec-array.prototype.concat
+description: Prefer Array constructor of current realm record
+info: |
+    1. Let O be ? ToObject(this value).
+    2. Let A be ? ArraySpeciesCreate(O, 0).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    6. If IsConstructor(C) is true, then
+       a. Let thisRealm be the current Realm Record.
+       b. Let realmC be ? GetFunctionRealm(C).
+       c. If thisRealm and realmC are not the same Realm Record, then
+          i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
+             be undefined.
+    [...]
+---*/
+
+var array = [];
+var callCount = 0;
+var OArray = $.createRealm().global.Array;
+var speciesDesc = {
+  get: function() {
+    callCount += 1;
+  }
+};
+var result;
+array.constructor = OArray;
+
+Object.defineProperty(Array, Symbol.species, speciesDesc);
+Object.defineProperty(OArray, Symbol.species, speciesDesc);
+
+result = array.concat();
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert.sameValue(callCount, 0, 'Species constructor is not referenced');

--- a/test/built-ins/Array/prototype/concat/create-proto-from-ctor-realm-non-array.js
+++ b/test/built-ins/Array/prototype/concat/create-proto-from-ctor-realm-non-array.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.1
+esid: sec-array.prototype.concat
+description: Accept non-Array constructors from other realms
+info: |
+    1. Let O be ? ToObject(this value).
+    2. Let A be ? ArraySpeciesCreate(O, 0).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    6. If IsConstructor(C) is true, then
+       a. Let thisRealm be the current Realm Record.
+       b. Let realmC be ? GetFunctionRealm(C).
+       c. If thisRealm and realmC are not the same Realm Record, then
+          i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
+             be undefined.
+    [...]
+---*/
+
+var array = [];
+var callCount = 0;
+var CustomCtor = function() {};
+var OObject = $.createRealm().global.Object;
+var speciesDesc = {
+  get: function() {
+    callCount += 1;
+  }
+};
+var result;
+array.constructor = OObject;
+OObject[Symbol.species] = CustomCtor;
+
+Object.defineProperty(Array, Symbol.species, speciesDesc);
+
+result = array.concat();
+
+assert.sameValue(Object.getPrototypeOf(result), CustomCtor.prototype);
+assert.sameValue(callCount, 0, 'Array species constructor is not referenced');

--- a/test/built-ins/Array/prototype/filter/create-proto-from-ctor-realm-array.js
+++ b/test/built-ins/Array/prototype/filter/create-proto-from-ctor-realm-array.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.7
+esid: sec-array.prototype.filter
+description: Prefer Array constructor of current realm record
+info: |
+    1. Let O be ? ToObject(this value).
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, 0).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    6. If IsConstructor(C) is true, then
+       a. Let thisRealm be the current Realm Record.
+       b. Let realmC be ? GetFunctionRealm(C).
+       c. If thisRealm and realmC are not the same Realm Record, then
+          i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
+             be undefined.
+    [...]
+---*/
+
+var array = [];
+var callCount = 0;
+var OArray = $.createRealm().global.Array;
+var speciesDesc = {
+  get: function() {
+    callCount += 1;
+  }
+};
+var result;
+array.constructor = OArray;
+
+Object.defineProperty(Array, Symbol.species, speciesDesc);
+Object.defineProperty(OArray, Symbol.species, speciesDesc);
+
+result = array.concat(function() {});
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert.sameValue(callCount, 0, 'Species constructor is not referenced');

--- a/test/built-ins/Array/prototype/filter/create-proto-from-ctor-realm-non-array.js
+++ b/test/built-ins/Array/prototype/filter/create-proto-from-ctor-realm-non-array.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.7
+esid: sec-array.prototype.filter
+description: Accept non-Array constructors from other realms
+info: |
+    1. Let O be ? ToObject(this value).
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, 0).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    6. If IsConstructor(C) is true, then
+       a. Let thisRealm be the current Realm Record.
+       b. Let realmC be ? GetFunctionRealm(C).
+       c. If thisRealm and realmC are not the same Realm Record, then
+          i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
+             be undefined.
+    [...]
+---*/
+
+var array = [];
+var callCount = 0;
+var CustomCtor = function() {};
+var OObject = $.createRealm().global.Object;
+var speciesDesc = {
+  get: function() {
+    callCount += 1;
+  }
+};
+var result;
+array.constructor = OObject;
+OObject[Symbol.species] = CustomCtor;
+
+Object.defineProperty(Array, Symbol.species, speciesDesc);
+
+result = array.filter(function() {});
+
+assert.sameValue(Object.getPrototypeOf(result), CustomCtor.prototype);
+assert.sameValue(callCount, 0, 'Array species constructor is not referenced');

--- a/test/built-ins/Array/prototype/map/create-proto-from-ctor-realm-array.js
+++ b/test/built-ins/Array/prototype/map/create-proto-from-ctor-realm-array.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.15
+esid: sec-array.prototype.map
+description: Prefer Array constructor of current realm record
+info: |
+    1. Let O be ? ToObject(this value).
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, len).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    6. If IsConstructor(C) is true, then
+       a. Let thisRealm be the current Realm Record.
+       b. Let realmC be ? GetFunctionRealm(C).
+       c. If thisRealm and realmC are not the same Realm Record, then
+          i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
+             be undefined.
+    [...]
+---*/
+
+var array = [];
+var callCount = 0;
+var OArray = $.createRealm().global.Array;
+var speciesDesc = {
+  get: function() {
+    callCount += 1;
+  }
+};
+var result;
+array.constructor = OArray;
+
+Object.defineProperty(Array, Symbol.species, speciesDesc);
+Object.defineProperty(OArray, Symbol.species, speciesDesc);
+
+result = array.map(function() {});
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert.sameValue(callCount, 0, 'Species constructor is not referenced');

--- a/test/built-ins/Array/prototype/map/create-proto-from-ctor-realm-non-array.js
+++ b/test/built-ins/Array/prototype/map/create-proto-from-ctor-realm-non-array.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.15
+esid: sec-array.prototype.map
+description: Accept non-Array constructors from other realms
+info: |
+    1. Let O be ? ToObject(this value).
+    [...]
+    5. Let A be ? ArraySpeciesCreate(O, len).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    6. If IsConstructor(C) is true, then
+       a. Let thisRealm be the current Realm Record.
+       b. Let realmC be ? GetFunctionRealm(C).
+       c. If thisRealm and realmC are not the same Realm Record, then
+          i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
+             be undefined.
+    [...]
+---*/
+
+var array = [];
+var callCount = 0;
+var CustomCtor = function() {};
+var OObject = $.createRealm().global.Object;
+var speciesDesc = {
+  get: function() {
+    callCount += 1;
+  }
+};
+var result;
+array.constructor = OObject;
+OObject[Symbol.species] = CustomCtor;
+
+Object.defineProperty(Array, Symbol.species, speciesDesc);
+
+result = array.map(function() {});
+
+assert.sameValue(Object.getPrototypeOf(result), CustomCtor.prototype);
+assert.sameValue(callCount, 0, 'Array species constructor is not referenced');

--- a/test/built-ins/Array/prototype/slice/create-proto-from-ctor-realm-array.js
+++ b/test/built-ins/Array/prototype/slice/create-proto-from-ctor-realm-array.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.22
+esid: sec-array.prototype.slice
+description: Prefer Array constructor of current realm record
+info: |
+    1. Let O be ? ToObject(this value).
+    [...]
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    6. If IsConstructor(C) is true, then
+       a. Let thisRealm be the current Realm Record.
+       b. Let realmC be ? GetFunctionRealm(C).
+       c. If thisRealm and realmC are not the same Realm Record, then
+          i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
+             be undefined.
+    [...]
+---*/
+
+var array = [];
+var callCount = 0;
+var OArray = $.createRealm().global.Array;
+var speciesDesc = {
+  get: function() {
+    callCount += 1;
+  }
+};
+var result;
+array.constructor = OArray;
+
+Object.defineProperty(Array, Symbol.species, speciesDesc);
+Object.defineProperty(OArray, Symbol.species, speciesDesc);
+
+result = array.slice();
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert.sameValue(callCount, 0, 'Species constructor is not referenced');

--- a/test/built-ins/Array/prototype/slice/create-proto-from-ctor-realm-non-array.js
+++ b/test/built-ins/Array/prototype/slice/create-proto-from-ctor-realm-non-array.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.22
+esid: sec-array.prototype.slice
+description: Accept non-Array constructors from other realms
+info: |
+    1. Let O be ? ToObject(this value).
+    [...]
+    8. Let A be ? ArraySpeciesCreate(O, count).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    6. If IsConstructor(C) is true, then
+       a. Let thisRealm be the current Realm Record.
+       b. Let realmC be ? GetFunctionRealm(C).
+       c. If thisRealm and realmC are not the same Realm Record, then
+          i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
+             be undefined.
+    [...]
+---*/
+
+var array = [];
+var callCount = 0;
+var CustomCtor = function() {};
+var OObject = $.createRealm().global.Object;
+var speciesDesc = {
+  get: function() {
+    callCount += 1;
+  }
+};
+var result;
+array.constructor = OObject;
+OObject[Symbol.species] = CustomCtor;
+
+Object.defineProperty(Array, Symbol.species, speciesDesc);
+
+result = array.slice();
+
+assert.sameValue(Object.getPrototypeOf(result), CustomCtor.prototype);
+assert.sameValue(callCount, 0, 'Array species constructor is not referenced');

--- a/test/built-ins/Array/prototype/splice/create-proto-from-ctor-realm-array.js
+++ b/test/built-ins/Array/prototype/splice/create-proto-from-ctor-realm-array.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.25
+esid: sec-array.prototype.splice
+description: Prefer Array constructor of current realm record
+info: |
+    1. Let O be ? ToObject(this value).
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    6. If IsConstructor(C) is true, then
+       a. Let thisRealm be the current Realm Record.
+       b. Let realmC be ? GetFunctionRealm(C).
+       c. If thisRealm and realmC are not the same Realm Record, then
+          i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
+             be undefined.
+    [...]
+---*/
+
+var array = [];
+var callCount = 0;
+var OArray = $.createRealm().global.Array;
+var speciesDesc = {
+  get: function() {
+    callCount += 1;
+  }
+};
+var result;
+array.constructor = OArray;
+
+Object.defineProperty(Array, Symbol.species, speciesDesc);
+Object.defineProperty(OArray, Symbol.species, speciesDesc);
+
+result = array.splice();
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert.sameValue(callCount, 0, 'Species constructor is not referenced');

--- a/test/built-ins/Array/prototype/splice/create-proto-from-ctor-realm-non-array.js
+++ b/test/built-ins/Array/prototype/splice/create-proto-from-ctor-realm-non-array.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 22.1.3.25
+esid: sec-array.prototype.splice
+description: Accept non-Array constructors from other realms
+info: |
+    1. Let O be ? ToObject(this value).
+    [...]
+    9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
+    [...]
+
+    9.4.2.3 ArraySpeciesCreate
+
+    [...]
+    5. Let C be ? Get(originalArray, "constructor").
+    6. If IsConstructor(C) is true, then
+       a. Let thisRealm be the current Realm Record.
+       b. Let realmC be ? GetFunctionRealm(C).
+       c. If thisRealm and realmC are not the same Realm Record, then
+          i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
+             be undefined.
+    [...]
+---*/
+
+var array = [];
+var callCount = 0;
+var CustomCtor = function() {};
+var OObject = $.createRealm().global.Object;
+var speciesDesc = {
+  get: function() {
+    callCount += 1;
+  }
+};
+var result;
+array.constructor = OObject;
+OObject[Symbol.species] = CustomCtor;
+
+Object.defineProperty(Array, Symbol.species, speciesDesc);
+
+result = array.splice();
+
+assert.sameValue(Object.getPrototypeOf(result), CustomCtor.prototype);
+assert.sameValue(callCount, 0, 'Array species constructor is not referenced');

--- a/test/built-ins/ArrayBuffer/proto-from-ctor-realm.js
+++ b/test/built-ins/ArrayBuffer/proto-from-ctor-realm.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-arraybuffer-length
+es6id: 24.1.1.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    5. Return ? AllocateArrayBuffer(NewTarget, byteLength).
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(ArrayBuffer, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.ArrayBuffer.prototype);

--- a/test/built-ins/Boolean/proto-from-ctor-realm.js
+++ b/test/built-ins/Boolean/proto-from-ctor-realm.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-boolean-constructor-boolean-value
+es6id: 19.3.1.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    3. Let O be ? OrdinaryCreateFromConstructor(NewTarget,
+       "%BooleanPrototype%", « [[BooleanData]] »).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(Boolean, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.Boolean.prototype);

--- a/test/built-ins/DataView/proto-from-ctor-realm.js
+++ b/test/built-ins/DataView/proto-from-ctor-realm.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview-buffer-byteoffset-bytelength
+es6id: 24.2.2.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    12. Let O be ? OrdinaryCreateFromConstructor(NewTarget,
+        "%DataViewPrototype%", « [[DataView]], [[ViewedArrayBuffer]],
+        [[ByteLength]], [[ByteOffset]] »).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+var buffer = new ArrayBuffer(0);
+
+var o = Reflect.construct(DataView, [buffer, 0], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.DataView.prototype);

--- a/test/built-ins/Date/proto-from-ctor-realm-one.js
+++ b/test/built-ins/Date/proto-from-ctor-realm-one.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date-value
+es6id: 20.3.2.2
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    3. If NewTarget is not undefined, then
+       [...]
+       c. Let O be ? OrdinaryCreateFromConstructor(NewTarget,
+          "%DatePrototype%", « [[DateValue]] »).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(Date, [0], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.Date.prototype);

--- a/test/built-ins/Date/proto-from-ctor-realm-two.js
+++ b/test/built-ins/Date/proto-from-ctor-realm-two.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date-year-month-date-hours-minutes-seconds-ms
+es6id: 20.3.2.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    3. If NewTarget is not undefined, then
+       [...]
+       j. Let O be ? OrdinaryCreateFromConstructor(NewTarget,
+          "%DatePrototype%", « [[DateValue]] »).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(Date, [1970, 0], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.Date.prototype);

--- a/test/built-ins/Date/proto-from-ctor-realm-zero.js
+++ b/test/built-ins/Date/proto-from-ctor-realm-zero.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date-constructor-date
+es6id: 20.3.2.3
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    3. If NewTarget is not undefined, then
+       a. Let O be ? OrdinaryCreateFromConstructor(NewTarget,
+          "%DatePrototype%", « [[DateValue]] »).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(Date, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.Date.prototype);

--- a/test/built-ins/Error/proto-from-ctor-realm.js
+++ b/test/built-ins/Error/proto-from-ctor-realm.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-error-message
+es6id: 19.5.1.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%ErrorPrototype%",
+       « [[ErrorData]] »).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(Error, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.Error.prototype);

--- a/test/built-ins/Function/call-bind-this-realm-undef.js
+++ b/test/built-ins/Function/call-bind-this-realm-undef.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-ecmascript-function-objects-call-thisargument-argumentslist
+es6id: 9.2.1
+description: The "this" value is set to the global This value
+info: >
+  [...]
+  6. Perform OrdinaryCallBindThis(F, calleeContext, thisArgument).
+  [...]
+
+  9.2.1.2OrdinaryCallBindThis ( F, calleeContext, thisArgument )#
+
+  [...]
+  5. If thisMode is strict, let thisValue be thisArgument.
+  6. Else,
+     a. If thisArgument is null or undefined, then
+        i. Let globalEnv be calleeRealm.[[GlobalEnv]].
+        ii. Let globalEnvRec be globalEnv's EnvironmentRecord.
+        iii. Let thisValue be globalEnvRec.[[GlobalThisValue]].
+  [...]
+---*/
+
+var other = $.createRealm().global;
+var func = new other.Function('return this;');
+var subject;
+
+assert.sameValue(func(), other, 'implicit undefined');
+assert.sameValue(func.call(undefined), other, 'explicit undefined');
+assert.sameValue(func.call(null), other, 'null');

--- a/test/built-ins/Function/call-bind-this-realm-value.js
+++ b/test/built-ins/Function/call-bind-this-realm-value.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-ecmascript-function-objects-call-thisargument-argumentslist
+es6id: 9.2.1
+description: The "this" value is wrapped in an object using the callee realm
+info: >
+  [...]
+  6. Perform OrdinaryCallBindThis(F, calleeContext, thisArgument).
+  [...]
+
+  9.2.1.2OrdinaryCallBindThis ( F, calleeContext, thisArgument )#
+
+  [...]
+  5. If thisMode is strict, let thisValue be thisArgument.
+  6. Else,
+     a. If thisArgument is null or undefined, then
+        [...]
+     b. Else,
+        i. Let thisValue be ! ToObject(thisArgument).
+        ii. NOTE ToObject produces wrapper objects using calleeRealm.
+  [...]
+---*/
+
+var other = $.createRealm().global;
+var func = new other.Function('return this;');
+var subject;
+
+subject = func.call(true);
+assert.sameValue(subject.constructor, other.Boolean, 'boolean constructor');
+assert(subject instanceof other.Boolean, 'boolean instanceof');
+
+subject = func.call(1);
+assert.sameValue(subject.constructor, other.Number, 'number constructor');
+assert(subject instanceof other.Number, 'number instanceof');
+
+subject = func.call('');
+assert.sameValue(subject.constructor, other.String, 'string constructor');
+assert(subject instanceof other.String, 'string instanceof');
+
+subject = func.call({});
+assert.sameValue(subject.constructor, Object, 'object constructor');
+assert(subject instanceof Object, 'object instanceof');

--- a/test/built-ins/Function/internals/Call/class-ctor-realm.js
+++ b/test/built-ins/Function/internals/Call/class-ctor-realm.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-ecmascript-function-objects-call-thisargument-argumentslist
+es6id: 9.2.1
+description: >
+  Error when invoking a class constructor (honoring the Realm of the current
+  execution context)
+info: |
+  [...]
+  2. If F's [[FunctionKind]] internal slot is "classConstructor", throw a
+     TypeError exception.
+features: [class]
+---*/
+
+var C = $.createRealm().global.eval('0, class {}');
+
+assert.throws(TypeError, function() {
+  C();
+});

--- a/test/built-ins/Function/internals/Call/class-ctor.js
+++ b/test/built-ins/Function/internals/Call/class-ctor.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-ecmascript-function-objects-call-thisargument-argumentslist
+es6id: 9.2.1
+description: Error when invoking a class constructor
+info: |
+  [...]
+  2. If F's [[FunctionKind]] internal slot is "classConstructor", throw a
+     TypeError exception.
+features: [class]
+---*/
+
+class C {}
+
+assert.throws(TypeError, function() {
+  C();
+});

--- a/test/built-ins/Function/internals/Construct/base-ctor-revoked-proxy-realm.js
+++ b/test/built-ins/Function/internals/Construct/base-ctor-revoked-proxy-realm.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+es6id: 9.2.2
+description: >
+  Error retrieving function realm from revoked Proxy exotic object (honoring
+  the Realm of the current execution context)
+info: |
+  [...]
+  5. If kind is "base", then
+     a. Let thisArgument be ? OrdinaryCreateFromConstructor(newTarget,
+        "%ObjectPrototype%").
+  [...]
+
+  9.1.13 OrdinaryCreateFromConstructor
+
+  [...]
+  2. Let proto be ? GetPrototypeFromConstructor(constructor,
+     intrinsicDefaultProto).
+  [...]
+
+  9.1.14 GetPrototypeFromConstructor
+
+  [...]
+  3. Let proto be ? Get(constructor, "prototype").
+  4. If Type(proto) is not Object, then
+     a. Let realm be ? GetFunctionRealm(constructor).
+
+  7.3.22 GetFunctionRealm
+
+  [...]
+  2. If obj has a [[Realm]] internal slot, then
+     [...]
+  3. If obj is a Bound Function exotic object, then
+     [...]
+  4. If obj is a Proxy exotic object, then
+     a. If the value of the [[ProxyHandler]] internal slot of obj is null,
+        throw a TypeError exception.
+features: [Proxy]
+---*/
+
+var other = $.createRealm().global;
+// Defer proxy revocation until after the `constructor` property has been
+// accessed
+var handlers = {
+  get: function() {
+    handle.revoke();
+  }
+};
+var handle = other.Proxy.revocable(function() {}, handlers);
+var f = handle.proxy;
+
+assert.sameValue(typeof f, 'function');
+
+assert.throws(TypeError, function() {
+  new f();
+});

--- a/test/built-ins/Function/internals/Construct/base-ctor-revoked-proxy.js
+++ b/test/built-ins/Function/internals/Construct/base-ctor-revoked-proxy.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+es6id: 9.2.2
+description: Error retrieving function realm from revoked Proxy exotic object
+info: |
+  [...]
+  5. If kind is "base", then
+     a. Let thisArgument be ? OrdinaryCreateFromConstructor(newTarget,
+        "%ObjectPrototype%").
+  [...]
+
+  9.1.13 OrdinaryCreateFromConstructor
+
+  [...]
+  2. Let proto be ? GetPrototypeFromConstructor(constructor,
+     intrinsicDefaultProto).
+  [...]
+
+  9.1.14 GetPrototypeFromConstructor
+
+  [...]
+  3. Let proto be ? Get(constructor, "prototype").
+  4. If Type(proto) is not Object, then
+     a. Let realm be ? GetFunctionRealm(constructor).
+
+  7.3.22 GetFunctionRealm
+
+  [...]
+  2. If obj has a [[Realm]] internal slot, then
+     [...]
+  3. If obj is a Bound Function exotic object, then
+     [...]
+  4. If obj is a Proxy exotic object, then
+     a. If the value of the [[ProxyHandler]] internal slot of obj is null,
+        throw a TypeError exception.
+features: [Proxy]
+---*/
+
+// Defer proxy revocation until after the `constructor` property has been
+// accessed
+var handlers = {
+  get: function() {
+    handle.revoke();
+  }
+};
+var handle = Proxy.revocable(function() {}, handlers);
+var f = handle.proxy;
+
+assert.sameValue(typeof f, 'function');
+
+assert.throws(TypeError, function() {
+  new f();
+});

--- a/test/built-ins/Function/internals/Construct/derived-return-val-realm.js
+++ b/test/built-ins/Function/internals/Construct/derived-return-val-realm.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+es6id: 9.2.2
+description: >
+  Error when derived constructor returns a non-undefined value (honoring
+  the Realm of the current execution context)
+info: |
+  [...]
+  13. If result.[[Type]] is return, then
+      a. If Type(result.[[Value]]) is Object, return
+         NormalCompletion(result.[[Value]]).
+      b. If kind is "base", return NormalCompletion(thisArgument).
+      c. If result.[[Value]] is not undefined, throw a TypeError exception.
+  [...]
+features: [class]
+---*/
+
+var C = $.createRealm().global.eval(
+  '0, class extends Object {' +
+  '  constructor() {' +
+  '    return null;' +
+  '  }' +
+  '}'
+);
+
+assert.throws(TypeError, function() {
+  new C();
+});

--- a/test/built-ins/Function/internals/Construct/derived-return-val.js
+++ b/test/built-ins/Function/internals/Construct/derived-return-val.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+es6id: 9.2.2
+description: Error when derived constructor returns a non-undefined value
+info: |
+  [...]
+  13. If result.[[Type]] is return, then
+      a. If Type(result.[[Value]]) is Object, return
+         NormalCompletion(result.[[Value]]).
+      b. If kind is "base", return NormalCompletion(thisArgument).
+      c. If result.[[Value]] is not undefined, throw a TypeError exception.
+  [...]
+features: [class]
+---*/
+
+class C extends Object {
+  constructor() {
+    return null;
+  }
+}
+
+assert.throws(TypeError, function() {
+  new C();
+});

--- a/test/built-ins/Function/internals/Construct/derived-this-uninitialized-realm.js
+++ b/test/built-ins/Function/internals/Construct/derived-this-uninitialized-realm.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+es6id: 9.2.2
+description: >
+  Error when derived constructor does not intialize the `this` binding
+  (honoring the Realm of the current execution context)
+info: |
+  [...]
+  15. Return ? envRec.GetThisBinding().
+
+  8.1.1.3.4 GetThisBinding ()
+
+  [...]
+  3. If envRec.[[ThisBindingStatus]] is "uninitialized", throw a ReferenceError
+     exception.
+features: [class]
+---*/
+
+var C = $.createRealm().global.eval(
+  'class C extends Object {' +
+  '  constructor() {}' +
+  '}'
+);
+
+assert.throws(ReferenceError, function() {
+  new C();
+});

--- a/test/built-ins/Function/internals/Construct/derived-this-uninitialized.js
+++ b/test/built-ins/Function/internals/Construct/derived-this-uninitialized.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+es6id: 9.2.2
+description: >
+    Error when derived constructor does not intialize the `this` binding
+info: |
+  [...]
+  15. Return ? envRec.GetThisBinding().
+
+  8.1.1.3.4 GetThisBinding ()
+
+  [...]
+  3. If envRec.[[ThisBindingStatus]] is "uninitialized", throw a ReferenceError
+     exception.
+features: [class]
+---*/
+
+class C extends Object {
+  constructor() {}
+}
+
+assert.throws(ReferenceError, function() {
+  new C();
+});

--- a/test/built-ins/Function/proto-from-ctor-realm.js
+++ b/test/built-ins/Function/proto-from-ctor-realm.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-function-p1-p2-pn-body
+es6id: 19.2.1.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    5. Return ? CreateDynamicFunction(C, NewTarget, "normal", args).
+
+    19.2.1.1.1 Runtime Semantics: CreateDynamicFunction
+
+    [...]
+    2. If kind is "normal", then
+       [...]
+       c. Let fallbackProto be "%FunctionPrototype%".
+    [...]
+    22. Let proto be ? GetPrototypeFromConstructor(newTarget, fallbackProto).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(Function, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.Function.prototype);

--- a/test/built-ins/Function/prototype/bind/get-fn-realm.js
+++ b/test/built-ins/Function/prototype/bind/get-fn-realm.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-getfunctionrealm
+es6id: 7.3.22
+description: >
+    The realm of a bound function exotic object is the realm of its target
+    function
+info: |
+    [...]
+    2. If obj has a [[Realm]] internal slot, then
+       a, Return obj's [[Realm]] internal slot.
+    3. If obj is a Bound Function exotic object, then
+       a. Let target be obj's [[BoundTargetFunction]] internal slot.
+       b. Return ? GetFunctionRealm(target).
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+var B = Function.prototype.bind.call(C);
+
+assert.sameValue(Object.getPrototypeOf(new B()), C.prototype);

--- a/test/built-ins/Function/prototype/bind/proto-from-ctor-realm.js
+++ b/test/built-ins/Function/prototype/bind/proto-from-ctor-realm.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-bound-function-exotic-objects-construct-argumentslist-newtarget
+es6id: 9.4.1.2
+description: Default [[Prototype]] value derived from realm of the constructor
+info: |
+    [...]
+    6. Return ? Construct(target, args, newTarget).
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var D = function(){}.bind();
+
+var d = Reflect.construct(D, [], C);
+
+assert.sameValue(Object.getPrototypeOf(d), other.Object.prototype);

--- a/test/built-ins/GeneratorFunction/proto-from-ctor-realm.js
+++ b/test/built-ins/GeneratorFunction/proto-from-ctor-realm.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-generatorfunction
+es6id: 25.2.1.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    3. Return ? CreateDynamicFunction(C, NewTarget, "generator", args).
+
+    19.2.1.1.1 Runtime Semantics: CreateDynamicFunction
+
+    [...]
+    3. Else,
+       [...]
+       c. Let fallbackProto be "%Generator%".
+    [...]
+    22. Let proto be ? GetPrototypeFromConstructor(newTarget, fallbackProto).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var GeneratorFunction = Object.getPrototypeOf(function* () {}).constructor;
+var other = $.createRealm().global;
+var OtherGeneratorFunction = Object.getPrototypeOf(
+    other.eval('(0, function* () {})')
+).constructor;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(GeneratorFunction, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), OtherGeneratorFunction.prototype);

--- a/test/built-ins/Map/proto-from-ctor-realm.js
+++ b/test/built-ins/Map/proto-from-ctor-realm.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-map-iterable
+es6id: 23.1.1.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    3. Let map be ? OrdinaryCreateFromConstructor(NewTarget, "%MapPrototype%",
+       « [[MapData]] »).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(Map, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.Map.prototype);

--- a/test/built-ins/Number/proto-from-ctor-realm.js
+++ b/test/built-ins/Number/proto-from-ctor-realm.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-number-constructor-number-value
+es6id: 20.1.1.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    4. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%NumberPrototype%",
+       « [[NumberData]] »).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(Number, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.Number.prototype);

--- a/test/built-ins/Object/proto-from-ctor.js
+++ b/test/built-ins/Object/proto-from-ctor.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object-value
+es6id: 19.1.1.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    1. If NewTarget is neither undefined nor the active function, then
+       a. Return ? OrdinaryCreateFromConstructor(NewTarget, "%ObjectPrototype%").
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(Object, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.Object.prototype);

--- a/test/built-ins/Promise/proto-from-ctor-realm.js
+++ b/test/built-ins/Promise/proto-from-ctor-realm.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-promise-executor
+es6id: 25.4.3.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    3. Let promise be ? OrdinaryCreateFromConstructor(NewTarget,
+       "%PromisePrototype%", « [[PromiseState]], [[PromiseResult]],
+       [[PromiseFulfillReactions]], [[PromiseRejectReactions]],
+       [[PromiseIsHandled]] »).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(Promise, [function() {}], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.Promise.prototype);

--- a/test/built-ins/Proxy/apply/arguments-realm.js
+++ b/test/built-ins/Proxy/apply/arguments-realm.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist
+es6id: 9.5.13
+description: >
+  Arguments array is created in the Realm of the current execution context
+info: |
+  [...]
+  7. Let argArray be CreateArrayFromList(argumentsList).
+  8. Return ? Call(trap, handler, « target, thisArgument, argArray »).
+---*/
+
+var f = $.createRealm().global.eval(
+  'new Proxy(function() {}, { apply: function(_, __, args) { return args; } })'
+);
+
+assert.sameValue(f().constructor, Array);

--- a/test/built-ins/Proxy/apply/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/apply/trap-is-not-callable-realm.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist
+es6id: 9.5.13
+description: >
+  Throws if trap is not callable (honoring the Realm of the current execution
+  context)
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var p = new OProxy(function() {}, {
+  apply: {}
+});
+
+assert.throws(TypeError, function() {
+  p();
+});

--- a/test/built-ins/Proxy/construct/arguments-realm.js
+++ b/test/built-ins/Proxy/construct/arguments-realm.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget
+es6id: 9.5.14
+description: >
+  Arguments array is created in the Realm of the current execution context
+info: |
+  [...]
+  7. Let argArray be CreateArrayFromList(argumentsList).
+  8. Let newObj be ? Call(trap, handler, « target, argArray, newTarget »).
+  [...]
+---*/
+
+var C = $.createRealm().global.eval(
+  'new Proxy(function() {}, { construct: function(_, args) { return args; } })'
+);
+
+assert.sameValue(new C().constructor, Array);

--- a/test/built-ins/Proxy/construct/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/construct/trap-is-not-callable-realm.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget
+es6id: 9.5.14
+description: >
+  Throws if trap is not callable (honoring the Realm of the current execution
+  context)
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var p = new OProxy(function() {}, {
+  construct: {}
+});
+
+assert.throws(TypeError, function() {
+  new p();
+});

--- a/test/built-ins/Proxy/construct/trap-is-undefined-proto-from-ctor-realm.js
+++ b/test/built-ins/Proxy/construct/trap-is-undefined-proto-from-ctor-realm.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget
+es6id: 9.5.14
+description: >
+    If trap is undefined, propagate the construct to the target object,
+    honoring the Realm of the newTarget value
+info: >
+    [[Construct]] ( argumentsList, newTarget)
+
+    7. If trap is undefined, then
+        b. Return Construct(target, argumentsList, newTarget).
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var P = new Proxy(function() {}, {});
+
+var p = Reflect.construct(P, [], C);
+
+assert.sameValue(Object.getPrototypeOf(p), other.Object.prototype);

--- a/test/built-ins/Proxy/defineProperty/desc-realm.js
+++ b/test/built-ins/Proxy/defineProperty/desc-realm.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+es6id: 9.5.6
+description: >
+  Property descriptor object is created in the Realm of the current execution
+  context
+info: |
+  [[DefineOwnProperty]] (P, Desc)
+
+  ...
+  8. Let descObj be FromPropertyDescriptor(Desc).
+  9. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target, P,
+     descObj »)).
+  ...
+
+  6.2.4.4 FromPropertyDescriptor
+
+  ...
+  2. Let obj be ObjectCreate(%ObjectPrototype%).
+  ...
+  11. Return obj.
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var desc;
+var p = new OProxy({}, {
+  defineProperty: function(_, __, _desc) {
+    desc = _desc;
+    return desc;
+  }
+});
+
+p.a = 0;
+
+assert.sameValue(Object.getPrototypeOf(desc), Object.prototype);

--- a/test/built-ins/Proxy/defineProperty/null-handler-realm.js
+++ b/test/built-ins/Proxy/defineProperty/null-handler-realm.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+es6id: 9.5.6
+description: >
+  Throws a TypeError exception if handler is null (honoring the realm of the
+  current execution context).
+info: |
+  1. Assert: IsPropertyKey(P) is true.
+  2. Let handler be O.[[ProxyHandler]].
+  3. If handler is null, throw a TypeError exception.
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var p = OProxy.revocable(Object.create(null), {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+  p.proxy.prop = null;
+});

--- a/test/built-ins/Proxy/defineProperty/targetdesc-configurable-desc-not-configurable-realm.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-configurable-desc-not-configurable-realm.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+es6id: 9.5.6
+description: >
+    Throw a TypeError exception if Desc is not configurable and target property
+    descriptor is configurable and trap result is true (honoring the realm of
+    the current execution context).
+info: |
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    20. Else targetDesc is not undefined,
+        b. If settingConfigFalse is true and targetDesc.[[Configurable]] is
+        true, throw a TypeError exception.
+    ...
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var target = Object.create(null);
+var p = new OProxy(target, {
+  defineProperty: function() {
+    return true;
+  }
+});
+
+Object.defineProperty(target, 'prop', {
+  value: 1,
+  configurable: true
+});
+
+assert.throws(TypeError, function() {
+  Object.defineProperty(p, 'prop', {
+    value: 1,
+    configurable: false
+  });
+});

--- a/test/built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor-not-configurable-target-realm.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor-not-configurable-target-realm.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+es6id: 9.5.6
+description: >
+    Throw a TypeError exception if Desc and target property descriptor are not
+    compatible and trap result is true.
+info: |
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    20. Else targetDesc is not undefined,
+        a. If IsCompatiblePropertyDescriptor(extensibleTarget, Desc ,
+        targetDesc) is false, throw a TypeError exception.
+    ...
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var target = Object.create(null);
+var p = new OProxy(target, {
+  defineProperty: function() {
+    return true;
+  }
+});
+
+Object.defineProperty(target, 'prop', {
+  value: 1,
+  configurable: false
+});
+
+assert.throws(TypeError, function() {
+  Object.defineProperty(p, 'prop', {
+    value: 1,
+    configurable: true
+  });
+});

--- a/test/built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor-realm.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor-realm.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+es6id: 9.5.6
+description: >
+    Throw a TypeError exception if Desc and target property descriptor are not
+    compatible and trap result is true (honoring the realm of the current
+    execution context).
+info: |
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    20. Else targetDesc is not undefined,
+        a. If IsCompatiblePropertyDescriptor(extensibleTarget, Desc ,
+        targetDesc) is false, throw a TypeError exception.
+    ...
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var target = Object.create(null);
+var p = new OProxy(target, {
+  defineProperty: function() {
+    return true;
+  }
+});
+
+Object.defineProperty(target, 'prop', {
+  value: 1
+});
+
+assert.throws(TypeError, function() {
+  Object.defineProperty(p, 'prop', {
+    value: 2
+  });
+});

--- a/test/built-ins/Proxy/defineProperty/targetdesc-undefined-not-configurable-descriptor-realm.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-undefined-not-configurable-descriptor-realm.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+es6id: 9.5.6
+description: >
+    Throw a TypeError exception if Desc is not configurable and target property
+    descriptor is undefined, and trap result is true (honoring the realm of the
+    current execution context).
+info: |
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    19. If targetDesc is undefined, then
+        ...
+        b. If settingConfigFalse is true, throw a TypeError exception.
+    ...
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var target = Object.create(null);
+var p = new OProxy(target, {
+  defineProperty: function() {
+    return true;
+  }
+});
+
+assert.throws(TypeError, function() {
+  Object.defineProperty(p, 'prop', {
+    configurable: false
+  });
+});

--- a/test/built-ins/Proxy/defineProperty/targetdesc-undefined-target-is-not-extensible-realm.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-undefined-target-is-not-extensible-realm.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+es6id: 9.5.6
+description: >
+    Throw a TypeError exception if Desc is not configurable and target is not
+    extensible, and trap result is true (honoring the realm of the current
+    execution context).
+info: |
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    19. If targetDesc is undefined, then
+        a. If extensibleTarget is false, throw a TypeError exception.
+    ...
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var target = Object.create(null);
+var p = new OProxy(target, {
+  defineProperty: function() {
+    return true;
+  }
+});
+
+Object.preventExtensions(target);
+
+assert.throws(TypeError, function() {
+  p.prop = null;
+});

--- a/test/built-ins/Proxy/defineProperty/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/defineProperty/trap-is-not-callable-realm.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+es6id: 9.5.6
+description: >
+  Throws if trap is not callable (honoring the Realm of the current execution
+  context)
+info: |
+    [[DefineOwnProperty]] (P, Desc)
+
+    ...
+    6. Let trap be GetMethod(handler, "defineProperty").
+    ...
+        7.3.9 GetMethod (O, P)
+        ...
+        2. Let func be GetV(O, P).
+        5. If IsCallable(func) is false, throw a TypeError exception.
+        ...
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var p = new OProxy({}, {
+  defineProperty: {}
+});
+
+assert.throws(TypeError, function() {
+  Object.defineProperty(p, "foo", {
+    value: 1
+  });
+});

--- a/test/built-ins/Proxy/deleteProperty/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/deleteProperty/trap-is-not-callable-realm.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-delete-p
+es6id: 9.5.10
+description: >
+  Throws when trap is not callable. (honoring the Realm of the current
+  execution context)
+info: |
+    9.5.10 [[Delete]] (P)
+
+    6. Let trap be GetMethod(handler, "deleteProperty").
+    ...
+
+    7.3.9 GetMethod (O, P)
+
+    5. If IsCallable(func) is false, throw a TypeError exception.
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var p = new OProxy({}, {
+  deleteProperty: {}
+});
+
+assert.throws(TypeError, function() {
+  delete p.attr;
+});

--- a/test/built-ins/Proxy/get-fn-realm.js
+++ b/test/built-ins/Proxy/get-fn-realm.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-getfunctionrealm
+es6id: 7.3.22
+description: >
+    The realm of a proxy exotic object is the realm of its target function
+info: |
+    [...]
+    2. If obj has a [[Realm]] internal slot, then
+       a, Return obj's [[Realm]] internal slot.
+    3. If obj is a Bound Function exotic object, then
+       [...]
+    4. If obj is a Proxy exotic object, then
+       a. If the value of the [[ProxyHandler]] internal slot of obj is null,
+          throw a TypeError exception.
+       b. Let proxyTarget be the value of obj's [[ProxyTarget]] internal slot.
+       c. Return ? GetFunctionRealm(proxyTarget).
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+// Ensure that the proxy does not report a `prototype` property
+var P = new Proxy(C, { get: function() {} });
+
+assert.sameValue(Object.getPrototypeOf(new P()), other.Object.prototype);

--- a/test/built-ins/Proxy/get/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/get/trap-is-not-callable-realm.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver
+es6id: 9.5.8
+description: >
+  Throws if trap is not callable (honoring the Realm of the current execution
+  context)
+info: |
+    [[Get]] (P, Receiver)
+
+    6. Let trap be GetMethod(handler, "get").
+    ...
+
+    7.3.9 GetMethod (O, P)
+
+    5. If IsCallable(func) is false, throw a TypeError exception.
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var p = new OProxy({}, {
+  get: {}
+});
+
+assert.throws(TypeError, function() {
+  p.attr;
+});
+
+assert.throws(TypeError, function() {
+  p["attr"];
+});

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/result-type-is-not-object-nor-undefined-realm.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/result-type-is-not-object-nor-undefined-realm.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p
+es6id: 9.5.5
+description: >
+  Error when trap result is neither Object nor undefined (honoring the Realm of
+  the current execution context)
+info: |
+  [...]
+  9. If Type(trapResultObj) is neither Object nor Undefined, throw a TypeError
+     exception.
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+
+var p = new OProxy({}, {
+  getOwnPropertyDescriptor: function() { return null; }
+});
+
+assert.throws(TypeError, function() {
+  Object.getOwnPropertyDescriptor(p, 'x');
+});

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/trap-is-not-callable-realm.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p
+es6id: 9.5.5
+description: >
+  Throws if trap is not callable (honoring the Realm of the current execution
+  context)
+info: |
+    [[GetOwnProperty]] (P)
+
+    ...
+    2. Let handler be the value of the [[ProxyHandler]] internal slot of O.
+    ...
+    5. Let target be the value of the [[ProxyTarget]] internal slot of O.
+    6. Let trap be GetMethod(handler, "getOwnPropertyDescriptor").
+    ...
+        7.3.9 GetMethod (O, P)
+        ...
+        2. Let func be GetV(O, P).
+        5. If IsCallable(func) is false, throw a TypeError exception.
+        ...
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var p = new OProxy({}, {
+  getOwnPropertyDescriptor: {}
+});
+
+assert.throws(TypeError, function() {
+  Object.getOwnPropertyDescriptor(p, "foo");
+});

--- a/test/built-ins/Proxy/getPrototypeOf/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/getPrototypeOf/trap-is-not-callable-realm.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
+es6id: 9.5.1
+description: >
+  Throws if trap is not callable (honoring the Realm of the current execution
+  context)
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var p = new OProxy({}, {
+  getPrototypeOf: {}
+});
+
+assert.throws(TypeError, function() {
+  Object.getPrototypeOf(p);
+});

--- a/test/built-ins/Proxy/has/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/has/trap-is-not-callable-realm.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p
+es6id: 9.5.7
+description: >
+  Throws if trap is not callable (honoring the Realm of the current execution
+  context)
+info: |
+    [[HasProperty]] (P)
+
+    ...
+    6. Let trap be GetMethod(handler, "has").
+    ...
+        7.3.9 GetMethod (O, P)
+        ...
+        2. Let func be GetV(O, P).
+        5. If IsCallable(func) is false, throw a TypeError exception.
+        ...
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var p = new OProxy({}, {
+  has: {}
+});
+
+assert.throws(TypeError, function() {
+  "attr" in p;
+});

--- a/test/built-ins/Proxy/isExtensible/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/isExtensible/trap-is-not-callable-realm.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-isextensible
+es6id: 9.5.3
+description: >
+  Throws if trap is not callable (honoring the Realm of the current execution
+  context)
+info: |
+    [[IsExtensible]] ( )
+
+    ...
+    1. Let handler be the value of the [[ProxyHandler]] internal slot of O.
+    ...
+    5. Let trap be GetMethod(handler, "isExtensible").
+    ...
+        7.3.9 GetMethod (O, P)
+        ...
+        2. Let func be GetV(O, P).
+        5. If IsCallable(func) is false, throw a TypeError exception.
+        ...
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var p = new OProxy({}, {
+  isExtensible: {}
+});
+
+assert.throws(TypeError, function() {
+  Object.isExtensible(p);
+});

--- a/test/built-ins/Proxy/ownKeys/return-not-list-object-throws-realm.js
+++ b/test/built-ins/Proxy/ownKeys/return-not-list-object-throws-realm.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
+es6id: 9.5.12
+description: >
+    If return is not a list object, throw a TypeError exception  (honoring
+    the Realm of the current execution context)
+info: |
+    ...
+    7. Let trapResultArray be ? Call(trap, handler, « target »).
+    8. Let trapResult be ? CreateListFromArrayLike(trapResultArray, « String,
+       Symbol »).
+    ...
+
+    7.3.17 CreateListFromArrayLike (obj [, elementTypes] )
+
+    ...
+    3. If Type(obj) is not Object, throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var other = $.createRealm().global;
+var p = new other.Proxy({}, {
+    ownKeys: function() {
+        return undefined;
+    }
+});
+
+assert.throws(TypeError, function() {
+    Object.keys(p);
+});

--- a/test/built-ins/Proxy/ownKeys/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/ownKeys/trap-is-not-callable-realm.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
+es6id: 9.5.12
+description: >
+  Throws if trap is not callable (honoring the Realm of the current execution
+  context)
+info: |
+    [[OwnPropertyKeys]] ( )
+
+    5. Let trap be GetMethod(handler, "ownKeys").
+    ...
+
+    7.3.9 GetMethod (O, P)
+
+    5. If IsCallable(func) is false, throw a TypeError exception.
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var p = new OProxy({attr:1}, {
+  ownKeys: {}
+});
+
+assert.throws(TypeError, function() {
+  Object.keys(p);
+});

--- a/test/built-ins/Proxy/preventExtensions/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/preventExtensions/trap-is-not-callable-realm.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-preventextensions
+es6id: 9.5.4
+description: >
+  Throws if trap is not callable (honoring the Realm of the current execution
+  context)
+info: |
+    [[PreventExtensions]] ( )
+
+    ...
+    1. Let handler be the value of the [[ProxyHandler]] internal slot of O.
+    ...
+    5. Let trap be GetMethod(handler, "preventExtensions").
+    ...
+        7.3.9 GetMethod (O, P)
+        ...
+        2. Let func be GetV(O, P).
+        5. If IsCallable(func) is false, throw a TypeError exception.
+        ...
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var p = new OProxy({}, {
+  preventExtensions: {}
+});
+
+assert.throws(TypeError, function() {
+  Object.preventExtensions(p);
+});

--- a/test/built-ins/Proxy/set/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/set/trap-is-not-callable-realm.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver
+es6id: 9.5.9
+description: >
+  Throws if trap is not callable (honoring the Realm of the current execution
+  context)
+info: |
+    [[Set]] ( P, V, Receiver)
+
+    6. Let trap be GetMethod(handler, "set").
+    ...
+
+    7.3.9 GetMethod (O, P)
+
+    5. If IsCallable(func) is false, throw a TypeError exception.
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var p = new OProxy({}, {
+  set: {}
+});
+
+assert.throws(TypeError, function() {
+  p.attr = 1;
+});
+
+assert.throws(TypeError, function() {
+  p["attr"] = 1;
+});

--- a/test/built-ins/Proxy/setPrototypeOf/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/setPrototypeOf/trap-is-not-callable-realm.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v
+es6id: 9.5.2
+description: >
+  Throws if trap is not callable (honoring the Realm of the current execution
+  context)
+info: |
+    [[SetPrototypeOf]] (V)
+
+    ...
+    2. Let handler be the value of the [[ProxyHandler]] internal slot of O.
+    ...
+    5. Let target be the value of the [[ProxyTarget]] internal slot of O.
+    6. Let trap be GetMethod(handler, "setPrototypeOf").
+    ...
+        7.3.9 GetMethod (O, P)
+        ...
+        2. Let func be GetV(O, P).
+        5. If IsCallable(func) is false, throw a TypeError exception.
+        ...
+---*/
+
+var OProxy = $.createRealm().global.Proxy;
+var p = new OProxy({}, {
+  setPrototypeOf: {}
+});
+
+assert.throws(TypeError, function() {
+ Object.setPrototypeOf(p, {
+   value: 1
+ });
+});

--- a/test/built-ins/RegExp/proto-from-ctor-realm.js
+++ b/test/built-ins/RegExp/proto-from-ctor-realm.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-boolean-constructor-boolean-value
+es6id: 19.2.3.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    2. If NewTarget is not undefined, let newTarget be NewTarget.
+    [...]
+    7. Let O be ? RegExpAlloc(newTarget).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(RegExp, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.RegExp.prototype);

--- a/test/built-ins/RegExp/prototype/Symbol.split/splitter-proto-from-ctor-realm.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/splitter-proto-from-ctor-realm.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-regexp.prototype-@@split
+es6id: TODO
+description: Default [[Prototype]] value derived from realm of the constructor
+info: >
+    10. Let splitter be ? Construct(C, « rx, newFlags »).
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Symbol.species]
+---*/
+
+var other = $.createRealm().global;
+other.shared = null;
+var C = new other.Function('shared = this; return /./;');
+C.prototype = null;
+
+var r = /./;
+r.constructor = function() {};
+r.constructor[Symbol.species] = C;
+
+r[Symbol.split]();
+
+assert.sameValue(Object.getPrototypeOf(other.shared), other.Object.prototype);

--- a/test/built-ins/RegExp/prototype/Symbol.split/splitter-proto-from-ctor-realm.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/splitter-proto-from-ctor-realm.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-regexp.prototype-@@split
-es6id: TODO
+es6id: 21.2.5.11
 description: Default [[Prototype]] value derived from realm of the constructor
 info: >
     10. Let splitter be ? Construct(C, « rx, newFlags »).

--- a/test/built-ins/Set/proto-from-ctor-realm.js
+++ b/test/built-ins/Set/proto-from-ctor-realm.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-set-iterable
+es6id: 23.2.1.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    2. Let set be ? OrdinaryCreateFromConstructor(NewTarget, "%SetPrototype%",
+       « [[SetData]] »).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(Set, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.Set.prototype);

--- a/test/built-ins/String/proto-from-ctor-realm.js
+++ b/test/built-ins/String/proto-from-ctor-realm.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string-constructor-string-value
+es6id: 21.1.1.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    4. Return ? StringCreate(s, ? GetPrototypeFromConstructor(NewTarget,
+       "%StringPrototype%")).
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(String, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.String.prototype);

--- a/test/built-ins/Symbol/for/cross-realm.js
+++ b/test/built-ins/Symbol/for/cross-realm.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.for
+es6id: 19.4.2.1
+description: Global symbol registry is shared by all realms
+info: >
+    The GlobalSymbolRegistry is a List that is globally available. It is shared
+    by all realms. Prior to the evaluation of any ECMAScript code it is
+    initialized as a new empty List.
+---*/
+
+var OSymbol = $.createRealm().global.Symbol;
+var parent = Symbol.for('parent');
+var child = OSymbol.for('child');
+
+assert.notSameValue(Symbol.for, OSymbol.for);
+assert.sameValue(parent, OSymbol.for('parent'));
+assert.sameValue(Symbol.for('child'), child);

--- a/test/built-ins/Symbol/hasInstance/cross-realm.js
+++ b/test/built-ins/Symbol/hasInstance/cross-realm.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.hasinstance
+es6id: 19.4.2.2
+description: Value shared by all realms
+info: >
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [Symbol.hasInstance]
+---*/
+
+var OSymbol = $.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.hasInstance, OSymbol.hasInstance);

--- a/test/built-ins/Symbol/isConcatSpreadable/cross-realm.js
+++ b/test/built-ins/Symbol/isConcatSpreadable/cross-realm.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.isconcatspreadable
+es6id: 19.4.2.3
+description: Value shared by all realms
+info: >
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [Symbol.isConcatSpreadable]
+---*/
+
+var OSymbol = $.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.isConcatSpreadable, OSymbol.isConcatSpreadable);

--- a/test/built-ins/Symbol/iterator/cross-realm.js
+++ b/test/built-ins/Symbol/iterator/cross-realm.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.iterator
+es6id: 19.4.2.4
+description: Value shared by all realms
+info: >
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [Symbol.iterator]
+---*/
+
+var OSymbol = $.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.iterator, OSymbol.iterator);

--- a/test/built-ins/Symbol/keyFor/cross-realm.js
+++ b/test/built-ins/Symbol/keyFor/cross-realm.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.keyfor
+es6id: 19.4.2.5
+description: Global symbol registry is shared by all realms
+info: >
+    The GlobalSymbolRegistry is a List that is globally available. It is shared
+    by all realms. Prior to the evaluation of any ECMAScript code it is
+    initialized as a new empty List.
+---*/
+
+var OSymbol = $.createRealm().global.Symbol;
+var parent = Symbol.for('parent');
+var child = OSymbol.for('child');
+
+assert.notSameValue(Symbol.keyFor, OSymbol.keyFor);
+assert.sameValue(OSymbol.keyFor(parent), 'parent');
+assert.sameValue(Symbol.keyFor(child), 'child');

--- a/test/built-ins/Symbol/match/cross-realm.js
+++ b/test/built-ins/Symbol/match/cross-realm.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.match
+es6id: 19.4.2.6
+description: Value shared by all realms
+info: >
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [Symbol.match]
+---*/
+
+var OSymbol = $.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.match, OSymbol.match);

--- a/test/built-ins/Symbol/replace/cross-realm.js
+++ b/test/built-ins/Symbol/replace/cross-realm.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.replace
+es6id: 19.4.2.8
+description: Value shared by all realms
+info: >
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [Symbol.replace]
+---*/
+
+var OSymbol = $.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.replace, OSymbol.replace);

--- a/test/built-ins/Symbol/search/cross-realm.js
+++ b/test/built-ins/Symbol/search/cross-realm.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.search
+es6id: 19.4.2.9
+description: Value shared by all realms
+info: >
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [Symbol.search]
+---*/
+
+var OSymbol = $.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.search, OSymbol.search);

--- a/test/built-ins/Symbol/species/cross-realm.js
+++ b/test/built-ins/Symbol/species/cross-realm.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.species
+es6id: 19.4.2.10
+description: Value shared by all realms
+info: >
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [Symbol.species]
+---*/
+
+var OSymbol = $.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.species, OSymbol.species);

--- a/test/built-ins/Symbol/split/cross-realm.js
+++ b/test/built-ins/Symbol/split/cross-realm.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.split
+es6id: 19.4.2.11
+description: Value shared by all realms
+info: >
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [Symbol.split]
+---*/
+
+var OSymbol = $.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.split, OSymbol.split);

--- a/test/built-ins/Symbol/toPrimitive/cross-realm.js
+++ b/test/built-ins/Symbol/toPrimitive/cross-realm.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.toprimitive
+es6id: 19.4.2.12
+description: Value shared by all realms
+info: >
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [Symbol.split]
+---*/
+
+var OSymbol = $.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.split, OSymbol.split);

--- a/test/built-ins/Symbol/toStringTag/cross-realm.js
+++ b/test/built-ins/Symbol/toStringTag/cross-realm.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.tostringtag
+es6id: 19.4.2.13
+description: Value shared by all realms
+info: >
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [Symbol.toStringTag]
+---*/
+
+var OSymbol = $.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.toStringTag, OSymbol.toStringTag);

--- a/test/built-ins/Symbol/unscopables/cross-realm.js
+++ b/test/built-ins/Symbol/unscopables/cross-realm.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.unscopables
+es6id: 19.4.2.14
+description: Value shared by all realms
+info: >
+  Unless otherwise specified, well-known symbols values are shared by all
+  realms.
+features: [Symbol.unscopables]
+---*/
+
+var OSymbol = $.createRealm().global.Symbol;
+
+assert.sameValue(Symbol.unscopables, OSymbol.unscopables);

--- a/test/built-ins/ThrowTypeError/distinct-cross-realm.js
+++ b/test/built-ins/ThrowTypeError/distinct-cross-realm.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%throwtypeerror%
+description: >
+  %ThrowTypeError% is defined once for each realm.
+info: >
+  %ThrowTypeError% ( )
+
+  The %ThrowTypeError% intrinsic is an anonymous built-in function
+  object that is defined once for each realm.
+---*/
+
+var other = $.createRealm().global;
+var localArgs = function(){ "use strict"; return arguments; }();
+var otherArgs = (new other.Function('return arguments;'))();
+var localThrowTypeError = Object.getOwnPropertyDescriptor(localArgs, "callee").get;
+var otherThrowTypeError = Object.getOwnPropertyDescriptor(otherArgs, "callee").get;
+
+assert.notSameValue(localThrowTypeError, otherThrowTypeError);

--- a/test/built-ins/TypedArrays/buffer-arg-proto-from-ctor-realm.js
+++ b/test/built-ins/TypedArrays/buffer-arg-proto-from-ctor-realm.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-typedarray-buffer-byteoffset-length
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    4. Let O be ? AllocateTypedArray(constructorName, NewTarget,
+       "%TypedArrayPrototype%").
+    [...]
+
+    22.2.4.2.1 Runtime Semantics: AllocateTypedArray
+
+    1. Let proto be ? GetPrototypeFromConstructor(newTarget, defaultProto).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    5. Return proto.
+includes: [testTypedArray.js]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+testWithTypedArrayConstructors(function(TA) {
+  var ta = Reflect.construct(TA, [new ArrayBuffer(8)], C);
+
+  assert.sameValue(Object.getPrototypeOf(ta), other[TA.name].prototype);
+});

--- a/test/built-ins/TypedArrays/internals/DefineOwnProperty/detached-buffer-realm.js
+++ b/test/built-ins/TypedArrays/internals/DefineOwnProperty/detached-buffer-realm.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-integer-indexed-exotic-objects-defineownproperty-p-desc
+description: |
+  Throws a TypeError if object has valid numeric index and a detached buffer
+  (honoring the Realm of the current execution context)
+info: >
+  9.4.5.3 [[DefineOwnProperty]] ( P, Desc)
+  ...
+  3. If Type(P) is String, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      ...
+      xi. If Desc has a [[Value]] field, then
+        1. Let value be Desc.[[Value]].
+        2. Return ? IntegerIndexedElementSet(O, intIndex, value).
+  ...
+
+  9.4.5.9 IntegerIndexedElementSet ( O, index, value )
+
+  ...
+  4. Let buffer be the value of O's [[ViewedArrayBuffer]] internal slot.
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var desc = {
+  value: 0,
+  configurable: false,
+  enumerable: true,
+  writable: true
+};
+
+testWithTypedArrayConstructors(function(TA) {
+  var OtherTA = other[TA.name];
+  var sample = new OtherTA(1);
+
+  $DETACHBUFFER(sample.buffer);
+
+  assert.throws(TypeError, function() {
+    Reflect.defineProperty(sample, '0', desc);
+  });
+});

--- a/test/built-ins/TypedArrays/internals/Get/detached-buffer-realm.js
+++ b/test/built-ins/TypedArrays/internals/Get/detached-buffer-realm.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-integer-indexed-exotic-objects-get-p-receiver
+description: >
+  Throws a TypeError if key has a numeric index and object has a detached
+  buffer (honoring the Realm of the current execution context)
+info: >
+  9.4.5.4 [[Get]] (P, Receiver)
+
+  ...
+  2. If Type(P) is String, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      i. Return ? IntegerIndexedElementGet(O, numericIndex).
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var other = $.createRealm().global;
+
+testWithTypedArrayConstructors(function(TA) {
+  var OtherTA = other[TA.name];
+  var sample = new OtherTA(1);
+
+  $DETACHBUFFER(sample.buffer);
+
+  assert.throws(TypeError, function() {
+    sample[0];
+  });
+});

--- a/test/built-ins/TypedArrays/internals/GetOwnProperty/detached-buffer-realm.js
+++ b/test/built-ins/TypedArrays/internals/GetOwnProperty/detached-buffer-realm.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-integer-indexed-exotic-objects-getownproperty-p
+description: >
+  Throws a TypeError if this has a detached buffer (honoring the Realm of the
+  current execution context)
+info: >
+  9.4.5.1 [[GetOwnProperty]] ( P )
+
+  ...
+  3. If Type(P) is String, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      i. Let value be ? IntegerIndexedElementGet(O, numericIndex).
+  ...
+
+  9.4.5.8 IntegerIndexedElementGet ( O, index )
+
+  ...
+  3. Let buffer be the value of O's [[ViewedArrayBuffer]] internal slot.
+  4. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var other = $.createRealm().global;
+
+testWithTypedArrayConstructors(function(TA) {
+  var OtherTA = other[TA.name];
+  var sample = new OtherTA(1);
+
+  $DETACHBUFFER(sample.buffer);
+
+  assert.throws(TypeError, function() {
+    Object.getOwnPropertyDescriptor(sample, 0);
+  });
+});

--- a/test/built-ins/TypedArrays/internals/HasProperty/detached-buffer-realm.js
+++ b/test/built-ins/TypedArrays/internals/HasProperty/detached-buffer-realm.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-integer-indexed-exotic-objects-hasproperty-p
+description: >
+  Throws a TypeError if this has a detached buffer (honoring the Realm of the
+  current execution context)
+info: >
+  9.4.5.2 [[HasProperty]](P)
+
+  ...
+  3. If Type(P) is String, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      i. Let buffer be the value of O's [[ViewedArrayBuffer]] internal slot.
+      ii. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+features: [Reflect]
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var other = $.createRealm().global;
+
+testWithTypedArrayConstructors(function(TA) {
+  var OtherTA = other[TA.name];
+  var sample = new OtherTA(1);
+
+  $DETACHBUFFER(sample.buffer);
+
+  assert.throws(TypeError, function() {
+    Reflect.has(sample, '0');
+  }, '0');
+});

--- a/test/built-ins/TypedArrays/internals/Set/detached-buffer-realm.js
+++ b/test/built-ins/TypedArrays/internals/Set/detached-buffer-realm.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-integer-indexed-exotic-objects-set-p-v-receiver
+description: >
+  Throws a TypeError if key has a numeric index and object has a detached
+  buffer (honoring the Realm of the current execution context)
+info: >
+  9.4.5.5 [[Set]] ( P, V, Receiver)
+
+  ...
+  2. If Type(P) is String, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      i. Return ? IntegerIndexedElementSet(O, numericIndex, V).
+  ...
+
+  9.4.5.9 IntegerIndexedElementSet ( O, index, value )
+
+  ...
+  3. Let numValue be ? ToNumber(value).
+  4. Let buffer be the value of O's [[ViewedArrayBuffer]] internal slot.
+  5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+var other = $.createRealm().global;
+
+testWithTypedArrayConstructors(function(TA) {
+  var OtherTA = other[TA.name];
+  var sample = new OtherTA(1);
+
+  $DETACHBUFFER(sample.buffer);
+
+  assert.throws(TypeError, function() {
+    sample[0] = 0;
+  });
+});

--- a/test/built-ins/TypedArrays/length-arg-proto-from-ctor-realm.js
+++ b/test/built-ins/TypedArrays/length-arg-proto-from-ctor-realm.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-typedarray-length
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    8. Return ? AllocateTypedArray(constructorName, NewTarget,
+       "%TypedArrayPrototype%", elementLength).
+
+    22.2.4.2.1 Runtime Semantics: AllocateTypedArray
+
+    1. Let proto be ? GetPrototypeFromConstructor(newTarget, defaultProto).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    5. Return proto.
+includes: [testTypedArray.js]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+testWithTypedArrayConstructors(function(TA) {
+  var ta = Reflect.construct(TA, [0], C);
+
+  assert.sameValue(Object.getPrototypeOf(ta), other[TA.name].prototype);
+});

--- a/test/built-ins/TypedArrays/no-args-proto-from-ctor-realm.js
+++ b/test/built-ins/TypedArrays/no-args-proto-from-ctor-realm.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-typedarray
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    3. Return ? AllocateTypedArray(constructorName, NewTarget,
+       "%TypedArrayPrototype%", 0).
+
+    22.2.4.2.1 Runtime Semantics: AllocateTypedArray
+
+    1. Let proto be ? GetPrototypeFromConstructor(newTarget, defaultProto).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    5. Return proto.
+includes: [testTypedArray.js]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+testWithTypedArrayConstructors(function(TA) {
+  var ta = Reflect.construct(TA, [], C);
+
+  assert.sameValue(Object.getPrototypeOf(ta), other[TA.name].prototype);
+});

--- a/test/built-ins/TypedArrays/object-arg-proto-from-ctor-realm.js
+++ b/test/built-ins/TypedArrays/object-arg-proto-from-ctor-realm.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-typedarray-object
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    4. Let O be ? AllocateTypedArray(constructorName, NewTarget,
+       "%TypedArrayPrototype%").
+    [...]
+
+    22.2.4.2.1 Runtime Semantics: AllocateTypedArray
+
+    1. Let proto be ? GetPrototypeFromConstructor(newTarget, defaultProto).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    5. Return proto.
+includes: [testTypedArray.js]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+testWithTypedArrayConstructors(function(TA) {
+  var ta = Reflect.construct(TA, [{}], C);
+
+  assert.sameValue(Object.getPrototypeOf(ta), other[TA.name].prototype);
+});

--- a/test/built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-custom-species-proto-from-ctor-realm.js
+++ b/test/built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-custom-species-proto-from-ctor-realm.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-typedarray-typedarray
+description: >
+  Derive the ArrayBuffer prototype from the realm of the species constructor
+info: >
+  22.2.4.3 TypedArray ( typedArray )
+
+  This description applies only if the TypedArray function is called with at
+  least one argument and the Type of the first argument is Object and that
+  object has a [[TypedArrayName]] internal slot.
+
+  ...
+  18. Else,
+    a. Let bufferConstructor be ? SpeciesConstructor(srcData, %ArrayBuffer%).
+    b. Let data be ? AllocateArrayBuffer(bufferConstructor, byteLength).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  ...
+  5. Let S be ? Get(C, @@species).
+  6. If S is either undefined or null, return defaultConstructor.
+  7. If IsConstructor(S) is true, return S.
+  ...
+
+  9.1.14 GetPrototypeFromConstructor
+
+  ...
+  3. Let proto be ? Get(constructor, "prototype").
+  4. If Type(proto) is not Object, then
+     a. Let realm be ? GetFunctionRealm(constructor).
+     b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+  ...
+includes: [testTypedArray.js]
+features: [Symbol.species]
+---*/
+
+var sample1 = new Int8Array();
+var sample2 = new Int16Array();
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = TA === Int8Array ? sample2 : sample1;
+  var ctor = {};
+
+  sample.buffer.constructor = ctor;
+
+  ctor[Symbol.species] = C;
+
+  var typedArray = new TA(sample);
+  assert.sameValue(
+    Object.getPrototypeOf(typedArray.buffer), other.ArrayBuffer.prototype
+  );
+});

--- a/test/built-ins/TypedArrays/typedarray-arg-proto-from-ctor-realm.js
+++ b/test/built-ins/TypedArrays/typedarray-arg-proto-from-ctor-realm.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-typedarray-typedarray
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    4. Let O be ? AllocateTypedArray(constructorName, NewTarget,
+       "%TypedArrayPrototype%").
+    [...]
+
+    22.2.4.2.1 Runtime Semantics: AllocateTypedArray
+
+    1. Let proto be ? GetPrototypeFromConstructor(newTarget, defaultProto).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    5. Return proto.
+includes: [testTypedArray.js]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+testWithTypedArrayConstructors(function(TA) {
+  var ta = Reflect.construct(TA, [new TA()], C);
+
+  assert.sameValue(Object.getPrototypeOf(ta), other[TA.name].prototype);
+});

--- a/test/built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-custom-proto-from-ctor-realm.js
+++ b/test/built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-custom-proto-from-ctor-realm.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-typedarray-typedarray
+description: >
+  Derive the ArrayBuffer prototype from the realm of the species constructor
+info: >
+  22.2.4.3 TypedArray ( typedArray )
+
+  This description applies only if the TypedArray function is called with at
+  least one argument and the Type of the first argument is Object and that
+  object has a [[TypedArrayName]] internal slot.
+
+  ...
+  17. If SameValue(elementType, srcType) is true, then
+    a. Let data be ? CloneArrayBuffer(srcData, srcByteOffset).
+  ...
+
+  24.1.1.4 CloneArrayBuffer ( srcBuffer, srcByteOffset [ , cloneConstructor ] )
+
+  ...
+  2. If cloneConstructor is not present, then
+    a. Let cloneConstructor be ? SpeciesConstructor(srcBuffer, %ArrayBuffer%).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  ...
+  5. Let S be ? Get(C, @@species).
+  6. If S is either undefined or null, return defaultConstructor.
+  7. If IsConstructor(S) is true, return S.
+  ...
+
+  24.1.1.4 CloneArrayBuffer ( srcBuffer, srcByteOffset [ , cloneConstructor ] )
+
+  ...
+  8. Let targetBuffer be ? AllocateArrayBuffer(cloneConstructor, cloneLength).
+  ...
+
+  9.1.14 GetPrototypeFromConstructor
+
+  ...
+  3. Let proto be ? Get(constructor, "prototype").
+  4. If Type(proto) is not Object, then
+     a. Let realm be ? GetFunctionRealm(constructor).
+     b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+  ...
+includes: [testTypedArray.js]
+features: [Symbol.species]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA();
+  var ctor = {};
+
+  sample.buffer.constructor = ctor;
+
+  ctor[Symbol.species] = C;
+
+  var typedArray = new TA(sample);
+  assert.sameValue(
+    Object.getPrototypeOf(typedArray.buffer), other.ArrayBuffer.prototype
+  );
+});

--- a/test/built-ins/WeakMap/proto-from-ctor-realm.js
+++ b/test/built-ins/WeakMap/proto-from-ctor-realm.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-weakmap-iterable
+es6id: 23.3.1.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    2. Let map be ? OrdinaryCreateFromConstructor(NewTarget,
+       "%WeakMapPrototype%", « [[WeakMapData]] »).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(WeakMap, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.WeakMap.prototype);

--- a/test/built-ins/WeakSet/proto-from-ctor-realm.js
+++ b/test/built-ins/WeakSet/proto-from-ctor-realm.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-weakset-iterable
+es6id: 23.4.1.1
+description: Default [[Prototype]] value derived from realm of the newTarget
+info: |
+    [...]
+    2. Let set be ? OrdinaryCreateFromConstructor(NewTarget,
+       "%WeakSetPrototype%", « [[WeakSetData]] »).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+var o = Reflect.construct(WeakSet, [], C);
+
+assert.sameValue(Object.getPrototypeOf(o), other.WeakSet.prototype);

--- a/test/language/eval-code/indirect/realm.js
+++ b/test/language/eval-code/indirect/realm.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: TODO
+es6id: TODO
+description: TODO
+info: |
+  TODO
+---*/
+
+var other = $.createRealm().global;
+var otherEval = other.eval;
+
+otherEval("var x = 23;");
+assert.sameValue(typeof x, 'undefined');
+assert.sameValue(other.x, 23);

--- a/test/language/eval-code/indirect/realm.js
+++ b/test/language/eval-code/indirect/realm.js
@@ -1,16 +1,33 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: TODO
-es6id: TODO
-description: TODO
+esid: sec-performeval
+es6id: 18.2.1.1
+description: >
+  Uses the global variable envrionment of the running execution context
 info: |
-  TODO
+  [...]
+  12. Let ctx be the running execution context. If direct is true, ctx will be
+      the execution context that performed the direct eval. If direct is false,
+      ctx will be the execution context for the invocation of the eval
+      function.
+  13. If direct is true, then
+      [...]
+  14. Else,
+      a. Let lexEnv be NewDeclarativeEnvironment(evalRealm.[[GlobalEnv]]).
+      b. Let varEnv be evalRealm.[[GlobalEnv]].
+  [...]
+  17. Let evalCxt be a new ECMAScript code execution context.
+  [...]
+  21. Set the evalCxt's VariableEnvironment to varEnv.
+  [...]
+  24. Let result be EvalDeclarationInstantiation(body, varEnv, lexEnv,
+      strictEval).
 ---*/
 
 var other = $.createRealm().global;
 var otherEval = other.eval;
 
-otherEval("var x = 23;");
+otherEval('var x = 23;');
 assert.sameValue(typeof x, 'undefined');
 assert.sameValue(other.x, 23);

--- a/test/language/expressions/call/eval-realm-indirect.js
+++ b/test/language/expressions/call/eval-realm-indirect.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-function-calls-runtime-semantics-evaluation
+es6id: 12.3.4.1
+description: >
+    An eval function from another realm is not a candidate for direct eval
+info: |
+    [...]
+    3. If Type(ref) is Reference and IsPropertyReference(ref) is false and GetReferencedName(ref) is "eval", then
+       a. If SameValue(func, %eval%) is true, then
+          [...]
+flags: [noStrict]
+---*/
+
+var x = 'outside';
+var result;
+
+(function() {
+  var eval = $.createRealm().global.eval;
+
+  eval('var x = "inside";');
+
+  result = x;
+}());
+
+assert.sameValue(result, 'outside');

--- a/test/language/expressions/generators/eval-body-proto-realm.js
+++ b/test/language/expressions/generators/eval-body-proto-realm.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-generator-function-definitions-runtime-semantics-evaluatebody
+es6id: 14.4.11
+description: >
+    Default [[Prototype]] value derived from realm of the generator function
+info: >
+    1. Let G be ? OrdinaryCreateFromConstructor(functionObject,
+       "%GeneratorPrototype%", « [[GeneratorState]], [[GeneratorContext]] »).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+---*/
+
+var other = $.createRealm().global;
+var g = other.eval('(0, function*() {})');
+var GeneratorPrototype = Object.getPrototypeOf(g.prototype);
+g.prototype = null;
+var instance;
+
+instance = g();
+
+assert.sameValue(Object.getPrototypeOf(instance), GeneratorPrototype);

--- a/test/language/expressions/new/non-ctor-err-realm.js
+++ b/test/language/expressions/new/non-ctor-err-realm.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-new-operator
+es6id: 12.3.3
+description: Realm of error object produced when operand is not a constructor
+info: |
+  NewExpression : new NewExpression
+
+  1. Return ? EvaluateNew(NewExpression, empty).
+
+  MemberExpression : new MemberExpression Arguments
+
+  1. Return ? EvaluateNew(MemberExpression, Arguments).
+
+  12.3.3.1.1 Runtime Semantics: EvaluateNew
+
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+---*/
+
+var otherParseInt = $.createRealm().global.parseInt;
+
+assert.sameValue(typeof otherParseInt, 'function');
+
+assert.throws(TypeError, function() {
+  new otherParseInt(0);
+}, 'production including Arguments');
+
+assert.throws(TypeError, function() {
+  new otherParseInt;
+}, 'production eliding Arguments');

--- a/test/language/expressions/super/realm.js
+++ b/test/language/expressions/super/realm.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-super-keyword
+es6id: 12.3.5
+description: >
+    Default [[Prototype]] value derived from realm of the newTarget value
+info: >
+    1. Let newTarget be GetNewTarget().
+    [...]
+    6. Let result be ? Construct(func, argList, newTarget).
+    [...]
+
+    9.1.14 GetPrototypeFromConstructor
+
+    [...]
+    3. Let proto be ? Get(constructor, "prototype").
+    4. If Type(proto) is not Object, then
+       a. Let realm be ? GetFunctionRealm(constructor).
+       b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
+    [...]
+features: [Reflect]
+---*/
+
+var other = $.createRealm().global;
+var C = new other.Function();
+C.prototype = null;
+
+class B extends function() {} {
+  constructor() {
+    super();
+  }
+}
+
+var b = Reflect.construct(B, [], C);
+
+assert.sameValue(Object.getPrototypeOf(b), other.Object.prototype);

--- a/test/language/expressions/tagged-template/cache-realm.js
+++ b/test/language/expressions/tagged-template/cache-realm.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-template-literals
+es6id: 12.2.9
+description: Each realm has a distinct template registry
+info: |
+  TemplateLiteral:NoSubstitutionTemplate
+
+    [...]
+    2. Let siteObj be GetTemplateObject(templateLiteral).
+    [...]
+
+  TemplateLiteral:TemplateHeadExpressionTemplateSpans
+
+    [...]
+    2. Let siteObj be GetTemplateObject(templateLiteral).
+    [...]
+
+  Runtime Semantics: GetTemplateObject ( templateLiteral )#
+
+
+     1. Let rawStrings be TemplateStrings of templateLiteral with argument
+        true.
+     2. Let realm be the current Realm Record.
+     3. Let templateRegistry be realm.[[TemplateMap]].
+     4. For each element e of templateRegistry, do
+        a, If e.[[Strings]] and rawStrings contain the same values in the same
+           order, then
+           i. Return e.[[Array]].
+---*/
+
+var other = $.createRealm().global;
+var strings1, strings2;
+
+strings1 = (function(strings) { return strings; })`1234`;
+strings2 = other.eval('(function(strings) { return strings; })`1234`');
+
+assert.notSameValue(strings1, strings2);

--- a/test/language/types/reference/get-value-prop-base-primitive-realm.js
+++ b/test/language/types/reference/get-value-prop-base-primitive-realm.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-getvalue
+es6id: 6.2.3.1
+description: >
+  When the base of a property reference is primitive, it is coerced to an
+  object during value retrieval (honoring the realm of the current execution
+  context)
+info: >
+  [...]
+  5. If IsPropertyReference(V) is true, then
+     a. If HasPrimitiveBase(V) is true, then
+        i. Assert: In this case, base will never be null or undefined.
+        ii. Let base be ToObject(base).
+     b. Return ? base.[[Get]](GetReferencedName(V), GetThisValue(V)).
+features: [Symbol]
+---*/
+
+var other = $.createRealm().global;
+
+other.Number.prototype.test262 = 'number prototype';
+other.value = 1;
+assert.sameValue(other.eval('value.test262'), 'number prototype');
+
+other.String.prototype.test262 = 'string prototype';
+other.value = '';
+assert.sameValue(other.eval('value.test262'), 'string prototype');
+
+other.Boolean.prototype.test262 = 'Boolean prototype';
+other.value = true;
+assert.sameValue(other.eval('value.test262'), 'Boolean prototype');
+
+other.Symbol.prototype.test262 = 'Symbol prototype';
+other.value = Symbol();
+assert.sameValue(other.eval('value.test262'), 'Symbol prototype');

--- a/test/language/types/reference/put-value-prop-base-primitive-realm.js
+++ b/test/language/types/reference/put-value-prop-base-primitive-realm.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-putvalue
+es6id: 6.2.3.2
+description: >
+  When the base of a property reference is primitive, it is coerced to an
+  object during value assignment (honoring the realm of the current execution
+  context)
+info: >
+  [...]
+  6. Else if IsPropertyReference(V) is true, then
+     a. If HasPrimitiveBase(V) is true, then
+        i. Assert: In this case, base will never be null or undefined.
+        ii. Set base to ToObject(base).
+     b. Let succeeded be ? base.[[Set]](GetReferencedName(V), W,
+        GetThisValue(V)).
+     c. If succeeded is false and IsStrictReference(V) is true, throw a
+        TypeError exception.
+     d. Return.
+features: [Symbol, Proxy]
+---*/
+
+var other = $.createRealm().global;
+var numberCount = 0;
+var stringCount = 0;
+var booleanCount = 0;
+var symbolCount = 0;
+var spy;
+
+spy = new Proxy({}, { set: function() { numberCount += 1; return true; } });
+Object.setPrototypeOf(other.Number.prototype, spy);
+other.eval('0..test262 = null;');
+assert.sameValue(numberCount, 1, 'number');
+
+spy = new Proxy({}, { set: function() { stringCount += 1; return true; } });
+Object.setPrototypeOf(other.String.prototype, spy);
+other.eval('"".test262 = null;');
+assert.sameValue(stringCount, 1, 'string');
+
+spy = new Proxy({}, { set: function() { booleanCount += 1; return true; } });
+Object.setPrototypeOf(other.Boolean.prototype, spy);
+other.eval('true.test262 = null;');
+assert.sameValue(booleanCount, 1, 'string');
+
+spy = new Proxy({}, { set: function() { symbolCount += 1; return true; } });
+Object.setPrototypeOf(other.Symbol.prototype, spy);
+other.eval('Symbol().test262 = null;');
+assert.sameValue(symbolCount, 1, 'string');


### PR DESCRIPTION
ECMA262 defines a "realm" as follows:

> Before it is evaluated, all ECMAScript code must be associated with a realm.
> Conceptually, a realm consists of a set of intrinsic objects, an ECMAScript
> global environment, all of the ECMAScript code that is loaded within the
> scope of that global environment, and other associated state and resources.

Although there is currently no standard mechanism for the creation of realms,
many hosts offer this functionality through custom APIs. In those hosts, the
semantics describing realm interactions are directly observable.

In order to guarantee conformance to the specification in advance of a
standardized API, Test262 now requires that hosts provide a `$.createRealm`
function whose behavior is defined in the projects "INTERPRETING.md" file.

Use this host-provided API to ensure that implementations correctly observe the
specification text that dictates realm interactions.