### PR TITLE
Improve coverage for section 12, "Expression"

### DIFF
--- a/test/language/eval-code/direct/new.target-arrow.js
+++ b/test/language/eval-code/direct/new.target-arrow.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: >
+  A direct eval in the functon code of an ArrowFunction may not contain
+  `new.target`
+info: |
+  - It is a Syntax Error if StatementList Contains NewTarget unless the source
+    code containing NewTarget is eval code that is being processed by a direct
+    eval that is contained in function code that is not the function code of an
+    ArrowFunction.
+features: [arrow-function]
+---*/
+
+var caught;
+var f = () => eval('new.target;');
+
+try {
+  f();
+} catch (err) {
+  caught = err;
+}
+
+assert.sameValue(typeof caught, 'object');
+assert.sameValue(caught.constructor, SyntaxError);

--- a/test/language/eval-code/direct/new.target-fn.js
+++ b/test/language/eval-code/direct/new.target-fn.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: >
+  A direct eval in the functon code of a non-ArrowFunction may contain
+  `new.target`
+info: |
+  - It is a Syntax Error if StatementList Contains NewTarget unless the source
+    code containing NewTarget is eval code that is being processed by a direct
+    eval that is contained in function code that is not the function code of an
+    ArrowFunction.
+features: [arrow-function]
+---*/
+
+var newTarget = null;
+var getNewTarget = function() {
+  newTarget = eval('new.target;');
+};
+
+getNewTarget();
+
+assert.sameValue(newTarget, undefined);
+
+new getNewTarget();
+
+assert.sameValue(newTarget, getNewTarget);

--- a/test/language/eval-code/direct/new.target.js
+++ b/test/language/eval-code/direct/new.target.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: A direct eval in global code may not contain `new.target`
+info: |
+  - It is a Syntax Error if StatementList Contains NewTarget unless the source
+    code containing NewTarget is eval code that is being processed by a direct
+    eval that is contained in function code that is not the function code of an
+    ArrowFunction.
+---*/
+
+var caught;
+
+try {
+  eval('new.target;');
+} catch (err) {
+  caught = err;
+}
+
+assert.sameValue(typeof caught, 'object');
+assert.sameValue(caught.constructor, SyntaxError);

--- a/test/language/eval-code/indirect/new.target.js
+++ b/test/language/eval-code/indirect/new.target.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: >
+  An indirect eval may not contain `new.target`
+info: |
+  - It is a Syntax Error if StatementList Contains NewTarget unless the source
+    code containing NewTarget is eval code that is being processed by a direct
+    eval that is contained in function code that is not the function code of an
+    ArrowFunction.
+---*/
+
+var caught;
+
+try {
+  (0,eval)('new.target;');
+} catch (err) {
+  caught = err;
+}
+
+assert.sameValue(typeof caught, 'object', 'object value thrown (global code)');
+assert.sameValue(
+  caught.constructor, SyntaxError, 'SyntaxError thrown (global code)'
+);
+
+caught = null;
+
+try {
+  (function() {
+    (0,eval)('new.target;');
+  })();
+} catch (err) {
+  caught = err;
+}
+
+assert.sameValue(
+  typeof caught, 'object', 'object value thrown (function code)'
+);
+assert.sameValue(
+  caught.constructor, SyntaxError, 'SyntaxError thrown (function code)'
+);

--- a/test/language/expressions/call/with-base-obj.js
+++ b/test/language/expressions/call/with-base-obj.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-function-calls-runtime-semantics-evaluation
+es6id: 12.3.4.1
+description: Correct retrieval of environment's "with" base object
+info: |
+  4. If Type(ref) is Reference, then
+     a. If IsPropertyReference(ref) is true, then
+        [...]
+     b. Else the base of ref is an Environment Record,
+        i. Let refEnv be GetBase(ref).
+        ii. Let thisValue be refEnv.WithBaseObject().
+  [...]
+  8. Return ? EvaluateDirectCall(func, thisValue, Arguments, tailCall).
+flags: [noStrict]
+---*/
+
+var viaMember, viaCall;
+var obj = {
+  method: function() {
+    viaCall = this;
+  },
+  get attribute() {
+    viaMember = this;
+  }
+};
+
+with (obj) {
+  method();
+  attribute;
+}
+
+assert.sameValue(viaCall, obj, 'via CallExpression');
+assert.sameValue(viaMember, obj, 'via MemberExpression');

--- a/test/language/expressions/conditional/in-branch-1.js
+++ b/test/language/expressions/conditional/in-branch-1.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-conditional-operator
+es6id: 12.13
+description: >
+  The first AssignmentExpression may include the `in` keyword in any context
+info: |
+  Syntax
+
+  ConditionalExpression[In, Yield] :
+    LogicalORExpression[?In, ?Yield]
+    LogicalORExpression[?In, ?Yield] ? AssignmentExpression[+In, ?Yield] : AssignmentExpression[?In, ?Yield]
+---*/
+
+var cond1Count = 0;
+var cond2Count = 0;
+var cond1 = function() {
+  cond1Count += 1;
+  return {};
+};
+var cond2 = function() {
+  cond2Count += 1;
+};
+for (true ? '' in cond1() : cond2(); false; ) ;
+
+assert.sameValue(cond1Count, 1);
+assert.sameValue(cond2Count, 0);

--- a/test/language/expressions/conditional/in-branch-2.js
+++ b/test/language/expressions/conditional/in-branch-2.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-conditional-operator
+es6id: 12.13
+description: >
+  The second AssignmentExpression cannot include the `in` keyword in contexts
+  where it is disallowed.
+info: |
+  Syntax
+
+  ConditionalExpression[In, Yield] :
+    LogicalORExpression[?In, ?Yield]
+    LogicalORExpression[?In, ?Yield] ? AssignmentExpression[+In, ?Yield] : AssignmentExpression[?In, ?Yield]
+negative: SyntaxError
+---*/
+
+for (true ? 0 : 0 in {}; false; ) ;

--- a/test/language/expressions/conditional/in-condition.js
+++ b/test/language/expressions/conditional/in-condition.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-conditional-operator
+es6id: 12.13
+description: >
+  The expression's LogicalORExpression sub-expression cannot include the `in`
+  keyword in contexts where it is disallowed.
+info: |
+  Syntax
+
+  ConditionalExpression[In, Yield] :
+    LogicalORExpression[?In, ?Yield]
+    LogicalORExpression[?In, ?Yield] ? AssignmentExpression[+In, ?Yield] : AssignmentExpression[?In, ?Yield]
+negative: SyntaxError
+---*/
+
+for ('' in {} ? 0 : 0; false; ) ;

--- a/test/language/expressions/delete/super-property.js
+++ b/test/language/expressions/delete/super-property.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-delete-operator-runtime-semantics-evaluation
+es6id: 12.5.4.2
+description: SuperReferences may not be deleted
+info: |
+  [...]
+  5.If IsPropertyReference(ref) is true, then
+    a. If IsSuperReference(ref) is true, throw a ReferenceError exception.
+features: [class]
+---*/
+
+var caught;
+
+class C extends Object {
+  constructor() {
+    try {
+      delete super.x;
+    } catch (err) {
+      caught = err;
+    }
+  }
+}
+
+// When the "construct" invocation completes and the "this" value is
+// uninitialized, the specification dictates that a ReferenceError must be
+// thrown. That behavior is tested elsewhere, so the error is ignored (if it is
+// produced at all).
+try {
+  new C();
+} catch (_) {}
+
+assert.sameValue(typeof caught, 'object');
+assert.sameValue(caught.constructor, ReferenceError);

--- a/test/language/expressions/new.target/asi.js
+++ b/test/language/expressions/new.target/asi.js
@@ -1,0 +1,66 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-meta-properties-runtime-semantics-evaluation
+es6id: 12.3.8.1
+description: NewTarget is composed of three distinct tokens
+---*/
+
+var newTarget = null;
+
+var withSpaces = function() {
+  newTarget = new   .   target;
+};
+
+withSpaces();
+assert.sameValue(newTarget, undefined, 'tokens seperated by whitespace');
+
+new withSpaces();
+assert.sameValue(newTarget, withSpaces, 'tokens separateed by whitespace');
+
+newTarget = null;
+
+var withLineBreaks = function() {
+  newTarget = new
+
+.
+
+target;
+};
+
+withLineBreaks();
+assert.sameValue(newTarget, undefined, 'tokens seperated by line breaks');
+
+new withLineBreaks();
+assert.sameValue(newTarget, withLineBreaks, 'tokens seperated by line breaks');
+
+var withSLDC = function() {
+  newTarget = new/* */./* */target;
+};
+
+withSLDC();
+assert.sameValue(
+  newTarget, undefined, 'tokens separated by SingleLineDelimitedComments'
+);
+
+new withSLDC();
+assert.sameValue(
+  newTarget, withSLDC, 'tokens separated by SingleLineDelimitedComments'
+);
+
+
+var withMLC = function() {
+  newTarget = new/*
+  */./*
+  */target;
+};
+
+withMLC();
+assert.sameValue(
+  newTarget, undefined, 'tokens separated by MultiLineComments'
+);
+
+new withMLC();
+assert.sameValue(
+  newTarget, withMLC, 'tokens separated by MultiLineComments'
+);

--- a/test/language/expressions/new.target/value-via-call.js
+++ b/test/language/expressions/new.target/value-via-call.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-function-calls-runtime-semantics-evaluation
+es6id: 12.3.4.1
+description: Value when invoked via CallExpression
+info: |
+  CallExpression : MemberExpressionArguments
+
+  [...]
+  8. Return ? EvaluateDirectCall(func, thisValue, Arguments, tailCall).
+---*/
+
+var newTarget = null;
+
+function f() {
+  newTarget = new.target;
+}
+
+f();
+
+assert.sameValue(newTarget, undefined);

--- a/test/language/expressions/new.target/value-via-fpapply.js
+++ b/test/language/expressions/new.target/value-via-fpapply.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-function.prototype.apply
+es6id: 19.2.3.1
+description: Value when invoked via `Function.prototype.apply`
+info: |
+  [...]
+  5. Return ? Call(func, thisArg, argList).
+---*/
+
+var newTarget = null;
+
+function f() {
+  newTarget = new.target;
+}
+
+f.apply({});
+
+assert.sameValue(newTarget, undefined);

--- a/test/language/expressions/new.target/value-via-fpcall.js
+++ b/test/language/expressions/new.target/value-via-fpcall.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-function.prototype.call
+es6id: 19.2.3.3
+description: Value when invoked via `Function.prototype.call`
+info: |
+  [...]
+  5. Return ? Call(func, thisArg, argList).
+---*/
+
+var newTarget = null;
+
+function f() {
+  newTarget = new.target;
+}
+
+f.call({});
+
+assert.sameValue(newTarget, undefined);

--- a/test/language/expressions/new.target/value-via-member.js
+++ b/test/language/expressions/new.target/value-via-member.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-property-accessors-runtime-semantics-evaluation
+es6id: 12.3.2.1
+description: Value when invoked via MemberExpression
+info: |
+  MemberExpression:MemberExpression.IdentifierName
+
+  [...]
+  6. Return a value of type Reference whose base value component is bv, whose
+     referenced name component is propertyNameString, and whose strict
+     reference flag is strict.
+
+  13.5.1 Runtime Semantics: Evaluation
+
+  ExpressionStatement : Expression ;
+
+  1. Let exprRef be the result of evaluating Expression.
+  2. Return ? GetValue(exprRef).
+---*/
+
+var newTarget = null;
+
+var obj = {
+  get m() {
+    newTarget = new.target;
+  }
+};
+
+obj.m;
+
+assert.sameValue(newTarget, undefined);

--- a/test/language/expressions/new.target/value-via-new.js
+++ b/test/language/expressions/new.target/value-via-new.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-new-operator-runtime-semantics-evaluation
+es6id: 12.3.3.1
+description: Value when invoked via NewExpression
+info: |
+  NewExpression:newNewExpression
+
+  1. Return ? EvaluateNew(NewExpression, empty).
+
+  MemberExpression:newMemberExpressionArguments
+
+  2. Return ? EvaluateNew(MemberExpression, Arguments).
+
+  12.3.3.1.1 Runtime Semantics: EvaluateNew
+
+  [...]
+  8. Return ? Construct(constructor, argList).
+
+  7.3.13 Construct (F [ , argumentsList [ , newTarget ]])
+
+  1. If newTarget was not passed, let newTarget be F.
+---*/
+
+var newTarget = null;
+function f() {
+  newTarget = new.target;
+}
+
+new f;
+
+assert.sameValue(newTarget, f, 'Invoked without Arguments');
+
+newTarget = null;
+
+new f();
+
+assert.sameValue(newTarget, f, 'Invoked with Arguments');

--- a/test/language/expressions/new.target/value-via-reflect-apply.js
+++ b/test/language/expressions/new.target/value-via-reflect-apply.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-reflect.apply
+es6id: 26.1.1
+description: Value when invoked via `Reflect.apply`
+info: |
+  [...]
+  5. Return ? Call(target, thisArgument, args).
+features: [Reflect]
+---*/
+
+var newTarget = null;
+
+function f() {
+  newTarget = new.target;
+}
+
+Reflect.apply(f, {}, []);
+
+assert.sameValue(newTarget, undefined);

--- a/test/language/expressions/new.target/value-via-reflect-construct.js
+++ b/test/language/expressions/new.target/value-via-reflect-construct.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-reflect.construct
+es6id: 26.1.2
+description: Value when invoked via `Reflect.construct`
+info: |
+  [...]
+  2. If newTarget is not present, let newTarget be target.
+  [...]
+  5. Return ? Construct(target, args, newTarget).
+features: [Reflect]
+---*/
+
+var customNewTarget = function() {};
+var newTarget = null;
+
+function f() {
+  newTarget = new.target;
+}
+
+Reflect.construct(f, []);
+
+assert.sameValue(newTarget, f, 'NewTarget unspecified');
+
+Reflect.construct(f, [], customNewTarget);
+
+assert.sameValue(newTarget, customNewTarget, 'NewTarget explicitly defined');

--- a/test/language/expressions/new.target/value-via-super-call.js
+++ b/test/language/expressions/new.target/value-via-super-call.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-super-keyword-runtime-semantics-evaluation
+es6id: 12.3.5.1
+description: Value when invoked via SuperCall
+info: |
+  SuperCall : super Arguments
+
+  1. Let newTarget be GetNewTarget().
+  [...]
+  6. Let result be ? Construct(func, argList, newTarget).
+  [...]
+features: [class]
+---*/
+
+var baseNewTarget, parentNewTarget;
+
+class Base {
+  constructor() {
+    baseNewTarget = new.target;
+  }
+}
+
+class Parent extends Base {
+  constructor() {
+    parentNewTarget = new.target;
+    super();
+  }
+}
+
+class Child extends Parent {
+  constructor() {
+    super();
+  }
+}
+
+new Child();
+
+assert.sameValue(parentNewTarget, Child, 'within "parent" constructor');
+assert.sameValue(baseNewTarget, Child, 'within "base" constructor');

--- a/test/language/expressions/new.target/value-via-super-property.js
+++ b/test/language/expressions/new.target/value-via-super-property.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-super-keyword-runtime-semantics-evaluation
+es6id: 12.3.5.1
+description: Value when invoked via SuperCall
+info: |
+  SuperCall : super Arguments
+
+  1. Let newTarget be GetNewTarget().
+  [...]
+  6. Let result be ? Construct(func, argList, newTarget).
+  [...]
+features: [class]
+---*/
+
+var baseNewTarget = null;
+var parentNewTarget = null;
+
+class Base {
+  get fromBase() {
+    baseNewTarget = new.target;
+  }
+}
+
+class Parent extends Base {
+  get fromParent() {
+    parentNewTarget = new.target;
+  }
+}
+
+class Child extends Parent {
+  constructor() {
+    super.fromParent;
+    super.fromBase;
+  }
+}
+
+// When the "construct" invocation completes and the "this" value is
+// uninitialized, the specification dictates that a ReferenceError must be
+// thrown. That behavior is tested elsewhere, so the error is ignored (if it is
+// produced at all).
+try {
+  new Child();
+} catch (_) {}
+
+assert.sameValue(parentNewTarget, undefined, 'within "parent" method');
+assert.sameValue(baseNewTarget, undefined, 'witin "base" method');

--- a/test/language/expressions/new.target/value-via-super-property.js
+++ b/test/language/expressions/new.target/value-via-super-property.js
@@ -14,35 +14,21 @@ info: |
 features: [class]
 ---*/
 
-var baseNewTarget = null;
-var parentNewTarget = null;
+var newTarget = null;
 
-class Base {
-  get fromBase() {
-    baseNewTarget = new.target;
-  }
-}
-
-class Parent extends Base {
-  get fromParent() {
-    parentNewTarget = new.target;
+class Parent {
+  get attr() {
+    newTarget = new.target;
   }
 }
 
 class Child extends Parent {
   constructor() {
-    super.fromParent;
-    super.fromBase;
+    super();
+    super.attr;
   }
 }
 
-// When the "construct" invocation completes and the "this" value is
-// uninitialized, the specification dictates that a ReferenceError must be
-// thrown. That behavior is tested elsewhere, so the error is ignored (if it is
-// produced at all).
-try {
-  new Child();
-} catch (_) {}
+new Child();
 
-assert.sameValue(parentNewTarget, undefined, 'within "parent" method');
-assert.sameValue(baseNewTarget, undefined, 'witin "base" method');
+assert.sameValue(newTarget, undefined);

--- a/test/language/expressions/new.target/value-via-tagged-template.js
+++ b/test/language/expressions/new.target/value-via-tagged-template.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-tagged-templates-runtime-semantics-evaluation
+es6id: 12.3.7.1
+description: Value when invoked via tagged template
+info: |
+   MemberExpression : MemberExpression TemplateLiteral
+
+   [...]
+   4. Return ? EvaluateCall(tagRef, TemplateLiteral, tailCall).
+features: [template]
+---*/
+
+var newTarget = null;
+
+function f() {
+  newTarget = new.target;
+}
+
+f``;
+
+assert.sameValue(newTarget, undefined);

--- a/test/language/expressions/object/cover-initialized-name.js
+++ b/test/language/expressions/object/cover-initialized-name.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object-initializer-static-semantics-early-errors
+es6id: 12.2.6.1
+description: Initialized name is explicitly barred from object initializers
+info: |
+  PropertyDefinition : CoverInitializedName
+
+  - Always throw a Syntax Error if code matches this production.
+
+  NOTE This production exists so that ObjectLiteral can serve as a cover
+       grammar for ObjectAssignmentPattern. It cannot occur in an actual object
+       initializer.
+
+  12.2.6 Object Initializer
+
+  Syntax
+
+  [...]
+
+  CoverInitializedName[Yield]:
+
+    IdentifierReference[?Yield] Initializer[+In, ?Yield]
+negative: SyntaxError
+---*/
+
+({ a = 1 });

--- a/test/language/global-code/new.target-arrow.js
+++ b/test/language/global-code/new.target-arrow.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: An ArrowFunction in global code may not contain `new.target`
+info: |
+  - It is a Syntax Error if StatementList Contains NewTarget unless the source
+    code containing NewTarget is eval code that is being processed by a direct
+    eval that is contained in function code that is not the function code of an
+    ArrowFunction.
+
+  14.2.3 Static Semantics: Contains
+
+  With parameter symbol.
+
+  ArrowFunction : ArrowParameters => ConciseBody
+
+  1. If symbol is not one of NewTarget, SuperProperty, SuperCall, super or
+     this, return false.
+  2. If ArrowParameters Contains symbol is true, return true.
+  3. Return ConciseBody Contains symbol.
+
+  NOTE Normally, Contains does not look inside most function forms. However,
+       Contains is used to detect new.target, this, and super usage within an
+       ArrowFunction.
+features: [arrow-function]
+negative: SyntaxError
+---*/
+
+() => {
+  new.target;
+};

--- a/test/language/global-code/new.target.js
+++ b/test/language/global-code/new.target.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: Global code may not contain `new.target`
+info: |
+  - It is a Syntax Error if StatementList Contains NewTarget unless the source
+    code containing NewTarget is eval code that is being processed by a direct
+    eval that is contained in function code that is not the function code of an
+    ArrowFunction.
+negative: SyntaxError
+---*/
+
+new.target;


### PR DESCRIPTION
Add miscellaneous tests for previously-untested details as discovered in a
recent coverage audit.

