### PR TITLE
Remove invalid tests

### DIFF
--- a/test/built-ins/Error/15.11-1.js
+++ b/test/built-ins/Error/15.11-1.js
@@ -1,9 +1,0 @@
-// Copyright (c) 2012 Ecma International.  All rights reserved.
-// This code is governed by the BSD license found in the LICENSE file.
-
-/*---
-es5id: 15.11-1
-description: Error - ConversionError has been removed from IE9 standard mode
----*/
-
-assert.sameValue(typeof ConversionError, "undefined", 'typeof ConversionError');

--- a/test/built-ins/Error/15.11-2.js
+++ b/test/built-ins/Error/15.11-2.js
@@ -1,9 +1,0 @@
-// Copyright (c) 2012 Ecma International.  All rights reserved.
-// This code is governed by the BSD license found in the LICENSE file.
-
-/*---
-es5id: 15.11-2
-description: Error - RegExpError has been removed from IE9 standard mode
----*/
-
-assert.sameValue(typeof RegExpError, "undefined", 'typeof RegExpError');


### PR DESCRIPTION
ConversionError and RegExpError tests are methods that existed on
something that preceeded a IE9 Standard. They do not exist in the
specs, at least since ES5.

It's not test262 responsibility to maintain these tests as these
features can be freely implemented by any runtime.