### PR TITLE
Annex b skip fib

### DIFF
--- a/src/annex-b-fns/eval-func-no-skip-try.case
+++ b/src/annex-b-fns/eval-func-no-skip-try.case
@@ -13,6 +13,15 @@ info: |
         has F as a BindingIdentifier would not produce any Early Errors for
         body, then
     [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
 ---*/
 
 //- before

--- a/src/annex-b-fns/eval-func-no-skip-try.case
+++ b/src/annex-b-fns/eval-func-no-skip-try.case
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension is observed when creation of variable binding would not produce an
+  early error (try statement)
+template: eval-func
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+---*/
+
+//- before
+try {
+  throw null;
+} catch (f) {
+//- body
+return 123;
+//- after
+}
+
+assert.sameValue(
+  typeof f,
+  'function',
+  'binding value is updated following evaluation'
+);
+assert.sameValue(f(), 123);

--- a/src/annex-b-fns/eval-func-no-skip-try.case
+++ b/src/annex-b-fns/eval-func-no-skip-try.case
@@ -25,6 +25,10 @@ info: |
 ---*/
 
 //- before
+assert.sameValue(
+  f, undefined, 'Initialized binding created prior to evaluation'
+);
+
 try {
   throw null;
 } catch (f) {

--- a/src/annex-b-fns/eval-func-skip-early-err-block.case
+++ b/src/annex-b-fns/eval-func-skip-early-err-block.case
@@ -6,12 +6,12 @@ desc: >
   early error (Block statement)
 template: eval-func
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/eval-func-skip-early-err-block.case
+++ b/src/annex-b-fns/eval-func-skip-early-err-block.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (Block statement)
+template: eval-func
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- before
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+{
+let f = 123;
+//- after
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/eval-func-skip-early-err-for-in.case
+++ b/src/annex-b-fns/eval-func-skip-early-err-for-in.case
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (for-of statement)
+template: eval-func
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- before
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f in { key: 0 }) {
+//- after
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/eval-func-skip-early-err-for-in.case
+++ b/src/annex-b-fns/eval-func-skip-early-err-for-in.case
@@ -6,12 +6,12 @@ desc: >
   early error (for-of statement)
 template: eval-func
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/eval-func-skip-early-err-for-of.case
+++ b/src/annex-b-fns/eval-func-skip-early-err-for-of.case
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (for-of statement)
+template: eval-func
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- before
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f of [0]) {
+//- after
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/eval-func-skip-early-err-for-of.case
+++ b/src/annex-b-fns/eval-func-skip-early-err-for-of.case
@@ -6,12 +6,12 @@ desc: >
   early error (for-of statement)
 template: eval-func
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/eval-func-skip-early-err-for.case
+++ b/src/annex-b-fns/eval-func-skip-early-err-for.case
@@ -6,12 +6,12 @@ desc: >
   early error (for statement)
 template: eval-func
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/eval-func-skip-early-err-for.case
+++ b/src/annex-b-fns/eval-func-skip-early-err-for.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (for statement)
+template: eval-func
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- before
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f; ; ) {
+//- after
+  break;
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/eval-func-skip-early-err-switch.case
+++ b/src/annex-b-fns/eval-func-skip-early-err-switch.case
@@ -6,12 +6,12 @@ desc: >
   early error (switch statement)
 template: eval-func
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/eval-func-skip-early-err-switch.case
+++ b/src/annex-b-fns/eval-func-skip-early-err-switch.case
@@ -1,0 +1,41 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (switch statement)
+template: eval-func
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- before
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+switch (0) {
+  default:
+    let f;
+//- after
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/eval-func-skip-early-err-try.case
+++ b/src/annex-b-fns/eval-func-skip-early-err-try.case
@@ -1,0 +1,50 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension is not observed when creation of variable binding would produce an
+  early error (try statement)
+template: eval-func
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+//- before
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+try {
+  throw {};
+} catch ({ f }) {
+//- after
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/eval-global-no-skip-try.case
+++ b/src/annex-b-fns/eval-global-no-skip-try.case
@@ -13,6 +13,15 @@ info: |
         has F as a BindingIdentifier would not produce any Early Errors for
         body, then
     [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
 ---*/
 
 //- before

--- a/src/annex-b-fns/eval-global-no-skip-try.case
+++ b/src/annex-b-fns/eval-global-no-skip-try.case
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension is observed when creation of variable binding would not produce an
+  early error (try statement)
+template: eval-global
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+---*/
+
+//- before
+try {
+  throw null;
+} catch (f) {
+//- body
+return 123;
+//- after
+}
+//- teardown
+assert.sameValue(
+  typeof f,
+  'function',
+  'binding value is updated following evaluation'
+);
+assert.sameValue(f(), 123);

--- a/src/annex-b-fns/eval-global-no-skip-try.case
+++ b/src/annex-b-fns/eval-global-no-skip-try.case
@@ -25,6 +25,10 @@ info: |
 ---*/
 
 //- before
+assert.sameValue(
+  f, undefined, 'Initialized binding created prior to evaluation'
+);
+
 try {
   throw null;
 } catch (f) {
@@ -32,7 +36,7 @@ try {
 return 123;
 //- after
 }
-//- teardown
+
 assert.sameValue(
   typeof f,
   'function',

--- a/src/annex-b-fns/eval-global-skip-early-err-block.case
+++ b/src/annex-b-fns/eval-global-skip-early-err-block.case
@@ -6,12 +6,12 @@ desc: >
   early error (Block statement)
 template: eval-global
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/eval-global-skip-early-err-block.case
+++ b/src/annex-b-fns/eval-global-skip-early-err-block.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (Block statement)
+template: eval-global
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- setup
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+//- before
+{
+let f = 123;
+//- after
+}
+//- teardown
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/eval-global-skip-early-err-for-in.case
+++ b/src/annex-b-fns/eval-global-skip-early-err-for-in.case
@@ -6,12 +6,12 @@ desc: >
   early error (for-of statement)
 template: eval-global
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/eval-global-skip-early-err-for-in.case
+++ b/src/annex-b-fns/eval-global-skip-early-err-for-in.case
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (for-of statement)
+template: eval-global
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- setup
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+//- before
+for (let f in { key: 0 }) {
+//- after
+}
+//- teardown
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/eval-global-skip-early-err-for-of.case
+++ b/src/annex-b-fns/eval-global-skip-early-err-for-of.case
@@ -6,12 +6,12 @@ desc: >
   early error (for-of statement)
 template: eval-global
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/eval-global-skip-early-err-for-of.case
+++ b/src/annex-b-fns/eval-global-skip-early-err-for-of.case
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (for-of statement)
+template: eval-global
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- setup
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+//- before
+for (let f of [0]) {
+//- after
+}
+//- teardown
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/eval-global-skip-early-err-for.case
+++ b/src/annex-b-fns/eval-global-skip-early-err-for.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (for statement)
+template: eval-global
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- setup
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+//- before
+for (let f; ; ) {
+//- after
+  break;
+}
+//- teardown
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/eval-global-skip-early-err-for.case
+++ b/src/annex-b-fns/eval-global-skip-early-err-for.case
@@ -6,12 +6,12 @@ desc: >
   early error (for statement)
 template: eval-global
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/eval-global-skip-early-err-switch.case
+++ b/src/annex-b-fns/eval-global-skip-early-err-switch.case
@@ -1,0 +1,41 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (switch statement)
+template: eval-global
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- setup
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+//- before
+switch (0) {
+  default:
+    let f;
+//- after
+}
+//- teardown
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/eval-global-skip-early-err-switch.case
+++ b/src/annex-b-fns/eval-global-skip-early-err-switch.case
@@ -6,12 +6,12 @@ desc: >
   early error (switch statement)
 template: eval-global
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/eval-global-skip-early-err-try.case
+++ b/src/annex-b-fns/eval-global-skip-early-err-try.case
@@ -1,0 +1,50 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension is not observed when creation of variable binding would produce an
+  early error (try statement)
+template: eval-global
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+//- before
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+try {
+  throw {};
+} catch ({ f }) {
+//- after
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/func-no-skip-try.case
+++ b/src/annex-b-fns/func-no-skip-try.case
@@ -14,6 +14,15 @@ info: |
        b. Perform varEnvRec.InitializeBinding(F, undefined).
        c. Append F to instantiatedVarNames.
     [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
 ---*/
 
 //- before

--- a/src/annex-b-fns/func-no-skip-try.case
+++ b/src/annex-b-fns/func-no-skip-try.case
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension is observed when creation of variable binding would not produce an
+  early error (try statement)
+template: func
+info: |
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+---*/
+
+//- before
+assert.sameValue(
+  f, undefined, 'Initialized binding created prior to evaluation'
+);
+
+try {
+  throw null;
+} catch (f) {
+//- body
+return 123;
+//- after
+}
+
+assert.sameValue(
+  typeof f,
+  'function',
+  'binding value is updated following evaluation'
+);
+assert.sameValue(f(), 123);

--- a/src/annex-b-fns/func-skip-early-err-block.case
+++ b/src/annex-b-fns/func-skip-early-err-block.case
@@ -6,12 +6,12 @@ desc: >
   early error (Block statement)
 template: func
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/func-skip-early-err-block.case
+++ b/src/annex-b-fns/func-skip-early-err-block.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (Block statement)
+template: func
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- before
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+{
+let f = 123;
+//- after
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/func-skip-early-err-for-in.case
+++ b/src/annex-b-fns/func-skip-early-err-for-in.case
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (for-of statement)
+template: func
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- before
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f in { key: 0 }) {
+//- after
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/func-skip-early-err-for-in.case
+++ b/src/annex-b-fns/func-skip-early-err-for-in.case
@@ -6,12 +6,12 @@ desc: >
   early error (for-of statement)
 template: func
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/func-skip-early-err-for-of.case
+++ b/src/annex-b-fns/func-skip-early-err-for-of.case
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (for-of statement)
+template: func
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- before
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f of [0]) {
+//- after
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/func-skip-early-err-for-of.case
+++ b/src/annex-b-fns/func-skip-early-err-for-of.case
@@ -6,12 +6,12 @@ desc: >
   early error (for-of statement)
 template: func
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/func-skip-early-err-for.case
+++ b/src/annex-b-fns/func-skip-early-err-for.case
@@ -6,12 +6,12 @@ desc: >
   early error (for statement)
 template: func
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/func-skip-early-err-for.case
+++ b/src/annex-b-fns/func-skip-early-err-for.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (for statement)
+template: func
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- before
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f; ; ) {
+//- after
+  break;
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/func-skip-early-err-switch.case
+++ b/src/annex-b-fns/func-skip-early-err-switch.case
@@ -6,12 +6,12 @@ desc: >
   early error (switch statement)
 template: func
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/src/annex-b-fns/func-skip-early-err-switch.case
+++ b/src/annex-b-fns/func-skip-early-err-switch.case
@@ -1,0 +1,41 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (switch statement)
+template: func
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- before
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+switch (0) {
+  default:
+    let f;
+//- after
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/func-skip-early-err-try.case
+++ b/src/annex-b-fns/func-skip-early-err-try.case
@@ -1,0 +1,51 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension is observed when creation of variable binding would not produce an
+  early error (try statement)
+template: func
+info: |
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+//- before
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+try {
+  throw {};
+} catch ({ f }) {
+//- after
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/global-no-skip-try.case
+++ b/src/annex-b-fns/global-no-skip-try.case
@@ -13,6 +13,15 @@ info: |
        F as a BindingIdentifier would not produce any Early Errors for script,
        then
     [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
 ---*/
 
 //- setup

--- a/src/annex-b-fns/global-no-skip-try.case
+++ b/src/annex-b-fns/global-no-skip-try.case
@@ -1,0 +1,36 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension is observed when creation of variable binding would not produce an
+  early error (try statement)
+template: global
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- setup
+assert.sameValue(
+  f, undefined, 'Initialized binding created prior to evaluation'
+);
+
+try {
+  throw null;
+} catch (f) {
+//- body
+return 123;
+//- teardown
+}
+
+assert.sameValue(
+  typeof f,
+  'function',
+  'binding value is updated following evaluation'
+);
+assert.sameValue(f(), 123);

--- a/src/annex-b-fns/global-skip-early-err-block.case
+++ b/src/annex-b-fns/global-skip-early-err-block.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (Block statement)
+template: global
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- setup
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+{
+let f = 123;
+//- teardown
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/global-skip-early-err-for-in.case
+++ b/src/annex-b-fns/global-skip-early-err-for-in.case
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (for-of statement)
+template: global
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- setup
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f in { key: 0 }) {
+//- teardown
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/global-skip-early-err-for-of.case
+++ b/src/annex-b-fns/global-skip-early-err-for-of.case
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (for-of statement)
+template: global
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- setup
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f of [0]) {
+//- teardown
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/global-skip-early-err-for.case
+++ b/src/annex-b-fns/global-skip-early-err-for.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (for statement)
+template: global
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- setup
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f; ; ) {
+//- teardown
+  break;
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/global-skip-early-err-switch.case
+++ b/src/annex-b-fns/global-skip-early-err-switch.case
@@ -1,0 +1,41 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension not observed when creation of variable binding would produce an
+  early error (switch statement)
+template: global
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+//- setup
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+switch (0) {
+  default:
+    let f;
+//- teardown
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/src/annex-b-fns/global-skip-early-err-try.case
+++ b/src/annex-b-fns/global-skip-early-err-try.case
@@ -1,0 +1,50 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+  Extension is observed when creation of variable binding would not produce an
+  early error (try statement)
+template: global
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+//- setup
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+try {
+  throw {};
+} catch ({ f }) {
+//- teardown
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Block statement in eval code con
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Block stat
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-exsting-block-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated (Block statement in eval code co
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Block statement in eval 
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-exsting-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Block stat
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Block statement in eval 
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-exsting-var-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Block stat
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-init.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-init.js
@@ -6,9 +6,9 @@ description: Variable binding is initialized to `undefined` in outer scope (Bloc
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
        i. If varEnvRec is a global Environment Record, then

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-no-skip-param.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-no-skip-param.js
@@ -6,9 +6,9 @@ description: Extension observed when there is a formal parameter with the same n
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-no-skip-try.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-no-skip-try.case
+// - src/annex-b-fns/eval-func/direct-block.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.sameValue(\
+      f, undefined, "Initialized binding created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw null;\
+    } catch (f) {{ function f() { return 123; } }}\
+    \
+    assert.sameValue(\
+      typeof f,\
+      "function",\
+      "binding value is updated following evaluation"\
+    );\
+    assert.sameValue(f(), 123);'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-block.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-block.case
+// - src/annex-b-fns/eval-func/direct-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    {\
+    let f = 123;{ function f() {  } }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-block.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-for-in.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-func/direct-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f in { key: 0 }) {{ function f() {  } }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-for-in.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-for-of.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-func/direct-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f of [0]) {{ function f() {  } }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-for-of.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-for.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for.case
+// - src/annex-b-fns/eval-func/direct-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f; ; ) {{ function f() {  } }break;\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-for.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-switch.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-switch.case
+// - src/annex-b-fns/eval-func/direct-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    switch (0) {\
+      default:\
+        let f;{ function f() {  } }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-switch.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-try.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-try.case
+// - src/annex-b-fns/eval-func/direct-block.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw {};\
+    } catch ({ f }) {{ function f() {  } }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-block-decl-eval-func-update.js
+++ b/test/annexB/language/eval-code/direct/func-block-decl-eval-func-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Block state
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-init.js
@@ -6,18 +6,18 @@ description: Variable binding is initialized to `undefined` in outer scope (IfSt
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
        i. If varEnvRec is a global Environment Record, then

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-no-skip-param.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-no-skip-param.js
@@ -6,18 +6,18 @@ description: Extension observed when there is a formal parameter with the same n
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-no-skip-try.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-no-skip-try.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-decl-a.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.sameValue(\
+      f, undefined, "Initialized binding created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw null;\
+    } catch (f) {if (true) function f() { return 123; } else function _f() {}}\
+    \
+    assert.sameValue(\
+      typeof f,\
+      "function",\
+      "binding value is updated following evaluation"\
+    );\
+    assert.sameValue(f(), 123);'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-block.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-block.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    {\
+    let f = 123;if (true) function f() {  } else function _f() {}}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-in.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f in { key: 0 }) {if (true) function f() {  } else function _f() {}}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-of.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f of [0]) {if (true) function f() {  } else function _f() {}}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f; ; ) {if (true) function f() {  } else function _f() {}break;\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-switch.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-switch.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    switch (0) {\
+      default:\
+        let f;if (true) function f() {  } else function _f() {}}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-try.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-try.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-decl-a.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw {};\
+    } catch ({ f }) {if (true) function f() {  } else function _f() {}}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-init.js
@@ -6,18 +6,18 @@ description: Variable binding is initialized to `undefined` in outer scope (IfSt
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
        i. If varEnvRec is a global Environment Record, then

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-no-skip-param.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-no-skip-param.js
@@ -6,18 +6,18 @@ description: Extension observed when there is a formal parameter with the same n
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-no-skip-try.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-no-skip-try.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-decl-b.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.sameValue(\
+      f, undefined, "Initialized binding created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw null;\
+    } catch (f) {if (false) function _f() {} else function f() { return 123; }}\
+    \
+    assert.sameValue(\
+      typeof f,\
+      "function",\
+      "binding value is updated following evaluation"\
+    );\
+    assert.sameValue(f(), 123);'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-block.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-block.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    {\
+    let f = 123;if (false) function _f() {} else function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-in.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f in { key: 0 }) {if (false) function _f() {} else function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-of.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f of [0]) {if (false) function _f() {} else function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f; ; ) {if (false) function _f() {} else function f() {  }break;\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-switch.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-switch.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    switch (0) {\
+      default:\
+        let f;if (false) function _f() {} else function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-try.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-try.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-decl-b.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw {};\
+    } catch ({ f }) {if (false) function _f() {} else function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-init.js
@@ -6,18 +6,18 @@ description: Variable binding is initialized to `undefined` in outer scope (IfSt
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
        i. If varEnvRec is a global Environment Record, then

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-no-skip-param.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-no-skip-param.js
@@ -6,18 +6,18 @@ description: Extension observed when there is a formal parameter with the same n
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-no-skip-try.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-no-skip-try.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-stmt.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.sameValue(\
+      f, undefined, "Initialized binding created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw null;\
+    } catch (f) {if (true) function f() { return 123; } else ;}\
+    \
+    assert.sameValue(\
+      typeof f,\
+      "function",\
+      "binding value is updated following evaluation"\
+    );\
+    assert.sameValue(f(), 123);'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-block.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-block.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    {\
+    let f = 123;if (true) function f() {  } else ;}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-in.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f in { key: 0 }) {if (true) function f() {  } else ;}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-of.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f of [0]) {if (true) function f() {  } else ;}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f; ; ) {if (true) function f() {  } else ;break;\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-switch.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-switch.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    switch (0) {\
+      default:\
+        let f;if (true) function f() {  } else ;}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-try.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-try.case
+// - src/annex-b-fns/eval-func/direct-if-decl-else-stmt.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw {};\
+    } catch ({ f }) {if (true) function f() {  } else ;}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement without an else clau
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement without an else cla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement without an e
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement without an e
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-init.js
@@ -6,18 +6,18 @@ description: Variable binding is initialized to `undefined` in outer scope (IfSt
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
        i. If varEnvRec is a global Environment Record, then

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-no-skip-param.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-no-skip-param.js
@@ -6,18 +6,18 @@ description: Extension observed when there is a formal parameter with the same n
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-no-skip-try.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-no-skip-try.case
+// - src/annex-b-fns/eval-func/direct-if-decl-no-else.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.sameValue(\
+      f, undefined, "Initialized binding created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw null;\
+    } catch (f) {if (true) function f() { return 123; }}\
+    \
+    assert.sameValue(\
+      typeof f,\
+      "function",\
+      "binding value is updated following evaluation"\
+    );\
+    assert.sameValue(f(), 123);'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-block.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-block.case
+// - src/annex-b-fns/eval-func/direct-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    {\
+    let f = 123;if (true) function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-in.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-func/direct-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f in { key: 0 }) {if (true) function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-of.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-func/direct-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f of [0]) {if (true) function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for.case
+// - src/annex-b-fns/eval-func/direct-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f; ; ) {if (true) function f() {  }break;\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-switch.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-switch.case
+// - src/annex-b-fns/eval-func/direct-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    switch (0) {\
+      default:\
+        let f;if (true) function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-try.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-try.case
+// - src/annex-b-fns/eval-func/direct-if-decl-no-else.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw {};\
+    } catch ({ f }) {if (true) function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-init.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-init.js
@@ -6,18 +6,18 @@ description: Variable binding is initialized to `undefined` in outer scope (IfSt
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
        i. If varEnvRec is a global Environment Record, then

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-no-skip-param.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-no-skip-param.js
@@ -6,18 +6,18 @@ description: Extension observed when there is a formal parameter with the same n
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-no-skip-try.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-no-skip-try.case
+// - src/annex-b-fns/eval-func/direct-if-stmt-else-decl.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.sameValue(\
+      f, undefined, "Initialized binding created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw null;\
+    } catch (f) {if (false) ; else function f() { return 123; }}\
+    \
+    assert.sameValue(\
+      typeof f,\
+      "function",\
+      "binding value is updated following evaluation"\
+    );\
+    assert.sameValue(f(), 123);'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-block.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-block.case
+// - src/annex-b-fns/eval-func/direct-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    {\
+    let f = 123;if (false) ; else function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-in.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-func/direct-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f in { key: 0 }) {if (false) ; else function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-of.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-func/direct-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f of [0]) {if (false) ; else function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for.case
+// - src/annex-b-fns/eval-func/direct-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f; ; ) {if (false) ; else function f() {  }break;\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-switch.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-switch.case
+// - src/annex-b-fns/eval-func/direct-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    switch (0) {\
+      default:\
+        let f;if (false) ; else function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-try.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-try.case
+// - src/annex-b-fns/eval-func/direct-if-stmt-else-decl.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw {};\
+    } catch ({ f }) {if (false) ; else function f() {  }}\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-update.js
+++ b/test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Function declaration in the `cas
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Function d
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-exsting-block-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated (Function declaration in the `ca
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Function declaration in 
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-exsting-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Function d
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Function declaration in 
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-exsting-var-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Function d
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-init.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-init.js
@@ -6,9 +6,9 @@ description: Variable binding is initialized to `undefined` in outer scope (Func
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
        i. If varEnvRec is a global Environment Record, then

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-no-skip-param.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-no-skip-param.js
@@ -6,9 +6,9 @@ description: Extension observed when there is a formal parameter with the same n
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-no-skip-try.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-no-skip-try.case
+// - src/annex-b-fns/eval-func/direct-switch-case.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.sameValue(\
+      f, undefined, "Initialized binding created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw null;\
+    } catch (f) {switch (1) {' +
+    '  case 1:' +
+    '    function f() { return 123; }' +
+    '}\
+    }\
+    \
+    assert.sameValue(\
+      typeof f,\
+      "function",\
+      "binding value is updated following evaluation"\
+    );\
+    assert.sameValue(f(), 123);'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-block.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-block.case
+// - src/annex-b-fns/eval-func/direct-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    {\
+    let f = 123;switch (1) {' +
+    '  case 1:' +
+    '    function f() {  }' +
+    '}\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-block.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-for-in.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-func/direct-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f in { key: 0 }) {switch (1) {' +
+    '  case 1:' +
+    '    function f() {  }' +
+    '}\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-for-in.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-for-of.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-func/direct-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f of [0]) {switch (1) {' +
+    '  case 1:' +
+    '    function f() {  }' +
+    '}\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-for-of.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-for.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for.case
+// - src/annex-b-fns/eval-func/direct-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f; ; ) {switch (1) {' +
+    '  case 1:' +
+    '    function f() {  }' +
+    '}\
+    break;\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-for.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-switch.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-switch.case
+// - src/annex-b-fns/eval-func/direct-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    switch (0) {\
+      default:\
+        let f;switch (1) {' +
+    '  case 1:' +
+    '    function f() {  }' +
+    '}\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-switch.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-try.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-try.case
+// - src/annex-b-fns/eval-func/direct-switch-case.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw {};\
+    } catch ({ f }) {switch (1) {' +
+    '  case 1:' +
+    '    function f() {  }' +
+    '}\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-switch-case-eval-func-update.js
+++ b/test/annexB/language/eval-code/direct/func-switch-case-eval-func-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Function de
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Funtion declaration in the `defa
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Funtion de
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-exsting-block-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated (Funtion declaration in the `def
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Funtion declaration in t
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-exsting-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Funtion de
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Funtion declaration in t
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-exsting-var-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Funtion de
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-init.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-init.js
@@ -6,9 +6,9 @@ description: Variable binding is initialized to `undefined` in outer scope (Funt
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
        i. If varEnvRec is a global Environment Record, then

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-no-skip-param.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-no-skip-param.js
@@ -6,9 +6,9 @@ description: Extension observed when there is a formal parameter with the same n
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-no-skip-try.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-no-skip-try.case
+// - src/annex-b-fns/eval-func/direct-switch-dflt.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.sameValue(\
+      f, undefined, "Initialized binding created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw null;\
+    } catch (f) {switch (1) {' +
+    '  default:' +
+    '    function f() { return 123; }' +
+    '}\
+    }\
+    \
+    assert.sameValue(\
+      typeof f,\
+      "function",\
+      "binding value is updated following evaluation"\
+    );\
+    assert.sameValue(f(), 123);'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-block.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-block.case
+// - src/annex-b-fns/eval-func/direct-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    {\
+    let f = 123;switch (1) {' +
+    '  default:' +
+    '    function f() {  }' +
+    '}\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-block.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-in.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-func/direct-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f in { key: 0 }) {switch (1) {' +
+    '  default:' +
+    '    function f() {  }' +
+    '}\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-in.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-of.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-func/direct-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f of [0]) {switch (1) {' +
+    '  default:' +
+    '    function f() {  }' +
+    '}\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-of.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-for.case
+// - src/annex-b-fns/eval-func/direct-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    for (let f; ; ) {switch (1) {' +
+    '  default:' +
+    '    function f() {  }' +
+    '}\
+    break;\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-switch.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-switch.case
+// - src/annex-b-fns/eval-func/direct-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    switch (0) {\
+      default:\
+        let f;switch (1) {' +
+    '  default:' +
+    '    function f() {  }' +
+    '}\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-switch.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-try.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-func-skip-early-err-try.case
+// - src/annex-b-fns/eval-func/direct-switch-dflt.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  eval(
+    'assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created prior to evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created prior to evaluation"\
+    );\
+    \
+    try {\
+      throw {};\
+    } catch ({ f }) {switch (1) {' +
+    '  default:' +
+    '    function f() {  }' +
+    '}\
+    }\
+    \
+    assert.throws(ReferenceError, function() {\
+      f;\
+    }, "An initialized binding is not created following evaluation");\
+    assert.sameValue(\
+      typeof f,\
+      "undefined",\
+      "An uninitialized binding is not created following evaluation"\
+    );'
+  );
+}());

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-update.js
+++ b/test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Funtion dec
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Block statement in eval code con
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Block stat
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-block-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated (Block statement in eval code co
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Block statement in eval 
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Block stat
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-global-init.js
@@ -7,16 +7,16 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -24,7 +24,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-global-update.js
@@ -7,9 +7,9 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -21,7 +21,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Block statement in eval 
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-exsting-var-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Block stat
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-init.js
@@ -7,14 +7,14 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 eval(
@@ -24,5 +24,5 @@ eval(
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  { function f() {  } }'
+{ function f() {  } }'
 );

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-no-skip-try.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/direct-block.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {{ function f() { return 123; } }}\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-block.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/direct-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  '{\
+  let f = 123;{ function f() {  } }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-block.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-for-in.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/direct-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f in { key: 0 }) {{ function f() {  } }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/direct-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f of [0]) {{ function f() {  } }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-for-of.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-for.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/direct-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f; ; ) {{ function f() {  } }break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-for.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-switch.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/direct-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'switch (0) {\
+    default:\
+      let f;{ function f() {  } }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-switch.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err-try.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/direct-block.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {{ function f() {  } }}\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/global-block-decl-eval-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-block-decl-eval-global-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Block state
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-global-init.js
@@ -7,25 +7,25 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -33,7 +33,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-global-update.js
@@ -7,18 +7,18 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -30,7 +30,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-init.js
@@ -7,23 +7,23 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 eval(
@@ -33,5 +33,5 @@ eval(
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  if (true) function f() {  } else function _f() {}'
+if (true) function f() {  } else function _f() {}'
 );

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-no-skip-try.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-decl-a.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.3
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {if (true) function f() { return 123; } else function _f() {}}\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.3
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  '{\
+  let f = 123;if (true) function f() {  } else function _f() {}}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.3
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f in { key: 0 }) {if (true) function f() {  } else function _f() {}}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.3
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f of [0]) {if (true) function f() {  } else function _f() {}}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.3
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f; ; ) {if (true) function f() {  } else function _f() {}break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.3
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'switch (0) {\
+    default:\
+      let f;if (true) function f() {  } else function _f() {}}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-decl-a.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.3
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {if (true) function f() {  } else function _f() {}}\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-global-init.js
@@ -7,25 +7,25 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -33,7 +33,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-global-update.js
@@ -7,18 +7,18 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -30,7 +30,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-init.js
@@ -7,23 +7,23 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 eval(
@@ -33,5 +33,5 @@ eval(
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  if (false) function _f() {} else function f() {  }'
+if (false) function _f() {} else function f() {  }'
 );

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-no-skip-try.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-decl-b.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {if (false) function _f() {} else function f() { return 123; }}\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  '{\
+  let f = 123;if (false) function _f() {} else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f in { key: 0 }) {if (false) function _f() {} else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f of [0]) {if (false) function _f() {} else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f; ; ) {if (false) function _f() {} else function f() {  }break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'switch (0) {\
+    default:\
+      let f;if (false) function _f() {} else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-decl-b.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {if (false) function _f() {} else function f() {  }}\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-global-init.js
@@ -7,25 +7,25 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -33,7 +33,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-global-update.js
@@ -7,18 +7,18 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -30,7 +30,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-init.js
@@ -7,23 +7,23 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 eval(
@@ -33,5 +33,5 @@ eval(
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  if (true) function f() {  } else ;'
+if (true) function f() {  } else ;'
 );

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-no-skip-try.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-stmt.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {if (true) function f() { return 123; } else ;}\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-block.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  '{\
+  let f = 123;if (true) function f() {  } else ;}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f in { key: 0 }) {if (true) function f() {  } else ;}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f of [0]) {if (true) function f() {  } else ;}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f; ; ) {if (true) function f() {  } else ;break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'switch (0) {\
+    default:\
+      let f;if (true) function f() {  } else ;}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-try.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/direct-if-decl-else-stmt.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {if (true) function f() {  } else ;}\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement without an else clau
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement without an else cla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement without an e
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-global-init.js
@@ -7,25 +7,25 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -33,7 +33,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-global-update.js
@@ -7,18 +7,18 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -30,7 +30,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement without an e
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-init.js
@@ -7,23 +7,23 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 eval(
@@ -33,5 +33,5 @@ eval(
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  if (true) function f() {  }'
+if (true) function f() {  }'
 );

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-no-skip-try.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/direct-if-decl-no-else.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {if (true) function f() { return 123; }}\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-block.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/direct-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  '{\
+  let f = 123;if (true) function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/direct-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f in { key: 0 }) {if (true) function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/direct-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f of [0]) {if (true) function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/direct-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f; ; ) {if (true) function f() {  }break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-switch.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/direct-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'switch (0) {\
+    default:\
+      let f;if (true) function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-try.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/direct-if-decl-no-else.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {if (true) function f() {  }}\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-global-init.js
@@ -7,25 +7,25 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -33,7 +33,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-global-update.js
@@ -7,18 +7,18 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -30,7 +30,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-init.js
@@ -7,23 +7,23 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 eval(
@@ -33,5 +33,5 @@ eval(
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  if (false) ; else function f() {  }'
+if (false) ; else function f() {  }'
 );

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-no-skip-try.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/direct-if-stmt-else-decl.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {if (false) ; else function f() { return 123; }}\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-block.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/direct-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  '{\
+  let f = 123;if (false) ; else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/direct-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f in { key: 0 }) {if (false) ; else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/direct-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f of [0]) {if (false) ; else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/direct-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f; ; ) {if (false) ; else function f() {  }break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/direct-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'switch (0) {\
+    default:\
+      let f;if (false) ; else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-try.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/direct-if-stmt-else-decl.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {if (false) ; else function f() {  }}\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Function declaration in the `cas
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Function d
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-block-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated (Function declaration in the `ca
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Function declaration in 
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Function d
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-global-init.js
@@ -7,16 +7,16 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -24,7 +24,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-global-update.js
@@ -7,9 +7,9 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -21,7 +21,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Function declaration in 
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-exsting-var-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Function d
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-init.js
@@ -7,14 +7,14 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 eval(
@@ -24,7 +24,7 @@ eval(
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  switch (1) {' +
+switch (1) {' +
   '  case 1:' +
   '    function f() {  }' +
   '}\

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-no-skip-try.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/direct-switch-case.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {switch (1) {' +
+  '  case 1:' +
+  '    function f() { return 123; }' +
+  '}\
+  }\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-block.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-block.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/direct-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  '{\
+  let f = 123;switch (1) {' +
+  '  case 1:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-for-in.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/direct-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f in { key: 0 }) {switch (1) {' +
+  '  case 1:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/direct-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f of [0]) {switch (1) {' +
+  '  case 1:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-for-of.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-for.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/direct-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f; ; ) {switch (1) {' +
+  '  case 1:' +
+  '    function f() {  }' +
+  '}\
+  break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-for.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-switch.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/direct-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'switch (0) {\
+    default:\
+      let f;switch (1) {' +
+  '  case 1:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-switch.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-try.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/direct-switch-case.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {switch (1) {' +
+  '  case 1:' +
+  '    function f() {  }' +
+  '}\
+  }\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/global-switch-case-eval-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-switch-case-eval-global-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Function de
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Funtion declaration in the `defa
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Funtion de
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-block-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated (Funtion declaration in the `def
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Funtion declaration in t
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Funtion de
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-global-init.js
@@ -7,16 +7,16 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -24,7 +24,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-global-update.js
@@ -7,9 +7,9 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -21,7 +21,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Funtion declaration in t
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-exsting-var-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Funtion de
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-init.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-init.js
@@ -7,14 +7,14 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 eval(
@@ -24,7 +24,7 @@ eval(
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  switch (1) {' +
+switch (1) {' +
   '  default:' +
   '    function f() {  }' +
   '}\

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-no-skip-try.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/direct-switch-dflt.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {switch (1) {' +
+  '  default:' +
+  '    function f() { return 123; }' +
+  '}\
+  }\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-block.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-block.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/direct-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  '{\
+  let f = 123;switch (1) {' +
+  '  default:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-in.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/direct-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f in { key: 0 }) {switch (1) {' +
+  '  default:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/direct-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f of [0]) {switch (1) {' +
+  '  default:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-of.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/direct-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'for (let f; ; ) {switch (1) {' +
+  '  default:' +
+  '    function f() {  }' +
+  '}\
+  break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-switch.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/direct-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+eval(
+  'switch (0) {\
+    default:\
+      let f;switch (1) {' +
+  '  default:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-switch.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-try.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/direct-switch-dflt.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+eval(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {switch (1) {' +
+  '  default:' +
+  '    function f() {  }' +
+  '}\
+  }\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-update.js
+++ b/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Funtion dec
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Block statement in eval code con
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Block stat
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-block-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated (Block statement in eval code co
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Block statement in eval 
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Block stat
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-global-init.js
@@ -7,16 +7,16 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -24,7 +24,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-global-update.js
@@ -7,9 +7,9 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -21,7 +21,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Block statement in eval 
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-exsting-var-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Block stat
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-init.js
@@ -7,14 +7,14 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 (0,eval)(
@@ -24,5 +24,5 @@ info: >
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  { function f() {  } }'
+{ function f() {  } }'
 );

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-no-skip-try.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/indirect-block.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {{ function f() { return 123; } }}\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-block.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/indirect-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  '{\
+  let f = 123;{ function f() {  } }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-block.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/indirect-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f in { key: 0 }) {{ function f() {  } }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-in.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-of.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/indirect-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f of [0]) {{ function f() {  } }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-for.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/indirect-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f; ; ) {{ function f() {  } }break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-for.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-switch.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/indirect-block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'switch (0) {\
+    default:\
+      let f;{ function f() {  } }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-switch.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-try.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/indirect-block.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (Block statement in eval code containing a function declaration)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {{ function f() {  } }}\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Block state
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-global-init.js
@@ -7,25 +7,25 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -33,7 +33,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-global-update.js
@@ -7,18 +7,18 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -30,7 +30,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-init.js
@@ -7,23 +7,23 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 (0,eval)(
@@ -33,5 +33,5 @@ info: >
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  if (true) function f() {  } else function _f() {}'
+if (true) function f() {  } else function _f() {}'
 );

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-no-skip-try.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-decl-a.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.3
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {if (true) function f() { return 123; } else function _f() {}}\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.3
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  '{\
+  let f = 123;if (true) function f() {  } else function _f() {}}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.3
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f in { key: 0 }) {if (true) function f() {  } else function _f() {}}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.3
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f of [0]) {if (true) function f() {  } else function _f() {}}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.3
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f; ; ) {if (true) function f() {  } else function _f() {}break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.3
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'switch (0) {\
+    default:\
+      let f;if (true) function f() {  } else function _f() {}}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-decl-a.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.3
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {if (true) function f() {  } else function _f() {}}\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-global-init.js
@@ -7,25 +7,25 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -33,7 +33,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-global-update.js
@@ -7,18 +7,18 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -30,7 +30,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-init.js
@@ -7,23 +7,23 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 (0,eval)(
@@ -33,5 +33,5 @@ info: >
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  if (false) function _f() {} else function f() {  }'
+if (false) function _f() {} else function f() {  }'
 );

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-no-skip-try.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-decl-b.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {if (false) function _f() {} else function f() { return 123; }}\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  '{\
+  let f = 123;if (false) function _f() {} else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f in { key: 0 }) {if (false) function _f() {} else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f of [0]) {if (false) function _f() {} else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f; ; ) {if (false) function _f() {} else function f() {  }break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'switch (0) {\
+    default:\
+      let f;if (false) function _f() {} else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-decl-b.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement with a declaration in both statement positions in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {if (false) function _f() {} else function f() {  }}\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-global-init.js
@@ -7,25 +7,25 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -33,7 +33,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-global-update.js
@@ -7,18 +7,18 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -30,7 +30,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-init.js
@@ -7,23 +7,23 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 (0,eval)(
@@ -33,5 +33,5 @@ info: >
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  if (true) function f() {  } else ;'
+if (true) function f() {  } else ;'
 );

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-no-skip-try.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-stmt.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {if (true) function f() { return 123; } else ;}\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-block.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  '{\
+  let f = 123;if (true) function f() {  } else ;}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f in { key: 0 }) {if (true) function f() {  } else ;}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f of [0]) {if (true) function f() {  } else ;}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f; ; ) {if (true) function f() {  } else ;break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'switch (0) {\
+    default:\
+      let f;if (true) function f() {  } else ;}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-try.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-else-stmt.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement with a declaration in the first statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {if (true) function f() {  } else ;}\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement without an else clau
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement without an else cla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement without an e
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-global-init.js
@@ -7,25 +7,25 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -33,7 +33,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-global-update.js
@@ -7,18 +7,18 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -30,7 +30,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement without an e
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-init.js
@@ -7,23 +7,23 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 (0,eval)(
@@ -33,5 +33,5 @@ info: >
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  if (true) function f() {  }'
+if (true) function f() {  }'
 );

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-no-skip-try.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-no-else.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {if (true) function f() { return 123; }}\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-block.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  '{\
+  let f = 123;if (true) function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f in { key: 0 }) {if (true) function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f of [0]) {if (true) function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f; ; ) {if (true) function f() {  }break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-switch.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'switch (0) {\
+    default:\
+      let f;if (true) function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-try.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/indirect-if-decl-no-else.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement without an else clause in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {if (true) function f() {  }}\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-global-init.js
@@ -7,25 +7,25 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -33,7 +33,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-global-update.js
@@ -7,18 +7,18 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -30,7 +30,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-init.js
@@ -7,23 +7,23 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 (0,eval)(
@@ -33,5 +33,5 @@ info: >
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  if (false) ; else function f() {  }'
+if (false) ; else function f() {  }'
 );

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-no-skip-try.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/indirect-if-stmt-else-decl.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {if (false) ; else function f() { return 123; }}\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-block.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/indirect-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  '{\
+  let f = 123;if (false) ; else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/indirect-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f in { key: 0 }) {if (false) ; else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/indirect-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f of [0]) {if (false) ; else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/indirect-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f; ; ) {if (false) ; else function f() {  }break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/indirect-if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'switch (0) {\
+    default:\
+      let f;if (false) ; else function f() {  }}'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-try.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/indirect-if-stmt-else-decl.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (IfStatement with a declaration in the second statement position in eval code)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {if (false) ; else function f() {  }}\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Function declaration in the `cas
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Function d
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-block-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated (Function declaration in the `ca
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Function declaration in 
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Function d
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-global-init.js
@@ -7,16 +7,16 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -24,7 +24,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-global-update.js
@@ -7,9 +7,9 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -21,7 +21,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Function declaration in 
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-exsting-var-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Function d
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-init.js
@@ -7,14 +7,14 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 (0,eval)(
@@ -24,7 +24,7 @@ info: >
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  switch (1) {' +
+switch (1) {' +
   '  case 1:' +
   '    function f() {  }' +
   '}\

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-no-skip-try.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/indirect-switch-case.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {switch (1) {' +
+  '  case 1:' +
+  '    function f() { return 123; }' +
+  '}\
+  }\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-block.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-block.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/indirect-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  '{\
+  let f = 123;switch (1) {' +
+  '  case 1:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/indirect-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f in { key: 0 }) {switch (1) {' +
+  '  case 1:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-in.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/indirect-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f of [0]) {switch (1) {' +
+  '  case 1:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-of.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-for.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/indirect-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f; ; ) {switch (1) {' +
+  '  case 1:' +
+  '    function f() {  }' +
+  '}\
+  break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-for.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-switch.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/indirect-switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'switch (0) {\
+    default:\
+      let f;switch (1) {' +
+  '  case 1:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-switch.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err-try.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/indirect-switch-case.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (Function declaration in the `case` clause of a `switch` statement in eval code)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {switch (1) {' +
+  '  case 1:' +
+  '    function f() {  }' +
+  '}\
+  }\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Function de
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-block-scoping.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Funtion declaration in the `defa
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Funtion de
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-block-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-block-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated (Funtion declaration in the `def
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-fn-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Funtion declaration in t
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-fn-update.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Funtion de
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-global-init.js
@@ -7,16 +7,16 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
     8.1.1.4.18 CreateGlobalFunctionBinding
-    
+
     [...]
     5. If existingProp is undefined or existingProp.[[Configurable]] is true,
        then
@@ -24,7 +24,7 @@ info: >
     6. Else,
        a. Let desc be the PropertyDescriptor{[[Value]]: V }.
     [...]
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: 'x',

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-global-update.js
@@ -7,9 +7,9 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -21,7 +21,7 @@ info: >
        v. Let fobj be ! benvRec.GetBindingValue(F, false).
        vi. Perform ? genvRec.SetMutableBinding(F, fobj, false).
        vii. Return NormalCompletion(empty). 
-    
+
 ---*/
 Object.defineProperty(fnGlobalObject(), 'f', {
   value: function() { return 'Another function'; },

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-var-no-init.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Funtion declaration in t
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     a. If declaredFunctionOrVarNames does not contain F, then
     [...]

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-var-update.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-exsting-var-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Funtion de
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-init.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-init.js
@@ -7,14 +7,14 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     i. If varEnvRec is a global Environment Record, then
        i. Perform ? varEnvRec.CreateGlobalFunctionBinding(F, undefined, true).
     [...]
-    
+
 ---*/
 
 (0,eval)(
@@ -24,7 +24,7 @@ info: >
   verifyEnumerable(global, "f");\
   verifyWritable(global, "f");\
   verifyConfigurable(global, "f");\
-  switch (1) {' +
+switch (1) {' +
   '  default:' +
   '    function f() {  }' +
   '}\

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-no-skip-try.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-no-skip-try.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-no-skip-try.case
+// - src/annex-b-fns/eval-global/indirect-switch-dflt.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.sameValue(\
+    f, undefined, "Initialized binding created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw null;\
+  } catch (f) {switch (1) {' +
+  '  default:' +
+  '    function f() { return 123; }' +
+  '}\
+  }\
+  \
+  assert.sameValue(\
+    typeof f,\
+    "function",\
+    "binding value is updated following evaluation"\
+  );\
+  assert.sameValue(f(), 123);'
+);

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-block.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-block.case
+// - src/annex-b-fns/eval-global/indirect-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  '{\
+  let f = 123;switch (1) {' +
+  '  default:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-block.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-block.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-in.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-in.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-in.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-in.case
+// - src/annex-b-fns/eval-global/indirect-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f in { key: 0 }) {switch (1) {' +
+  '  default:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-of.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for-of.case
+// - src/annex-b-fns/eval-global/indirect-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f of [0]) {switch (1) {' +
+  '  default:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-of.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-of.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-for.case
+// - src/annex-b-fns/eval-global/indirect-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'for (let f; ; ) {switch (1) {' +
+  '  default:' +
+  '    function f() {  }' +
+  '}\
+  break;\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-switch.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-switch.case
+// - src/annex-b-fns/eval-global/indirect-switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+(0,eval)(
+  'switch (0) {\
+    default:\
+      let f;switch (1) {' +
+  '  default:' +
+  '    function f() {  }' +
+  '}\
+  }'
+);
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-switch.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-switch.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.3 Changes to EvalDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
     [...]
 ---*/
 assert.throws(ReferenceError, function() {

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-try.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-try.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/eval-global-skip-early-err-try.case
+// - src/annex-b-fns/eval-global/indirect-switch-dflt.template
+/*---
+description: Extension is not observed when creation of variable binding would produce an early error (try statement) (Funtion declaration in the `default` clause of a `switch` statement in eval code in the global scope)
+esid: sec-web-compat-evaldeclarationinstantiation
+es6id: B.3.3.3
+flags: [generated, noStrict]
+info: |
+    B.3.3.3 Changes to EvalDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        body, then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(0,eval)(
+  'assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created prior to evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created prior to evaluation"\
+  );\
+  \
+  try {\
+    throw {};\
+  } catch ({ f }) {switch (1) {' +
+  '  default:' +
+  '    function f() {  }' +
+  '}\
+  }\
+  \
+  assert.throws(ReferenceError, function() {\
+    f;\
+  }, "An initialized binding is not created following evaluation");\
+  assert.sameValue(\
+    typeof f,\
+    "undefined",\
+    "An uninitialized binding is not created following evaluation"\
+  );'
+);

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-update.js
+++ b/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Funtion dec
 esid: sec-web-compat-evaldeclarationinstantiation
 es6id: B.3.3.3
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.3 Changes to EvalDeclarationInstantiation
-    
+
     [...]
     b. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/block-decl-func-block-scoping.js
+++ b/test/annexB/language/function-code/block-decl-func-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Block statement in function scop
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/function-code/block-decl-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/function-code/block-decl-func-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Block stat
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]
@@ -17,7 +17,7 @@ var init;
 
 (function() {
   init = f;
-  
+
   {
     function f() {}
   }

--- a/test/annexB/language/function-code/block-decl-func-exsting-block-fn-update.js
+++ b/test/annexB/language/function-code/block-decl-func-exsting-block-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated (Block statement in function sco
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/block-decl-func-exsting-fn-no-init.js
+++ b/test/annexB/language/function-code/block-decl-func-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Block statement in funct
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/block-decl-func-exsting-fn-update.js
+++ b/test/annexB/language/function-code/block-decl-func-exsting-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Block stat
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -31,7 +31,7 @@ var after;
   }
 
   after = f;
-  
+
   function f() {
     return 'outer declaration';
   }

--- a/test/annexB/language/function-code/block-decl-func-exsting-var-no-init.js
+++ b/test/annexB/language/function-code/block-decl-func-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Block statement in funct
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/block-decl-func-exsting-var-update.js
+++ b/test/annexB/language/function-code/block-decl-func-exsting-var-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Block stat
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -31,7 +31,7 @@ var after;
   }
 
   after = f;
-  
+
   var f = 123;
 }());
 

--- a/test/annexB/language/function-code/block-decl-func-init.js
+++ b/test/annexB/language/function-code/block-decl-func-init.js
@@ -6,9 +6,9 @@ description: Variable binding is initialized to `undefined` in outer scope (Bloc
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
        a. Perform ! varEnvRec.CreateMutableBinding(F, false).

--- a/test/annexB/language/function-code/block-decl-func-no-skip-try.js
+++ b/test/annexB/language/function-code/block-decl-func-no-skip-try.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-no-skip-try.case
+// - src/annex-b-fns/func/block.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Block statement in function scope containing a function declaration)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.sameValue(
+    f, undefined, 'Initialized binding created prior to evaluation'
+  );
+
+  try {
+    throw null;
+  } catch (f) {
+
+  {
+    function f() { return 123; }
+  }
+
+  }
+
+  assert.sameValue(
+    typeof f,
+    'function',
+    'binding value is updated following evaluation'
+  );
+  assert.sameValue(f(), 123);
+}());

--- a/test/annexB/language/function-code/block-decl-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-early-err-block.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-block.case
+// - src/annex-b-fns/func/block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Block statement in function scope containing a function declaration)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  {
+  let f = 123;
+
+  {
+    function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/block-decl-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-early-err-block.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/block-decl-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-early-err-for-in.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-in.case
+// - src/annex-b-fns/func/block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Block statement in function scope containing a function declaration)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f in { key: 0 }) {
+
+  {
+    function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/block-decl-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-early-err-for-in.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/block-decl-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-early-err-for-of.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-of.case
+// - src/annex-b-fns/func/block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Block statement in function scope containing a function declaration)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f of [0]) {
+
+  {
+    function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/block-decl-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-early-err-for-of.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/block-decl-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-early-err-for.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for.case
+// - src/annex-b-fns/func/block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Block statement in function scope containing a function declaration)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f; ; ) {
+
+  {
+    function f() {  }
+  }
+
+  break;
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/block-decl-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-early-err-for.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/block-decl-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-early-err-switch.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/block-decl-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-early-err-switch.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-switch.case
+// - src/annex-b-fns/func/block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Block statement in function scope containing a function declaration)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  switch (0) {
+    default:
+      let f;
+
+  {
+    function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/block-decl-func-skip-early-err-try.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-early-err-try.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-try.case
+// - src/annex-b-fns/func/block.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Block statement in function scope containing a function declaration)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  try {
+    throw {};
+  } catch ({ f }) {
+
+  {
+    function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/block-decl-func-skip-early-err.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/block-decl-func-skip-param.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-param.js
@@ -6,9 +6,9 @@ description: Extension not observed when there is a formal parameter with the sa
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/block-decl-func-update.js
+++ b/test/annexB/language/function-code/block-decl-func-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Block state
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-block-scoping.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]
@@ -26,7 +26,7 @@ var init;
 
 (function() {
   init = f;
-  
+
   {
     function f() {}
   }

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-exsting-block-fn-update.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-exsting-fn-no-init.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-exsting-fn-update.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -38,7 +38,7 @@ var after;
   if (true) function f() { return 'inner declaration'; } else function _f() {}
 
   after = f;
-  
+
   function f() {
     return 'outer declaration';
   }

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-exsting-var-no-init.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-exsting-var-update.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -38,7 +38,7 @@ var after;
   if (true) function f() { return 'function declaration'; } else function _f() {}
 
   after = f;
-  
+
   var f = 123;
 }());
 

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-init.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-init.js
@@ -6,18 +6,18 @@ description: Variable binding is initialized to `undefined` in outer scope (IfSt
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
        a. Perform ! varEnvRec.CreateMutableBinding(F, false).

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-no-skip-try.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-no-skip-try.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-no-skip-try.case
+// - src/annex-b-fns/func/if-decl-else-decl-a.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.sameValue(
+    f, undefined, 'Initialized binding created prior to evaluation'
+  );
+
+  try {
+    throw null;
+  } catch (f) {
+
+  if (true) function f() { return 123; } else function _f() {}
+
+  }
+
+  assert.sameValue(
+    typeof f,
+    'function',
+    'binding value is updated following evaluation'
+  );
+  assert.sameValue(f(), 123);
+}());

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-block.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-block.case
+// - src/annex-b-fns/func/if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  {
+  let f = 123;
+
+  if (true) function f() {  } else function _f() {}
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for-in.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-in.case
+// - src/annex-b-fns/func/if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f in { key: 0 }) {
+
+  if (true) function f() {  } else function _f() {}
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for-of.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-of.case
+// - src/annex-b-fns/func/if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f of [0]) {
+
+  if (true) function f() {  } else function _f() {}
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for.case
+// - src/annex-b-fns/func/if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f; ; ) {
+
+  if (true) function f() {  } else function _f() {}
+
+  break;
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-switch.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-switch.case
+// - src/annex-b-fns/func/if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  switch (0) {
+    default:
+      let f;
+
+  if (true) function f() {  } else function _f() {}
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-try.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-try.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-try.case
+// - src/annex-b-fns/func/if-decl-else-decl-a.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  try {
+    throw {};
+  } catch ({ f }) {
+
+  if (true) function f() {  } else function _f() {}
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-param.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-param.js
@@ -6,18 +6,18 @@ description: Extension not observed when there is a formal parameter with the sa
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-update.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-block-scoping.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]
@@ -26,7 +26,7 @@ var init;
 
 (function() {
   init = f;
-  
+
   {
     function f() {}
   }

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-exsting-block-fn-update.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-exsting-fn-no-init.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-exsting-fn-update.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -38,7 +38,7 @@ var after;
   if (false) function _f() {} else function f() { return 'inner declaration'; }
 
   after = f;
-  
+
   function f() {
     return 'outer declaration';
   }

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-exsting-var-no-init.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-exsting-var-update.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -38,7 +38,7 @@ var after;
   if (false) function _f() {} else function f() { return 'function declaration'; }
 
   after = f;
-  
+
   var f = 123;
 }());
 

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-init.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-init.js
@@ -6,18 +6,18 @@ description: Variable binding is initialized to `undefined` in outer scope (IfSt
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
        a. Perform ! varEnvRec.CreateMutableBinding(F, false).

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-no-skip-try.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-no-skip-try.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-no-skip-try.case
+// - src/annex-b-fns/func/if-decl-else-decl-b.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.sameValue(
+    f, undefined, 'Initialized binding created prior to evaluation'
+  );
+
+  try {
+    throw null;
+  } catch (f) {
+
+  if (false) function _f() {} else function f() { return 123; }
+
+  }
+
+  assert.sameValue(
+    typeof f,
+    'function',
+    'binding value is updated following evaluation'
+  );
+  assert.sameValue(f(), 123);
+}());

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-block.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-block.case
+// - src/annex-b-fns/func/if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  {
+  let f = 123;
+
+  if (false) function _f() {} else function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for-in.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-in.case
+// - src/annex-b-fns/func/if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f in { key: 0 }) {
+
+  if (false) function _f() {} else function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for-of.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-of.case
+// - src/annex-b-fns/func/if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f of [0]) {
+
+  if (false) function _f() {} else function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for.case
+// - src/annex-b-fns/func/if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f; ; ) {
+
+  if (false) function _f() {} else function f() {  }
+
+  break;
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-switch.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-switch.case
+// - src/annex-b-fns/func/if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  switch (0) {
+    default:
+      let f;
+
+  if (false) function _f() {} else function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-try.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-try.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-try.case
+// - src/annex-b-fns/func/if-decl-else-decl-b.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  try {
+    throw {};
+  } catch ({ f }) {
+
+  if (false) function _f() {} else function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-param.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-param.js
@@ -6,18 +6,18 @@ description: Extension not observed when there is a formal parameter with the sa
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-update.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-block-scoping.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]
@@ -26,7 +26,7 @@ var init;
 
 (function() {
   init = f;
-  
+
   {
     function f() {}
   }

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-exsting-block-fn-update.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-exsting-fn-no-init.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-exsting-fn-update.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -38,7 +38,7 @@ var after;
   if (true) function f() { return 'inner declaration'; } else ;
 
   after = f;
-  
+
   function f() {
     return 'outer declaration';
   }

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-exsting-var-no-init.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-exsting-var-update.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -38,7 +38,7 @@ var after;
   if (true) function f() { return 'function declaration'; } else ;
 
   after = f;
-  
+
   var f = 123;
 }());
 

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-init.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-init.js
@@ -6,18 +6,18 @@ description: Variable binding is initialized to `undefined` in outer scope (IfSt
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
        a. Perform ! varEnvRec.CreateMutableBinding(F, false).

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-no-skip-try.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-no-skip-try.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-no-skip-try.case
+// - src/annex-b-fns/func/if-decl-else-stmt.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in the first statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.sameValue(
+    f, undefined, 'Initialized binding created prior to evaluation'
+  );
+
+  try {
+    throw null;
+  } catch (f) {
+
+  if (true) function f() { return 123; } else ;
+
+  }
+
+  assert.sameValue(
+    typeof f,
+    'function',
+    'binding value is updated following evaluation'
+  );
+  assert.sameValue(f(), 123);
+}());

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-block.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-block.case
+// - src/annex-b-fns/func/if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in the first statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  {
+  let f = 123;
+
+  if (true) function f() {  } else ;
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for-in.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-in.case
+// - src/annex-b-fns/func/if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the first statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f in { key: 0 }) {
+
+  if (true) function f() {  } else ;
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for-of.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-of.case
+// - src/annex-b-fns/func/if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the first statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f of [0]) {
+
+  if (true) function f() {  } else ;
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for.case
+// - src/annex-b-fns/func/if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in the first statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f; ; ) {
+
+  if (true) function f() {  } else ;
+
+  break;
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-switch.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-switch.case
+// - src/annex-b-fns/func/if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in the first statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  switch (0) {
+    default:
+      let f;
+
+  if (true) function f() {  } else ;
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-try.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-try.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-try.case
+// - src/annex-b-fns/func/if-decl-else-stmt.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in the first statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  try {
+    throw {};
+  } catch ({ f }) {
+
+  if (true) function f() {  } else ;
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-param.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-param.js
@@ -6,18 +6,18 @@ description: Extension not observed when there is a formal parameter with the sa
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-update.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/if-decl-no-else-func-block-scoping.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement without an else clau
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/function-code/if-decl-no-else-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]
@@ -26,7 +26,7 @@ var init;
 
 (function() {
   init = f;
-  
+
   {
     function f() {}
   }

--- a/test/annexB/language/function-code/if-decl-no-else-func-exsting-block-fn-update.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement without an else cla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/if-decl-no-else-func-exsting-fn-no-init.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement without an e
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/if-decl-no-else-func-exsting-fn-update.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -38,7 +38,7 @@ var after;
   if (true) function f() { return 'inner declaration'; }
 
   after = f;
-  
+
   function f() {
     return 'outer declaration';
   }

--- a/test/annexB/language/function-code/if-decl-no-else-func-exsting-var-no-init.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement without an e
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/if-decl-no-else-func-exsting-var-update.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -38,7 +38,7 @@ var after;
   if (true) function f() { return 'function declaration'; }
 
   after = f;
-  
+
   var f = 123;
 }());
 

--- a/test/annexB/language/function-code/if-decl-no-else-func-init.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-init.js
@@ -6,18 +6,18 @@ description: Variable binding is initialized to `undefined` in outer scope (IfSt
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
        a. Perform ! varEnvRec.CreateMutableBinding(F, false).

--- a/test/annexB/language/function-code/if-decl-no-else-func-no-skip-try.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-no-skip-try.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-no-skip-try.case
+// - src/annex-b-fns/func/if-decl-no-else.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement without an else clause in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.sameValue(
+    f, undefined, 'Initialized binding created prior to evaluation'
+  );
+
+  try {
+    throw null;
+  } catch (f) {
+
+  if (true) function f() { return 123; }
+
+  }
+
+  assert.sameValue(
+    typeof f,
+    'function',
+    'binding value is updated following evaluation'
+  );
+  assert.sameValue(f(), 123);
+}());

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-block.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-block.case
+// - src/annex-b-fns/func/if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement without an else clause in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  {
+  let f = 123;
+
+  if (true) function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for-in.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-in.case
+// - src/annex-b-fns/func/if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement without an else clause in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f in { key: 0 }) {
+
+  if (true) function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for-of.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-of.case
+// - src/annex-b-fns/func/if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement without an else clause in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f of [0]) {
+
+  if (true) function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for.case
+// - src/annex-b-fns/func/if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement without an else clause in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f; ; ) {
+
+  if (true) function f() {  }
+
+  break;
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-switch.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-switch.case
+// - src/annex-b-fns/func/if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement without an else clause in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  switch (0) {
+    default:
+      let f;
+
+  if (true) function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-try.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-try.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-try.case
+// - src/annex-b-fns/func/if-decl-no-else.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement without an else clause in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  try {
+    throw {};
+  } catch ({ f }) {
+
+  if (true) function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-param.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-param.js
@@ -6,18 +6,18 @@ description: Extension not observed when there is a formal parameter with the sa
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/if-decl-no-else-func-update.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-block-scoping.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]
@@ -26,7 +26,7 @@ var init;
 
 (function() {
   init = f;
-  
+
   {
     function f() {}
   }

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-exsting-block-fn-update.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-exsting-block-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-exsting-fn-no-init.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-exsting-fn-update.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-exsting-fn-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -38,7 +38,7 @@ var after;
   if (false) ; else function f() { return 'inner declaration'; }
 
   after = f;
-  
+
   function f() {
     return 'outer declaration';
   }

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-exsting-var-no-init.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-exsting-var-update.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-exsting-var-update.js
@@ -6,18 +6,18 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -38,7 +38,7 @@ var after;
   if (false) ; else function f() { return 'function declaration'; }
 
   after = f;
-  
+
   var f = 123;
 }());
 

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-init.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-init.js
@@ -6,18 +6,18 @@ description: Variable binding is initialized to `undefined` in outer scope (IfSt
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
        a. Perform ! varEnvRec.CreateMutableBinding(F, false).

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-no-skip-try.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-no-skip-try.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-no-skip-try.case
+// - src/annex-b-fns/func/if-stmt-else-decl.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in the second statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.sameValue(
+    f, undefined, 'Initialized binding created prior to evaluation'
+  );
+
+  try {
+    throw null;
+  } catch (f) {
+
+  if (false) ; else function f() { return 123; }
+
+  }
+
+  assert.sameValue(
+    typeof f,
+    'function',
+    'binding value is updated following evaluation'
+  );
+  assert.sameValue(f(), 123);
+}());

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-block.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-block.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-block.case
+// - src/annex-b-fns/func/if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in the second statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  {
+  let f = 123;
+
+  if (false) ; else function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for-in.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-in.case
+// - src/annex-b-fns/func/if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the second statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f in { key: 0 }) {
+
+  if (false) ; else function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for-in.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for-of.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for-of.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-of.case
+// - src/annex-b-fns/func/if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the second statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f of [0]) {
+
+  if (false) ; else function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for.case
+// - src/annex-b-fns/func/if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in the second statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f; ; ) {
+
+  if (false) ; else function f() {  }
+
+  break;
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-switch.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-switch.case
+// - src/annex-b-fns/func/if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in the second statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  switch (0) {
+    default:
+      let f;
+
+  if (false) ; else function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-switch.js
@@ -16,12 +16,12 @@ info: |
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
 
 
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-try.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-try.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-try.case
+// - src/annex-b-fns/func/if-stmt-else-decl.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in the second statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  try {
+    throw {};
+  } catch ({ f }) {
+
+  if (false) ; else function f() {  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-param.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-param.js
@@ -6,18 +6,18 @@ description: Extension not observed when there is a formal parameter with the sa
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-update.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/switch-case-func-block-scoping.js
+++ b/test/annexB/language/function-code/switch-case-func-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Function declaration in the `cas
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/function-code/switch-case-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/function-code/switch-case-func-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Function d
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]
@@ -17,7 +17,7 @@ var init;
 
 (function() {
   init = f;
-  
+
   {
     function f() {}
   }

--- a/test/annexB/language/function-code/switch-case-func-exsting-block-fn-update.js
+++ b/test/annexB/language/function-code/switch-case-func-exsting-block-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated (Function declaration in the `ca
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/switch-case-func-exsting-fn-no-init.js
+++ b/test/annexB/language/function-code/switch-case-func-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Function declaration in 
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/switch-case-func-exsting-fn-update.js
+++ b/test/annexB/language/function-code/switch-case-func-exsting-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Function d
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -32,7 +32,7 @@ var after;
   }
 
   after = f;
-  
+
   function f() {
     return 'outer declaration';
   }

--- a/test/annexB/language/function-code/switch-case-func-exsting-var-no-init.js
+++ b/test/annexB/language/function-code/switch-case-func-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Function declaration in 
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/switch-case-func-exsting-var-update.js
+++ b/test/annexB/language/function-code/switch-case-func-exsting-var-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Function d
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -32,7 +32,7 @@ var after;
   }
 
   after = f;
-  
+
   var f = 123;
 }());
 

--- a/test/annexB/language/function-code/switch-case-func-init.js
+++ b/test/annexB/language/function-code/switch-case-func-init.js
@@ -6,9 +6,9 @@ description: Variable binding is initialized to `undefined` in outer scope (Func
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
        a. Perform ! varEnvRec.CreateMutableBinding(F, false).

--- a/test/annexB/language/function-code/switch-case-func-no-skip-try.js
+++ b/test/annexB/language/function-code/switch-case-func-no-skip-try.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-no-skip-try.case
+// - src/annex-b-fns/func/switch-case.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Function declaration in the `case` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.sameValue(
+    f, undefined, 'Initialized binding created prior to evaluation'
+  );
+
+  try {
+    throw null;
+  } catch (f) {
+
+  switch (1) {
+    case 1:
+      function f() { return 123; }
+  }
+
+  }
+
+  assert.sameValue(
+    typeof f,
+    'function',
+    'binding value is updated following evaluation'
+  );
+  assert.sameValue(f(), 123);
+}());

--- a/test/annexB/language/function-code/switch-case-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-early-err-block.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-block.case
+// - src/annex-b-fns/func/switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Function declaration in the `case` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  {
+  let f = 123;
+
+  switch (1) {
+    case 1:
+      function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/switch-case-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-early-err-block.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/switch-case-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-early-err-for-in.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-in.case
+// - src/annex-b-fns/func/switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Function declaration in the `case` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f in { key: 0 }) {
+
+  switch (1) {
+    case 1:
+      function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/switch-case-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-early-err-for-in.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/switch-case-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-early-err-for-of.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-of.case
+// - src/annex-b-fns/func/switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Function declaration in the `case` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f of [0]) {
+
+  switch (1) {
+    case 1:
+      function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/switch-case-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-early-err-for-of.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/switch-case-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-early-err-for.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for.case
+// - src/annex-b-fns/func/switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Function declaration in the `case` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f; ; ) {
+
+  switch (1) {
+    case 1:
+      function f() {  }
+  }
+
+  break;
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/switch-case-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-early-err-for.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/switch-case-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-early-err-switch.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-switch.case
+// - src/annex-b-fns/func/switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Function declaration in the `case` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  switch (0) {
+    default:
+      let f;
+
+  switch (1) {
+    case 1:
+      function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/switch-case-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-early-err-switch.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/switch-case-func-skip-early-err-try.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-early-err-try.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-try.case
+// - src/annex-b-fns/func/switch-case.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Function declaration in the `case` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  try {
+    throw {};
+  } catch ({ f }) {
+
+  switch (1) {
+    case 1:
+      function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/switch-case-func-skip-early-err.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/switch-case-func-skip-param.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-param.js
@@ -6,9 +6,9 @@ description: Extension not observed when there is a formal parameter with the sa
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/switch-case-func-update.js
+++ b/test/annexB/language/function-code/switch-case-func-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Function de
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/switch-dflt-func-block-scoping.js
+++ b/test/annexB/language/function-code/switch-dflt-func-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Funtion declaration in the `defa
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/function-code/switch-dflt-func-exsting-block-fn-no-init.js
+++ b/test/annexB/language/function-code/switch-dflt-func-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Funtion de
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]
@@ -17,7 +17,7 @@ var init;
 
 (function() {
   init = f;
-  
+
   {
     function f() {}
   }

--- a/test/annexB/language/function-code/switch-dflt-func-exsting-block-fn-update.js
+++ b/test/annexB/language/function-code/switch-dflt-func-exsting-block-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated (Funtion declaration in the `def
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/function-code/switch-dflt-func-exsting-fn-no-init.js
+++ b/test/annexB/language/function-code/switch-dflt-func-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Funtion declaration in t
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/switch-dflt-func-exsting-fn-update.js
+++ b/test/annexB/language/function-code/switch-dflt-func-exsting-fn-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Funtion de
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -32,7 +32,7 @@ var after;
   }
 
   after = f;
-  
+
   function f() {
     return 'outer declaration';
   }

--- a/test/annexB/language/function-code/switch-dflt-func-exsting-var-no-init.js
+++ b/test/annexB/language/function-code/switch-dflt-func-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Funtion declaration in t
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
     [...]

--- a/test/annexB/language/function-code/switch-dflt-func-exsting-var-update.js
+++ b/test/annexB/language/function-code/switch-dflt-func-exsting-var-update.js
@@ -6,9 +6,9 @@ description: Variable-scoped binding is updated following evaluation (Funtion de
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
@@ -32,7 +32,7 @@ var after;
   }
 
   after = f;
-  
+
   var f = 123;
 }());
 

--- a/test/annexB/language/function-code/switch-dflt-func-init.js
+++ b/test/annexB/language/function-code/switch-dflt-func-init.js
@@ -6,9 +6,9 @@ description: Variable binding is initialized to `undefined` in outer scope (Funt
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     2. If instantiatedVarNames does not contain F, then
        a. Perform ! varEnvRec.CreateMutableBinding(F, false).

--- a/test/annexB/language/function-code/switch-dflt-func-no-skip-try.js
+++ b/test/annexB/language/function-code/switch-dflt-func-no-skip-try.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-no-skip-try.case
+// - src/annex-b-fns/func/switch-dflt.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Funtion declaration in the `default` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.sameValue(
+    f, undefined, 'Initialized binding created prior to evaluation'
+  );
+
+  try {
+    throw null;
+  } catch (f) {
+
+  switch (1) {
+    default:
+      function f() { return 123; }
+  }
+
+  }
+
+  assert.sameValue(
+    typeof f,
+    'function',
+    'binding value is updated following evaluation'
+  );
+  assert.sameValue(f(), 123);
+}());

--- a/test/annexB/language/function-code/switch-dflt-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-early-err-block.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-block.case
+// - src/annex-b-fns/func/switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Funtion declaration in the `default` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  {
+  let f = 123;
+
+  switch (1) {
+    default:
+      function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/switch-dflt-func-skip-early-err-block.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-early-err-block.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/switch-dflt-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-early-err-for-in.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-in.case
+// - src/annex-b-fns/func/switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Funtion declaration in the `default` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f in { key: 0 }) {
+
+  switch (1) {
+    default:
+      function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/switch-dflt-func-skip-early-err-for-in.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-early-err-for-in.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/switch-dflt-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-early-err-for-of.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for-of.case
+// - src/annex-b-fns/func/switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Funtion declaration in the `default` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f of [0]) {
+
+  switch (1) {
+    default:
+      function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/switch-dflt-func-skip-early-err-for-of.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-early-err-for-of.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/switch-dflt-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-early-err-for.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-for.case
+// - src/annex-b-fns/func/switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Funtion declaration in the `default` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  for (let f; ; ) {
+
+  switch (1) {
+    default:
+      function f() {  }
+  }
+
+  break;
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/switch-dflt-func-skip-early-err-for.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-early-err-for.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/switch-dflt-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-early-err-switch.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-switch.case
+// - src/annex-b-fns/func/switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Funtion declaration in the `default` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  switch (0) {
+    default:
+      let f;
+
+  switch (1) {
+    default:
+      function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/switch-dflt-func-skip-early-err-switch.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-early-err-switch.js
@@ -7,12 +7,12 @@ esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
 info: |
-    B.3.3.2 Changes to GlobalDeclarationInstantiation
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
 
     [...]
-    b. If replacing the FunctionDeclaration f with a VariableStatement that has
-       F as a BindingIdentifier would not produce any Early Errors for script,
-       then
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
     [...]
 ---*/
 

--- a/test/annexB/language/function-code/switch-dflt-func-skip-early-err-try.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-early-err-try.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-early-err-try.case
+// - src/annex-b-fns/func/switch-dflt.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Funtion declaration in the `default` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    2. If instantiatedVarNames does not contain F, then
+       a. Perform ! varEnvRec.CreateMutableBinding(F, false).
+       b. Perform varEnvRec.InitializeBinding(F, undefined).
+       c. Append F to instantiatedVarNames.
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+
+(function() {
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created prior to evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created prior to evaluation'
+  );
+
+  try {
+    throw {};
+  } catch ({ f }) {
+
+  switch (1) {
+    default:
+      function f() {  }
+  }
+
+  }
+
+  assert.throws(ReferenceError, function() {
+    f;
+  }, 'An initialized binding is not created following evaluation');
+  assert.sameValue(
+    typeof f,
+    'undefined',
+    'An uninitialized binding is not created following evaluation'
+  );
+}());

--- a/test/annexB/language/function-code/switch-dflt-func-skip-early-err.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/switch-dflt-func-skip-param.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-param.js
@@ -6,9 +6,9 @@ description: Extension not observed when there is a formal parameter with the sa
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     ii. If replacing the FunctionDeclaration f with a VariableStatement that
         has F as a BindingIdentifier would not produce any Early Errors for

--- a/test/annexB/language/function-code/switch-dflt-func-update.js
+++ b/test/annexB/language/function-code/switch-dflt-func-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Funtion dec
 esid: sec-web-compat-functiondeclarationinstantiation
 es6id: B.3.3.1
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.1 Changes to FunctionDeclarationInstantiation
-    
+
     [...]
     3. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/global-code/block-decl-global-block-scoping.js
+++ b/test/annexB/language/global-code/block-decl-global-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Block statement in the global sc
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/global-code/block-decl-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/global-code/block-decl-global-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Block stat
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/block-decl-global-exsting-block-fn-update.js
+++ b/test/annexB/language/global-code/block-decl-global-exsting-block-fn-update.js
@@ -6,13 +6,13 @@ description: Variable-scoped binding is updated (Block statement in the global s
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/block-decl-global-exsting-fn-no-init.js
+++ b/test/annexB/language/global-code/block-decl-global-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Block statement in the g
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     1. Let fnDefinable be ? envRec.CanDeclareGlobalFunction(F).
     2. If fnDefinable is true, then

--- a/test/annexB/language/global-code/block-decl-global-exsting-fn-update.js
+++ b/test/annexB/language/global-code/block-decl-global-exsting-fn-update.js
@@ -6,13 +6,13 @@ description: Variable-scoped binding is updated following evaluation (Block stat
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/block-decl-global-exsting-var-no-init.js
+++ b/test/annexB/language/global-code/block-decl-global-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Block statement in the g
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/block-decl-global-exsting-var-update.js
+++ b/test/annexB/language/global-code/block-decl-global-exsting-var-update.js
@@ -6,13 +6,13 @@ description: Variable-scoped binding is updated following evaluation (Block stat
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/block-decl-global-init.js
+++ b/test/annexB/language/global-code/block-decl-global-init.js
@@ -7,15 +7,15 @@ esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).
        ii. Append F to declaredFunctionOrVarNames.
     [...]
-    
+
 ---*/
 var global = fnGlobalObject();
 assert.sameValue(f, undefined, 'binding is initialized to `undefined`');

--- a/test/annexB/language/global-code/block-decl-global-no-skip-try.js
+++ b/test/annexB/language/global-code/block-decl-global-no-skip-try.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-no-skip-try.case
+// - src/annex-b-fns/global/block.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Block statement in the global scope containing a function declaration)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.sameValue(
+  f, undefined, 'Initialized binding created prior to evaluation'
+);
+
+try {
+  throw null;
+} catch (f) {
+
+{
+  function f() { return 123; }
+}
+
+}
+
+assert.sameValue(
+  typeof f,
+  'function',
+  'binding value is updated following evaluation'
+);
+assert.sameValue(f(), 123);

--- a/test/annexB/language/global-code/block-decl-global-skip-early-err-block.js
+++ b/test/annexB/language/global-code/block-decl-global-skip-early-err-block.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-block.case
+// - src/annex-b-fns/global/block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Block statement in the global scope containing a function declaration)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+{
+let f = 123;
+
+{
+  function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/block-decl-global-skip-early-err-for-in.js
+++ b/test/annexB/language/global-code/block-decl-global-skip-early-err-for-in.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-in.case
+// - src/annex-b-fns/global/block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Block statement in the global scope containing a function declaration)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f in { key: 0 }) {
+
+{
+  function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/block-decl-global-skip-early-err-for-of.js
+++ b/test/annexB/language/global-code/block-decl-global-skip-early-err-for-of.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-of.case
+// - src/annex-b-fns/global/block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Block statement in the global scope containing a function declaration)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f of [0]) {
+
+{
+  function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/block-decl-global-skip-early-err-for.js
+++ b/test/annexB/language/global-code/block-decl-global-skip-early-err-for.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for.case
+// - src/annex-b-fns/global/block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Block statement in the global scope containing a function declaration)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f; ; ) {
+
+{
+  function f() {  }
+}
+
+  break;
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/block-decl-global-skip-early-err-switch.js
+++ b/test/annexB/language/global-code/block-decl-global-skip-early-err-switch.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-switch.case
+// - src/annex-b-fns/global/block.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Block statement in the global scope containing a function declaration)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+switch (0) {
+  default:
+    let f;
+
+{
+  function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/block-decl-global-skip-early-err-try.js
+++ b/test/annexB/language/global-code/block-decl-global-skip-early-err-try.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-try.case
+// - src/annex-b-fns/global/block.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Block statement in the global scope containing a function declaration)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+try {
+  throw {};
+} catch ({ f }) {
+
+{
+  function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/block-decl-global-skip-early-err.js
+++ b/test/annexB/language/global-code/block-decl-global-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If replacing the FunctionDeclaration f with a VariableStatement that has
        F as a BindingIdentifier would not produce any Early Errors for script,

--- a/test/annexB/language/global-code/block-decl-global-update.js
+++ b/test/annexB/language/global-code/block-decl-global-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Block state
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     e. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-block-scoping.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-exsting-block-fn-update.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-exsting-block-fn-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-exsting-fn-no-init.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     1. Let fnDefinable be ? envRec.CanDeclareGlobalFunction(F).
     2. If fnDefinable is true, then

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-exsting-fn-update.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-exsting-fn-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-exsting-var-no-init.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-exsting-var-update.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-exsting-var-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-init.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-init.js
@@ -7,24 +7,24 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).
        ii. Append F to declaredFunctionOrVarNames.
     [...]
-    
+
 ---*/
 var global = fnGlobalObject();
 assert.sameValue(f, undefined, 'binding is initialized to `undefined`');

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-no-skip-try.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-no-skip-try.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-no-skip-try.case
+// - src/annex-b-fns/global/if-decl-else-decl-a.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in both statement positions in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.sameValue(
+  f, undefined, 'Initialized binding created prior to evaluation'
+);
+
+try {
+  throw null;
+} catch (f) {
+
+if (true) function f() { return 123; } else function _f() {}
+
+}
+
+assert.sameValue(
+  typeof f,
+  'function',
+  'binding value is updated following evaluation'
+);
+assert.sameValue(f(), 123);

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-block.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-block.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-block.case
+// - src/annex-b-fns/global/if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in both statement positions in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+{
+let f = 123;
+
+if (true) function f() {  } else function _f() {}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for-in.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for-in.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-in.case
+// - src/annex-b-fns/global/if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f in { key: 0 }) {
+
+if (true) function f() {  } else function _f() {}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for-of.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for-of.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-of.case
+// - src/annex-b-fns/global/if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f of [0]) {
+
+if (true) function f() {  } else function _f() {}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for.case
+// - src/annex-b-fns/global/if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in both statement positions in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f; ; ) {
+
+if (true) function f() {  } else function _f() {}
+
+  break;
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-switch.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-switch.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-switch.case
+// - src/annex-b-fns/global/if-decl-else-decl-a.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in both statement positions in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+switch (0) {
+  default:
+    let f;
+
+if (true) function f() {  } else function _f() {}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-try.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-try.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-try.case
+// - src/annex-b-fns/global/if-decl-else-decl-a.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in both statement positions in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+try {
+  throw {};
+} catch ({ f }) {
+
+if (true) function f() {  } else function _f() {}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If replacing the FunctionDeclaration f with a VariableStatement that has
        F as a BindingIdentifier would not produce any Early Errors for script,

--- a/test/annexB/language/global-code/if-decl-else-decl-a-global-update.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-a-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     e. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-block-scoping.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-exsting-block-fn-update.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-exsting-block-fn-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-exsting-fn-no-init.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     1. Let fnDefinable be ? envRec.CanDeclareGlobalFunction(F).
     2. If fnDefinable is true, then

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-exsting-fn-update.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-exsting-fn-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-exsting-var-no-init.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-exsting-var-update.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-exsting-var-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-init.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-init.js
@@ -7,24 +7,24 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).
        ii. Append F to declaredFunctionOrVarNames.
     [...]
-    
+
 ---*/
 var global = fnGlobalObject();
 assert.sameValue(f, undefined, 'binding is initialized to `undefined`');

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-no-skip-try.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-no-skip-try.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-no-skip-try.case
+// - src/annex-b-fns/global/if-decl-else-decl-b.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in both statement positions in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.sameValue(
+  f, undefined, 'Initialized binding created prior to evaluation'
+);
+
+try {
+  throw null;
+} catch (f) {
+
+if (false) function _f() {} else function f() { return 123; }
+
+}
+
+assert.sameValue(
+  typeof f,
+  'function',
+  'binding value is updated following evaluation'
+);
+assert.sameValue(f(), 123);

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-block.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-block.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-block.case
+// - src/annex-b-fns/global/if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in both statement positions in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+{
+let f = 123;
+
+if (false) function _f() {} else function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for-in.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for-in.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-in.case
+// - src/annex-b-fns/global/if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f in { key: 0 }) {
+
+if (false) function _f() {} else function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for-of.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for-of.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-of.case
+// - src/annex-b-fns/global/if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in both statement positions in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f of [0]) {
+
+if (false) function _f() {} else function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for.case
+// - src/annex-b-fns/global/if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in both statement positions in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f; ; ) {
+
+if (false) function _f() {} else function f() {  }
+
+  break;
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-switch.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-switch.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-switch.case
+// - src/annex-b-fns/global/if-decl-else-decl-b.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in both statement positions in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+switch (0) {
+  default:
+    let f;
+
+if (false) function _f() {} else function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-try.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-try.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-try.case
+// - src/annex-b-fns/global/if-decl-else-decl-b.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in both statement positions in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+try {
+  throw {};
+} catch ({ f }) {
+
+if (false) function _f() {} else function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If replacing the FunctionDeclaration f with a VariableStatement that has
        F as a BindingIdentifier would not produce any Early Errors for script,

--- a/test/annexB/language/global-code/if-decl-else-decl-b-global-update.js
+++ b/test/annexB/language/global-code/if-decl-else-decl-b-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     e. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-block-scoping.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-exsting-block-fn-update.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-exsting-block-fn-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-exsting-fn-no-init.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     1. Let fnDefinable be ? envRec.CanDeclareGlobalFunction(F).
     2. If fnDefinable is true, then

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-exsting-fn-update.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-exsting-fn-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-exsting-var-no-init.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-exsting-var-update.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-exsting-var-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-init.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-init.js
@@ -7,24 +7,24 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).
        ii. Append F to declaredFunctionOrVarNames.
     [...]
-    
+
 ---*/
 var global = fnGlobalObject();
 assert.sameValue(f, undefined, 'binding is initialized to `undefined`');

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-no-skip-try.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-no-skip-try.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-no-skip-try.case
+// - src/annex-b-fns/global/if-decl-else-stmt.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in the first statement position in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.sameValue(
+  f, undefined, 'Initialized binding created prior to evaluation'
+);
+
+try {
+  throw null;
+} catch (f) {
+
+if (true) function f() { return 123; } else ;
+
+}
+
+assert.sameValue(
+  typeof f,
+  'function',
+  'binding value is updated following evaluation'
+);
+assert.sameValue(f(), 123);

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-block.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-block.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-block.case
+// - src/annex-b-fns/global/if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in the first statement position in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+{
+let f = 123;
+
+if (true) function f() {  } else ;
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for-in.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for-in.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-in.case
+// - src/annex-b-fns/global/if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the first statement position in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f in { key: 0 }) {
+
+if (true) function f() {  } else ;
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for-of.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for-of.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-of.case
+// - src/annex-b-fns/global/if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the first statement position in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f of [0]) {
+
+if (true) function f() {  } else ;
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for.case
+// - src/annex-b-fns/global/if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in the first statement position in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f; ; ) {
+
+if (true) function f() {  } else ;
+
+  break;
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-switch.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-switch.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-switch.case
+// - src/annex-b-fns/global/if-decl-else-stmt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in the first statement position in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+switch (0) {
+  default:
+    let f;
+
+if (true) function f() {  } else ;
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-try.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-try.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-try.case
+// - src/annex-b-fns/global/if-decl-else-stmt.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in the first statement position in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+try {
+  throw {};
+} catch ({ f }) {
+
+if (true) function f() {  } else ;
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If replacing the FunctionDeclaration f with a VariableStatement that has
        F as a BindingIdentifier would not produce any Early Errors for script,

--- a/test/annexB/language/global-code/if-decl-else-stmt-global-update.js
+++ b/test/annexB/language/global-code/if-decl-else-stmt-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     e. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/global-code/if-decl-no-else-global-block-scoping.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement without an else clau
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/global-code/if-decl-no-else-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/if-decl-no-else-global-exsting-block-fn-update.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-exsting-block-fn-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated (IfStatement without an else cla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-decl-no-else-global-exsting-fn-no-init.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement without an e
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     1. Let fnDefinable be ? envRec.CanDeclareGlobalFunction(F).
     2. If fnDefinable is true, then

--- a/test/annexB/language/global-code/if-decl-no-else-global-exsting-fn-update.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-exsting-fn-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-decl-no-else-global-exsting-var-no-init.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement without an e
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/if-decl-no-else-global-exsting-var-update.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-exsting-var-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-decl-no-else-global-init.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-init.js
@@ -7,24 +7,24 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).
        ii. Append F to declaredFunctionOrVarNames.
     [...]
-    
+
 ---*/
 var global = fnGlobalObject();
 assert.sameValue(f, undefined, 'binding is initialized to `undefined`');

--- a/test/annexB/language/global-code/if-decl-no-else-global-no-skip-try.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-no-skip-try.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-no-skip-try.case
+// - src/annex-b-fns/global/if-decl-no-else.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement without an else clause in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.sameValue(
+  f, undefined, 'Initialized binding created prior to evaluation'
+);
+
+try {
+  throw null;
+} catch (f) {
+
+if (true) function f() { return 123; }
+
+}
+
+assert.sameValue(
+  typeof f,
+  'function',
+  'binding value is updated following evaluation'
+);
+assert.sameValue(f(), 123);

--- a/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-block.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-block.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-block.case
+// - src/annex-b-fns/global/if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement without an else clause in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+{
+let f = 123;
+
+if (true) function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for-in.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for-in.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-in.case
+// - src/annex-b-fns/global/if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement without an else clause in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f in { key: 0 }) {
+
+if (true) function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for-of.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for-of.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-of.case
+// - src/annex-b-fns/global/if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement without an else clause in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f of [0]) {
+
+if (true) function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for.case
+// - src/annex-b-fns/global/if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement without an else clause in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f; ; ) {
+
+if (true) function f() {  }
+
+  break;
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-switch.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-switch.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-switch.case
+// - src/annex-b-fns/global/if-decl-no-else.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement without an else clause in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+switch (0) {
+  default:
+    let f;
+
+if (true) function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-try.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-try.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-try.case
+// - src/annex-b-fns/global/if-decl-no-else.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement without an else clause in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+try {
+  throw {};
+} catch ({ f }) {
+
+if (true) function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If replacing the FunctionDeclaration f with a VariableStatement that has
        F as a BindingIdentifier would not produce any Early Errors for script,

--- a/test/annexB/language/global-code/if-decl-no-else-global-update.js
+++ b/test/annexB/language/global-code/if-decl-no-else-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     e. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-block-scoping.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-block-scoping.js
@@ -6,18 +6,18 @@ description: A block-scoped binding is created (IfStatement with a declaration i
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -25,7 +25,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-exsting-block-fn-no-init.js
@@ -6,18 +6,18 @@ description: Does not re-initialize binding created by similar forms (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-exsting-block-fn-update.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-exsting-block-fn-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated (IfStatement with a declaration 
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-exsting-fn-no-init.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-exsting-fn-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     1. Let fnDefinable be ? envRec.CanDeclareGlobalFunction(F).
     2. If fnDefinable is true, then

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-exsting-fn-update.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-exsting-fn-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-exsting-var-no-init.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-exsting-var-no-init.js
@@ -6,18 +6,18 @@ description: Existing variable binding is not modified (IfStatement with a decla
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-exsting-var-update.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-exsting-var-update.js
@@ -6,22 +6,22 @@ description: Variable-scoped binding is updated following evaluation (IfStatemen
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-init.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-init.js
@@ -7,24 +7,24 @@ esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).
        ii. Append F to declaredFunctionOrVarNames.
     [...]
-    
+
 ---*/
 var global = fnGlobalObject();
 assert.sameValue(f, undefined, 'binding is initialized to `undefined`');

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-no-skip-try.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-no-skip-try.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-no-skip-try.case
+// - src/annex-b-fns/global/if-stmt-else-decl.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in the second statement position in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.sameValue(
+  f, undefined, 'Initialized binding created prior to evaluation'
+);
+
+try {
+  throw null;
+} catch (f) {
+
+if (false) ; else function f() { return 123; }
+
+}
+
+assert.sameValue(
+  typeof f,
+  'function',
+  'binding value is updated following evaluation'
+);
+assert.sameValue(f(), 123);

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-block.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-block.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-block.case
+// - src/annex-b-fns/global/if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (IfStatement with a declaration in the second statement position in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+{
+let f = 123;
+
+if (false) ; else function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for-in.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for-in.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-in.case
+// - src/annex-b-fns/global/if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the second statement position in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f in { key: 0 }) {
+
+if (false) ; else function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for-of.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for-of.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-of.case
+// - src/annex-b-fns/global/if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (IfStatement with a declaration in the second statement position in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f of [0]) {
+
+if (false) ; else function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for.case
+// - src/annex-b-fns/global/if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (IfStatement with a declaration in the second statement position in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f; ; ) {
+
+if (false) ; else function f() {  }
+
+  break;
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-switch.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-switch.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-switch.case
+// - src/annex-b-fns/global/if-stmt-else-decl.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (IfStatement with a declaration in the second statement position in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+switch (0) {
+  default:
+    let f;
+
+if (false) ; else function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-try.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-try.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-try.case
+// - src/annex-b-fns/global/if-stmt-else-decl.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (IfStatement with a declaration in the second statement position in the global scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+try {
+  throw {};
+} catch ({ f }) {
+
+if (false) ; else function f() {  }
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err.js
@@ -6,18 +6,18 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If replacing the FunctionDeclaration f with a VariableStatement that has
        F as a BindingIdentifier would not produce any Early Errors for script,

--- a/test/annexB/language/global-code/if-stmt-else-decl-global-update.js
+++ b/test/annexB/language/global-code/if-stmt-else-decl-global-update.js
@@ -6,18 +6,18 @@ description: Variable binding value is updated following evaluation (IfStatement
 esid: sec-functiondeclarations-in-ifstatement-statement-clauses
 es6id: B.3.4
 flags: [generated, noStrict]
-info: >
+info: |
     The following rules for IfStatement augment those in 13.6:
-    
+
     IfStatement[Yield, Return]:
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
         if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
         if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
-    
+
 
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     e. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/global-code/switch-case-global-block-scoping.js
+++ b/test/annexB/language/global-code/switch-case-global-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Function declaration in the `cas
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/global-code/switch-case-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/global-code/switch-case-global-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Function d
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/switch-case-global-exsting-block-fn-update.js
+++ b/test/annexB/language/global-code/switch-case-global-exsting-block-fn-update.js
@@ -6,13 +6,13 @@ description: Variable-scoped binding is updated (Function declaration in the `ca
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/switch-case-global-exsting-fn-no-init.js
+++ b/test/annexB/language/global-code/switch-case-global-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Function declaration in 
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     1. Let fnDefinable be ? envRec.CanDeclareGlobalFunction(F).
     2. If fnDefinable is true, then

--- a/test/annexB/language/global-code/switch-case-global-exsting-fn-update.js
+++ b/test/annexB/language/global-code/switch-case-global-exsting-fn-update.js
@@ -6,13 +6,13 @@ description: Variable-scoped binding is updated following evaluation (Function d
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/switch-case-global-exsting-var-no-init.js
+++ b/test/annexB/language/global-code/switch-case-global-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Function declaration in 
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/switch-case-global-exsting-var-update.js
+++ b/test/annexB/language/global-code/switch-case-global-exsting-var-update.js
@@ -6,13 +6,13 @@ description: Variable-scoped binding is updated following evaluation (Function d
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/switch-case-global-init.js
+++ b/test/annexB/language/global-code/switch-case-global-init.js
@@ -7,15 +7,15 @@ esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).
        ii. Append F to declaredFunctionOrVarNames.
     [...]
-    
+
 ---*/
 var global = fnGlobalObject();
 assert.sameValue(f, undefined, 'binding is initialized to `undefined`');

--- a/test/annexB/language/global-code/switch-case-global-no-skip-try.js
+++ b/test/annexB/language/global-code/switch-case-global-no-skip-try.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-no-skip-try.case
+// - src/annex-b-fns/global/switch-case.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Function declaration in the `case` clause of a `switch` statement in the global scope)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.sameValue(
+  f, undefined, 'Initialized binding created prior to evaluation'
+);
+
+try {
+  throw null;
+} catch (f) {
+
+switch (1) {
+  case 1:
+    function f() { return 123; }
+}
+
+}
+
+assert.sameValue(
+  typeof f,
+  'function',
+  'binding value is updated following evaluation'
+);
+assert.sameValue(f(), 123);

--- a/test/annexB/language/global-code/switch-case-global-skip-early-err-block.js
+++ b/test/annexB/language/global-code/switch-case-global-skip-early-err-block.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-block.case
+// - src/annex-b-fns/global/switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Function declaration in the `case` clause of a `switch` statement in the global scope)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+{
+let f = 123;
+
+switch (1) {
+  case 1:
+    function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/switch-case-global-skip-early-err-for-in.js
+++ b/test/annexB/language/global-code/switch-case-global-skip-early-err-for-in.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-in.case
+// - src/annex-b-fns/global/switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Function declaration in the `case` clause of a `switch` statement in the global scope)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f in { key: 0 }) {
+
+switch (1) {
+  case 1:
+    function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/switch-case-global-skip-early-err-for-of.js
+++ b/test/annexB/language/global-code/switch-case-global-skip-early-err-for-of.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-of.case
+// - src/annex-b-fns/global/switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Function declaration in the `case` clause of a `switch` statement in the global scope)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f of [0]) {
+
+switch (1) {
+  case 1:
+    function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/switch-case-global-skip-early-err-for.js
+++ b/test/annexB/language/global-code/switch-case-global-skip-early-err-for.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for.case
+// - src/annex-b-fns/global/switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Function declaration in the `case` clause of a `switch` statement in the global scope)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f; ; ) {
+
+switch (1) {
+  case 1:
+    function f() {  }
+}
+
+  break;
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/switch-case-global-skip-early-err-switch.js
+++ b/test/annexB/language/global-code/switch-case-global-skip-early-err-switch.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-switch.case
+// - src/annex-b-fns/global/switch-case.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Function declaration in the `case` clause of a `switch` statement in the global scope)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+switch (0) {
+  default:
+    let f;
+
+switch (1) {
+  case 1:
+    function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/switch-case-global-skip-early-err-try.js
+++ b/test/annexB/language/global-code/switch-case-global-skip-early-err-try.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-try.case
+// - src/annex-b-fns/global/switch-case.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Function declaration in the `case` clause of a `switch` statement in the global scope)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+try {
+  throw {};
+} catch ({ f }) {
+
+switch (1) {
+  case 1:
+    function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/switch-case-global-skip-early-err.js
+++ b/test/annexB/language/global-code/switch-case-global-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If replacing the FunctionDeclaration f with a VariableStatement that has
        F as a BindingIdentifier would not produce any Early Errors for script,

--- a/test/annexB/language/global-code/switch-case-global-update.js
+++ b/test/annexB/language/global-code/switch-case-global-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Function de
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     e. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in

--- a/test/annexB/language/global-code/switch-dflt-global-block-scoping.js
+++ b/test/annexB/language/global-code/switch-dflt-global-block-scoping.js
@@ -6,9 +6,9 @@ description: A block-scoped binding is created (Funtion declaration in the `defa
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     13.2.14 Runtime Semantics: BlockDeclarationInstantiation
-    
+
     [...]
     4. For each element d in declarations do
        a. For each element dn of the BoundNames of d do
@@ -16,7 +16,7 @@ info: >
              [...]
           ii. Else,
               2. Perform ! envRec.CreateMutableBinding(dn, false).
-    
+
        b. If d is a GeneratorDeclaration production or a FunctionDeclaration
           production, then
           i. Let fn be the sole element of the BoundNames of d.

--- a/test/annexB/language/global-code/switch-dflt-global-exsting-block-fn-no-init.js
+++ b/test/annexB/language/global-code/switch-dflt-global-exsting-block-fn-no-init.js
@@ -6,9 +6,9 @@ description: Does not re-initialize binding created by similar forms (Funtion de
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/switch-dflt-global-exsting-block-fn-update.js
+++ b/test/annexB/language/global-code/switch-dflt-global-exsting-block-fn-update.js
@@ -6,13 +6,13 @@ description: Variable-scoped binding is updated (Funtion declaration in the `def
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/switch-dflt-global-exsting-fn-no-init.js
+++ b/test/annexB/language/global-code/switch-dflt-global-exsting-fn-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Funtion declaration in t
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     1. Let fnDefinable be ? envRec.CanDeclareGlobalFunction(F).
     2. If fnDefinable is true, then

--- a/test/annexB/language/global-code/switch-dflt-global-exsting-fn-update.js
+++ b/test/annexB/language/global-code/switch-dflt-global-exsting-fn-update.js
@@ -6,13 +6,13 @@ description: Variable-scoped binding is updated following evaluation (Funtion de
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/switch-dflt-global-exsting-var-no-init.js
+++ b/test/annexB/language/global-code/switch-dflt-global-exsting-var-no-init.js
@@ -6,9 +6,9 @@ description: Existing variable binding is not modified (Funtion declaration in t
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).

--- a/test/annexB/language/global-code/switch-dflt-global-exsting-var-update.js
+++ b/test/annexB/language/global-code/switch-dflt-global-exsting-var-update.js
@@ -6,13 +6,13 @@ description: Variable-scoped binding is updated following evaluation (Funtion de
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
     [...]
     c. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in
        14.1.21:
-    
+
        i. Let genv be the running execution context's VariableEnvironment.
        ii. Let genvRec be genv's EnvironmentRecord.
        ii. Let benv be the running execution context's LexicalEnvironment.

--- a/test/annexB/language/global-code/switch-dflt-global-init.js
+++ b/test/annexB/language/global-code/switch-dflt-global-init.js
@@ -7,15 +7,15 @@ esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
 includes: [fnGlobalObject.js, propertyHelper.js]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If declaredFunctionOrVarNames does not contain F, then
        i. Perform ? envRec.CreateGlobalFunctionBinding(F, undefined, false).
        ii. Append F to declaredFunctionOrVarNames.
     [...]
-    
+
 ---*/
 var global = fnGlobalObject();
 assert.sameValue(f, undefined, 'binding is initialized to `undefined`');

--- a/test/annexB/language/global-code/switch-dflt-global-no-skip-try.js
+++ b/test/annexB/language/global-code/switch-dflt-global-no-skip-try.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-no-skip-try.case
+// - src/annex-b-fns/global/switch-dflt.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Funtion declaration in the `default` clause of a `switch` statement in the global scope)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.sameValue(
+  f, undefined, 'Initialized binding created prior to evaluation'
+);
+
+try {
+  throw null;
+} catch (f) {
+
+switch (1) {
+  default:
+    function f() { return 123; }
+}
+
+}
+
+assert.sameValue(
+  typeof f,
+  'function',
+  'binding value is updated following evaluation'
+);
+assert.sameValue(f(), 123);

--- a/test/annexB/language/global-code/switch-dflt-global-skip-early-err-block.js
+++ b/test/annexB/language/global-code/switch-dflt-global-skip-early-err-block.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-block.case
+// - src/annex-b-fns/global/switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (Block statement) (Funtion declaration in the `default` clause of a `switch` statement in the global scope)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+{
+let f = 123;
+
+switch (1) {
+  default:
+    function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/switch-dflt-global-skip-early-err-for-in.js
+++ b/test/annexB/language/global-code/switch-dflt-global-skip-early-err-for-in.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-in.case
+// - src/annex-b-fns/global/switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Funtion declaration in the `default` clause of a `switch` statement in the global scope)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f in { key: 0 }) {
+
+switch (1) {
+  default:
+    function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/switch-dflt-global-skip-early-err-for-of.js
+++ b/test/annexB/language/global-code/switch-dflt-global-skip-early-err-for-of.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for-of.case
+// - src/annex-b-fns/global/switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for-of statement) (Funtion declaration in the `default` clause of a `switch` statement in the global scope)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f of [0]) {
+
+switch (1) {
+  default:
+    function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/switch-dflt-global-skip-early-err-for.js
+++ b/test/annexB/language/global-code/switch-dflt-global-skip-early-err-for.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-for.case
+// - src/annex-b-fns/global/switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (for statement) (Funtion declaration in the `default` clause of a `switch` statement in the global scope)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+for (let f; ; ) {
+
+switch (1) {
+  default:
+    function f() {  }
+}
+
+  break;
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/switch-dflt-global-skip-early-err-switch.js
+++ b/test/annexB/language/global-code/switch-dflt-global-skip-early-err-switch.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-switch.case
+// - src/annex-b-fns/global/switch-dflt.template
+/*---
+description: Extension not observed when creation of variable binding would produce an early error (switch statement) (Funtion declaration in the `default` clause of a `switch` statement in the global scope)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+switch (0) {
+  default:
+    let f;
+
+switch (1) {
+  default:
+    function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/switch-dflt-global-skip-early-err-try.js
+++ b/test/annexB/language/global-code/switch-dflt-global-skip-early-err-try.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/global-skip-early-err-try.case
+// - src/annex-b-fns/global/switch-dflt.template
+/*---
+description: Extension is observed when creation of variable binding would not produce an early error (try statement) (Funtion declaration in the `default` clause of a `switch` statement in the global scope)
+esid: sec-web-compat-globaldeclarationinstantiation
+es6id: B.3.3.2
+flags: [generated, noStrict]
+info: |
+    B.3.3.2 Changes to GlobalDeclarationInstantiation
+
+    [...]
+    b. If replacing the FunctionDeclaration f with a VariableStatement that has
+       F as a BindingIdentifier would not produce any Early Errors for script,
+       then
+    [...]
+
+    B.3.5 VariableStatements in Catch Blocks
+
+    [...]
+    - It is a Syntax Error if any element of the BoundNames of CatchParameter
+      also occurs in the VarDeclaredNames of Block unless CatchParameter is
+      CatchParameter:BindingIdentifier and that element is only bound by a
+      VariableStatement, the VariableDeclarationList of a for statement, or the
+      ForBinding of a for-in statement.
+---*/
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created prior to evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created prior to evaluation'
+);
+
+try {
+  throw {};
+} catch ({ f }) {
+
+switch (1) {
+  default:
+    function f() {  }
+}
+
+}
+
+assert.throws(ReferenceError, function() {
+  f;
+}, 'An initialized binding is not created following evaluation');
+assert.sameValue(
+  typeof f,
+  'undefined',
+  'An uninitialized binding is not created following evaluation'
+);

--- a/test/annexB/language/global-code/switch-dflt-global-skip-early-err.js
+++ b/test/annexB/language/global-code/switch-dflt-global-skip-early-err.js
@@ -6,9 +6,9 @@ description: Extension not observed when creation of variable binding would prod
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     b. If replacing the FunctionDeclaration f with a VariableStatement that has
        F as a BindingIdentifier would not produce any Early Errors for script,

--- a/test/annexB/language/global-code/switch-dflt-global-update.js
+++ b/test/annexB/language/global-code/switch-dflt-global-update.js
@@ -6,9 +6,9 @@ description: Variable binding value is updated following evaluation (Funtion dec
 esid: sec-web-compat-globaldeclarationinstantiation
 es6id: B.3.3.2
 flags: [generated, noStrict]
-info: >
+info: |
     B.3.3.2 Changes to GlobalDeclarationInstantiation
-    
+
     [...]
     e. When the FunctionDeclaration f is evaluated, perform the following steps
        in place of the FunctionDeclaration Evaluation algorithm provided in


### PR DESCRIPTION
There's extra noise here because the test generation tool has changed since the
"annex B function-in-block" tests were first introduced. I've documented this
in a standalone commit, and I'm happy to submit that as a separate pull request
(blocking this one) if my reviewers would prefer that.

This should resolve gh-697.

> The "variable-like" function hoisting semantics defined in Annex B extension
> B.3.3 is only applied if "[...] replacing the FunctionDeclaration f with a
> VariableStatement that has F as a BindingIdentifier would not produce any Early
> Errors [...]". Test262 previously included tests for this condition when the
> disqualifying early error originated from the ScriptBody and FunctionBody
> productions.
>
> Add test cases to assert the behavior when it is disqualified by all other
> relevant early errors: Block statements, `for` statements, `for-of` statements,
> `for-in` statements, and Switch statements.