### PR TITLE
Add bit-precision tests for TypedArray#copyWithin

### DIFF
--- a/test/built-ins/TypedArray/prototype/copyWithin/bit-precision.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/bit-precision.js
@@ -16,14 +16,13 @@ info: |
 includes: [nans.js, compareArray.js, testTypedArray.js]
 ---*/
 
-var distinctNaNsDouble = new Array(distinctNaNs.length * 2);
-
-distinctNaNs.forEach(function(v, i) {
-  distinctNaNsDouble[i] = v;
-});
-
 function body(FloatArray) {
-  var subject = new FloatArray(distinctNaNsDouble);
+  var subject = new FloatArray(distinctNaNs.length * 2);
+
+  distinctNaNs.forEach(function(v, i) {
+    subject[i] = v;
+  });
+
   var originalBytes, copiedBytes;
   var length = distinctNaNs.length * FloatArray.BYTES_PER_ELEMENT;
 

--- a/test/built-ins/TypedArray/prototype/copyWithin/bit-precision.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/bit-precision.js
@@ -23,17 +23,20 @@ distinctNaNs.forEach(function(v, i) {
 });
 
 function body(FloatArray) {
-  var originalValues = new FloatArray(distinctNaNs);
   var subject = new FloatArray(distinctNaNsDouble);
-
   var originalBytes, copiedBytes;
+  var length = distinctNaNs.length * FloatArray.BYTES_PER_ELEMENT;
 
-  originalBytes = new Uint8Array(originalValues.buffer);
+  originalBytes = new Uint8Array(
+    subject.buffer,
+    0,
+    length
+  );
 
   subject.copyWithin(distinctNaNs.length, 0);
   copiedBytes = new Uint8Array(
     subject.buffer,
-    distinctNaNs.length * FloatArray.BYTES_PER_ELEMENT
+    length
   );
 
   assert(compareArray(originalBytes, copiedBytes));

--- a/test/built-ins/TypedArray/prototype/copyWithin/bit-precision.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/bit-precision.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.copywithin
+es6id: 22.2.3.5
+description: Preservation of bit-level encoding
+info: |
+  Array.prototype.copyWithin (target, start [ , end ] )
+
+  12. Repeat, while count > 0
+    [...]
+    d. If fromPresent is true, then
+      i. Let fromVal be ? Get(O, fromKey).
+      ii. Perform ? Set(O, toKey, fromVal, true).
+includes: [nans.js, compareArray.js, testTypedArray.js]
+---*/
+
+var distinctNaNsDouble = new Array(distinctNaNs.length * 2);
+
+distinctNaNs.forEach(function(v, i) {
+  distinctNaNsDouble[i] = v;
+});
+
+function body(FloatArray) {
+  var originalValues = new FloatArray(distinctNaNs);
+  var subject = new FloatArray(distinctNaNsDouble);
+
+  var originalBytes, copiedBytes;
+
+  originalBytes = new Uint8Array(originalValues.buffer);
+
+  subject.copyWithin(distinctNaNs.length, 0);
+  copiedBytes = new Uint8Array(
+    subject.buffer,
+    distinctNaNs.length * FloatArray.BYTES_PER_ELEMENT
+  );
+
+  assert(compareArray(originalBytes, copiedBytes));
+}
+
+testWithTypedArrayConstructors(body, [Float32Array, Float64Array]);


### PR DESCRIPTION
I'm not 100% convinced the nan bit encoding is preserved w/ copyWithin, but it's good to check.

@littledan would you mind reviewing this one?