### PR TITLE
Use global values on typeof tests for Number values

### DIFF
--- a/test/language/expressions/typeof/number.js
+++ b/test/language/expressions/typeof/number.js
@@ -11,29 +11,29 @@ description: typeof (number value) === "number"
 assert.sameValue(
   typeof 1,
   "number",
-  '#1: typeof 1 === "number". Actual: ' + (typeof 1)
+  'typeof 1 === "number". Actual: ' + (typeof 1)
 );
 
 assert.sameValue(
-  typeof Number.NaN,
+  typeof NaN,
   "number",
-  '#2: typeof NaN === "number". Actual: ' + (typeof NaN)
+  'typeof NaN === "number". Actual: ' + (typeof NaN)
 );
 
 assert.sameValue(
-  typeof Number.POSITIVE_INFINITY,
+  typeof Infinity,
   "number",
-  '#3: typeof Infinity === "number". Actual: ' + (typeof Infinity)
+  'typeof Infinity === "number". Actual: ' + (typeof Infinity)
 );
 
 assert.sameValue(
-  typeof Number.NEGATIVE_INFINITY,
+  typeof -Infinity,
   "number",
-  '#4: typeof -Infinity === "number". Actual: ' + (typeof -Infinity)
+  'typeof -Infinity === "number". Actual: ' + (typeof -Infinity)
 );
 
 assert.sameValue(
   typeof Math.PI,
   "number",
-  '#5: typeof Math.PI === "number". Actual: ' + (typeof Math.PI)
+  'typeof Math.PI === "number". Actual: ' + (typeof Math.PI)
 );


### PR DESCRIPTION
This is a pure miscellaneous change to use global values of NaN and Infinity instead of their namespaced equivalents.

Ref https://github.com/tc39/test262/pull/690/files/9ae0567a50b4367cf0c692da947ed3613e2e35c3#r69049894

cc @suwc