### PR TITLE
Improve coverage for class "name" inference

### DIFF
--- a/src/dstr-assignment/array-elem-init-fn-name-class.case
+++ b/src/dstr-assignment/array-elem-init-fn-name-class.case
@@ -21,13 +21,14 @@ features: [class]
 ---*/
 
 //- setup
-var xCls, cls;
+var xCls, cls, xCls2;
 //- elems
-[ xCls = class x {},cls = class {} ]
+[ xCls = class x {}, cls = class {}, xCls2 = class { static name() {} } ]
 //- vals
 []
 //- body
 assert(xCls.name !== 'xCls');
+assert(xCls2.name !== 'xCls2');
 
 assert.sameValue(cls.name, 'cls');
 verifyNotEnumerable(cls, 'name');

--- a/src/dstr-assignment/obj-id-init-fn-name-class.case
+++ b/src/dstr-assignment/obj-id-init-fn-name-class.case
@@ -20,13 +20,14 @@ features: [class]
 ---*/
 
 //- setup
-var xCls, cls;
+var xCls, cls, xCls2;
 //- elems
-{ xCls = class x {}, cls = class {} }
+{ xCls = class x {}, cls = class {}, xCls2 = class { static name() {} } }
 //- vals
 {}
 //- body
 assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');
 
 assert.sameValue(cls.name, 'cls');
 verifyNotEnumerable(cls, 'name');

--- a/src/dstr-assignment/obj-prop-elem-init-fn-name-class.case
+++ b/src/dstr-assignment/obj-prop-elem-init-fn-name-class.case
@@ -21,13 +21,14 @@ features: [class]
 ---*/
 
 //- setup
-var xCls, cls;
+var xCls, cls, xCls2;
 //- elems
-{ x: xCls = class x {}, x: cls = class {} }
+{ x: xCls = class x {}, x: cls = class {}, x: xCls2 = class { static name() {} } }
 //- vals
 {}
 //- body
 assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');
 
 assert.sameValue(cls.name, 'cls');
 verifyNotEnumerable(cls, 'name');

--- a/src/dstr-binding/ary-ptrn-elem-id-init-fn-name-class.case
+++ b/src/dstr-binding/ary-ptrn-elem-id-init-fn-name-class.case
@@ -20,9 +20,10 @@ info: |
 ---*/
 
 //- elems
-[cls = class {}, xCls = class X {}]
+[cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]
 //- vals
 []
 //- body
 assert.sameValue(cls.name, 'cls');
 assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');

--- a/src/dstr-binding/obj-ptrn-id-init-fn-name-class.case
+++ b/src/dstr-binding/obj-ptrn-id-init-fn-name-class.case
@@ -19,9 +19,10 @@ info: |
 ---*/
 
 //- elems
-{ cls = class {}, xCls = class X {} }
+{ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }
 //- vals
 {}
 //- body
 assert.sameValue(cls.name, 'cls');
 assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');

--- a/test/language/expressions/arrow-function/dstr-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/arrow-function/dstr-ary-ptrn-elem-id-init-fn-name-class.js
@@ -54,9 +54,10 @@ info: |
 
 var callCount = 0;
 var f;
-f = ([cls = class {}, xCls = class X {}]) => {
+f = ([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) => {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 

--- a/test/language/expressions/arrow-function/dstr-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/arrow-function/dstr-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -54,9 +54,10 @@ info: |
 
 var callCount = 0;
 var f;
-f = ([cls = class {}, xCls = class X {}] = []) => {
+f = ([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) => {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 

--- a/test/language/expressions/arrow-function/dstr-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/arrow-function/dstr-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -53,9 +53,10 @@ info: |
 
 var callCount = 0;
 var f;
-f = ({ cls = class {}, xCls = class X {} } = {}) => {
+f = ({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) => {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 

--- a/test/language/expressions/arrow-function/dstr-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/arrow-function/dstr-obj-ptrn-id-init-fn-name-class.js
@@ -53,9 +53,10 @@ info: |
 
 var callCount = 0;
 var f;
-f = ({ cls = class {}, xCls = class X {} }) => {
+f = ({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) => {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 

--- a/test/language/expressions/assignment/dstr-array-elem-init-fn-name-class.js
+++ b/test/language/expressions/assignment/dstr-array-elem-init-fn-name-class.js
@@ -27,14 +27,15 @@ info: |
           GetReferencedName(lref)).
 
 ---*/
-var xCls, cls;
+var xCls, cls, xCls2;
 
 var result;
 var vals = [];
 
-result = [ xCls = class x {},cls = class {} ] = vals;
+result = [ xCls = class x {}, cls = class {}, xCls2 = class { static name() {} } ] = vals;
 
 assert(xCls.name !== 'xCls');
+assert(xCls2.name !== 'xCls2');
 
 assert.sameValue(cls.name, 'cls');
 verifyNotEnumerable(cls, 'name');

--- a/test/language/expressions/assignment/dstr-obj-id-init-fn-name-class.js
+++ b/test/language/expressions/assignment/dstr-obj-id-init-fn-name-class.js
@@ -26,14 +26,15 @@ info: |
           iii. If hasNameProperty is false, perform SetFunctionName(v, P).
 
 ---*/
-var xCls, cls;
+var xCls, cls, xCls2;
 
 var result;
 var vals = {};
 
-result = { xCls = class x {}, cls = class {} } = vals;
+result = { xCls = class x {}, cls = class {}, xCls2 = class { static name() {} } } = vals;
 
 assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');
 
 assert.sameValue(cls.name, 'cls');
 verifyNotEnumerable(cls, 'name');

--- a/test/language/expressions/assignment/dstr-obj-prop-elem-init-fn-name-class.js
+++ b/test/language/expressions/assignment/dstr-obj-prop-elem-init-fn-name-class.js
@@ -27,14 +27,15 @@ info: |
           GetReferencedName(lref)).
 
 ---*/
-var xCls, cls;
+var xCls, cls, xCls2;
 
 var result;
 var vals = {};
 
-result = { x: xCls = class x {}, x: cls = class {} } = vals;
+result = { x: xCls = class x {}, x: cls = class {}, x: xCls2 = class { static name() {} } } = vals;
 
 assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');
 
 assert.sameValue(cls.name, 'cls');
 verifyNotEnumerable(cls, 'name');

--- a/test/language/expressions/assignment/fn-name-class.js
+++ b/test/language/expressions/assignment/fn-name-class.js
@@ -22,12 +22,14 @@ includes: [propertyHelper.js]
 features: [class]
 ---*/
 
-var xCls, cls;
+var xCls, cls, xCls2;
 
 xCls = class x {};
 cls = class {};
+xCls2 = class { static name() {} };
 
-assert(xCls.name !== 'xCls');
+assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');
 
 assert.sameValue(cls.name, 'cls');
 verifyNotEnumerable(cls, 'name');

--- a/test/language/expressions/class/dstr-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
@@ -78,9 +78,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  *method([cls = class {}, xCls = class X {}]) {
+  *method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -78,9 +78,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  *method([cls = class {}, xCls = class X {}] = []) {
+  *method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -77,9 +77,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  *method({ cls = class {}, xCls = class X {} } = {}) {
+  *method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-gen-meth-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-gen-meth-obj-ptrn-id-init-fn-name-class.js
@@ -77,9 +77,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  *method({ cls = class {}, xCls = class X {} }) {
+  *method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
@@ -78,9 +78,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  static *method([cls = class {}, xCls = class X {}]) {
+  static *method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -78,9 +78,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  static *method([cls = class {}, xCls = class X {}] = []) {
+  static *method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -77,9 +77,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  static *method({ cls = class {}, xCls = class X {} } = {}) {
+  static *method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
@@ -77,9 +77,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  static *method({ cls = class {}, xCls = class X {} }) {
+  static *method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-meth-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-meth-ary-ptrn-elem-id-init-fn-name-class.js
@@ -75,9 +75,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  method([cls = class {}, xCls = class X {}]) {
+  method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -75,9 +75,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  method([cls = class {}, xCls = class X {}] = []) {
+  method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-meth-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -74,9 +74,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  method({ cls = class {}, xCls = class X {} } = {}) {
+  method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-meth-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-meth-obj-ptrn-id-init-fn-name-class.js
@@ -74,9 +74,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  method({ cls = class {}, xCls = class X {} }) {
+  method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
@@ -75,9 +75,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  static method([cls = class {}, xCls = class X {}]) {
+  static method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -75,9 +75,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  static method([cls = class {}, xCls = class X {}] = []) {
+  static method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -74,9 +74,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  static method({ cls = class {}, xCls = class X {} } = {}) {
+  static method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/class/dstr-meth-static-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/class/dstr-meth-static-obj-ptrn-id-init-fn-name-class.js
@@ -74,9 +74,10 @@ info: |
 
 var callCount = 0;
 var C = class {
-  static method({ cls = class {}, xCls = class X {} }) {
+  static method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/function/dstr-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/function/dstr-ary-ptrn-elem-id-init-fn-name-class.js
@@ -55,9 +55,10 @@ info: |
 
 var callCount = 0;
 var f;
-f = function([cls = class {}, xCls = class X {}]) {
+f = function([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 

--- a/test/language/expressions/function/dstr-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/function/dstr-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -55,9 +55,10 @@ info: |
 
 var callCount = 0;
 var f;
-f = function([cls = class {}, xCls = class X {}] = []) {
+f = function([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 

--- a/test/language/expressions/function/dstr-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/function/dstr-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -54,9 +54,10 @@ info: |
 
 var callCount = 0;
 var f;
-f = function({ cls = class {}, xCls = class X {} } = {}) {
+f = function({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 

--- a/test/language/expressions/function/dstr-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/function/dstr-obj-ptrn-id-init-fn-name-class.js
@@ -54,9 +54,10 @@ info: |
 
 var callCount = 0;
 var f;
-f = function({ cls = class {}, xCls = class X {} }) {
+f = function({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 

--- a/test/language/expressions/generators/dstr-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/generators/dstr-ary-ptrn-elem-id-init-fn-name-class.js
@@ -55,9 +55,10 @@ info: |
 
 var callCount = 0;
 var f;
-f = function*([cls = class {}, xCls = class X {}]) {
+f = function*([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 

--- a/test/language/expressions/generators/dstr-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/generators/dstr-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -55,9 +55,10 @@ info: |
 
 var callCount = 0;
 var f;
-f = function*([cls = class {}, xCls = class X {}] = []) {
+f = function*([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 

--- a/test/language/expressions/generators/dstr-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/generators/dstr-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -54,9 +54,10 @@ info: |
 
 var callCount = 0;
 var f;
-f = function*({ cls = class {}, xCls = class X {} } = {}) {
+f = function*({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 

--- a/test/language/expressions/generators/dstr-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/generators/dstr-obj-ptrn-id-init-fn-name-class.js
@@ -54,9 +54,10 @@ info: |
 
 var callCount = 0;
 var f;
-f = function*({ cls = class {}, xCls = class X {} }) {
+f = function*({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 

--- a/test/language/expressions/object/dstr-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/object/dstr-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
@@ -60,9 +60,10 @@ info: |
 
 var callCount = 0;
 var obj = {
-  *method([cls = class {}, xCls = class X {}]) {
+  *method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/object/dstr-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/object/dstr-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -60,9 +60,10 @@ info: |
 
 var callCount = 0;
 var obj = {
-  *method([cls = class {}, xCls = class X {}] = []) {
+  *method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/object/dstr-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/object/dstr-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -59,9 +59,10 @@ info: |
 
 var callCount = 0;
 var obj = {
-  *method({ cls = class {}, xCls = class X {} } = {}) {
+  *method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/object/dstr-gen-meth-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/object/dstr-gen-meth-obj-ptrn-id-init-fn-name-class.js
@@ -59,9 +59,10 @@ info: |
 
 var callCount = 0;
 var obj = {
-  *method({ cls = class {}, xCls = class X {} }) {
+  *method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/object/dstr-meth-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/object/dstr-meth-ary-ptrn-elem-id-init-fn-name-class.js
@@ -57,9 +57,10 @@ info: |
 
 var callCount = 0;
 var obj = {
-  method([cls = class {}, xCls = class X {}]) {
+  method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/object/dstr-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/expressions/object/dstr-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -57,9 +57,10 @@ info: |
 
 var callCount = 0;
 var obj = {
-  method([cls = class {}, xCls = class X {}] = []) {
+  method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/object/dstr-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/object/dstr-meth-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -56,9 +56,10 @@ info: |
 
 var callCount = 0;
 var obj = {
-  method({ cls = class {}, xCls = class X {} } = {}) {
+  method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/expressions/object/dstr-meth-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/expressions/object/dstr-meth-obj-ptrn-id-init-fn-name-class.js
@@ -56,9 +56,10 @@ info: |
 
 var callCount = 0;
 var obj = {
-  method({ cls = class {}, xCls = class X {} }) {
+  method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
@@ -76,9 +76,10 @@ info: |
 
 var callCount = 0;
 class C {
-  *method([cls = class {}, xCls = class X {}]) {
+  *method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -76,9 +76,10 @@ info: |
 
 var callCount = 0;
 class C {
-  *method([cls = class {}, xCls = class X {}] = []) {
+  *method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -75,9 +75,10 @@ info: |
 
 var callCount = 0;
 class C {
-  *method({ cls = class {}, xCls = class X {} } = {}) {
+  *method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-gen-meth-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-gen-meth-obj-ptrn-id-init-fn-name-class.js
@@ -75,9 +75,10 @@ info: |
 
 var callCount = 0;
 class C {
-  *method({ cls = class {}, xCls = class X {} }) {
+  *method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
@@ -76,9 +76,10 @@ info: |
 
 var callCount = 0;
 class C {
-  static *method([cls = class {}, xCls = class X {}]) {
+  static *method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -76,9 +76,10 @@ info: |
 
 var callCount = 0;
 class C {
-  static *method([cls = class {}, xCls = class X {}] = []) {
+  static *method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -75,9 +75,10 @@ info: |
 
 var callCount = 0;
 class C {
-  static *method({ cls = class {}, xCls = class X {} } = {}) {
+  static *method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
@@ -75,9 +75,10 @@ info: |
 
 var callCount = 0;
 class C {
-  static *method({ cls = class {}, xCls = class X {} }) {
+  static *method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-meth-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-meth-ary-ptrn-elem-id-init-fn-name-class.js
@@ -74,9 +74,10 @@ info: |
 
 var callCount = 0;
 class C {
-  method([cls = class {}, xCls = class X {}]) {
+  method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -74,9 +74,10 @@ info: |
 
 var callCount = 0;
 class C {
-  method([cls = class {}, xCls = class X {}] = []) {
+  method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-meth-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -73,9 +73,10 @@ info: |
 
 var callCount = 0;
 class C {
-  method({ cls = class {}, xCls = class X {} } = {}) {
+  method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-meth-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-meth-obj-ptrn-id-init-fn-name-class.js
@@ -73,9 +73,10 @@ info: |
 
 var callCount = 0;
 class C {
-  method({ cls = class {}, xCls = class X {} }) {
+  method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
@@ -74,9 +74,10 @@ info: |
 
 var callCount = 0;
 class C {
-  static method([cls = class {}, xCls = class X {}]) {
+  static method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -74,9 +74,10 @@ info: |
 
 var callCount = 0;
 class C {
-  static method([cls = class {}, xCls = class X {}] = []) {
+  static method([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -73,9 +73,10 @@ info: |
 
 var callCount = 0;
 class C {
-  static method({ cls = class {}, xCls = class X {} } = {}) {
+  static method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/class/dstr-meth-static-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/class/dstr-meth-static-obj-ptrn-id-init-fn-name-class.js
@@ -73,9 +73,10 @@ info: |
 
 var callCount = 0;
 class C {
-  static method({ cls = class {}, xCls = class X {} }) {
+  static method({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
     assert.sameValue(cls.name, 'cls');
     assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
     callCount = callCount + 1;
   }
 };

--- a/test/language/statements/const/dstr-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/const/dstr-ary-ptrn-elem-id-init-fn-name-class.js
@@ -32,7 +32,8 @@ info: |
     8. Return InitializeReferencedBinding(lhs, v).
 ---*/
 
-const [cls = class {}, xCls = class X {}] = [];
+const [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = [];
 
 assert.sameValue(cls.name, 'cls');
 assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');

--- a/test/language/statements/const/dstr-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/const/dstr-obj-ptrn-id-init-fn-name-class.js
@@ -31,7 +31,8 @@ info: |
                bindingId).
 ---*/
 
-const { cls = class {}, xCls = class X {} } = {};
+const { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {};
 
 assert.sameValue(cls.name, 'cls');
 assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');

--- a/test/language/statements/const/fn-name-class.js
+++ b/test/language/statements/const/fn-name-class.js
@@ -19,8 +19,10 @@ features: [class]
 
 const xCls = class x {};
 const cls = class {};
+const xCls2 = class { static name() {} };
 
-assert(xCls.name !== 'xCls');
+assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');
 
 assert.sameValue(cls.name, 'cls');
 verifyNotEnumerable(cls, 'name');

--- a/test/language/statements/for-of/dstr-array-elem-init-fn-name-class.js
+++ b/test/language/statements/for-of/dstr-array-elem-init-fn-name-class.js
@@ -36,12 +36,13 @@ info: |
           GetReferencedName(lref)).
 
 ---*/
-var xCls, cls;
+var xCls, cls, xCls2;
 
 var counter = 0;
 
-for ([ xCls = class x {},cls = class {} ] of [[]]) {
+for ([ xCls = class x {}, cls = class {}, xCls2 = class { static name() {} } ] of [[]]) {
   assert(xCls.name !== 'xCls');
+  assert(xCls2.name !== 'xCls2');
 
   assert.sameValue(cls.name, 'cls');
   verifyNotEnumerable(cls, 'name');

--- a/test/language/statements/for-of/dstr-const-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-of/dstr-const-ary-ptrn-elem-id-init-fn-name-class.js
@@ -53,9 +53,10 @@ info: |
 
 var iterCount = 0;
 
-for (const [cls = class {}, xCls = class X {}] of [[]]) {
+for (const [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] of [[]]) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
 
   iterCount += 1;
 }

--- a/test/language/statements/for-of/dstr-const-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-of/dstr-const-obj-ptrn-id-init-fn-name-class.js
@@ -52,9 +52,10 @@ info: |
 
 var iterCount = 0;
 
-for (const { cls = class {}, xCls = class X {} } of [{}]) {
+for (const { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } of [{}]) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
 
   iterCount += 1;
 }

--- a/test/language/statements/for-of/dstr-let-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-of/dstr-let-ary-ptrn-elem-id-init-fn-name-class.js
@@ -53,9 +53,10 @@ info: |
 
 var iterCount = 0;
 
-for (let [cls = class {}, xCls = class X {}] of [[]]) {
+for (let [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] of [[]]) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
 
   iterCount += 1;
 }

--- a/test/language/statements/for-of/dstr-let-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-of/dstr-let-obj-ptrn-id-init-fn-name-class.js
@@ -52,9 +52,10 @@ info: |
 
 var iterCount = 0;
 
-for (let { cls = class {}, xCls = class X {} } of [{}]) {
+for (let { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } of [{}]) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
 
   iterCount += 1;
 }

--- a/test/language/statements/for-of/dstr-obj-id-init-fn-name-class.js
+++ b/test/language/statements/for-of/dstr-obj-id-init-fn-name-class.js
@@ -35,12 +35,13 @@ info: |
           iii. If hasNameProperty is false, perform SetFunctionName(v, P).
 
 ---*/
-var xCls, cls;
+var xCls, cls, xCls2;
 
 var counter = 0;
 
-for ({ xCls = class x {}, cls = class {} } of [{}]) {
+for ({ xCls = class x {}, cls = class {}, xCls2 = class { static name() {} } } of [{}]) {
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
 
   assert.sameValue(cls.name, 'cls');
   verifyNotEnumerable(cls, 'name');

--- a/test/language/statements/for-of/dstr-obj-prop-elem-init-fn-name-class.js
+++ b/test/language/statements/for-of/dstr-obj-prop-elem-init-fn-name-class.js
@@ -36,12 +36,13 @@ info: |
           GetReferencedName(lref)).
 
 ---*/
-var xCls, cls;
+var xCls, cls, xCls2;
 
 var counter = 0;
 
-for ({ x: xCls = class x {}, x: cls = class {} } of [{}]) {
+for ({ x: xCls = class x {}, x: cls = class {}, x: xCls2 = class { static name() {} } } of [{}]) {
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
 
   assert.sameValue(cls.name, 'cls');
   verifyNotEnumerable(cls, 'name');

--- a/test/language/statements/for-of/dstr-var-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-of/dstr-var-ary-ptrn-elem-id-init-fn-name-class.js
@@ -50,9 +50,10 @@ info: |
 
 var iterCount = 0;
 
-for (var [cls = class {}, xCls = class X {}] of [[]]) {
+for (var [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] of [[]]) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
 
   iterCount += 1;
 }

--- a/test/language/statements/for-of/dstr-var-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-of/dstr-var-obj-ptrn-id-init-fn-name-class.js
@@ -49,9 +49,10 @@ info: |
 
 var iterCount = 0;
 
-for (var { cls = class {}, xCls = class X {} } of [{}]) {
+for (var { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } of [{}]) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
 
   iterCount += 1;
 }

--- a/test/language/statements/for/dstr-const-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for/dstr-const-ary-ptrn-elem-id-init-fn-name-class.js
@@ -53,9 +53,10 @@ info: |
 
 var iterCount = 0;
 
-for (const [cls = class {}, xCls = class X {}] = []; iterCount < 1; ) {
+for (const [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []; iterCount < 1; ) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
 
   iterCount += 1;
 }

--- a/test/language/statements/for/dstr-const-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for/dstr-const-obj-ptrn-id-init-fn-name-class.js
@@ -52,9 +52,10 @@ info: |
 
 var iterCount = 0;
 
-for (const { cls = class {}, xCls = class X {} } = {}; iterCount < 1; ) {
+for (const { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}; iterCount < 1; ) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
 
   iterCount += 1;
 }

--- a/test/language/statements/for/dstr-let-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for/dstr-let-ary-ptrn-elem-id-init-fn-name-class.js
@@ -53,9 +53,10 @@ info: |
 
 var iterCount = 0;
 
-for (let [cls = class {}, xCls = class X {}] = []; iterCount < 1; ) {
+for (let [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []; iterCount < 1; ) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
 
   iterCount += 1;
 }

--- a/test/language/statements/for/dstr-let-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for/dstr-let-obj-ptrn-id-init-fn-name-class.js
@@ -52,9 +52,10 @@ info: |
 
 var iterCount = 0;
 
-for (let { cls = class {}, xCls = class X {} } = {}; iterCount < 1; ) {
+for (let { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}; iterCount < 1; ) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
 
   iterCount += 1;
 }

--- a/test/language/statements/for/dstr-var-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for/dstr-var-ary-ptrn-elem-id-init-fn-name-class.js
@@ -47,9 +47,10 @@ info: |
 
 var iterCount = 0;
 
-for (var [cls = class {}, xCls = class X {}] = []; iterCount < 1; ) {
+for (var [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []; iterCount < 1; ) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   iterCount += 1;
 }
 

--- a/test/language/statements/for/dstr-var-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for/dstr-var-obj-ptrn-id-init-fn-name-class.js
@@ -46,9 +46,10 @@ info: |
 
 var iterCount = 0;
 
-for (var { cls = class {}, xCls = class X {} } = {}; iterCount < 1; ) {
+for (var { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}; iterCount < 1; ) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   iterCount += 1;
 }
 

--- a/test/language/statements/function/dstr-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/function/dstr-ary-ptrn-elem-id-init-fn-name-class.js
@@ -55,9 +55,10 @@ info: |
 ---*/
 
 var callCount = 0;
-function f([cls = class {}, xCls = class X {}]) {
+function f([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 f([]);

--- a/test/language/statements/function/dstr-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/function/dstr-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -55,9 +55,10 @@ info: |
 ---*/
 
 var callCount = 0;
-function f([cls = class {}, xCls = class X {}] = []) {
+function f([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 f();

--- a/test/language/statements/function/dstr-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/function/dstr-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -54,9 +54,10 @@ info: |
 ---*/
 
 var callCount = 0;
-function f({ cls = class {}, xCls = class X {} } = {}) {
+function f({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 f();

--- a/test/language/statements/function/dstr-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/function/dstr-obj-ptrn-id-init-fn-name-class.js
@@ -54,9 +54,10 @@ info: |
 ---*/
 
 var callCount = 0;
-function f({ cls = class {}, xCls = class X {} }) {
+function f({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 f({});

--- a/test/language/statements/generators/dstr-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/generators/dstr-ary-ptrn-elem-id-init-fn-name-class.js
@@ -54,9 +54,10 @@ info: |
 ---*/
 
 var callCount = 0;
-function* f([cls = class {}, xCls = class X {}]) {
+function* f([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 f([]).next();

--- a/test/language/statements/generators/dstr-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/generators/dstr-dflt-ary-ptrn-elem-id-init-fn-name-class.js
@@ -54,9 +54,10 @@ info: |
 ---*/
 
 var callCount = 0;
-function* f([cls = class {}, xCls = class X {}] = []) {
+function* f([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = []) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 f().next();

--- a/test/language/statements/generators/dstr-dflt-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/generators/dstr-dflt-obj-ptrn-id-init-fn-name-class.js
@@ -53,9 +53,10 @@ info: |
 ---*/
 
 var callCount = 0;
-function* f({ cls = class {}, xCls = class X {} } = {}) {
+function* f({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {}) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 f().next();

--- a/test/language/statements/generators/dstr-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/generators/dstr-obj-ptrn-id-init-fn-name-class.js
@@ -53,9 +53,10 @@ info: |
 ---*/
 
 var callCount = 0;
-function* f({ cls = class {}, xCls = class X {} }) {
+function* f({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   callCount = callCount + 1;
 };
 f({}).next();

--- a/test/language/statements/let/dstr-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/let/dstr-ary-ptrn-elem-id-init-fn-name-class.js
@@ -32,7 +32,8 @@ info: |
     8. Return InitializeReferencedBinding(lhs, v).
 ---*/
 
-let [cls = class {}, xCls = class X {}] = [];
+let [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = [];
 
 assert.sameValue(cls.name, 'cls');
 assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');

--- a/test/language/statements/let/dstr-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/let/dstr-obj-ptrn-id-init-fn-name-class.js
@@ -31,7 +31,8 @@ info: |
                bindingId).
 ---*/
 
-let { cls = class {}, xCls = class X {} } = {};
+let { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {};
 
 assert.sameValue(cls.name, 'cls');
 assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');

--- a/test/language/statements/let/fn-name-class.js
+++ b/test/language/statements/let/fn-name-class.js
@@ -19,8 +19,10 @@ features: [class]
 
 let xCls = class x {};
 let cls = class {};
+let xCls2 = class { static name() {} };
 
-assert(xCls.name !== 'xCls');
+assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');
 
 assert.sameValue(cls.name, 'cls');
 verifyNotEnumerable(cls, 'name');

--- a/test/language/statements/try/dstr-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/try/dstr-ary-ptrn-elem-id-init-fn-name-class.js
@@ -34,9 +34,10 @@ var ranCatch = false;
 
 try {
   throw [];
-} catch ([cls = class {}, xCls = class X {}]) {
+} catch ([cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }]) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   ranCatch = true;
 }
 

--- a/test/language/statements/try/dstr-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/try/dstr-obj-ptrn-id-init-fn-name-class.js
@@ -33,9 +33,10 @@ var ranCatch = false;
 
 try {
   throw {};
-} catch ({ cls = class {}, xCls = class X {} }) {
+} catch ({ cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } }) {
   assert.sameValue(cls.name, 'cls');
   assert.notSameValue(xCls.name, 'xCls');
+  assert.notSameValue(xCls2.name, 'xCls2');
   ranCatch = true;
 }
 

--- a/test/language/statements/variable/dstr-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/variable/dstr-ary-ptrn-elem-id-init-fn-name-class.js
@@ -31,7 +31,8 @@ info: |
     8. Return InitializeReferencedBinding(lhs, v).
 ---*/
 
-var [cls = class {}, xCls = class X {}] = [];
+var [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] = [];
 
 assert.sameValue(cls.name, 'cls');
 assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');

--- a/test/language/statements/variable/dstr-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/variable/dstr-obj-ptrn-id-init-fn-name-class.js
@@ -30,7 +30,8 @@ info: |
                bindingId).
 ---*/
 
-var { cls = class {}, xCls = class X {} } = {};
+var { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } = {};
 
 assert.sameValue(cls.name, 'cls');
 assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');

--- a/test/language/statements/variable/fn-name-class.js
+++ b/test/language/statements/variable/fn-name-class.js
@@ -19,8 +19,10 @@ features: [class]
 
 var xCls = class x {};
 var cls = class {};
+var xCls2 = class { static name() {} };
 
-assert(xCls.name !== 'xCls');
+assert.notSameValue(xCls.name, 'xCls');
+assert.notSameValue(xCls2.name, 'xCls2');
 
 assert.sameValue(cls.name, 'cls');
 verifyNotEnumerable(cls, 'name');


### PR DESCRIPTION
This is technically part of section 14. I recently submitted a patch for
coverage in that section (see gh-717), but because this change involves the
generation tool, I thought it would be easier on my reviewers if it were
submitted separately.

As usual, this change set factors all the procedurally-generated changes into
a dedicated commit.

