### PR TITLE
Improve coverage for section 15: Scripts and Modules

### DIFF
--- a/test/language/eval-code/direct/super-call-arrow.js
+++ b/test/language/eval-code/direct/super-call-arrow.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: >
+  A direct eval in the functon code of an ArrowFunction may not contain
+  SuperCall
+info: |
+  - It is a Syntax Error if StatementList Contains super unless the source code
+    containing super is eval code that is being processed by a direct eval that
+    is contained in function code that is not the function code of an
+    ArrowFunction.
+features: [super, arrow-function]
+---*/
+
+var caught;
+var f = () => eval('super();');
+
+try {
+  f();
+} catch (err) {
+  caught = err;
+}
+
+assert.sameValue(typeof caught, 'object');
+assert.sameValue(caught.constructor, SyntaxError);

--- a/test/language/eval-code/direct/super-call-fn.js
+++ b/test/language/eval-code/direct/super-call-fn.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: >
+  A direct eval in the functon code of a non-ArrowFunction may contain
+  SuperCall
+info: |
+  - It is a Syntax Error if StatementList Contains super unless the source code
+    containing super is eval code that is being processed by a direct eval that
+    is contained in function code that is not the function code of an
+    ArrowFunction.
+features: [super]
+---*/
+
+var executed = false;
+function f() {
+  eval('executed = true; super();');
+}
+
+assert.throws(ReferenceError, function() {
+  f();
+});
+
+assert.sameValue(executed, true);

--- a/test/language/eval-code/direct/super-call.js
+++ b/test/language/eval-code/direct/super-call.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: A direct eval in global code may not contain SuperCall
+info: |
+  - It is a Syntax Error if StatementList Contains super unless the source code
+    containing super is eval code that is being processed by a direct eval that
+    is contained in function code that is not the function code of an
+    ArrowFunction.
+features: [super]
+---*/
+
+var caught;
+
+try {
+  eval('super();');
+} catch (err) {
+  caught = err;
+}
+
+assert.sameValue(typeof caught, 'object');
+assert.sameValue(caught.constructor, SyntaxError);

--- a/test/language/eval-code/direct/super-prop-arrow.js
+++ b/test/language/eval-code/direct/super-prop-arrow.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: >
+  A direct eval in the functon code of an ArrowFunction may not contain
+  SuperProperty
+info: |
+  - It is a Syntax Error if StatementList Contains super unless the source code
+    containing super is eval code that is being processed by a direct eval that
+    is contained in function code that is not the function code of an
+    ArrowFunction.
+features: [super, arrow-function]
+---*/
+
+var caught;
+var f = () => eval('super.property;');
+
+try {
+  f();
+} catch (err) {
+  caught = err;
+}
+
+assert.sameValue(typeof caught, 'object');
+assert.sameValue(caught.constructor, SyntaxError);

--- a/test/language/eval-code/direct/super-prop-method.js
+++ b/test/language/eval-code/direct/super-prop-method.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: >
+  A direct eval in the functon code of a non-ArrowFunction may contain
+  SuperProperty
+info: |
+  - It is a Syntax Error if StatementList Contains super unless the source code
+    containing super is eval code that is being processed by a direct eval that
+    is contained in function code that is not the function code of an
+    ArrowFunction.
+features: [super]
+---*/
+
+var superProp = null;
+var o = {
+  test262: null,
+  method() {
+    superProp = eval('super.test262;');
+  }
+};
+
+o.method();
+
+assert.sameValue(superProp, undefined);
+
+Object.setPrototypeOf(o, { test262: 262 });
+
+o.method();
+
+assert.sameValue(superProp, 262);

--- a/test/language/eval-code/direct/super-prop.js
+++ b/test/language/eval-code/direct/super-prop.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: A direct eval in global code may not contain SuperProperty
+info: |
+  - It is a Syntax Error if StatementList Contains super unless the source code
+    containing super is eval code that is being processed by a direct eval that
+    is contained in function code that is not the function code of an
+    ArrowFunction.
+features: [super]
+---*/
+
+var caught;
+
+try {
+  eval('super.property;');
+} catch (err) {
+  caught = err;
+}
+
+assert.sameValue(typeof caught, 'object');
+assert.sameValue(caught.constructor, SyntaxError);

--- a/test/language/eval-code/indirect/super-call.js
+++ b/test/language/eval-code/indirect/super-call.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: >
+  An indirect eval may not contain SuperCall
+info: |
+  - It is a Syntax Error if StatementList Contains super unless the source code
+    containing super is eval code that is being processed by a direct eval that
+    is contained in function code that is not the function code of an
+    ArrowFunction.
+features: [super]
+---*/
+
+var caught;
+
+try {
+  (0,eval)('super();');
+} catch (err) {
+  caught = err;
+}
+
+assert.sameValue(typeof caught, 'object', 'object value thrown (global code)');
+assert.sameValue(
+  caught.constructor, SyntaxError, 'SyntaxError thrown (global code)'
+);
+
+caught = null;
+
+try {
+  ({
+    m() {
+      (0,eval)('super();');
+    }
+  }).m();
+} catch (err) {
+  caught = err;
+}
+
+assert.sameValue(
+  typeof caught, 'object', 'object value thrown (function code)'
+);
+assert.sameValue(
+  caught.constructor, SyntaxError, 'SyntaxError thrown (function code)'
+);

--- a/test/language/eval-code/indirect/super-prop.js
+++ b/test/language/eval-code/indirect/super-prop.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: >
+  An indirect eval may not contain SuperProperty
+info: |
+  - It is a Syntax Error if StatementList Contains super unless the source code
+    containing super is eval code that is being processed by a direct eval that
+    is contained in function code that is not the function code of an
+    ArrowFunction.
+features: [super]
+---*/
+
+var caught;
+
+try {
+  (0,eval)('super.property;');
+} catch (err) {
+  caught = err;
+}
+
+assert.sameValue(typeof caught, 'object', 'object value thrown (global code)');
+assert.sameValue(
+  caught.constructor, SyntaxError, 'SyntaxError thrown (global code)'
+);
+
+caught = null;
+
+try {
+  ({
+    m() {
+      (0,eval)('super.property;');
+    }
+  }).m();
+} catch (err) {
+  caught = err;
+}
+
+assert.sameValue(
+  typeof caught, 'object', 'object value thrown (function code)'
+);
+assert.sameValue(
+  caught.constructor, SyntaxError, 'SyntaxError thrown (function code)'
+);

--- a/test/language/global-code/return.js
+++ b/test/language/global-code/return.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts
+es6id: 15.1
+description: ReturnStatement may not be used directly within global code
+info: |
+  Syntax
+
+  Script :
+    ScriptBodyopt
+
+  ScriptBody :
+    StatementList[~Yield, ~Return]
+negative: SyntaxError
+---*/
+
+return;

--- a/test/language/global-code/super-call-arrow.js
+++ b/test/language/global-code/super-call-arrow.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: An ArrowFunction in global code may not contain SuperCall
+info: |
+  - It is a Syntax Error if StatementList Contains super unless the source code
+    containing super is eval code that is being processed by a direct eval that
+    is contained in function code that is not the function code of an
+    ArrowFunction.
+
+  14.2.3 Static Semantics: Contains
+
+  With parameter symbol.
+
+  ArrowFunction : ArrowParameters => ConciseBody
+
+  1. If symbol is not one of NewTarget, SuperProperty, SuperCall, super or
+     this, return false.
+  2. If ArrowParameters Contains symbol is true, return true.
+  3. Return ConciseBody Contains symbol.
+
+  NOTE Normally, Contains does not look inside most function forms. However,
+       Contains is used to detect new.target, this, and super usage within an
+       ArrowFunction.
+features: [super, arrow-function]
+negative: SyntaxError
+---*/
+
+() => {
+  super();
+};

--- a/test/language/global-code/super-call.js
+++ b/test/language/global-code/super-call.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: Global code may not contain SuperCall
+info: |
+  - It is a Syntax Error if StatementList Contains super unless the source code
+    containing super is eval code that is being processed by a direct eval that
+    is contained in function code that is not the function code of an
+    ArrowFunction.
+negative: SyntaxError
+features: [super]
+---*/
+
+super();

--- a/test/language/global-code/super-prop-arrow.js
+++ b/test/language/global-code/super-prop-arrow.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: An ArrowFunction in global code may not contain SuperProperty
+info: |
+  - It is a Syntax Error if StatementList Contains super unless the source code
+    containing super is eval code that is being processed by a direct eval that
+    is contained in function code that is not the function code of an
+    ArrowFunction.
+
+  14.2.3 Static Semantics: Contains
+
+  With parameter symbol.
+
+  ArrowFunction : ArrowParameters => ConciseBody
+
+  1. If symbol is not one of NewTarget, SuperProperty, SuperCall, super or
+     this, return false.
+  2. If ArrowParameters Contains symbol is true, return true.
+  3. Return ConciseBody Contains symbol.
+
+  NOTE Normally, Contains does not look inside most function forms. However,
+       Contains is used to detect new.target, this, and super usage within an
+       ArrowFunction.
+features: [super, arrow-function]
+negative: SyntaxError
+---*/
+
+() => {
+  super.property;
+};

--- a/test/language/global-code/super-prop.js
+++ b/test/language/global-code/super-prop.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts-static-semantics-early-errors
+es6id: 15.1.1
+description: Global code may not contain SuperProperty
+info: |
+  - It is a Syntax Error if StatementList Contains super unless the source code
+    containing super is eval code that is being processed by a direct eval that
+    is contained in function code that is not the function code of an
+    ArrowFunction.
+negative: SyntaxError
+features: [super]
+---*/
+
+super.property;

--- a/test/language/global-code/yield-non-strict.js
+++ b/test/language/global-code/yield-non-strict.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts
+es6id: 15.1
+description: >
+  The `yield` token is interpreted as an Identifier when it appears in global
+  code (non-strict mode)
+info: |
+  Syntax
+
+  Script :
+    ScriptBodyopt
+
+  ScriptBody :
+    StatementList[~Yield, ~Return]
+flags: [noStrict]
+---*/
+
+// Avoid test failures in cases where the host has defined a `yield` property
+// on the global object.
+try {
+  yield = 0;
+} catch (_) {}

--- a/test/language/global-code/yield-strict.js
+++ b/test/language/global-code/yield-strict.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-scripts
+es6id: 15.1
+description: >
+  The `yield` token is interpreted as an Identifier when it appears in global
+  code (strict mode)
+info: |
+  Syntax
+
+  Script :
+    ScriptBodyopt
+
+  ScriptBody :
+    StatementList[~Yield, ~Return]
+flags: [onlyStrict]
+negative: SyntaxError
+---*/
+
+yield;

--- a/test/language/module-code/parse-err-return.js
+++ b/test/language/module-code/parse-err-return.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-modules
+es6id: 15.2
+description: ReturnStatement may not be used directly within ModuleBody
+info: |
+  Syntax
+
+  Module :
+    ModuleBodyopt
+
+  ModuleBody :
+    ModuleItemList
+
+  ModuleItemList :
+    ModuleItem
+    ModuleItemList ModuleItem
+
+  ModuleItem:
+    ImportDeclaration
+    ExportDeclaration
+    StatementListItem[~Yield, ~Return]
+flags: [module]
+negative: SyntaxError
+---*/
+
+return;

--- a/test/language/module-code/parse-err-yield.js
+++ b/test/language/module-code/parse-err-yield.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-modules
+es6id: 15.2
+description: YieldExpression may not be used directly within ModuleBody
+info: |
+  Syntax
+
+  Module :
+    ModuleBodyopt
+
+  ModuleBody :
+    ModuleItemList
+
+  ModuleItemList :
+    ModuleItem
+    ModuleItemList ModuleItem
+
+  ModuleItem:
+    ImportDeclaration
+    ExportDeclaration
+    StatementListItem[~Yield, ~Return]
+flags: [module]
+negative: SyntaxError
+---*/
+
+yield;


### PR DESCRIPTION
This changeset increases test coverage for the semantics defined in [ECMA262 section 15](https://tc39.github.io/ecma262/#sec-ecmascript-language-scripts-and-modules).

