### PR TITLE
Add tests for abrupt completions during JSON.parse

### DIFF
--- a/test/built-ins/JSON/parse/reviver-array-define-prop-err.js
+++ b/test/built-ins/JSON/parse/reviver-array-define-prop-err.js
@@ -5,6 +5,9 @@ esid: sec-internalizejsonproperty
 es6id: 24.3.1.1
 description: Abrupt completion from defining array property while reviving
 info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
   7. If IsCallable(reviver) is true, then
      [...]
      e. Return ? InternalizeJSONProperty(root, rootName).

--- a/test/built-ins/JSON/parse/reviver-array-define-prop-err.js
+++ b/test/built-ins/JSON/parse/reviver-array-define-prop-err.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+es6id: 24.3.1.1
+description: Abrupt completion from defining array property while reviving
+info: |
+  7. If IsCallable(reviver) is true, then
+     [...]
+     e. Return ? InternalizeJSONProperty(root, rootName).
+
+  Runtime Semantics: InternalizeJSONProperty ( holder, name)
+
+  1. Let val be ? Get(holder, name).
+  2. If Type(val) is Object, then
+     a. Let isArray be ? IsArray(val).
+     b. If isArray is true, then
+        i. Set I to 0.
+        ii. Let len be ? ToLength(? Get(val, "length")).
+        iii. Repeat while I < len,
+             1. Let newElement be ? InternalizeJSONProperty(val, !
+                ToString(I)).
+             2. If newElement is undefined, then
+                [...]
+             3. Else,
+                a. Perform ? CreateDataProperty(val, ! ToString(I),
+                   newElement).
+features: [Proxy]
+---*/
+
+var badDefine = new Proxy([null], {
+  defineProperty: function(_, name) {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  JSON.parse('["first", null]', function(_, value) {
+    if (value === 'first') {
+      this[1] = badDefine;
+    }
+    return value;
+  });
+});

--- a/test/built-ins/JSON/parse/reviver-array-delete-err.js
+++ b/test/built-ins/JSON/parse/reviver-array-delete-err.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+es6id: 24.3.1.1
+description: Abrupt completion from array property deletion while reviving
+info: |
+  7. If IsCallable(reviver) is true, then
+     [...]
+     e. Return ? InternalizeJSONProperty(root, rootName).
+
+  Runtime Semantics: InternalizeJSONProperty ( holder, name)
+
+  1. Let val be ? Get(holder, name).
+  2. If Type(val) is Object, then
+     a. Let isArray be ? IsArray(val).
+     b. If isArray is true, then
+        i. Set I to 0.
+        ii. Let len be ? ToLength(? Get(val, "length")).
+        iii. Repeat while I < len,
+             1. Let newElement be ? InternalizeJSONProperty(val, !
+                ToString(I)).
+             2. If newElement is undefined, then
+                a. Perform ? val.[[Delete]](! ToString(I)).
+features: [Proxy]
+---*/
+
+var badDelete = new Proxy([0], {
+  deleteProperty: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  JSON.parse('[0,0]', function() {
+    this[1] = badDelete;
+  });
+});

--- a/test/built-ins/JSON/parse/reviver-array-delete-err.js
+++ b/test/built-ins/JSON/parse/reviver-array-delete-err.js
@@ -5,6 +5,9 @@ esid: sec-internalizejsonproperty
 es6id: 24.3.1.1
 description: Abrupt completion from array property deletion while reviving
 info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
   7. If IsCallable(reviver) is true, then
      [...]
      e. Return ? InternalizeJSONProperty(root, rootName).

--- a/test/built-ins/JSON/parse/reviver-array-length-coerce-err.js
+++ b/test/built-ins/JSON/parse/reviver-array-length-coerce-err.js
@@ -6,6 +6,9 @@ es6id: 24.3.1.1
 description: >
   Abrupt completion from coercing array "length" property to a number value
 info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
   7. If IsCallable(reviver) is true, then
      [...]
      e. Return ? InternalizeJSONProperty(root, rootName).

--- a/test/built-ins/JSON/parse/reviver-array-length-coerce-err.js
+++ b/test/built-ins/JSON/parse/reviver-array-length-coerce-err.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+es6id: 24.3.1.1
+description: >
+  Abrupt completion from coercing array "length" property to a number value
+info: |
+  7. If IsCallable(reviver) is true, then
+     [...]
+     e. Return ? InternalizeJSONProperty(root, rootName).
+
+  Runtime Semantics: InternalizeJSONProperty ( holder, name)
+
+  1. Let val be ? Get(holder, name).
+  2. If Type(val) is Object, then
+     a. Let isArray be ? IsArray(val).
+     b. If isArray is true, then
+        i. Set I to 0.
+        ii. Let len be ? ToLength(? Get(val, "length")).
+features: [Proxy]
+---*/
+
+var uncoercible = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+var badLength = new Proxy([], {
+  get: function(_, name) {
+    if (name === 'length') {
+      return uncoercible;
+    }
+  }
+});
+
+assert.throws(Test262Error, function() {
+  JSON.parse('[0,0]', function() {
+    this[1] = badLength;
+  });
+});

--- a/test/built-ins/JSON/parse/reviver-array-length-get-err.js
+++ b/test/built-ins/JSON/parse/reviver-array-length-get-err.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+es6id: 24.3.1.1
+description: >
+  Abrupt completion from array "length" property access while reviving
+info: |
+  7. If IsCallable(reviver) is true, then
+     [...]
+     e. Return ? InternalizeJSONProperty(root, rootName).
+
+  Runtime Semantics: InternalizeJSONProperty ( holder, name)
+
+  1. Let val be ? Get(holder, name).
+  2. If Type(val) is Object, then
+     a. Let isArray be ? IsArray(val).
+     b. If isArray is true, then
+        i. Set I to 0.
+        ii. Let len be ? ToLength(? Get(val, "length")).
+features: [Proxy]
+---*/
+
+var badLength = new Proxy([], {
+  get: function(_, name) {
+    if (name === 'length') {
+      throw new Test262Error();
+    }
+  }
+});
+
+assert.throws(Test262Error, function() {
+  JSON.parse('[0,0]', function() {
+    this[1] = badLength;
+  });
+});

--- a/test/built-ins/JSON/parse/reviver-array-length-get-err.js
+++ b/test/built-ins/JSON/parse/reviver-array-length-get-err.js
@@ -6,6 +6,9 @@ es6id: 24.3.1.1
 description: >
   Abrupt completion from array "length" property access while reviving
 info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
   7. If IsCallable(reviver) is true, then
      [...]
      e. Return ? InternalizeJSONProperty(root, rootName).

--- a/test/built-ins/JSON/parse/reviver-call-err.js
+++ b/test/built-ins/JSON/parse/reviver-call-err.js
@@ -6,6 +6,9 @@ es6id: 24.3.1.1
 description: >
   Abrupt completion when reviver function returns an abrupt completion
 info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
   7. If IsCallable(reviver) is true, then
      [...]
      e. Return ? InternalizeJSONProperty(root, rootName).

--- a/test/built-ins/JSON/parse/reviver-call-err.js
+++ b/test/built-ins/JSON/parse/reviver-call-err.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+es6id: 24.3.1.1
+description: >
+  Abrupt completion when reviver function returns an abrupt completion
+info: |
+  7. If IsCallable(reviver) is true, then
+     [...]
+     e. Return ? InternalizeJSONProperty(root, rootName).
+
+  Runtime Semantics: InternalizeJSONProperty ( holder, name)
+
+  [...]
+  3. Return ? Call(reviver, holder, « name, val »).
+---*/
+
+assert.throws(Test262Error, function() {
+  JSON.parse('0', function() {
+    throw new Test262Error();
+  });
+});

--- a/test/built-ins/JSON/parse/reviver-get-name-err.js
+++ b/test/built-ins/JSON/parse/reviver-get-name-err.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+es6id: 24.3.1.1
+description: Abrupt completion from "holder" property access while reviving
+info: |
+  7. If IsCallable(reviver) is true, then
+     [...]
+     e. Return ? InternalizeJSONProperty(root, rootName).
+
+  Runtime Semantics: InternalizeJSONProperty ( holder, name)
+
+  1. Let val be ? Get(holder, name).
+---*/
+
+var thrower = function() {
+  throw new Test262Error();
+};
+
+assert.throws(Test262Error, function() {
+  JSON.parse('[0,0]', function() {
+    Object.defineProperty(this, '1', {
+      get: thrower
+    });
+  });
+});

--- a/test/built-ins/JSON/parse/reviver-get-name-err.js
+++ b/test/built-ins/JSON/parse/reviver-get-name-err.js
@@ -5,6 +5,9 @@ esid: sec-internalizejsonproperty
 es6id: 24.3.1.1
 description: Abrupt completion from "holder" property access while reviving
 info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
   7. If IsCallable(reviver) is true, then
      [...]
      e. Return ? InternalizeJSONProperty(root, rootName).

--- a/test/built-ins/JSON/parse/reviver-object-define-prop-err.js
+++ b/test/built-ins/JSON/parse/reviver-object-define-prop-err.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+es6id: 24.3.1.1
+description: Abrupt completion from defining object property while reviving
+info: |
+  7. If IsCallable(reviver) is true, then
+     [...]
+     e. Return ? InternalizeJSONProperty(root, rootName).
+
+  Runtime Semantics: InternalizeJSONProperty ( holder, name)
+
+  1. Let val be ? Get(holder, name).
+  2. If Type(val) is Object, then
+     a. Let isArray be ? IsArray(val).
+     b. If isArray is true, then
+        [...]
+     c. Else,
+        i. Let keys be ? EnumerableOwnProperties(val, "key").
+        ii. For each String P in keys do,
+            1. Let newElement be ? InternalizeJSONProperty(val, P).
+            2. If newElement is undefined, then
+               [...]
+            3. Else,
+               a. Perform ? CreateDataProperty(val, P, newElement).
+features: [Proxy]
+---*/
+
+var badDefine = new Proxy({ 0: null }, {
+  defineProperty: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  JSON.parse('["first", null]', function(_, value) {
+    if (value === 'first') {
+      this[1] = badDefine;
+    }
+    return value;
+  });
+});

--- a/test/built-ins/JSON/parse/reviver-object-define-prop-err.js
+++ b/test/built-ins/JSON/parse/reviver-object-define-prop-err.js
@@ -5,6 +5,9 @@ esid: sec-internalizejsonproperty
 es6id: 24.3.1.1
 description: Abrupt completion from defining object property while reviving
 info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
   7. If IsCallable(reviver) is true, then
      [...]
      e. Return ? InternalizeJSONProperty(root, rootName).

--- a/test/built-ins/JSON/parse/reviver-object-delete-err.js
+++ b/test/built-ins/JSON/parse/reviver-object-delete-err.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+es6id: 24.3.1.1
+description: Abrupt completion from object property deletion while reviving
+info: |
+  7. If IsCallable(reviver) is true, then
+     [...]
+     e. Return ? InternalizeJSONProperty(root, rootName).
+
+  Runtime Semantics: InternalizeJSONProperty ( holder, name)
+
+  1. Let val be ? Get(holder, name).
+  2. If Type(val) is Object, then
+     a. Let isArray be ? IsArray(val).
+     b. If isArray is true, then
+        [...]
+     c. Else,
+        i. Let keys be ? EnumerableOwnProperties(val, "key").
+        ii. For each String P in keys do,
+            1. Let newElement be ? InternalizeJSONProperty(val, P).
+            2. If newElement is undefined, then
+               a. Perform ? val.[[Delete]](P).
+features: [Proxy]
+---*/
+
+var badDelete = new Proxy({ a: 1 }, {
+  deleteProperty: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  JSON.parse('[0,0]', function() {
+    this[1] = badDelete;
+  });
+});

--- a/test/built-ins/JSON/parse/reviver-object-delete-err.js
+++ b/test/built-ins/JSON/parse/reviver-object-delete-err.js
@@ -5,6 +5,9 @@ esid: sec-internalizejsonproperty
 es6id: 24.3.1.1
 description: Abrupt completion from object property deletion while reviving
 info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
   7. If IsCallable(reviver) is true, then
      [...]
      e. Return ? InternalizeJSONProperty(root, rootName).

--- a/test/built-ins/JSON/parse/reviver-object-own-keys-err.js
+++ b/test/built-ins/JSON/parse/reviver-object-own-keys-err.js
@@ -5,6 +5,9 @@ esid: sec-internalizejsonproperty
 es6id: 24.3.1.1
 description: Abrupt completion from object property enumeration while reviving
 info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
   7. If IsCallable(reviver) is true, then
      [...]
      e. Return ? InternalizeJSONProperty(root, rootName).

--- a/test/built-ins/JSON/parse/reviver-object-own-keys-err.js
+++ b/test/built-ins/JSON/parse/reviver-object-own-keys-err.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+es6id: 24.3.1.1
+description: Abrupt completion from object property enumeration while reviving
+info: |
+  7. If IsCallable(reviver) is true, then
+     [...]
+     e. Return ? InternalizeJSONProperty(root, rootName).
+
+  Runtime Semantics: InternalizeJSONProperty ( holder, name)
+
+  1. Let val be ? Get(holder, name).
+  2. If Type(val) is Object, then
+     a. Let isArray be ? IsArray(val).
+     b. If isArray is true, then
+        [...]
+     c. Else,
+        i. Let keys be ? EnumerableOwnProperties(val, "key").
+features: [Proxy]
+---*/
+
+var badKeys = new Proxy({}, {
+  ownKeys: function() {
+    throw new Test262Error();
+  }
+});
+
+assert.throws(Test262Error, function() {
+  JSON.parse('[0,0]', function() {
+    this[1] = badKeys;
+  });
+});


### PR DESCRIPTION
Due to the use of the IsArray abstract operation, observing many of the
targeted semantics requires the use of a Proxy exotic object. Mark the
tests that require this unrelated ES2015 feature using a dedicated
"features" flag.