### PR TITLE
Add "how to run" on front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ Test262 tests conformance to the continually maintained draft future ECMAScript 
 ### Running Test262
 
 > See [INTERPRETING.md](./INTERPRETING.md)
+
+There are a number of volunteer-maintained projects that may be used to execute Test262 in various ECMAScript hosts:
+
+- https://github.com/bterlson/test262-harness (platform: Node.js)
+- https://github.com/test262-utils/test262-harness-py (platform: Python)


### PR DESCRIPTION
As a returning contributor, I see that the old test262.py runner is officially deprecated -- good!

But I don't know the "official" way to run the test suite, using my default installed node.

Here's a stab at adding that information to the front page README.md.  Please correct me if I'm wrong.