### PR TITLE
Improve coverage for section 20

### DIFF
--- a/test/built-ins/Date/UTC/coercion-errors.js
+++ b/test/built-ins/Date/UTC/coercion-errors.js
@@ -1,0 +1,60 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.utc
+es6id: 20.3.3.4
+description: Abrupt completions from coercing input values
+info: |
+  1. Let y be ? ToNumber(year).
+  2. Let m be ? ToNumber(month).
+  3. If date is supplied, let dt be ? ToNumber(date); else let dt be 1.
+  4. If hours is supplied, let h be ? ToNumber(hours); else let h be 0.
+  5. If minutes is supplied, let min be ? ToNumber(minutes); else let min be 0.
+  6. If seconds is supplied, let s be ? ToNumber(seconds); else let s be 0.
+  7. If ms is supplied, let milli be ? ToNumber(ms); else let milli be 0.
+  8. If y is not NaN and 0 ≤ ToInteger(y) ≤ 99, let yr be 1900+ToInteger(y);
+     otherwise, let yr be y.
+  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))). 
+---*/
+
+var thrower = { toString: function() { throw new Test262Error(); } };
+var counter = { toString: function() { callCount += 1; } };
+var callCount = 0;
+
+assert.throws(Test262Error, function() {
+  new Date(thrower, counter);
+}, 'year');
+assert.sameValue(callCount, 0, 'coercion halts following error from "year"');
+
+assert.throws(Test262Error, function() {
+  new Date(0, thrower, counter);
+}, 'month');
+assert.sameValue(callCount, 0, 'coercion halts following error from "month"');
+
+assert.throws(Test262Error, function() {
+  new Date(0, 0, thrower, counter);
+}, 'date');
+assert.sameValue(callCount, 0, 'coercion halts following error from "date"');
+
+assert.throws(Test262Error, function() {
+  new Date(0, 0, 1, thrower, counter);
+}, 'hours');
+assert.sameValue(callCount, 0, 'coercion halts following error from "hours"');
+
+assert.throws(Test262Error, function() {
+  new Date(0, 0, 1, 0, thrower, counter);
+}, 'minutes');
+assert.sameValue(
+  callCount, 0, 'coercion halts following error from "minutes"'
+);
+
+assert.throws(Test262Error, function() {
+  new Date(0, 0, 1, 0, 0, thrower, counter);
+}, 'seconds');
+assert.sameValue(
+  callCount, 0, 'coercion halts following error from "seconds"'
+);
+
+assert.throws(Test262Error, function() {
+  new Date(0, 0, 1, 0, 0, 0, thrower);
+}, 'ms');

--- a/test/built-ins/Date/UTC/coercion-order.js
+++ b/test/built-ins/Date/UTC/coercion-order.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.utc
+es6id: 20.3.3.4
+description: Order of input coercion
+info: |
+  1. Let y be ? ToNumber(year).
+  2. Let m be ? ToNumber(month).
+  3. If date is supplied, let dt be ? ToNumber(date); else let dt be 1.
+  4. If hours is supplied, let h be ? ToNumber(hours); else let h be 0.
+  5. If minutes is supplied, let min be ? ToNumber(minutes); else let min be 0.
+  6. If seconds is supplied, let s be ? ToNumber(seconds); else let s be 0.
+  7. If ms is supplied, let milli be ? ToNumber(ms); else let milli be 0.
+  8. If y is not NaN and 0 ≤ ToInteger(y) ≤ 99, let yr be 1900+ToInteger(y);
+     otherwise, let yr be y.
+  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))). 
+---*/
+
+var log = '';
+var year = { toString: function() { log += 'year'; return 0; } };
+var month = { toString: function() { log += 'month'; return 0; } };
+var date = { toString: function() { log += 'date'; return 1; } };
+var hours = { toString: function() { log += 'hours'; return 0; } };
+var minutes = { toString: function() { log += 'minutes'; return 0; } };
+var seconds = { toString: function() { log += 'seconds'; return 0; } };
+var ms = { toString: function() { log += 'ms'; return 0; } };
+
+new Date(year, month, date, hours,minutes, seconds, ms);
+
+assert.sameValue(log, 'yearmonthdatehoursminutessecondsms');

--- a/test/built-ins/Date/UTC/infinity-make-day.js
+++ b/test/built-ins/Date/UTC/infinity-make-day.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.utc
+es6id: 20.3.3.4
+description: Infinite values specified to MakeDay produce NaN
+info: |
+  [...]
+  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))). 
+
+  MakeDay (year, month, date)
+
+  1. If year is not finite or month is not finite or date is not finite, return
+     NaN.
+---*/
+
+assert.sameValue(Date.UTC(Infinity, 0), NaN, 'year: Infinity');
+assert.sameValue(Date.UTC(-Infinity, 0), NaN, 'year: -Infinity');
+
+assert.sameValue(Date.UTC(0, Infinity), NaN, 'month: Infinity');
+assert.sameValue(Date.UTC(0, -Infinity), NaN, 'month: -Infinity');
+
+assert.sameValue(Date.UTC(0, 0, Infinity), NaN, 'date: Infinity');
+assert.sameValue(Date.UTC(0, 0, -Infinity), NaN, 'date: -Infinity');

--- a/test/built-ins/Date/UTC/infinity-make-time.js
+++ b/test/built-ins/Date/UTC/infinity-make-time.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.utc
+es6id: 20.3.3.4
+description: Infinite values specified to MakeTime produce NaN
+info: |
+  [...]
+  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))). 
+
+  MakeTime (hour, min, sec, ms)
+
+  1. If hour is not finite or min is not finite or sec is not finite or ms is
+     not finite, return NaN.
+---*/
+
+assert.sameValue(Date.UTC(0, 0, 1, Infinity), NaN, 'hour: Infinity');
+assert.sameValue(Date.UTC(0, 0, 1, -Infinity), NaN, 'hour: -Infinity');
+
+assert.sameValue(Date.UTC(0, 0, 1, 0, Infinity), NaN, 'minute: Infinity');
+assert.sameValue(Date.UTC(0, 0, 1, 0, -Infinity), NaN, 'minute: -Infinity');
+
+assert.sameValue(Date.UTC(0, 0, 1, 0, 0, Infinity), NaN, 'second: Infinity');
+assert.sameValue(Date.UTC(0, 0, 1, 0, 0, -Infinity), NaN, 'second: -Infinity');
+
+assert.sameValue(Date.UTC(0, 0, 1, 0, 0, 0, Infinity), NaN, 'ms: Infinity');
+assert.sameValue(Date.UTC(0, 0, 1, 0, 0, 0, -Infinity), NaN, 'ms: -Infinity');

--- a/test/built-ins/Date/UTC/nans.js
+++ b/test/built-ins/Date/UTC/nans.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.utc
+es6id: 20.3.3.4
+description: NaN value handling
+info: |
+  1. Let y be ? ToNumber(year).
+  2. Let m be ? ToNumber(month).
+  3. If date is supplied, let dt be ? ToNumber(date); else let dt be 1.
+  4. If hours is supplied, let h be ? ToNumber(hours); else let h be 0.
+  5. If minutes is supplied, let min be ? ToNumber(minutes); else let min be 0.
+  6. If seconds is supplied, let s be ? ToNumber(seconds); else let s be 0.
+  7. If ms is supplied, let milli be ? ToNumber(ms); else let milli be 0.
+  8. If y is not NaN and 0 ≤ ToInteger(y) ≤ 99, let yr be 1900+ToInteger(y);
+     otherwise, let yr be y.
+  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))). 
+---*/
+
+assert.sameValue(new Date(NaN, 0).getTime(), NaN, 'year');
+assert.sameValue(new Date(1970, NaN).getTime(), NaN, 'month');
+assert.sameValue(new Date(1970, 0, NaN).getTime(), NaN, 'date');
+assert.sameValue(new Date(1970, 0, 1, NaN).getTime(), NaN, 'hours');
+assert.sameValue(new Date(1970, 0, 1, 0, NaN).getTime(), NaN, 'minutes');
+assert.sameValue(new Date(1970, 0, 1, 0, 0, NaN).getTime(), NaN, 'seconds');
+assert.sameValue(new Date(1970, 0, 1, 0, 0, 0, NaN).getTime(), NaN, 'ms');

--- a/test/built-ins/Date/UTC/overflow-make-day.js
+++ b/test/built-ins/Date/UTC/overflow-make-day.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.utc
+es6id: 20.3.3.4
+description: Values specified to MakeDay exceed their calendar boundaries
+info: |
+  [...]
+  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))). 
+
+  MakeDay (year, month, date)
+
+  [...]
+  5. Let ym be y + floor(m / 12).
+  [...]
+  7. Find a value t such that YearFromTime(t) is ym and MonthFromTime(t) is mn
+     and DateFromTime(t) is 1; but if this is not possible (because some
+     argument is out of range), return NaN.
+  8. Return Day(t) + dt - 1.
+---*/
+
+assert.sameValue(Date.UTC(2016, 12), 1483228800000, 'month: 12');
+assert.sameValue(Date.UTC(2016, 13), 1485907200000, 'month: 13');
+assert.sameValue(Date.UTC(2016, 144), 1830297600000, 'month: 144');
+
+assert.sameValue(Date.UTC(2016, 0, 33), 1454371200000, 'day greater than month');
+assert.sameValue(Date.UTC(2016, 2, -27), 1454371200000, 'day negative value');

--- a/test/built-ins/Date/UTC/overflow-make-time.js
+++ b/test/built-ins/Date/UTC/overflow-make-time.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.utc
+es6id: 20.3.3.4
+description: Values specified to MakeTime exceed their time boundaries
+info: |
+  [...]
+  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))). 
+
+  MakeTime (hour, min, sec, ms)
+
+  1. If hour is not finite or min is not finite or sec is not finite or ms is
+     not finite, return NaN.
+  2. Let h be ToInteger(hour).
+  3. Let m be ToInteger(min).
+  4. Let s be ToInteger(sec).
+  5. Let milli be ToInteger(ms).
+  6. Let t be h * msPerHour + m * msPerMinute + s * msPerSecond + milli,
+     performing the arithmetic according to IEEE 754-2008 rules (that is, as if
+     using the ECMAScript operators * and +).
+  7. Return t.
+---*/
+
+assert.sameValue(Date.UTC(2016, 6, 5, -1), 1467673200000, 'hour: -1');
+assert.sameValue(Date.UTC(2016, 6, 5, 24), 1467763200000, 'hour: 24');
+assert.sameValue(Date.UTC(2016, 6, 5, 0, -1), 1467676740000, 'minute: -1');
+assert.sameValue(Date.UTC(2016, 6, 5, 0, 60), 1467680400000, 'minute: 60');
+assert.sameValue(Date.UTC(2016, 6, 5, 0, 0, -1), 1467676799000, 'second: -1');
+assert.sameValue(Date.UTC(2016, 6, 5, 0, 0, 60), 1467676860000, 'second: 60');
+assert.sameValue(
+  Date.UTC(2016, 6, 5, 0, 0, 0, -1), 1467676799999, 'millisecond: -1'
+);
+assert.sameValue(
+  Date.UTC(2016, 6, 5, 0, 0, 0, 1000), 1467676801000, 'millisecond: 1000'
+);

--- a/test/built-ins/Date/UTC/return-value.js
+++ b/test/built-ins/Date/UTC/return-value.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.utc
+es6id: 20.3.3.4
+description: Return value of `Date.UTC`
+info: |
+  1. Let y be ? ToNumber(year).
+  2. Let m be ? ToNumber(month).
+  3. If date is supplied, let dt be ? ToNumber(date); else let dt be 1.
+  4. If hours is supplied, let h be ? ToNumber(hours); else let h be 0.
+  5. If minutes is supplied, let min be ? ToNumber(minutes); else let min be 0.
+  6. If seconds is supplied, let s be ? ToNumber(seconds); else let s be 0.
+  7. If ms is supplied, let milli be ? ToNumber(ms); else let milli be 0.
+  8. If y is not NaN and 0 ≤ ToInteger(y) ≤ 99, let yr be 1900+ToInteger(y);
+     otherwise, let yr be y.
+  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))). 
+---*/
+
+assert.sameValue(Date.UTC(1970, 0), 0, '1970, 0');
+assert.sameValue(Date.UTC(2016, 0), 1451606400000, '2016, 0');
+assert.sameValue(Date.UTC(2016, 6), 1467331200000, '2016, 6');
+
+assert.sameValue(Date.UTC(2016, 6, 1), 1467331200000, '2016, 6, 1');
+assert.sameValue(Date.UTC(2016, 6, 5), 1467676800000, '2016, 6, 5');
+
+assert.sameValue(Date.UTC(2016, 6, 5, 0), 1467676800000, '2016, 6, 5, 0');
+assert.sameValue(Date.UTC(2016, 6, 5, 15), 1467730800000, '2016, 6, 5, 15');
+
+assert.sameValue(
+  Date.UTC(2016, 6, 5, 15, 0), 1467730800000, '2016, 6, 5, 15, 0'
+);
+assert.sameValue(
+  Date.UTC(2016, 6, 5, 15, 34), 1467732840000, '2016, 6, 5, 15, 34'
+);
+
+assert.sameValue(
+  Date.UTC(2016, 6, 5, 15, 34, 0), 1467732840000, '2016, 6, 5, 15, 34, 0'
+);
+assert.sameValue(
+  Date.UTC(2016, 6, 5, 15, 34, 45), 1467732885000, '2016, 6, 5, 15, 34, 45'
+);
+
+
+assert.sameValue(
+  Date.UTC(2016, 6, 5, 15, 34, 45, 0),
+  1467732885000,
+  '2016, 6, 5, 15, 34, 45, 0'
+);
+assert.sameValue(
+  Date.UTC(2016, 6, 5, 15, 34, 45, 876),
+  1467732885876,
+  '2016, 6, 5, 15, 34, 45, 0'
+);

--- a/test/built-ins/Date/UTC/time-clip.js
+++ b/test/built-ins/Date/UTC/time-clip.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.utc
+es6id: 20.3.3.4
+description: Time clipping
+info: |
+  [...]
+  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))). 
+
+  TimeClip (time)
+
+  1. If time is not finite, return NaN.
+  2. If abs(time) > 8.64 × 1015, return NaN.
+---*/
+
+assert.notSameValue(Date.UTC(275760, 8, 13, 0, 0, 0, 0), NaN);
+assert.sameValue(Date.UTC(275760, 8, 13, 0, 0, 0, 1), NaN);

--- a/test/built-ins/Date/UTC/year-offset.js
+++ b/test/built-ins/Date/UTC/year-offset.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.utc
+es6id: 20.3.3.4
+description: Conditional offset of provided `year` value
+info: |
+  1. Let y be ? ToNumber(year).
+  [...]
+  8. If y is not NaN and 0 ≤ ToInteger(y) ≤ 99, let yr be 1900+ToInteger(y);
+     otherwise, let yr be y.
+  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))). 
+---*/
+
+assert.sameValue(Date.UTC(-1, 0), -62198755200000, '-1 (no offset)');
+
+assert.sameValue(Date.UTC(0, 0), -2208988800000, '+0');
+assert.sameValue(Date.UTC(-0, 0), -2208988800000, '-0');
+assert.sameValue(Date.UTC(-0.999999, 0), -2208988800000, '-0.999999');
+
+assert.sameValue(Date.UTC(70, 0), 0, '70');
+assert.sameValue(Date.UTC(70, 0), 0, '70.999999');
+
+assert.sameValue(Date.UTC(99, 0), 915148800000, '99');
+assert.sameValue(Date.UTC(99.999999, 0), 915148800000, '99.999999');
+
+assert.sameValue(Date.UTC(100, 0), -59011459200000, '100 (no offset)');

--- a/test/built-ins/Date/name.js
+++ b/test/built-ins/Date/name.js
@@ -1,0 +1,24 @@
+// Copyright (c) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date-constructor
+es6id: 20.3.2
+description: Constructor "name" property descriptor
+info: >
+  17 ECMAScript Standard Built-in Objects:
+
+  Every built-in Function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value is a
+  String.
+
+  Unless otherwise specified, the name property of a built-in Function object,
+  if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]:
+  false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Date.name, "Date");
+
+verifyNotEnumerable(Date, "name");
+verifyNotWritable(Date, "name");
+verifyConfigurable(Date, "name");

--- a/test/built-ins/Date/prototype/getDate/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getDate/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getdate
+es6id: 20.3.4.2
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getDate(), NaN);

--- a/test/built-ins/Date/prototype/getDate/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getDate/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getdate
+es6id: 20.3.4.2
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getDate = Date.prototype.getDate;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getDate, 'function');
+
+assert.throws(TypeError, function() {
+  getDate.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getDate.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getDate.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getDate/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getDate/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getdate
+es6id: 20.3.4.2
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getDate = Date.prototype.getDate;
+var symbol = Symbol();
+
+assert.sameValue(typeof getDate, 'function');
+
+assert.throws(TypeError, function() {
+  getDate.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getDate.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getDate.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getDate.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getDate.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getDate.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getDate/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getDate/this-value-valid-date.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getdate
+es6id: 20.3.4.2
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return DateFromTime(LocalTime(t)).
+---*/
+
+assert.sameValue(new Date(2016, 6, 6).getDate(), 6, 'first millisecond');
+assert.sameValue(
+  new Date(2016, 6, 6, 0, 0, 0, -1).getDate(), 5, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 23, 59, 59, 999).getDate(), 6, 'final millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 23, 59, 59, 1000).getDate(), 7, 'subsequent millisecond'
+);
+
+assert.sameValue(
+  new Date(2016, 1, 29).getDate(), 29, 'first millisecond (month boundary)'
+);
+assert.sameValue(
+  new Date(2016, 1, 29, 0, 0, 0, -1).getDate(),
+  28,
+  'previous millisecond (month boundary)'
+);
+assert.sameValue(
+  new Date(2016, 1, 29, 23, 59, 59, 999).getDate(),
+  29,
+  'final millisecond (month boundary)'
+);
+assert.sameValue(
+  new Date(2016, 1, 29, 23, 59, 59, 1000).getDate(),
+  1,
+  'subsequent millisecond (month boundary)'
+);

--- a/test/built-ins/Date/prototype/getDay/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getDay/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getday
+es6id: 20.3.4.3
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getDay(), NaN);

--- a/test/built-ins/Date/prototype/getDay/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getDay/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getday
+es6id: 20.3.4.3
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getDay = Date.prototype.getDay;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getDay, 'function');
+
+assert.throws(TypeError, function() {
+  getDay.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getDay.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getDay.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getDay/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getDay/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getday
+es6id: 20.3.4.3
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getDay = Date.prototype.getDay;
+var symbol = Symbol();
+
+assert.sameValue(typeof getDay, 'function');
+
+assert.throws(TypeError, function() {
+  getDay.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getDay.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getDay.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getDay.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getDay.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getDay.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getDay/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getDay/this-value-valid-date.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getday
+es6id: 20.3.4.3
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return WeekDay(LocalTime(t)).
+---*/
+
+assert.sameValue(new Date(2016, 6, 6).getDay(), 3, 'first millisecond');
+assert.sameValue(
+  new Date(2016, 6, 6, 0, 0, 0, -1).getDay(), 2, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 23, 59, 59, 999).getDay(), 3, 'final millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 23, 59, 59, 1000).getDay(), 4, 'subsequent millisecond'
+);
+
+assert.sameValue(
+  new Date(2016, 6, 9).getDay(), 6, 'first millisecond (week boundary)'
+);
+assert.sameValue(
+  new Date(2016, 6, 9, 0, 0, 0, -1).getDay(),
+  5,
+  'previous millisecond (week boundary)'
+);
+assert.sameValue(
+  new Date(2016, 6, 9, 23, 59, 59, 999).getDay(),
+  6,
+  'final millisecond (week boundary)'
+);
+assert.sameValue(
+  new Date(2016, 6, 9, 23, 59, 59, 1000).getDay(),
+  0,
+  'subsequent millisecond (week boundary)'
+);

--- a/test/built-ins/Date/prototype/getFullYear/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getFullYear/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getfullyear
+es6id: 20.3.4.4
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getFullYear(), NaN);

--- a/test/built-ins/Date/prototype/getFullYear/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getFullYear/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getfullyear
+es6id: 20.3.4.4
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getFullYear = Date.prototype.getFullYear;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getFullYear, 'function');
+
+assert.throws(TypeError, function() {
+  getFullYear.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getFullYear.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getFullYear.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getFullYear/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getFullYear/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getfullyear
+es6id: 20.3.4.4
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getFullYear = Date.prototype.getFullYear;
+var symbol = Symbol();
+
+assert.sameValue(typeof getFullYear, 'function');
+
+assert.throws(TypeError, function() {
+  getFullYear.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getFullYear.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getFullYear.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getFullYear.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getFullYear.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getFullYear.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getFullYear/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getFullYear/this-value-valid-date.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getfullyear
+es6id: 20.3.4.4
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return YearFromTime(LocalTime(t)).
+---*/
+
+assert.sameValue(new Date(2016, 0).getFullYear(), 2016, 'first millisecond');
+assert.sameValue(
+  new Date(2016, 0, 1, 0, 0, 0, -1).getFullYear(), 2015, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(2016, 11, 31, 23, 59, 59, 999).getFullYear(),
+  2016,
+  'final millisecond'
+);
+assert.sameValue(
+  new Date(2016, 11, 31, 23, 59, 59, 1000).getFullYear(),
+  2017,
+  'subsequent millisecond'
+);

--- a/test/built-ins/Date/prototype/getHours/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getHours/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.gethours
+es6id: 20.3.4.5
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getHours(), NaN);

--- a/test/built-ins/Date/prototype/getHours/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getHours/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.gethours
+es6id: 20.3.4.5
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getHours = Date.prototype.getHours;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getHours, 'function');
+
+assert.throws(TypeError, function() {
+  getHours.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getHours.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getHours.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getHours/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getHours/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.gethours
+es6id: 20.3.4.5
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getHours = Date.prototype.getHours;
+var symbol = Symbol();
+
+assert.sameValue(typeof getHours, 'function');
+
+assert.throws(TypeError, function() {
+  getHours.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getHours.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getHours.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getHours.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getHours.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getHours.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getHours/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getHours/this-value-valid-date.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.gethours
+es6id: 20.3.4.5
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return HourFromTime(LocalTime(t)).
+---*/
+
+assert.sameValue(new Date(2016, 6, 6, 13).getHours(), 13, 'first millisecond');
+assert.sameValue(
+  new Date(2016, 6, 6, 13, 0, 0, -1).getHours(), 12, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 13, 59, 59, 999).getHours(),
+  13,
+  'final millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 13, 59, 59, 1000).getHours(),
+  14,
+  'subsequent millisecond'
+);
+
+assert.sameValue(
+  new Date(2016, 6, 6, 23).getHours(), 23, 'first millisecond (hour boundary)'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 23, 0, 0, -1).getHours(),
+  22,
+  'previous millisecond (hour boundary)'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 23, 59, 59, 999).getHours(),
+  23,
+  'final millisecond (hour boundary)'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 23, 59, 59, 1000).getHours(),
+  0,
+  'subsequent millisecond (hour boundary)'
+);

--- a/test/built-ins/Date/prototype/getMilliseconds/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getMilliseconds/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getmilliseconds
+es6id: 20.3.4.6
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getMilliseconds(), NaN);

--- a/test/built-ins/Date/prototype/getMilliseconds/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getMilliseconds/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getmilliseconds
+es6id: 20.3.4.6
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getMilliseconds = Date.prototype.getMilliseconds;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getMilliseconds, 'function');
+
+assert.throws(TypeError, function() {
+  getMilliseconds.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getMilliseconds.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getMilliseconds.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getMilliseconds/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getMilliseconds/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getmilliseconds
+es6id: 20.3.4.6
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getMilliseconds = Date.prototype.getMilliseconds;
+var symbol = Symbol();
+
+assert.sameValue(typeof getMilliseconds, 'function');
+
+assert.throws(TypeError, function() {
+  getMilliseconds.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getMilliseconds.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getMilliseconds.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getMilliseconds.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getMilliseconds.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getMilliseconds.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getMilliseconds/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getMilliseconds/this-value-valid-date.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getmilliseconds
+es6id: 20.3.4.6
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return msFromTime(LocalTime(t)).
+---*/
+
+assert.sameValue(
+  new Date(2016, 6, 6).getMilliseconds(), 0, 'first millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 0, 0, 0, -1).getMilliseconds(),
+  999,
+  'previous millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 23, 59, 59, 999).getMilliseconds(),
+  999,
+  'final millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 23, 59, 59, 1000).getMilliseconds(),
+  0,
+  'subsequent millisecond'
+);

--- a/test/built-ins/Date/prototype/getMinutes/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getMinutes/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getminutes
+es6id: 20.3.4.7
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getMinutes(), NaN);

--- a/test/built-ins/Date/prototype/getMinutes/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getMinutes/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getminutes
+es6id: 20.3.4.7
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getMinutes = Date.prototype.getMinutes;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getMinutes, 'function');
+
+assert.throws(TypeError, function() {
+  getMinutes.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getMinutes.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getMinutes.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getMinutes/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getMinutes/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getminutes
+es6id: 20.3.4.7
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getMinutes = Date.prototype.getMinutes;
+var symbol = Symbol();
+
+assert.sameValue(typeof getMinutes, 'function');
+
+assert.throws(TypeError, function() {
+  getMinutes.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getMinutes.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getMinutes.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getMinutes.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getMinutes.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getMinutes.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getMinutes/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getMinutes/this-value-valid-date.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getminutes
+es6id: 20.3.4.7
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return MinFromTime(LocalTime(t)).
+---*/
+
+assert.sameValue(new Date(2016, 6, 6, 14, 6).getMinutes(), 6, 'first millisecond');
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 6, 0, -1).getMinutes(), 5, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 6, 59, 999).getMinutes(), 6, 'final millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 6, 59, 1000).getMinutes(), 7, 'subsequent millisecond'
+);
+
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 59).getMinutes(), 59, 'first millisecond (hour boundary)'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 59, 0, -1).getMinutes(),
+  58,
+  'previous millisecond (hour boundary)'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 59, 59, 999).getMinutes(),
+  59,
+  'final millisecond (hour boundary)'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 59, 59, 1000).getMinutes(),
+  0,
+  'subsequent millisecond (hour boundary)'
+);

--- a/test/built-ins/Date/prototype/getMonth/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getMonth/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getmonth
+es6id: 20.3.4.8
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getMonth(), NaN);

--- a/test/built-ins/Date/prototype/getMonth/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getMonth/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getmonth
+es6id: 20.3.4.8
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getMonth = Date.prototype.getMonth;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getMonth, 'function');
+
+assert.throws(TypeError, function() {
+  getMonth.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getMonth.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getMonth.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getMonth/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getMonth/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getmonth
+es6id: 20.3.4.8
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getMonth = Date.prototype.getMonth;
+var symbol = Symbol();
+
+assert.sameValue(typeof getMonth, 'function');
+
+assert.throws(TypeError, function() {
+  getMonth.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getMonth.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getMonth.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getMonth.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getMonth.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getMonth.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getMonth/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getMonth/this-value-valid-date.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getmonth
+es6id: 20.3.4.8
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return MonthFromTime(LocalTime(t)).
+---*/
+
+assert.sameValue(new Date(2016, 6).getMonth(), 6, 'first millisecond');
+assert.sameValue(
+  new Date(2016, 6, 0, 0, 0, 0, -1).getMonth(), 5, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 31, 23, 59, 59, 999).getMonth(), 6, 'final millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 31, 23, 59, 59, 1000).getMonth(), 7, 'subsequent millisecond'
+);
+
+assert.sameValue(
+  new Date(2016, 11, 31).getMonth(), 11, 'first millisecond (year boundary)'
+);
+assert.sameValue(
+  new Date(2016, 11, 0, 0, 0, 0, -1).getMonth(),
+  10,
+  'previous millisecond (year boundary)'
+);
+assert.sameValue(
+  new Date(2016, 11, 31, 23, 59, 59, 999).getMonth(),
+  11,
+  'final millisecond (year boundary)'
+);
+assert.sameValue(
+  new Date(2016, 11, 31, 23, 59, 59, 1000).getMonth(),
+  0,
+  'subsequent millisecond (year boundary)'
+);

--- a/test/built-ins/Date/prototype/getSeconds/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getSeconds/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getseconds
+es6id: 20.3.4.9
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getSeconds(), NaN);

--- a/test/built-ins/Date/prototype/getSeconds/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getSeconds/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getseconds
+es6id: 20.3.4.9
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getSeconds = Date.prototype.getSeconds;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getSeconds, 'function');
+
+assert.throws(TypeError, function() {
+  getSeconds.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getSeconds.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getSeconds.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getSeconds/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getSeconds/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getseconds
+es6id: 20.3.4.9
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getSeconds = Date.prototype.getSeconds;
+var symbol = Symbol();
+
+assert.sameValue(typeof getSeconds, 'function');
+
+assert.throws(TypeError, function() {
+  getSeconds.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getSeconds.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getSeconds.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getSeconds.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getSeconds.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getSeconds.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getSeconds/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getSeconds/this-value-valid-date.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getseconds
+es6id: 20.3.4.9
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return SecFromTime(LocalTime(t)).
+---*/
+
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 16, 30).getSeconds(),
+  30,
+  'first millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 16, 30, -1).getSeconds(), 29, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 16, 30, 999).getSeconds(), 30, 'final millisecond'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 16, 30, 1000).getSeconds(),
+  31,
+  'subsequent millisecond'
+);
+
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 16, 59).getSeconds(),
+  59,
+  'first millisecond (minute boundary)'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 16, 59, -1).getSeconds(),
+  58,
+  'previous millisecond (minute boundary)'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 16, 59, 999).getSeconds(),
+  59,
+  'final millisecond (minute boundary)'
+);
+assert.sameValue(
+  new Date(2016, 6, 6, 14, 16, 59, 1000).getSeconds(),
+  0,
+  'subsequent millisecond (minute boundary)'
+);

--- a/test/built-ins/Date/prototype/getTime/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getTime/this-value-invalid-date.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.gettime
+es6id: 20.3.4.10
+description: Return value for invalid date
+info: |
+  1. Return ? thisTimeValue(this value). 
+---*/
+
+assert.sameValue(new Date(NaN).getTime(), NaN);

--- a/test/built-ins/Date/prototype/getTime/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getTime/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.gettime
+es6id: 20.3.4.10
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Return ? thisTimeValue(this value). 
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getTime = Date.prototype.getTime;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getTime, 'function');
+
+assert.throws(TypeError, function() {
+  getTime.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getTime.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getTime.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getTime/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getTime/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.gettime
+es6id: 20.3.4.10
+description: Behavior when "this" value is not an Object
+info: |
+  1. Return ? thisTimeValue(this value). 
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getTime = Date.prototype.getTime;
+var symbol = Symbol();
+
+assert.sameValue(typeof getTime, 'function');
+
+assert.throws(TypeError, function() {
+  getTime.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getTime.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getTime.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getTime.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getTime.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getTime.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getTime/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getTime/this-value-valid-date.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.gettime
+es6id: 20.3.4.10
+description: Return value for valid dates
+info: |
+  1. Return ? thisTimeValue(this value). 
+---*/
+
+assert.sameValue(new Date(0).getTime(), 0, '+0');
+assert.sameValue(new Date(-0).getTime(), 0, '-0');
+assert.sameValue(new Date(-1).getTime(), -1);
+assert.sameValue(new Date(1).getTime(), 1);
+assert.sameValue(new Date(8640000000000000).getTime(), 8640000000000000);
+assert.sameValue(new Date(-8640000000000000).getTime(), -8640000000000000);

--- a/test/built-ins/Date/prototype/getTimezoneOffset/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getTimezoneOffset/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.gettimezoneoffset
+es6id: 20.3.4.11
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getTimezoneOffset(), NaN);

--- a/test/built-ins/Date/prototype/getTimezoneOffset/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getTimezoneOffset/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.gettimezoneoffset
+es6id: 20.3.4.11
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getTimezoneOffset = Date.prototype.getTimezoneOffset;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getTimezoneOffset, 'function');
+
+assert.throws(TypeError, function() {
+  getTimezoneOffset.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getTimezoneOffset.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getTimezoneOffset.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getTimezoneOffset/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getTimezoneOffset/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.gettimezoneoffset
+es6id: 20.3.4.11
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getTimezoneOffset = Date.prototype.getTimezoneOffset;
+var symbol = Symbol();
+
+assert.sameValue(typeof getTimezoneOffset, 'function');
+
+assert.throws(TypeError, function() {
+  getTimezoneOffset.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getTimezoneOffset.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getTimezoneOffset.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getTimezoneOffset.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getTimezoneOffset.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getTimezoneOffset.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getTimezoneOffset/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getTimezoneOffset/this-value-valid-date.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.gettimezoneoffset
+es6id: 20.3.4.11
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return (t - LocalTime(t)) / msPerMinute.
+---*/
+
+assert.sameValue(
+  typeof new Date(0).getTimezoneOffset(), 'number', 'Unix epoch'
+);
+
+assert.sameValue(
+  typeof new Date(8640000000000000).getTimezoneOffset(),
+  'number',
+  'latest representable time'
+);
+
+assert.sameValue(
+  typeof new Date(-8640000000000000).getTimezoneOffset(),
+  'number',
+  'earliest representable time'
+);
+
+assert.sameValue(
+  typeof new Date().getTimezoneOffset(), 'number', 'current time'
+);

--- a/test/built-ins/Date/prototype/getUTCDate/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getUTCDate/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcdate
+es6id: 20.3.4.12
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getUTCDate(), NaN);

--- a/test/built-ins/Date/prototype/getUTCDate/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getUTCDate/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcdate
+es6id: 20.3.4.12
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getUTCDate = Date.prototype.getUTCDate;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getUTCDate, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCDate.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getUTCDate.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getUTCDate.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getUTCDate/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getUTCDate/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcdate
+es6id: 20.3.4.12
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getUTCDate = Date.prototype.getUTCDate;
+var symbol = Symbol();
+
+assert.sameValue(typeof getUTCDate, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCDate.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getUTCDate.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getUTCDate.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getUTCDate.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getUTCDate.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getUTCDate.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getUTCDate/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getUTCDate/this-value-valid-date.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcdate
+es6id: 20.3.4.12
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return DateFromTime(t).
+---*/
+
+var july6 = 1467763200000;
+var feb29 = 1456704000000;
+var dayMs = 24 * 60 * 60 * 1000;
+
+assert.sameValue(new Date(july6).getUTCDate(), 6, 'first millisecond');
+assert.sameValue(
+  new Date(july6 - 1).getUTCDate(), 5, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(july6 + dayMs - 1).getUTCDate(), 6, 'final millisecond'
+);
+assert.sameValue(
+  new Date(july6 + dayMs).getUTCDate(), 7, 'subsequent millisecond'
+);
+
+assert.sameValue(
+  new Date(feb29).getUTCDate(), 29, 'first millisecond (month boundary)'
+);
+assert.sameValue(
+  new Date(feb29 - 1).getUTCDate(), 28, 'previous millisecond (month boundary)'
+);
+assert.sameValue(
+  new Date(feb29 + dayMs - 1).getUTCDate(),
+  29,
+  'final millisecond (month boundary)'
+);
+assert.sameValue(
+  new Date(feb29 + dayMs).getUTCDate(),
+  1,
+  'subsequent millisecond (month boundary)'
+);

--- a/test/built-ins/Date/prototype/getUTCDay/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getUTCDay/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcday
+es6id: 20.3.4.13
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getUTCDay(), NaN);

--- a/test/built-ins/Date/prototype/getUTCDay/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getUTCDay/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcday
+es6id: 20.3.4.13
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getUTCDay = Date.prototype.getUTCDay;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getUTCDay, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCDay.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getUTCDay.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getUTCDay.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getUTCDay/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getUTCDay/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcdaty
+es6id: 20.3.4.13
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getUTCDay = Date.prototype.getUTCDay;
+var symbol = Symbol();
+
+assert.sameValue(typeof getUTCDay, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCDay.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getUTCDay.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getUTCDay.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getUTCDay.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getUTCDay.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getUTCDay.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getUTCDay/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getUTCDay/this-value-valid-date.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcday
+es6id: 20.3.4.13
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return WeekDay(t).
+---*/
+
+var july6 = 1467763200000;
+var july9 = 1468022400000;
+var dayMs = 24 * 60 * 60 * 1000;
+
+assert.sameValue(new Date(july6).getUTCDay(), 3, 'first millisecond');
+assert.sameValue(
+  new Date(july6 - 1).getUTCDay(), 2, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(july6 + dayMs - 1).getUTCDay(), 3, 'final millisecond'
+);
+assert.sameValue(
+  new Date(july6 + dayMs).getUTCDay(), 4, 'subsequent millisecond'
+);
+
+assert.sameValue(
+  new Date(july9).getUTCDay(), 6, 'first millisecond (week boundary)'
+);
+assert.sameValue(
+  new Date(july9 - 1).getUTCDay(), 5, 'previous millisecond (week boundary)'
+);
+assert.sameValue(
+  new Date(july9 + dayMs - 1).getUTCDay(),
+  6,
+  'final millisecond (week boundary)'
+);
+assert.sameValue(
+  new Date(july9 + dayMs).getUTCDay(),
+  0,
+  'subsequent millisecond (week boundary)'
+);

--- a/test/built-ins/Date/prototype/getUTCFullYear/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getUTCFullYear/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcfullyear
+es6id: 20.3.4.14
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getUTCFullYear(), NaN);

--- a/test/built-ins/Date/prototype/getUTCFullYear/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getUTCFullYear/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcfullyear
+es6id: 20.3.4.14
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getUTCFullYear = Date.prototype.getUTCFullYear;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getUTCFullYear, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCFullYear.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getUTCFullYear.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getUTCFullYear.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getUTCFullYear/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getUTCFullYear/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcfullyear
+es6id: 20.3.4.14
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getUTCFullYear = Date.prototype.getUTCFullYear;
+var symbol = Symbol();
+
+assert.sameValue(typeof getUTCFullYear, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCFullYear.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getUTCFullYear.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getUTCFullYear.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getUTCFullYear.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getUTCFullYear.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getUTCFullYear.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getUTCFullYear/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getUTCFullYear/this-value-valid-date.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcfullyear
+es6id: 20.3.4.14
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return YearFromTime(t).
+---*/
+
+var dec31 = 1483142400000;
+var dayMs = 24 * 60 * 60 * 1000;
+
+assert.sameValue(new Date(dec31).getUTCFullYear(), 2016, 'first millisecond');
+assert.sameValue(
+  new Date(dec31 - 1).getUTCFullYear(), 2016, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(dec31 + dayMs - 1).getUTCFullYear(), 2016, 'final millisecond'
+);
+assert.sameValue(
+  new Date(dec31 + dayMs).getUTCFullYear(), 2017, 'subsequent millisecond'
+);

--- a/test/built-ins/Date/prototype/getUTCHours/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getUTCHours/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutchours
+es6id: 20.3.4.15
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getUTCHours(), NaN);

--- a/test/built-ins/Date/prototype/getUTCHours/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getUTCHours/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutchours
+es6id: 20.3.4.15
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getUTCHours = Date.prototype.getUTCHours;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getUTCHours, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCHours.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getUTCHours.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getUTCHours.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getUTCHours/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getUTCHours/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutchours
+es6id: 20.3.4.15
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getUTCHours = Date.prototype.getUTCHours;
+var symbol = Symbol();
+
+assert.sameValue(typeof getUTCHours, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCHours.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getUTCHours.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getUTCHours.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getUTCHours.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getUTCHours.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getUTCHours.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getUTCHours/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getUTCHours/this-value-valid-date.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutchours
+es6id: 20.3.4.15
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return HourFromTime(t).
+---*/
+
+var hour15 = 1467817200000;
+var hour23 = 1467846000000;
+var hourMs = 60 * 60 * 1000;
+
+assert.sameValue(new Date(hour15).getUTCHours(), 15, 'first millisecond');
+assert.sameValue(
+  new Date(hour15 - 1).getUTCHours(), 14, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(hour15 + hourMs - 1).getUTCHours(), 15, 'final millisecond'
+);
+assert.sameValue(
+  new Date(hour15 + hourMs).getUTCHours(), 16, 'subsequent millisecond'
+);
+
+assert.sameValue(
+  new Date(hour23).getUTCHours(), 23, 'first millisecond (day boundary)'
+);
+assert.sameValue(
+  new Date(hour23 - 1).getUTCHours(), 22, 'previous millisecond (day boundary)'
+);
+assert.sameValue(
+  new Date(hour23 + hourMs - 1).getUTCHours(),
+  23,
+  'final millisecond (day boundary)'
+);
+assert.sameValue(
+  new Date(hour23 + hourMs).getUTCHours(),
+  0,
+  'subsequent millisecond (day boundary)'
+);

--- a/test/built-ins/Date/prototype/getUTCMilliseconds/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getUTCMilliseconds/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcmilliseconds
+es6id: 20.3.4.16
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getUTCMilliseconds(), NaN);

--- a/test/built-ins/Date/prototype/getUTCMilliseconds/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getUTCMilliseconds/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcmilliseconds
+es6id: 20.3.4.16
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getUTCMilliseconds = Date.prototype.getUTCMilliseconds;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getUTCMilliseconds, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCMilliseconds.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getUTCMilliseconds.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getUTCMilliseconds.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getUTCMilliseconds/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getUTCMilliseconds/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcmilliseconds
+es6id: 20.3.4.16
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getUTCMilliseconds = Date.prototype.getUTCMilliseconds;
+var symbol = Symbol();
+
+assert.sameValue(typeof getUTCMilliseconds, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCMilliseconds.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getUTCMilliseconds.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getUTCMilliseconds.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getUTCMilliseconds.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getUTCMilliseconds.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getUTCMilliseconds.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getUTCMilliseconds/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getUTCMilliseconds/this-value-valid-date.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcmmilliseconds
+es6id: 20.3.4.16
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return msFromTime(t).
+---*/
+
+var july6 = 1467763200000;
+
+assert.sameValue(new Date(july6).getUTCMilliseconds(), 0, 'first millisecond');
+assert.sameValue(
+  new Date(july6 - 1).getUTCMilliseconds(), 999, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(july6 + 999).getUTCMilliseconds(), 999, 'final millisecond'
+);
+assert.sameValue(
+  new Date(july6 + 1000).getUTCMilliseconds(), 0, 'subsequent millisecond'
+);

--- a/test/built-ins/Date/prototype/getUTCMinutes/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getUTCMinutes/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcminutes
+es6id: 20.3.4.17
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getUTCMinutes(), NaN);

--- a/test/built-ins/Date/prototype/getUTCMinutes/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getUTCMinutes/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcminutes
+es6id: 20.3.4.17
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getUTCMinutes = Date.prototype.getUTCMinutes;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getUTCMinutes, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCMinutes.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getUTCMinutes.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getUTCMinutes.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getUTCMinutes/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getUTCMinutes/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcminutes
+es6id: 20.3.4.17
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getUTCMinutes = Date.prototype.getUTCMinutes;
+var symbol = Symbol();
+
+assert.sameValue(typeof getUTCMinutes, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCMinutes.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getUTCMinutes.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getUTCMinutes.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getUTCMinutes.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getUTCMinutes.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getUTCMinutes.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getUTCMinutes/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getUTCMinutes/this-value-valid-date.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcminutes
+es6id: 20.3.4.17
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return MinFromTime(t).
+---*/
+
+var threeTwentyTwo = 1467818520000;
+var threeFiftyNine = 1467820740000;
+var minMs = 60 * 1000;
+
+assert.sameValue(
+  new Date(threeTwentyTwo).getUTCMinutes(), 22, 'first millisecond'
+);
+assert.sameValue(
+  new Date(threeTwentyTwo - 1).getUTCMinutes(), 21, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(threeTwentyTwo + minMs - 1).getUTCMinutes(), 22, 'final millisecond'
+);
+assert.sameValue(
+  new Date(threeTwentyTwo + minMs).getUTCMinutes(),
+  23,
+  'subsequent millisecond'
+);
+
+assert.sameValue(
+  new Date(threeFiftyNine).getUTCMinutes(),
+  59,
+  'first millisecond (day boundary)'
+);
+assert.sameValue(
+  new Date(threeFiftyNine - 1).getUTCMinutes(),
+  58,
+  'previous millisecond (day boundary)'
+);
+assert.sameValue(
+  new Date(threeFiftyNine + minMs - 1).getUTCMinutes(),
+  59,
+  'final millisecond (day boundary)'
+);
+assert.sameValue(
+  new Date(threeFiftyNine + minMs).getUTCMinutes(),
+  0,
+  'subsequent millisecond (day boundary)'
+);

--- a/test/built-ins/Date/prototype/getUTCMonth/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getUTCMonth/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcmonth
+es6id: 20.3.4.18
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getUTCMonth(), NaN);

--- a/test/built-ins/Date/prototype/getUTCMonth/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getUTCMonth/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcmonth
+es6id: 20.3.4.18
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getUTCMonth = Date.prototype.getUTCMonth;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getUTCMonth, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCMonth.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getUTCMonth.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getUTCMonth.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getUTCMonth/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getUTCMonth/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcmonth
+es6id: 20.3.4.18
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getUTCMonth = Date.prototype.getUTCMonth;
+var symbol = Symbol();
+
+assert.sameValue(typeof getUTCMonth, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCMonth.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getUTCMonth.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getUTCMonth.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getUTCMonth.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getUTCMonth.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getUTCMonth.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getUTCMonth/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getUTCMonth/this-value-valid-date.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcmonth
+es6id: 20.3.4.18
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return MonthFromTime(t).
+---*/
+
+var july31 = 1469923200000;
+var dec31 = 1483142400000;
+var dayMs = 24 * 60 * 60 * 1000;
+
+assert.sameValue(new Date(july31).getUTCMonth(), 6, 'first millisecond');
+assert.sameValue(
+  new Date(july31 - 1).getUTCMonth(), 6, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(july31 + dayMs - 1).getUTCMonth(), 6, 'final millisecond'
+);
+assert.sameValue(
+  new Date(july31 + dayMs).getUTCMonth(), 7, 'subsequent millisecond'
+);
+
+assert.sameValue(
+  new Date(dec31).getUTCMonth(), 11, 'first millisecond (year boundary)'
+);
+assert.sameValue(
+  new Date(dec31 - 1).getUTCMonth(), 11, 'previous millisecond (year boundary)'
+);
+assert.sameValue(
+  new Date(dec31 + dayMs - 1).getUTCMonth(),
+  11,
+  'final millisecond (year boundary)'
+);
+assert.sameValue(
+  new Date(dec31 + dayMs).getUTCMonth(),
+  0,
+  'subsequent millisecond (year boundary)'
+);

--- a/test/built-ins/Date/prototype/getUTCSeconds/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/getUTCSeconds/this-value-invalid-date.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcseconds
+es6id: 20.3.4.19
+description: Return value for invalid date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+---*/
+
+assert.sameValue(new Date(NaN).getUTCSeconds(), NaN);

--- a/test/built-ins/Date/prototype/getUTCSeconds/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/getUTCSeconds/this-value-non-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcseconds
+es6id: 20.3.4.19
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var getUTCSeconds = Date.prototype.getUTCSeconds;
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof getUTCSeconds, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCSeconds.call({});
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  getUTCSeconds.call([]);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  getUTCSeconds.call(args);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/prototype/getUTCSeconds/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/getUTCSeconds/this-value-non-object.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcseconds
+es6id: 20.3.4.19
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var getUTCSeconds = Date.prototype.getUTCSeconds;
+var symbol = Symbol();
+
+assert.sameValue(typeof getUTCSeconds, 'function');
+
+assert.throws(TypeError, function() {
+  getUTCSeconds.call(0);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  getUTCSeconds.call(true);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  getUTCSeconds.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  getUTCSeconds.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  getUTCSeconds.call('');
+}, 'string');
+
+assert.throws(TypeError, function() {
+  getUTCSeconds.call(symbol);
+}, 'symbol');

--- a/test/built-ins/Date/prototype/getUTCSeconds/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/getUTCSeconds/this-value-valid-date.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.getutcseconds
+es6id: 20.3.4.19
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, return NaN.
+  3. Return SecFromTime(t).
+---*/
+
+var sec34 = 1467819394000;
+var sec59 = 1467819419000;
+
+assert.sameValue(new Date(sec34).getUTCSeconds(), 34, 'first millisecond');
+assert.sameValue(
+  new Date(sec34 - 1).getUTCSeconds(), 33, 'previous millisecond'
+);
+assert.sameValue(
+  new Date(sec34 + 999).getUTCSeconds(), 34, 'final millisecond'
+);
+assert.sameValue(
+  new Date(sec34 + 1000).getUTCSeconds(), 35, 'subsequent millisecond'
+);
+
+assert.sameValue(
+  new Date(sec59).getUTCSeconds(), 59, 'first millisecond (minute boundary)'
+);
+assert.sameValue(
+  new Date(sec59 - 1).getUTCSeconds(),
+  58,
+  'previous millisecond (minute boundary)'
+);
+assert.sameValue(
+  new Date(sec59 + 99).getUTCSeconds(),
+  59,
+  'final millisecond (minute boundary)'
+);
+assert.sameValue(
+  new Date(sec59 + 1000).getUTCSeconds(),
+  0,
+  'subsequent millisecond (minute boundary)'
+);

--- a/test/built-ins/Date/prototype/setDate/arg-to-number-err.js
+++ b/test/built-ins/Date/prototype/setDate/arg-to-number-err.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setdate
+es6id: 20.3.4.20
+description: Abrupt completion during type coercion of provided argument
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(date).
+---*/
+
+var date = new Date();
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setDate(obj);
+});
+
+assert.sameValue(date.getTime(), originalValue);

--- a/test/built-ins/Date/prototype/setDate/arg-to-number.js
+++ b/test/built-ins/Date/prototype/setDate/arg-to-number.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setdate
+es6id: 20.3.4.20
+description: Type coercion of provided argument
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(date).
+  3. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt),
+     TimeWithinDay(t)).
+  4. Let u be TimeClip(UTC(newDate)).
+  5. Set the [[DateValue]] internal slot of this Date object to u.
+  6. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setDate(arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue, new Date(2016, 6, 2).getTime(), 'application of specified value'
+);
+
+returnValue = date.setDate(null);
+
+assert.sameValue(returnValue, new Date(2016, 5, 30).getTime(), 'null');
+
+returnValue = date.setDate(true);
+
+assert.sameValue(returnValue, new Date(2016, 5, 1).getTime(), 'true');
+
+returnValue = date.setDate(false);
+
+assert.sameValue(returnValue, new Date(2016, 4, 31).getTime(), 'false');
+
+returnValue = date.setDate('   +00200.000E-0002	');
+
+assert.sameValue(returnValue, new Date(2016, 4, 2).getTime(), 'string');
+
+returnValue = date.setDate();
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setDate/new-value-time-clip.js
+++ b/test/built-ins/Date/prototype/setDate/new-value-time-clip.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setdate
+es6id: 20.3.4.20
+description: Behavior when new value exceeds [[DateValue]] limits
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(date).
+  3. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt),
+     TimeWithinDay(t)).
+  4. Let u be TimeClip(UTC(newDate)).
+  5. Set the [[DateValue]] internal slot of this Date object to u.
+  6. Return u.
+
+  TimeClip (time)
+
+  1. If time is not finite, return NaN.
+  2. If abs(time) > 8.64 × 1015, return NaN.
+---*/
+
+var date = new Date(8.64e15);
+var returnValue;
+
+assert.notSameValue(date.getTime(), NaN);
+
+returnValue = date.setDate(28);
+
+assert.sameValue(returnValue, NaN);

--- a/test/built-ins/Date/prototype/setDate/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/setDate/this-value-invalid-date.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setdate
+es6id: 20.3.4.20
+description: >
+  Behavior when the "this" value is a Date object describing an invald date
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(date).
+  3. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt),
+     TimeWithinDay(t)).
+  4. Let u be TimeClip(UTC(newDate)).
+  5. Set the [[DateValue]] internal slot of this Date object to u.
+  6. Return u.
+---*/
+
+var date = new Date(NaN);
+var result;
+
+result = date.setDate(0);
+
+assert.sameValue(result, NaN, 'return value');
+assert.sameValue(date.getTime(), NaN, '[[DateValue]] internal slot');

--- a/test/built-ins/Date/prototype/setDate/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/setDate/this-value-non-date.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setdate
+es6id: 20.3.4.20
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var setDate = Date.prototype.setDate;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof setDate, 'function');
+
+assert.throws(TypeError, function() {
+  setDate.call({}, arg);
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  setDate.call([], arg);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  setDate.call(args, arg);
+}, 'arguments exotic object');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setDate/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/setDate/this-value-non-object.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setdate
+es6id: 20.3.4.20
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var setDate = Date.prototype.setDate;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var symbol = Symbol();
+
+assert.sameValue(typeof setDate, 'function');
+
+assert.throws(TypeError, function() {
+  setDate.call(0, arg);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  setDate.call(true, arg);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  setDate.call(null, arg);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  setDate.call(undefined, arg);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  setDate.call('', arg);
+}, 'string');
+
+assert.throws(TypeError, function() {
+  setDate.call(symbol, arg);
+}, 'symbol');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setDate/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/setDate/this-value-valid-date.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setdate
+es6id: 20.3.4.20
+description: Return value for valid dates
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(date).
+  3. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt),
+     TimeWithinDay(t)).
+  4. Let u be TimeClip(UTC(newDate)).
+  5. Set the [[DateValue]] internal slot of this Date object to u.
+  6. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var returnValue, expected;
+
+returnValue = date.setDate(6);
+
+expected = new Date(2016, 6, 6).getTime();
+assert.sameValue(
+  returnValue, expected, 'within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setDate(0);
+
+expected = new Date(2016, 5, 30).getTime();
+assert.sameValue(
+  returnValue, expected, 'before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setDate(31);
+
+expected = new Date(2016, 6, 1).getTime();
+assert.sameValue(
+  returnValue, expected, 'after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setFullYear/arg-date-to-number-err.js
+++ b/test/built-ins/Date/prototype/setFullYear/arg-date-to-number-err.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setfullyear
+es6id: 20.3.4.21
+description: Abrupt completion during type coercion of provided "date"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+  4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be
+     ? ToNumber(month).
+  5. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+---*/
+
+var date = new Date();
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setFullYear(0, 0, obj);
+});
+
+assert.sameValue(date.getTime(), originalValue);

--- a/test/built-ins/Date/prototype/setFullYear/arg-date-to-number.js
+++ b/test/built-ins/Date/prototype/setFullYear/arg-date-to-number.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setfullyear
+es6id: 20.3.4.21
+description: Type coercion of provided "date"
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+  4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be
+     ? ToNumber(month).
+  5. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
+  7. Let u be TimeClip(UTC(newDate)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6, 7, 11, 36, 23, 2);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setFullYear(2016, 6, arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 2, 11, 36, 23, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setFullYear(2016, 6, null);
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 0, 11, 36, 23, 2).getTime(),
+  'null'
+);
+
+returnValue = date.setFullYear(2016, 6, true);
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 1, 11, 36, 23, 2).getTime(),
+  'true'
+);
+
+returnValue = date.setFullYear(2016, 6, false);
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 0, 11, 36, 23, 2).getTime(),
+  'false'
+);
+
+returnValue = date.setFullYear(2016, 6, '   +00200.000E-0002	');
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 2, 11, 36, 23, 2).getTime(),
+  'string'
+);
+
+returnValue = date.setFullYear(2016, 6, undefined);
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setFullYear/arg-month-to-number-err.js
+++ b/test/built-ins/Date/prototype/setFullYear/arg-month-to-number-err.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setfullyear
+es6id: 20.3.4.21
+description: Abrupt completion during type coercion of provided "month"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+  4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be
+     ? ToNumber(month).
+---*/
+
+var date = new Date();
+var callCount = 0;
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+var counter = {
+  valueOf: function() {
+    callCount += 1;
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setFullYear(0, obj, counter);
+});
+
+assert.sameValue(date.getTime(), originalValue);
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Date/prototype/setFullYear/arg-month-to-number.js
+++ b/test/built-ins/Date/prototype/setFullYear/arg-month-to-number.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setfullyear
+es6id: 20.3.4.21
+description: Type coercion of provided "month"
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+  4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be
+     ? ToNumber(month).
+  5. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
+  7. Let u be TimeClip(UTC(newDate)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6, 7, 11, 36, 23, 2);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setFullYear(2016, arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(2016, 2, 7, 11, 36, 23, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setFullYear(2016, null);
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 0, 7, 11, 36, 23, 2).getTime(),
+  'null'
+);
+
+returnValue = date.setFullYear(2016, true);
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 1, 7, 11, 36, 23, 2).getTime(),
+  'true'
+);
+
+returnValue = date.setFullYear(2016, false);
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 0, 7, 11, 36, 23, 2).getTime(),
+  'false'
+);
+
+returnValue = date.setFullYear(2016, '   +00200.000E-0002	');
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 2, 7, 11, 36, 23, 2).getTime(),
+  'string'
+);
+
+returnValue = date.setFullYear(2016, undefined);
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setFullYear/arg-year-to-number-err.js
+++ b/test/built-ins/Date/prototype/setFullYear/arg-year-to-number-err.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setfullyear
+es6id: 20.3.4.21
+description: Abrupt completion during type coercion of provided "year"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+---*/
+
+var date = new Date();
+var callCount = 0;
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+var counter = {
+  valueOf: function() {
+    callCount += 1;
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setFullYear(obj, counter, counter);
+});
+
+assert.sameValue(date.getTime(), originalValue);
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Date/prototype/setFullYear/arg-year-to-number.js
+++ b/test/built-ins/Date/prototype/setFullYear/arg-year-to-number.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setfullyear
+es6id: 20.3.4.21
+description: Type coercion of provided "year"
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+  4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be
+     ? ToNumber(month).
+  5. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
+  7. Let u be TimeClip(UTC(newDate)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6, 7, 11, 36, 23, 2);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setFullYear(arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(-1, 42, 7, 11, 36, 23, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setFullYear(null);
+
+assert.sameValue(
+  returnValue,
+  new Date(-1, 18, 7, 11, 36, 23, 2).getTime(),
+  'null'
+);
+
+returnValue = date.setFullYear(true);
+
+assert.sameValue(
+  returnValue,
+  new Date(-1, 30, 7, 11, 36, 23, 2).getTime(),
+  'true'
+);
+
+returnValue = date.setFullYear(false);
+
+assert.sameValue(
+  returnValue,
+  new Date(-1, 18, 7, 11, 36, 23, 2).getTime(),
+  'false'
+);
+
+returnValue = date.setFullYear('   +00200.000E-0002	');
+
+assert.sameValue(
+  returnValue,
+  new Date(-1, 42, 7, 11, 36, 23, 2).getTime(),
+  'string'
+);
+
+returnValue = date.setFullYear();
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setFullYear/new-value-time-clip.js
+++ b/test/built-ins/Date/prototype/setFullYear/new-value-time-clip.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setfullyear
+es6id: 20.3.4.21
+description: Behavior when new value exceeds [[DateValue]] limits
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+  4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be
+     ? ToNumber(month).
+  5. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
+  7. Let u be TimeClip(UTC(newDate)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+
+  TimeClip (time)
+
+  1. If time is not finite, return NaN.
+  2. If abs(time) > 8.64 × 1015, return NaN.
+---*/
+
+var maxMs = 8.64e15;
+var maxYear = 275760;
+var maxDate = 12;
+var maxMonth = 8;
+var date = new Date(maxMs);
+var returnValue;
+
+assert.notSameValue(date.getTime(), NaN);
+
+returnValue = date.setFullYear(maxYear + 1);
+
+assert.sameValue(returnValue, NaN, 'overflow due to year');
+
+date = new Date(maxMs);
+
+returnValue = date.setFullYear(maxYear, maxMonth + 1);
+
+assert.sameValue(returnValue, NaN, 'overflow due to month');
+
+date = new Date(maxMs);
+
+returnValue = date.setFullYear(maxYear, maxMonth, maxDate + 1);
+
+assert.sameValue(returnValue, NaN, 'overflow due to date');

--- a/test/built-ins/Date/prototype/setFullYear/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/setFullYear/this-value-invalid-date.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setfullyear
+es6id: 20.3.4.21
+description: >
+  Behavior when the "this" value is a Date object describing an invald date
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+  4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be
+     ? ToNumber(month).
+  5. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
+  7. Let u be TimeClip(UTC(newDate)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(NaN);
+var expected, result;
+
+result = date.setFullYear(2016);
+
+expected = new Date(2016, 0).getTime();
+assert.sameValue(result, expected, 'return value (year)');
+assert.sameValue(
+  date.getTime(), expected, '[[DateValue]] internal slot (year)'
+);
+
+date = new Date(NaN);
+
+result = date.setFullYear(2016, 6);
+
+expected = new Date(2016, 6).getTime();
+assert.sameValue(result, expected, 'return value (month)');
+assert.sameValue(
+  date.getTime(), expected, '[[DateValue]] internal slot (month)'
+);
+
+date = new Date(NaN);
+
+result = date.setFullYear(2016, 6, 7);
+
+expected = new Date(2016, 6, 7).getTime();
+assert.sameValue(result, expected, 'return value (date)');
+assert.sameValue(
+  date.getTime(), expected, '[[DateValue]] internal slot (month)'
+);

--- a/test/built-ins/Date/prototype/setFullYear/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/setFullYear/this-value-non-date.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setfullyear
+es6id: 20.3.4.21
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var setFullYear = Date.prototype.setFullYear;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof setFullYear, 'function');
+
+assert.throws(TypeError, function() {
+  setFullYear.call({}, arg);
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  setFullYear.call([], arg);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  setFullYear.call(args, arg);
+}, 'arguments exotic object');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setFullYear/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/setFullYear/this-value-non-object.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setfullyear
+es6id: 20.3.4.21
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var setFullYear = Date.prototype.setFullYear;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var symbol = Symbol();
+
+assert.sameValue(typeof setFullYear, 'function');
+
+assert.throws(TypeError, function() {
+  setFullYear.call(0, arg);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  setFullYear.call(true, arg);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  setFullYear.call(null, arg);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  setFullYear.call(undefined, arg);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  setFullYear.call('', arg);
+}, 'string');
+
+assert.throws(TypeError, function() {
+  setFullYear.call(symbol, arg);
+}, 'symbol');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setFullYear/this-value-valid-date-date.js
+++ b/test/built-ins/Date/prototype/setFullYear/this-value-valid-date-date.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setfullyear
+es6id: 20.3.4.21
+description: Return value for valid dates (setting date)
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+  4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be
+     ? ToNumber(month).
+  5. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
+  7. Let u be TimeClip(UTC(newDate)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var returnValue, expected;
+
+returnValue = date.setFullYear(2016, 6, 6);
+
+expected = new Date(2016, 6, 6).getTime();
+assert.sameValue(
+  returnValue, expected, 'date within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'date within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setFullYear(2016, 6, 0);
+
+expected = new Date(2016, 5, 30).getTime();
+assert.sameValue(
+  returnValue, expected, 'date before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'date before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setFullYear(2016, 5, 31);
+
+expected = new Date(2016, 6, 1).getTime();
+assert.sameValue(
+  returnValue, expected, 'date after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'date after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setFullYear/this-value-valid-date-month.js
+++ b/test/built-ins/Date/prototype/setFullYear/this-value-valid-date-month.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setfullyear
+es6id: 20.3.4.21
+description: Return value for valid dates (setting month)
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+  4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be
+     ? ToNumber(month).
+  5. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
+  7. Let u be TimeClip(UTC(newDate)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var returnValue, expected;
+
+returnValue = date.setFullYear(2016, 3);
+
+expected = new Date(2016, 3).getTime();
+assert.sameValue(
+  returnValue, expected, 'month within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'month within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setFullYear(2016, -1);
+
+expected = new Date(2015, 11).getTime();
+assert.sameValue(
+  returnValue, expected, 'month before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'month before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setFullYear(2016, 12);
+
+expected = new Date(2017, 0).getTime();
+assert.sameValue(
+  returnValue, expected, 'month after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'month after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setFullYear/this-value-valid-date-year.js
+++ b/test/built-ins/Date/prototype/setFullYear/this-value-valid-date-year.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setfullyear
+es6id: 20.3.4.21
+description: Return value for valid dates (setting year)
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+  4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be
+     ? ToNumber(month).
+  5. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
+  7. Let u be TimeClip(UTC(newDate)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var returnValue, expected;
+
+returnValue = date.setFullYear(2015);
+
+expected = new Date(2015, 6).getTime();
+assert.sameValue(returnValue, expected, 'year (return value)');
+assert.sameValue(date.getTime(), expected, 'year ([[DateValue]] slot)');

--- a/test/built-ins/Date/prototype/setHours/arg-hour-to-number-err.js
+++ b/test/built-ins/Date/prototype/setHours/arg-hour-to-number-err.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: Abrupt completion during type coercion of provided "hour"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(hour).
+---*/
+
+var date = new Date();
+var callCount = 0;
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+var counter = {
+  valueOf: function() {
+    callCount += 1;
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setHours(obj, counter, counter, counter);
+});
+
+assert.sameValue(date.getTime(), originalValue);
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Date/prototype/setHours/arg-hour-to-number.js
+++ b/test/built-ins/Date/prototype/setHours/arg-hour-to-number.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: Type coercion of provided "hour"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let h be ? ToNumber(hour).
+  3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ?
+     ToNumber(min).
+  4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  5. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  6. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  7. Let u be TimeClip(UTC(date)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setHours(arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 1, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setHours(null);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1, 0).getTime(), 'null');
+
+returnValue = date.setHours(true);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1, 1).getTime(), 'true');
+
+returnValue = date.setHours(false);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1, 0).getTime(), 'false');
+
+returnValue = date.setHours('   +00200.000E-0002	');
+
+assert.sameValue(returnValue, new Date(2016, 6, 1, 2).getTime(), 'string');
+
+returnValue = date.setHours();
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setHours/arg-min-to-number-err.js
+++ b/test/built-ins/Date/prototype/setHours/arg-min-to-number-err.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: Abrupt completion during type coercion of provided "min"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(hour).
+  3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ?
+     ToNumber(min).
+---*/
+
+var date = new Date();
+var callCount = 0;
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+var counter = {
+  valueOf: function() {
+    callCount += 1;
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setHours(0, obj, counter, counter);
+});
+
+assert.sameValue(date.getTime(), originalValue);
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Date/prototype/setHours/arg-min-to-number.js
+++ b/test/built-ins/Date/prototype/setHours/arg-min-to-number.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: Type coercion of provided "min"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let h be ? ToNumber(hour).
+  3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ?
+     ToNumber(min).
+  4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  5. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  6. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  7. Let u be TimeClip(UTC(date)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setHours(0, arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 1, 0, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setHours(0, null);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'null');
+
+returnValue = date.setHours(0, true);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1, 0, 1).getTime(), 'true');
+
+returnValue = date.setHours(0, false);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'false');
+
+returnValue = date.setHours(0, '   +00200.000E-0002	');
+
+assert.sameValue(returnValue, new Date(2016, 6, 1, 0, 2).getTime(), 'string');
+
+returnValue = date.setHours();
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setHours/arg-ms-to-number-err.js
+++ b/test/built-ins/Date/prototype/setHours/arg-ms-to-number-err.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: Abrupt completion during type coercion of provided "ms"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(hour).
+  3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ?
+     ToNumber(min).
+  4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  5. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+---*/
+
+var date = new Date();
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setHours(0, 0, 0, obj);
+});
+
+assert.sameValue(date.getTime(), originalValue);

--- a/test/built-ins/Date/prototype/setHours/arg-ms-to-number.js
+++ b/test/built-ins/Date/prototype/setHours/arg-ms-to-number.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: Type coercion of provided "ms"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let h be ? ToNumber(hour).
+  3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ?
+     ToNumber(min).
+  4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  5. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  6. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  7. Let u be TimeClip(UTC(date)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setHours(0, 0, 0, arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 1, 0, 0, 0, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setHours(0, 0, 0, null);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'null');
+
+returnValue = date.setHours(0, 0, 0, true);
+
+assert.sameValue(
+  returnValue, new Date(2016, 6, 1, 0, 0, 0, 1).getTime(), 'true'
+);
+
+returnValue = date.setHours(0, 0, 0, false);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'false');
+
+returnValue = date.setHours(0, 0, 0, '   +00200.000E-0002	');
+
+assert.sameValue(
+  returnValue, new Date(2016, 6, 1, 0, 0, 0, 2).getTime(), 'string'
+);
+
+returnValue = date.setHours();
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setHours/arg-sec-to-number-err.js
+++ b/test/built-ins/Date/prototype/setHours/arg-sec-to-number-err.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: Abrupt completion during type coercion of provided "sec"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(hour).
+  3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ?
+     ToNumber(min).
+  4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+---*/
+
+var date = new Date();
+var callCount = 0;
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+var counter = {
+  valueOf: function() {
+    callCount += 1;
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setHours(0, 0, obj, counter);
+});
+
+assert.sameValue(date.getTime(), originalValue);
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Date/prototype/setHours/arg-sec-to-number.js
+++ b/test/built-ins/Date/prototype/setHours/arg-sec-to-number.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: Type coercion of provided "sec"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let h be ? ToNumber(hour).
+  3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ?
+     ToNumber(min).
+  4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  5. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  6. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  7. Let u be TimeClip(UTC(date)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setHours(0, 0, arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 1, 0, 0, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setHours(0, 0, null);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'null');
+
+returnValue = date.setHours(0, 0, true);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1, 0, 0, 1).getTime(), 'true');
+
+returnValue = date.setHours(0, 0, false);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'false');
+
+returnValue = date.setHours(0, 0, '   +00200.000E-0002	');
+
+assert.sameValue(
+  returnValue, new Date(2016, 6, 1, 0, 0, 2).getTime(), 'string'
+);
+
+returnValue = date.setHours();
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setHours/new-value-time-clip.js
+++ b/test/built-ins/Date/prototype/setHours/new-value-time-clip.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: Behavior when new value exceeds [[DateValue]] limits
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let h be ? ToNumber(hour).
+  3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ?
+     ToNumber(min).
+  4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  5. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  6. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  7. Let u be TimeClip(UTC(date)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+
+  TimeClip (time)
+
+  1. If time is not finite, return NaN.
+  2. If abs(time) > 8.64 × 1015, return NaN.
+---*/
+
+var maxMs = 8.64e15;
+var date = new Date(maxMs);
+var returnValue;
+
+assert.notSameValue(date.getTime(), NaN);
+
+returnValue = date.setHours(24);
+
+assert.sameValue(returnValue, NaN, 'overflow due to hours');
+
+date = new Date(maxMs);
+
+returnValue = date.setHours(0, 24 * 60);
+
+assert.sameValue(returnValue, NaN, 'overflow due to minutes');
+
+date = new Date(maxMs);
+
+returnValue = date.setHours(0, 0, 24 * 60 * 60);
+
+assert.sameValue(returnValue, NaN, 'overflow due to seconds');
+
+date = new Date(maxMs);
+
+returnValue = date.setHours(0, 0, 0, 24 * 60 * 60 * 1000);
+
+assert.sameValue(returnValue, NaN, 'overflow due to milliseconds');

--- a/test/built-ins/Date/prototype/setHours/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/setHours/this-value-invalid-date.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: >
+  Behavior when the "this" value is a Date object describing an invald date
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let h be ? ToNumber(hour).
+  3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ?
+     ToNumber(min).
+  4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  5. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  6. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  7. Let u be TimeClip(UTC(date)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(NaN);
+var result;
+
+result = date.setHours(0);
+
+assert.sameValue(result, NaN, 'return value (hour)');
+assert.sameValue(date.getTime(), NaN, '[[DateValue]] internal slot (hour)');
+
+result = date.setHours(0, 0);
+
+assert.sameValue(result, NaN, 'return value (minute)');
+assert.sameValue(date.getTime(), NaN, '[[DateValue]] internal slot (minute)');
+
+result = date.setHours(0, 0, 0);
+
+assert.sameValue(result, NaN, 'return value (second)');
+assert.sameValue(date.getTime(), NaN, '[[DateValue]] internal slot (second)');
+
+result = date.setHours(0, 0, 0, 0);
+
+assert.sameValue(result, NaN, 'return value (ms)');
+assert.sameValue(date.getTime(), NaN, '[[DateValue]] internal slot (ms)');

--- a/test/built-ins/Date/prototype/setHours/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/setHours/this-value-non-date.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var setHours = Date.prototype.setHours;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof setHours, 'function');
+
+assert.throws(TypeError, function() {
+  setHours.call({}, arg);
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  setHours.call([], arg);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  setHours.call(args, arg);
+}, 'arguments exotic object');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setHours/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/setHours/this-value-non-object.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var setHours = Date.prototype.setHours;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var symbol = Symbol();
+
+assert.sameValue(typeof setHours, 'function');
+
+assert.throws(TypeError, function() {
+  setHours.call(0, arg);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  setHours.call(true, arg);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  setHours.call(null, arg);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  setHours.call(undefined, arg);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  setHours.call('', arg);
+}, 'string');
+
+assert.throws(TypeError, function() {
+  setHours.call(symbol, arg);
+}, 'symbol');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setHours/this-value-valid-date-hour.js
+++ b/test/built-ins/Date/prototype/setHours/this-value-valid-date-hour.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: Return value for valid dates (setting hour)
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let h be ? ToNumber(hour).
+  3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ?
+     ToNumber(min).
+  4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  5. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  6. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  7. Let u be TimeClip(UTC(date)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var returnValue, expected;
+
+returnValue = date.setHours(6);
+
+expected = new Date(2016, 6, 1, 6).getTime();
+assert.sameValue(
+  returnValue, expected, 'hour within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'hour within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setHours(-1);
+
+expected = new Date(2016, 5, 30, 23).getTime();
+assert.sameValue(
+  returnValue, expected, 'hour before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'hour before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setHours(24);
+
+expected = new Date(2016, 6, 1).getTime();
+assert.sameValue(
+  returnValue, expected, 'hour after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'hour after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setHours/this-value-valid-date-min.js
+++ b/test/built-ins/Date/prototype/setHours/this-value-valid-date-min.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: Return value for valid dates (setting min)
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let h be ? ToNumber(hour).
+  3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ?
+     ToNumber(min).
+  4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  5. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  6. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  7. Let u be TimeClip(UTC(date)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var returnValue, expected;
+
+returnValue = date.setHours(0, 23);
+
+expected = new Date(2016, 6, 1, 0, 23).getTime();
+assert.sameValue(
+  returnValue, expected, 'minute within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'minute within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setHours(0, -1);
+
+expected = new Date(2016, 5, 30, 23, 59).getTime();
+assert.sameValue(
+  returnValue, expected, 'minute before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'minute before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setHours(0, 60);
+
+expected = new Date(2016, 5, 30, 1).getTime();
+assert.sameValue(
+  returnValue, expected, 'minute after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'minute after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setHours/this-value-valid-date-ms.js
+++ b/test/built-ins/Date/prototype/setHours/this-value-valid-date-ms.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: Return value for valid dates (setting ms)
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let h be ? ToNumber(hour).
+  3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ?
+     ToNumber(min).
+  4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  5. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  6. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  7. Let u be TimeClip(UTC(date)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var returnValue, expected;
+
+returnValue = date.setHours(0, 0, 0, 543);
+
+expected = new Date(2016, 6, 1, 0, 0, 0, 543).getTime();
+assert.sameValue(
+  returnValue, expected, 'millisecond within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setHours(0, 0, 0, -1);
+
+expected = new Date(2016, 5, 30, 23, 59, 59, 999).getTime();
+assert.sameValue(
+  returnValue, expected, 'millisecond before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setHours(0, 0, 0, 1000);
+
+expected = new Date(2016, 5, 30, 0, 0, 1).getTime();
+assert.sameValue(
+  returnValue, expected, 'millisecond after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setHours/this-value-valid-date-sec.js
+++ b/test/built-ins/Date/prototype/setHours/this-value-valid-date-sec.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+es6id: 20.3.4.22
+description: Return value for valid dates (setting sec)
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let h be ? ToNumber(hour).
+  3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ?
+     ToNumber(min).
+  4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  5. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  6. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  7. Let u be TimeClip(UTC(date)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var returnValue, expected;
+
+returnValue = date.setHours(0, 0, 45);
+
+expected = new Date(2016, 6, 1, 0, 0, 45).getTime();
+assert.sameValue(
+  returnValue, expected, 'second within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'second within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setHours(0, 0, -1);
+
+expected = new Date(2016, 5, 30, 23, 59, 59).getTime();
+assert.sameValue(
+  returnValue, expected, 'second before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'second before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setHours(0, 0, 60);
+
+expected = new Date(2016, 5, 30, 0, 1).getTime();
+assert.sameValue(
+  returnValue, expected, 'second after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'second after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setMilliseconds/arg-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMilliseconds/arg-to-number-err.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmilliseconds
+es6id: 20.3.4.23
+description: Abrupt completion during type coercion of provided argument
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(date).
+---*/
+
+var date = new Date();
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setMilliseconds(obj);
+});
+
+assert.sameValue(date.getTime(), originalValue);

--- a/test/built-ins/Date/prototype/setMilliseconds/arg-to-number.js
+++ b/test/built-ins/Date/prototype/setMilliseconds/arg-to-number.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmilliseconds
+es6id: 20.3.4.23
+description: Type coercion of provided argument
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(date).
+  3. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt),
+     TimeWithinDay(t)).
+  4. Let u be TimeClip(UTC(newDate)).
+  5. Set the [[DateValue]] internal slot of this Date object to u.
+  6. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setMilliseconds(arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 1, 0, 0, 0, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setMilliseconds(null);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'null');
+
+returnValue = date.setMilliseconds(true);
+
+assert.sameValue(
+  returnValue, new Date(2016, 6, 1, 0, 0, 0, 1).getTime(), 'true'
+);
+
+returnValue = date.setMilliseconds(false);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'false');
+
+returnValue = date.setMilliseconds('   +00200.000E-0002	');
+
+assert.sameValue(
+  returnValue, new Date(2016, 6, 1, 0, 0, 0 , 2).getTime(), 'string'
+);
+
+returnValue = date.setMilliseconds();
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setMilliseconds/new-value-time-clip.js
+++ b/test/built-ins/Date/prototype/setMilliseconds/new-value-time-clip.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmilliseconds
+es6id: 20.3.4.23
+description: Behavior when new value exceeds [[DateValue]] limits
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(date).
+  3. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt),
+     TimeWithinDay(t)).
+  4. Let u be TimeClip(UTC(newDate)).
+  5. Set the [[DateValue]] internal slot of this Date object to u.
+  6. Return u.
+
+  TimeClip (time)
+
+  1. If time is not finite, return NaN.
+  2. If abs(time) > 8.64 × 1015, return NaN.
+---*/
+
+var date = new Date(8.64e15);
+var returnValue;
+
+assert.notSameValue(date.getTime(), NaN);
+
+returnValue = date.setMilliseconds(1);
+
+assert.sameValue(returnValue, NaN);

--- a/test/built-ins/Date/prototype/setMilliseconds/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/setMilliseconds/this-value-invalid-date.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmilliseconds
+es6id: 20.3.4.23
+description: >
+  Behavior when the "this" value is a Date object describing an invald date
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(date).
+  3. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt),
+     TimeWithinDay(t)).
+  4. Let u be TimeClip(UTC(newDate)).
+  5. Set the [[DateValue]] internal slot of this Date object to u.
+  6. Return u.
+---*/
+
+var date = new Date(NaN);
+var result;
+
+result = date.setMilliseconds(0);
+
+assert.sameValue(result, NaN, 'return value');
+assert.sameValue(date.getTime(), NaN, '[[DateValue]] internal slot');

--- a/test/built-ins/Date/prototype/setMilliseconds/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/setMilliseconds/this-value-non-date.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmilliseconds
+es6id: 20.3.4.23
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var setMilliseconds = Date.prototype.setMilliseconds;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof setMilliseconds, 'function');
+
+assert.throws(TypeError, function() {
+  setMilliseconds.call({}, arg);
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  setMilliseconds.call([], arg);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  setMilliseconds.call(args, arg);
+}, 'arguments exotic object');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setMilliseconds/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/setMilliseconds/this-value-non-object.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmilliseconds
+es6id: 20.3.4.23
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var setMilliseconds = Date.prototype.setMilliseconds;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var symbol = Symbol();
+
+assert.sameValue(typeof setMilliseconds, 'function');
+
+assert.throws(TypeError, function() {
+  setMilliseconds.call(0, arg);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  setMilliseconds.call(true, arg);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  setMilliseconds.call(null, arg);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  setMilliseconds.call(undefined, arg);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  setMilliseconds.call('', arg);
+}, 'string');
+
+assert.throws(TypeError, function() {
+  setMilliseconds.call(symbol, arg);
+}, 'symbol');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setMilliseconds/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/setMilliseconds/this-value-valid-date.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmilliseconds
+es6id: 20.3.4.23
+description: Return value for valid dates
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(date).
+  3. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt),
+     TimeWithinDay(t)).
+  4. Let u be TimeClip(UTC(newDate)).
+  5. Set the [[DateValue]] internal slot of this Date object to u.
+  6. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var returnValue, expected;
+
+returnValue = date.setMilliseconds(333);
+
+expected = new Date(2016, 6, 1, 0, 0, 0, 333).getTime();
+assert.sameValue(
+  returnValue, expected, 'within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setMilliseconds(-1);
+
+expected = new Date(2016, 5, 30, 23, 59, 59, 999).getTime();
+assert.sameValue(
+  returnValue, expected, 'before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setMilliseconds(1000);
+
+expected = new Date(2016, 6, 1).getTime();
+assert.sameValue(
+  returnValue, expected, 'after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setMinutes/arg-min-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMinutes/arg-min-to-number-err.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setminutes
+es6id: 20.3.4.24
+description: Abrupt completion during type coercion of provided "min"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let m be ? ToNumber(min).
+---*/
+
+var date = new Date();
+var callCount = 0;
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+var counter = {
+  valueOf: function() {
+    callCount += 1;
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setMinutes(obj, counter, counter);
+});
+
+assert.sameValue(date.getTime(), originalValue);
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Date/prototype/setMinutes/arg-min-to-number.js
+++ b/test/built-ins/Date/prototype/setMinutes/arg-min-to-number.js
@@ -1,0 +1,61 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setminutes
+es6id: 20.3.4.24
+description: Type coercion of provided "min"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let m be ? ToNumber(min).
+  3. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  4. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  5. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
+  6. Let u be TimeClip(UTC(date)).
+  7. Set the [[DateValue]] internal slot of this Date object to u.
+  8. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setMinutes(arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 1, 0, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setMinutes(null);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'null');
+
+returnValue = date.setMinutes(true);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1, 0, 1).getTime(), 'true');
+
+returnValue = date.setMinutes(false);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'false');
+
+returnValue = date.setMinutes('   +00200.000E-0002	');
+
+assert.sameValue(returnValue, new Date(2016, 6, 1, 0, 2).getTime(), 'string');
+
+returnValue = date.setMinutes();
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setMinutes/arg-ms-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMinutes/arg-ms-to-number-err.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setminutes
+es6id: 20.3.4.24
+description: Abrupt completion during type coercion of provided "ms"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let m be ? ToNumber(min).
+  3. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  4. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+---*/
+
+var date = new Date();
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setMinutes(0, 0, obj);
+});
+
+assert.sameValue(date.getTime(), originalValue);

--- a/test/built-ins/Date/prototype/setMinutes/arg-ms-to-number.js
+++ b/test/built-ins/Date/prototype/setMinutes/arg-ms-to-number.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setminutes
+es6id: 20.3.4.24
+description: Type coercion of provided "ms"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let m be ? ToNumber(min).
+  3. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  4. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  5. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
+  6. Let u be TimeClip(UTC(date)).
+  7. Set the [[DateValue]] internal slot of this Date object to u.
+  8. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setMinutes(0, 0, arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 1, 0, 0, 0, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setMinutes(0, 0, null);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'null');
+
+returnValue = date.setMinutes(0, 0, true);
+
+assert.sameValue(
+  returnValue, new Date(2016, 6, 1, 0, 0, 0, 1).getTime(), 'true'
+);
+
+returnValue = date.setMinutes(0, 0, false);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'false');
+
+returnValue = date.setMinutes(0, 0, '   +00200.000E-0002	');
+
+assert.sameValue(
+  returnValue, new Date(2016, 6, 1, 0, 0, 0, 2).getTime(), 'string'
+);
+
+returnValue = date.setMinutes(0, 0, undefined);
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setMinutes/arg-sec-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMinutes/arg-sec-to-number-err.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setminutes
+es6id: 20.3.4.24
+description: Abrupt completion during type coercion of provided "sec"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let m be ? ToNumber(min).
+  3. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+---*/
+
+var date = new Date();
+var callCount = 0;
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+var counter = {
+  valueOf: function() {
+    callCount += 1;
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setMinutes(0, 0, obj, counter);
+});
+
+assert.sameValue(date.getTime(), originalValue);
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Date/prototype/setMinutes/arg-sec-to-number.js
+++ b/test/built-ins/Date/prototype/setMinutes/arg-sec-to-number.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setminutes
+es6id: 20.3.4.24
+description: Type coercion of provided "sec"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let m be ? ToNumber(min).
+  3. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  4. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  5. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
+  6. Let u be TimeClip(UTC(date)).
+  7. Set the [[DateValue]] internal slot of this Date object to u.
+  8. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setMinutes(0, arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 1, 0, 0, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setMinutes(0, null);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'null');
+
+returnValue = date.setMinutes(0, true);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1, 0, 0, 1).getTime(), 'true');
+
+returnValue = date.setMinutes(0, false);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'false');
+
+returnValue = date.setMinutes(0, '   +00200.000E-0002	');
+
+assert.sameValue(
+  returnValue, new Date(2016, 6, 1, 0, 0, 2).getTime(), 'string'
+);
+
+returnValue = date.setMinutes(0, undefined);
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setMinutes/new-value-time-clip.js
+++ b/test/built-ins/Date/prototype/setMinutes/new-value-time-clip.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setminutes
+es6id: 20.3.4.24
+description: Behavior when new value exceeds [[DateValue]] limits
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let m be ? ToNumber(min).
+  3. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  4. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  5. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
+  6. Let u be TimeClip(UTC(date)).
+  7. Set the [[DateValue]] internal slot of this Date object to u.
+  8. Return u.
+
+  TimeClip (time)
+
+  1. If time is not finite, return NaN.
+  2. If abs(time) > 8.64 × 1015, return NaN.
+---*/
+
+var maxMs = 8.64e15;
+var date = new Date(maxMs);
+var returnValue;
+
+assert.notSameValue(date.getTime(), NaN);
+
+returnValue = date.setMinutes(24 * 60);
+
+assert.sameValue(returnValue, NaN, 'overflow due to minutes');
+
+date = new Date(maxMs);
+
+returnValue = date.setMinutes(0, 24 * 60 * 60);
+
+assert.sameValue(returnValue, NaN, 'overflow due to seconds');
+
+date = new Date(maxMs);
+
+returnValue = date.setMinutes(0, 0, 24 * 60 * 60 * 1000);
+
+assert.sameValue(returnValue, NaN, 'overflow due to milliseconds');

--- a/test/built-ins/Date/prototype/setMinutes/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/setMinutes/this-value-invalid-date.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setminutes
+es6id: 20.3.4.24
+description: >
+  Behavior when the "this" value is a Date object describing an invald date
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let h be ? ToNumber(hour).
+  3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ?
+     ToNumber(min).
+  4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ?
+     ToNumber(sec).
+  5. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  6. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  7. Let u be TimeClip(UTC(date)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(NaN);
+var result;
+
+result = date.setMinutes(0);
+
+assert.sameValue(result, NaN, 'return value (hour)');
+assert.sameValue(date.getTime(), NaN, '[[DateValue]] internal slot (hour)');
+
+result = date.setMinutes(0, 0);
+
+assert.sameValue(result, NaN, 'return value (minute)');
+assert.sameValue(date.getTime(), NaN, '[[DateValue]] internal slot (minute)');
+
+result = date.setMinutes(0, 0, 0);
+
+assert.sameValue(result, NaN, 'return value (second)');
+assert.sameValue(date.getTime(), NaN, '[[DateValue]] internal slot (second)');
+
+result = date.setMinutes(0, 0, 0, 0);
+
+assert.sameValue(result, NaN, 'return value (ms)');
+assert.sameValue(date.getTime(), NaN, '[[DateValue]] internal slot (ms)');

--- a/test/built-ins/Date/prototype/setMinutes/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/setMinutes/this-value-non-date.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setminutes
+es6id: 20.3.4.24
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var setMinutes = Date.prototype.setMinutes;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof setMinutes, 'function');
+
+assert.throws(TypeError, function() {
+  setMinutes.call({}, arg);
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  setMinutes.call([], arg);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  setMinutes.call(args, arg);
+}, 'arguments exotic object');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setMinutes/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/setMinutes/this-value-non-object.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setminutes
+es6id: 20.3.4.24
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var setMinutes = Date.prototype.setMinutes;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var symbol = Symbol();
+
+assert.sameValue(typeof setMinutes, 'function');
+
+assert.throws(TypeError, function() {
+  setMinutes.call(0, arg);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  setMinutes.call(true, arg);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  setMinutes.call(null, arg);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  setMinutes.call(undefined, arg);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  setMinutes.call('', arg);
+}, 'string');
+
+assert.throws(TypeError, function() {
+  setMinutes.call(symbol, arg);
+}, 'symbol');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setMinutes/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/setMinutes/this-value-valid-date.js
@@ -1,0 +1,130 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setminutes
+es6id: 20.3.4.24
+description: Return value for valid dates
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+  4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be
+     ? ToNumber(month).
+  5. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
+  7. Let u be TimeClip(UTC(newDate)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6, 1);
+var returnValue, expected;
+
+returnValue = date.setMinutes(23);
+
+expected = new Date(2016, 6, 1, 0, 23).getTime();
+assert.sameValue(
+  returnValue, expected, 'minute within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'minute within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setMinutes(-1);
+
+expected = new Date(2016, 5, 30, 23, 59).getTime();
+assert.sameValue(
+  returnValue, expected, 'minute before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'minute before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setMinutes(60);
+
+expected = new Date(2016, 6, 1).getTime();
+assert.sameValue(
+  returnValue, expected, 'minute after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'minute after time unit boundary ([[DateValue]] slot)'
+);
+
+date = new Date(2016, 6, 1);
+
+returnValue = date.setMinutes(0, 45);
+
+expected = new Date(2016, 6, 1, 0, 0, 45).getTime();
+assert.sameValue(
+  returnValue, expected, 'second within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'second within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setMinutes(0, -1);
+
+expected = new Date(2016, 5, 30, 23, 59, 59).getTime();
+assert.sameValue(
+  returnValue, expected, 'second before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'second before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setMinutes(0, 60);
+
+expected = new Date(2016, 5, 30, 23, 1).getTime();
+assert.sameValue(
+  returnValue, expected, 'second after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'second after time unit boundary ([[DateValue]] slot)'
+);
+
+date = new Date(2016, 6, 1);
+
+returnValue = date.setMinutes(0, 0, 345);
+
+expected = new Date(2016, 6, 1, 0, 0, 0, 345).getTime();
+assert.sameValue(
+  returnValue, expected, 'millisecond within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setMinutes(0, 0, -1);
+
+expected = new Date(2016, 5, 30, 23, 59, 59, 999).getTime();
+assert.sameValue(
+  returnValue, expected, 'millisecond before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setMinutes(0, 0, 1000);
+
+expected = new Date(2016, 5, 30, 23, 0, 1).getTime();
+assert.sameValue(
+  returnValue, expected, 'millisecond after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setMonth/arg-date-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMonth/arg-date-to-number-err.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmonth
+es6id: 20.3.4.25
+description: Abrupt completion during type coercion of provided "date"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let m be ? ToNumber(month).
+  3. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+---*/
+
+var date = new Date();
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setMonth(0, obj);
+});
+
+assert.sameValue(date.getTime(), originalValue);

--- a/test/built-ins/Date/prototype/setMonth/arg-date-to-number.js
+++ b/test/built-ins/Date/prototype/setMonth/arg-date-to-number.js
@@ -1,0 +1,76 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmonth
+es6id: 20.3.4.25
+description: Type coercion of provided "date"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let m be ? ToNumber(month).
+  3. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  4. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt),
+     TimeWithinDay(t)).
+  5. Let u be TimeClip(UTC(newDate)).
+  6. Set the [[DateValue]] internal slot of this Date object to u.
+  7. Return u.
+---*/
+
+var date = new Date(2016, 6, 7, 11, 36, 23, 2);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setMonth(6, arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 2, 11, 36, 23, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setMonth(6, null);
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 0, 11, 36, 23, 2).getTime(),
+  'null'
+);
+
+returnValue = date.setMonth(6, true);
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 1, 11, 36, 23, 2).getTime(),
+  'true'
+);
+
+returnValue = date.setMonth(6, false);
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 0, 11, 36, 23, 2).getTime(),
+  'false'
+);
+
+returnValue = date.setMonth(6, '   +00200.000E-0002	');
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 2, 11, 36, 23, 2).getTime(),
+  'string'
+);
+
+returnValue = date.setMonth(6, undefined);
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setMonth/arg-month-to-number-err.js
+++ b/test/built-ins/Date/prototype/setMonth/arg-month-to-number-err.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmonth
+es6id: 20.3.4.25
+description: Abrupt completion during type coercion of provided "month"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+  4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be
+     ? ToNumber(month).
+---*/
+
+var date = new Date();
+var callCount = 0;
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+var counter = {
+  valueOf: function() {
+    callCount += 1;
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setMonth(obj, counter);
+});
+
+assert.sameValue(date.getTime(), originalValue);
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Date/prototype/setMonth/arg-month-to-number.js
+++ b/test/built-ins/Date/prototype/setMonth/arg-month-to-number.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmonth
+es6id: 20.3.4.25
+description: Type coercion of provided "month"
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+  4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be
+     ? ToNumber(month).
+  5. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
+  7. Let u be TimeClip(UTC(newDate)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+---*/
+
+var date = new Date(2016, 6, 7, 11, 36, 23, 2);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setMonth(arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(2016, 2, 7, 11, 36, 23, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setMonth(null);
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 0, 7, 11, 36, 23, 2).getTime(),
+  'null'
+);
+
+returnValue = date.setMonth(true);
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 1, 7, 11, 36, 23, 2).getTime(),
+  'true'
+);
+
+returnValue = date.setMonth(false);
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 0, 7, 11, 36, 23, 2).getTime(),
+  'false'
+);
+
+returnValue = date.setMonth('   +00200.000E-0002	');
+
+assert.sameValue(
+  returnValue,
+  new Date(2016, 2, 7, 11, 36, 23, 2).getTime(),
+  'string'
+);
+
+returnValue = date.setMonth(undefined);
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setMonth/new-value-time-clip.js
+++ b/test/built-ins/Date/prototype/setMonth/new-value-time-clip.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmonth
+es6id: 20.3.4.25
+description: Behavior when new value exceeds [[DateValue]] limits
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. If t is NaN, let t be +0; otherwise, let t be LocalTime(t).
+  3. Let y be ? ToNumber(year).
+  4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be
+     ? ToNumber(month).
+  5. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
+  7. Let u be TimeClip(UTC(newDate)).
+  8. Set the [[DateValue]] internal slot of this Date object to u.
+  9. Return u.
+
+  TimeClip (time)
+
+  1. If time is not finite, return NaN.
+  2. If abs(time) > 8.64 × 1015, return NaN.
+---*/
+
+var maxMs = 8.64e15;
+var maxDate = 12;
+var maxMonth = 8;
+var date = new Date(maxMs);
+var returnValue;
+
+assert.notSameValue(date.getTime(), NaN);
+
+returnValue = date.setMonth(maxMonth + 1);
+
+assert.sameValue(returnValue, NaN, 'overflow due to month');
+
+date = new Date(maxMs);
+
+returnValue = date.setMonth(maxMonth, maxDate + 1);
+
+assert.sameValue(returnValue, NaN, 'overflow due to date');

--- a/test/built-ins/Date/prototype/setMonth/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/setMonth/this-value-invalid-date.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmonth
+es6id: 20.3.4.25
+description: >
+  Behavior when the "this" value is a Date object describing an invald date
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let m be ? ToNumber(month).
+  3. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  4. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt),
+     TimeWithinDay(t)).
+  5. Let u be TimeClip(UTC(newDate)).
+  6. Set the [[DateValue]] internal slot of this Date object to u.
+  7. Return u.
+---*/
+
+var date = new Date(NaN);
+var result;
+
+result = date.setMonth(6);
+
+assert.sameValue(result, NaN, 'return value (month)');
+assert.sameValue(date.getTime(), NaN, '[[DateValue]] internal slot (month)');
+
+date = new Date(NaN);
+
+result = date.setMonth(6, 7);
+
+assert.sameValue(result, NaN, 'return value (date)');
+assert.sameValue(date.getTime(), NaN, '[[DateValue]] internal slot (month)');

--- a/test/built-ins/Date/prototype/setMonth/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/setMonth/this-value-non-date.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmonth
+es6id: 20.3.4.25
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var setMonth = Date.prototype.setMonth;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof setMonth, 'function');
+
+assert.throws(TypeError, function() {
+  setMonth.call({}, arg);
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  setMonth.call([], arg);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  setMonth.call(args, arg);
+}, 'arguments exotic object');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setMonth/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/setMonth/this-value-non-object.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmonth
+es6id: 20.3.4.25
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var setMonth = Date.prototype.setMonth;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var symbol = Symbol();
+
+assert.sameValue(typeof setMonth, 'function');
+
+assert.throws(TypeError, function() {
+  setMonth.call(0, arg);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  setMonth.call(true, arg);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  setMonth.call(null, arg);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  setMonth.call(undefined, arg);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  setMonth.call('', arg);
+}, 'string');
+
+assert.throws(TypeError, function() {
+  setMonth.call(symbol, arg);
+}, 'symbol');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setMonth/this-value-valid-date-date.js
+++ b/test/built-ins/Date/prototype/setMonth/this-value-valid-date-date.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmonth
+es6id: 20.3.4.25
+description: Return value for valid dates (setting date)
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let m be ? ToNumber(month).
+  3. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  4. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt),
+     TimeWithinDay(t)).
+  5. Let u be TimeClip(UTC(newDate)).
+  6. Set the [[DateValue]] internal slot of this Date object to u.
+  7. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var returnValue, expected;
+
+returnValue = date.setMonth(6, 6);
+
+expected = new Date(2016, 6, 6).getTime();
+assert.sameValue(
+  returnValue, expected, 'date within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'date within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setMonth(6, 0);
+
+expected = new Date(2016, 5, 30).getTime();
+assert.sameValue(
+  returnValue, expected, 'date before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'date before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setMonth(5, 31);
+
+expected = new Date(2016, 6, 1).getTime();
+assert.sameValue(
+  returnValue, expected, 'date after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'date after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setMonth/this-value-valid-date-month.js
+++ b/test/built-ins/Date/prototype/setMonth/this-value-valid-date-month.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmonth
+es6id: 20.3.4.25
+description: Return value for valid dates (setting month)
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let m be ? ToNumber(month).
+  3. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be
+     ? ToNumber(date).
+  4. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt),
+     TimeWithinDay(t)).
+  5. Let u be TimeClip(UTC(newDate)).
+  6. Set the [[DateValue]] internal slot of this Date object to u.
+  7. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var returnValue, expected;
+
+returnValue = date.setMonth(3);
+
+expected = new Date(2016, 3).getTime();
+assert.sameValue(
+  returnValue, expected, 'month within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'month within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setMonth(-1);
+
+expected = new Date(2015, 11).getTime();
+assert.sameValue(
+  returnValue, expected, 'month before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'month before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setMonth(12);
+
+expected = new Date(2016, 0).getTime();
+assert.sameValue(
+  returnValue, expected, 'month after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'month after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setSeconds/arg-ms-to-number-err.js
+++ b/test/built-ins/Date/prototype/setSeconds/arg-ms-to-number-err.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setseconds
+es6id: 20.3.4.26
+description: Abrupt completion during type coercion of provided "ms"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let s be ? ToNumber(sec).
+  3. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+---*/
+
+var date = new Date();
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setSeconds(0, obj);
+});
+
+assert.sameValue(date.getTime(), originalValue);

--- a/test/built-ins/Date/prototype/setSeconds/arg-ms-to-number.js
+++ b/test/built-ins/Date/prototype/setSeconds/arg-ms-to-number.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setseconds
+es6id: 20.3.4.26
+description: Type coercion of provided "ms"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let s be ? ToNumber(sec).
+  3. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  4. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s,
+     milli)).
+  5. Let u be TimeClip(UTC(date)).
+  6. Set the [[DateValue]] internal slot of this Date object to u.
+  7. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setSeconds(0, arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 1, 0, 0, 0, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setSeconds(0, null);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'null');
+
+returnValue = date.setSeconds(0, true);
+
+assert.sameValue(
+  returnValue, new Date(2016, 6, 1, 0, 0, 0, 1).getTime(), 'true'
+);
+
+returnValue = date.setSeconds(0, false);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'false');
+
+returnValue = date.setSeconds(0, '   +00200.000E-0002	');
+
+assert.sameValue(
+  returnValue, new Date(2016, 6, 1, 0, 0, 0, 2).getTime(), 'string'
+);
+
+returnValue = date.setSeconds(0, undefined);
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setSeconds/arg-sec-to-number-err.js
+++ b/test/built-ins/Date/prototype/setSeconds/arg-sec-to-number-err.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setseconds
+es6id: 20.3.4.26
+description: Abrupt completion during type coercion of provided "sec"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let s be ? ToNumber(sec).
+---*/
+
+var date = new Date();
+var callCount = 0;
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+var counter = {
+  valueOf: function() {
+    callCount += 1;
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setSeconds(obj, counter);
+});
+
+assert.sameValue(date.getTime(), originalValue);
+assert.sameValue(callCount, 0);

--- a/test/built-ins/Date/prototype/setSeconds/arg-sec-to-number.js
+++ b/test/built-ins/Date/prototype/setSeconds/arg-sec-to-number.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setseconds
+es6id: 20.3.4.26
+description: Type coercion of provided "sec"
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let s be ? ToNumber(sec).
+  3. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  4. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s,
+     milli)).
+  5. Let u be TimeClip(UTC(date)).
+  6. Set the [[DateValue]] internal slot of this Date object to u.
+  7. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setSeconds(arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(
+  returnValue,
+  new Date(2016, 6, 1, 0, 0, 2).getTime(),
+  'application of specified value'
+);
+
+returnValue = date.setSeconds(null);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'null');
+
+returnValue = date.setSeconds(true);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1, 0, 0, 1).getTime(), 'true');
+
+returnValue = date.setSeconds(false);
+
+assert.sameValue(returnValue, new Date(2016, 6, 1).getTime(), 'false');
+
+returnValue = date.setSeconds('   +00200.000E-0002	');
+
+assert.sameValue(
+  returnValue, new Date(2016, 6, 1, 0, 0, 2).getTime(), 'string'
+);
+
+returnValue = date.setSeconds();
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setSeconds/new-value-time-clip.js
+++ b/test/built-ins/Date/prototype/setSeconds/new-value-time-clip.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setseconds
+es6id: 20.3.4.26
+description: Behavior when new value exceeds [[DateValue]] limits
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let s be ? ToNumber(sec).
+  3. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  4. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s,
+     milli)).
+  5. Let u be TimeClip(UTC(date)).
+  6. Set the [[DateValue]] internal slot of this Date object to u.
+  7. Return u.
+
+  TimeClip (time)
+
+  1. If time is not finite, return NaN.
+  2. If abs(time) > 8.64 × 1015, return NaN.
+---*/
+
+var maxMs = 8.64e15;
+var date = new Date(maxMs);
+var returnValue;
+
+assert.notSameValue(date.getTime(), NaN);
+
+returnValue = date.setSeconds(24 * 60 * 60);
+
+assert.sameValue(returnValue, NaN, 'overflow due to seconds');
+
+date = new Date(maxMs);
+
+returnValue = date.setSeconds(0, 24 * 60 * 60 * 1000);
+
+assert.sameValue(returnValue, NaN, 'overflow due to milliseconds');

--- a/test/built-ins/Date/prototype/setSeconds/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/setSeconds/this-value-invalid-date.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setseconds
+es6id: 20.3.4.26
+description: >
+  Behavior when the "this" value is a Date object describing an invald date
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let s be ? ToNumber(sec).
+  3. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  4. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s,
+     milli)).
+  5. Let u be TimeClip(UTC(date)).
+  6. Set the [[DateValue]] internal slot of this Date object to u.
+  7. Return u.
+---*/
+
+var date = new Date(NaN);
+var result;
+
+result = date.setSeconds(0);
+
+assert.sameValue(result, NaN, 'return value (second)');
+assert.sameValue(date.getTime(), NaN, '[[DateValue]] internal slot (second)');
+
+result = date.setSeconds(0, 0);
+
+assert.sameValue(result, NaN, 'return value (ms)');
+assert.sameValue(date.getTime(), NaN, '[[DateValue]] internal slot (ms)');

--- a/test/built-ins/Date/prototype/setSeconds/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/setSeconds/this-value-non-date.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setseconds
+es6id: 20.3.4.26
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var setSeconds = Date.prototype.setSeconds;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof setSeconds, 'function');
+
+assert.throws(TypeError, function() {
+  setSeconds.call({}, arg);
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  setSeconds.call([], arg);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  setSeconds.call(args, arg);
+}, 'arguments exotic object');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setSeconds/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/setSeconds/this-value-non-object.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setseconds
+es6id: 20.3.4.26
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var setSeconds = Date.prototype.setSeconds;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var symbol = Symbol();
+
+assert.sameValue(typeof setSeconds, 'function');
+
+assert.throws(TypeError, function() {
+  setSeconds.call(0, arg);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  setSeconds.call(true, arg);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  setSeconds.call(null, arg);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  setSeconds.call(undefined, arg);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  setSeconds.call('', arg);
+}, 'string');
+
+assert.throws(TypeError, function() {
+  setSeconds.call(symbol, arg);
+}, 'symbol');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setSeconds/this-value-valid-date-ms.js
+++ b/test/built-ins/Date/prototype/setSeconds/this-value-valid-date-ms.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setseconds
+es6id: 20.3.4.26
+description: Return value for valid dates (setting ms)
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let s be ? ToNumber(sec).
+  3. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  4. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s,
+     milli)).
+  5. Let u be TimeClip(UTC(date)).
+  6. Set the [[DateValue]] internal slot of this Date object to u.
+  7. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var returnValue, expected;
+
+returnValue = date.setSeconds(0, 543);
+
+expected = new Date(2016, 6, 1, 0, 0, 0, 543).getTime();
+assert.sameValue(
+  returnValue, expected, 'millisecond within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setSeconds(0, -1);
+
+expected = new Date(2016, 5, 30, 23, 59, 59, 999).getTime();
+assert.sameValue(
+  returnValue, expected, 'millisecond before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setSeconds(0, 1000);
+
+expected = new Date(2016, 5, 30, 23, 59, 1).getTime();
+assert.sameValue(
+  returnValue, expected, 'millisecond after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'millisecond after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setSeconds/this-value-valid-date-sec.js
+++ b/test/built-ins/Date/prototype/setSeconds/this-value-valid-date-sec.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setseconds
+es6id: 20.3.4.26
+description: Return value for valid dates (setting sec)
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let s be ? ToNumber(sec).
+  3. If ms is not specified, let milli be msFromTime(t); otherwise, let milli
+     be ? ToNumber(ms).
+  4. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s,
+     milli)).
+  5. Let u be TimeClip(UTC(date)).
+  6. Set the [[DateValue]] internal slot of this Date object to u.
+  7. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var returnValue, expected;
+
+returnValue = date.setSeconds(45);
+
+expected = new Date(2016, 6, 1, 0, 0, 45).getTime();
+assert.sameValue(
+  returnValue, expected, 'second within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), expected, 'second within unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setSeconds(-1);
+
+expected = new Date(2016, 5, 30, 23, 59, 59).getTime();
+assert.sameValue(
+  returnValue, expected, 'second before time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'second before time unit boundary ([[DateValue]] slot)'
+);
+
+returnValue = date.setSeconds(60);
+
+expected = new Date(2016, 6).getTime();
+assert.sameValue(
+  returnValue, expected, 'second after time unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(),
+  expected,
+  'second after time unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/prototype/setTime/arg-to-number-err.js
+++ b/test/built-ins/Date/prototype/setTime/arg-to-number-err.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.settime
+es6id: 20.3.4.27
+description: Abrupt completion during type coercion of provided argument
+info: |
+  1. Perform ? thisTimeValue(this value).
+  2. Let t be ? ToNumber(time).
+---*/
+
+var date = new Date();
+var originalValue = date.getTime();
+var obj = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, function() {
+  date.setTime(obj);
+});
+
+assert.sameValue(date.getTime(), originalValue);

--- a/test/built-ins/Date/prototype/setTime/arg-to-number.js
+++ b/test/built-ins/Date/prototype/setTime/arg-to-number.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.settime
+es6id: 20.3.4.27
+description: Type coercion of provided argument
+info: |
+  1. Perform ? thisTimeValue(this value).
+  2. Let t be ? ToNumber(time).
+  3. Let v be TimeClip(t).
+  4. Set the [[DateValue]] internal slot of this Date object to v.
+  5. Return v.
+---*/
+
+var date = new Date(2016, 6);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    args = arguments;
+    thisValue = this;
+    callCount += 1;
+    return 2;
+  }
+};
+var args, thisValue, returnValue;
+
+returnValue = date.setTime(arg);
+
+assert.sameValue(callCount, 1, 'invoked exactly once');
+assert.sameValue(args.length, 0, 'invoked without arguments');
+assert.sameValue(thisValue, arg, '"this" value');
+assert.sameValue(returnValue, 2, 'application of specified value');
+
+returnValue = date.setTime(null);
+
+assert.sameValue(returnValue, 0, 'null');
+
+returnValue = date.setTime(true);
+
+assert.sameValue(returnValue, 1, 'true');
+
+returnValue = date.setTime(false);
+
+assert.sameValue(returnValue, 0, 'false');
+
+returnValue = date.setTime('   +00200.000E-0002	');
+
+assert.sameValue(returnValue, 2, 'string');
+
+returnValue = date.setTime();
+
+assert.sameValue(returnValue, NaN, 'undefined');

--- a/test/built-ins/Date/prototype/setTime/new-value-time-clip.js
+++ b/test/built-ins/Date/prototype/setTime/new-value-time-clip.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.settime
+es6id: 20.3.4.27
+description: Behavior when new value exceeds [[DateValue]] limits
+info: |
+info: |
+  1. Perform ? thisTimeValue(this value).
+  2. Let t be ? ToNumber(time).
+  3. Let v be TimeClip(t).
+  4. Set the [[DateValue]] internal slot of this Date object to v.
+  5. Return v.
+
+  TimeClip (time)
+
+  1. If time is not finite, return NaN.
+  2. If abs(time) > 8.64 × 1015, return NaN.
+---*/
+
+var maxMs = 8.64e15;
+var date = new Date();
+var returnValue;
+
+assert.notSameValue(date.getTime(), NaN);
+
+returnValue = date.setTime(maxMs + 1);
+
+assert.sameValue(returnValue, NaN);

--- a/test/built-ins/Date/prototype/setTime/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/setTime/this-value-invalid-date.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.settime
+es6id: 20.3.4.27
+description: >
+  Behavior when the "this" value is a Date object describing an invald date
+info: |
+info: |
+  1. Perform ? thisTimeValue(this value).
+  2. Let t be ? ToNumber(time).
+  3. Let v be TimeClip(t).
+  4. Set the [[DateValue]] internal slot of this Date object to v.
+  5. Return v.
+---*/
+
+var date = new Date(NaN);
+var result;
+
+result = date.setTime(0);
+
+assert.sameValue(result, 0, 'return value');
+assert.sameValue(date.getTime(), 0, '[[DateValue]] internal slot');

--- a/test/built-ins/Date/prototype/setTime/this-value-non-date.js
+++ b/test/built-ins/Date/prototype/setTime/this-value-non-date.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.settime
+es6id: 20.3.4.27
+description: >
+  Behavior when "this" value is an Object without a [[DateValue]] internal slot
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+---*/
+
+var setTime = Date.prototype.setTime;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var args = (function() { return arguments; }());
+
+assert.sameValue(typeof setTime, 'function');
+
+assert.throws(TypeError, function() {
+  setTime.call({}, arg);
+}, 'ordinary object');
+
+assert.throws(TypeError, function() {
+  setTime.call([], arg);
+}, 'array exotic object');
+
+assert.throws(TypeError, function() {
+  setTime.call(args, arg);
+}, 'arguments exotic object');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setTime/this-value-non-object.js
+++ b/test/built-ins/Date/prototype/setTime/this-value-non-object.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.settime
+es6id: 20.3.4.27
+description: Behavior when "this" value is not an Object
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+
+  The abstract operation thisTimeValue(value) performs the following steps:
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+     a. Return value.[[DateValue]].
+  2. Throw a TypeError exception.
+features: [Symbol]
+---*/
+
+var setTime = Date.prototype.setTime;
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 1;
+  }
+};
+var symbol = Symbol();
+
+assert.sameValue(typeof setTime, 'function');
+
+assert.throws(TypeError, function() {
+  setTime.call(0, arg);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  setTime.call(true, arg);
+}, 'boolean');
+
+assert.throws(TypeError, function() {
+  setTime.call(null, arg);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  setTime.call(undefined, arg);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  setTime.call('', arg);
+}, 'string');
+
+assert.throws(TypeError, function() {
+  setTime.call(symbol, arg);
+}, 'symbol');
+
+assert.sameValue(callCount, 0, 'validation preceeds input coercion');

--- a/test/built-ins/Date/prototype/setTime/this-value-valid-date.js
+++ b/test/built-ins/Date/prototype/setTime/this-value-valid-date.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.settime
+es6id: 20.3.4.27
+description: Return value for valid dates
+info: |
+  1. Let t be LocalTime(? thisTimeValue(this value)).
+  2. Let dt be ? ToNumber(date).
+  3. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt),
+     TimeWithinDay(t)).
+  4. Let u be TimeClip(UTC(newDate)).
+  5. Set the [[DateValue]] internal slot of this Date object to u.
+  6. Return u.
+---*/
+
+var date = new Date(2016, 6);
+var returnValue;
+
+returnValue = date.setTime(6);
+
+assert.sameValue(
+  returnValue, 6, 'within unit boundary (return value)'
+);
+assert.sameValue(
+  date.getTime(), 6, 'within unit boundary ([[DateValue]] slot)'
+);

--- a/test/built-ins/Date/subclassing.js
+++ b/test/built-ins/Date/subclassing.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date-value
+es6id: 20.3.2.2
+description: Error retrieving `Symbol.toPrimitive` method from object value
+info: |
+  3. If NewTarget is not undefined, then
+     [...]
+     c. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%DatePrototype%",
+        « [[DateValue]] »).
+     [...]
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ ,
+  internalSlotsList ] )
+
+  [...]
+  2. Let proto be ? GetPrototypeFromConstructor(constructor,
+     intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+features: [Reflect]
+---*/
+
+var callCount = 0;
+var Ctor = function() {
+  callCount += 1;
+};
+var instance;
+
+instance = Reflect.construct(Date, [64], Ctor);
+
+assert.sameValue(
+  Object.getPrototypeOf(instance),
+  Ctor.prototype,
+  'constructor defines an object `prototype` property'
+);
+assert.sameValue(callCount, 0, 'constructor not invoked');
+assert.sameValue(
+  Date.prototype.getTime.call(instance),
+  64,
+  'proper subclass has a [[DateValue]] slot'
+);
+
+Ctor.prototype = null;
+instance = Reflect.construct(Date, [64], Ctor);
+
+assert.sameValue(
+  Object.getPrototypeOf(instance),
+  Date.prototype,
+  'constructor does not defines an object `prototype` property'
+);
+assert.sameValue(callCount, 0, 'constructor not invoked');
+assert.sameValue(
+  instance.getTime(), 64, 'direct instance has a [[DateValue]] slot'
+);

--- a/test/built-ins/Date/value-to-primitive-call-err.js
+++ b/test/built-ins/Date/value-to-primitive-call-err.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date-value
+es6id: 20.3.2.2
+description: Error invoking `Symbol.toPrimitive` method of object value
+info: |
+  3. If NewTarget is not undefined, then
+     a. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+        i. Let tv be thisTimeValue(value).
+     b. Else,
+        i. Let v be ? ToPrimitive(value).
+
+  ToPrimitive ( input [ , PreferredType ] )
+
+  [...]
+  4. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+features: [Symbol.toPrimitive]
+---*/
+
+var badToPrimitive = {};
+badToPrimitive[Symbol.toPrimitive] = function() {
+  throw new Test262Error();
+};
+
+assert.throws(Test262Error, function() {
+  new Date(badToPrimitive);
+});

--- a/test/built-ins/Date/value-to-primitive-call.js
+++ b/test/built-ins/Date/value-to-primitive-call.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date-value
+es6id: 20.3.2.2
+description: Invocation of `Symbol.toPrimitive` method of object value
+info: |
+  3. If NewTarget is not undefined, then
+     a. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+        i. Let tv be thisTimeValue(value).
+     b. Else,
+        i. Let v be ? ToPrimitive(value).
+        [...]
+
+
+  ToPrimitive ( input [ , PreferredType ] )
+
+  1. If PreferredType was not passed, let hint be "default".
+  2. Else if PreferredType is hint String, let hint be "string".
+  3. Else PreferredType is hint Number, let hint be "number".
+  4. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+  5. If exoticToPrim is not undefined, then
+     a. Let result be ? Call(exoticToPrim, input, « hint »).
+     [...]
+features: [Symbol.toPrimitive]
+---*/
+
+var spyToPrimitive = {};
+var callCount = 0;
+var thisValue, args;
+spyToPrimitive[Symbol.toPrimitive] = function() {
+  thisValue = this;
+  args = arguments;
+  callCount += 1;
+};
+
+new Date(spyToPrimitive);
+
+assert.sameValue(callCount, 1, 'function invoked exactly once');
+assert.sameValue(thisValue, spyToPrimitive, 'function "this" value');
+assert.sameValue(args.length, 1, 'function invoked with exactly one argument');
+assert.sameValue(args[0], 'default', 'argument value');

--- a/test/built-ins/Date/value-to-primitive-get-meth-err.js
+++ b/test/built-ins/Date/value-to-primitive-get-meth-err.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date-value
+es6id: 20.3.2.2
+description: Error retrieving `Symbol.toPrimitive` method from object value
+info: |
+  3. If NewTarget is not undefined, then
+     a. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+        i. Let tv be thisTimeValue(value).
+     b. Else,
+        i. Let v be ? ToPrimitive(value).
+        [...]
+features: [Symbol.toPrimitive]
+---*/
+
+var poisonedObject = {};
+var poisonedDate = new Date();
+Object.defineProperty(poisonedObject, Symbol.toPrimitive, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+Object.defineProperty(poisonedDate, Symbol.toPrimitive, {
+  get: function() {
+    throw new Test262Error();
+  }
+});
+
+Date(poisonedObject);
+
+new Date(poisonedDate);
+
+assert.throws(Test262Error, function() {
+  new Date(poisonedObject);
+});

--- a/test/built-ins/Date/value-to-primitive-result-faulty.js
+++ b/test/built-ins/Date/value-to-primitive-result-faulty.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date-value
+es6id: 20.3.2.2
+description: Exotic `Symbol.toPrimitive` method returns a non-primitive
+info: |
+  3. If NewTarget is not undefined, then
+     a. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+        i. Let tv be thisTimeValue(value).
+     b. Else,
+        i. Let v be ? ToPrimitive(value).
+
+  ToPrimitive ( input [ , PreferredType ] )
+
+  1. If PreferredType was not passed, let hint be "default".
+  2. Else if PreferredType is hint String, let hint be "string".
+  3. Else PreferredType is hint Number, let hint be "number".
+  4. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+  5. If exoticToPrim is not undefined, then
+     a. Let result be ? Call(exoticToPrim, input, « hint »).
+     b. If Type(result) is not Object, return result.
+     c. Throw a TypeError exception.
+features: [Symbol.toPrimitive]
+---*/
+
+var faultyToPrimitive = {};
+var returnValue;
+faultyToPrimitive[Symbol.toPrimitive] = function() {
+  return returnValue;
+};
+
+returnValue = {};
+assert.throws(TypeError, function() {
+  new Date(faultyToPrimitive);
+}, 'ordinary object');
+
+returnValue = [];
+assert.throws(TypeError, function() {
+  new Date(faultyToPrimitive);
+}, 'Array exotic object');
+
+returnValue = (function() { return arguments; }());
+assert.throws(TypeError, function() {
+  new Date(faultyToPrimitive);
+}, 'arguments exotic object');

--- a/test/built-ins/Date/value-to-primitive-result-non-string-prim.js
+++ b/test/built-ins/Date/value-to-primitive-result-non-string-prim.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date-value
+es6id: 20.3.2.2
+description: >
+  Exotic `Symbol.toPrimitive` method returns a primitive value other than a
+  string
+info: |
+  3. If NewTarget is not undefined, then
+     a. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+        i. Let tv be thisTimeValue(value).
+     b. Else,
+        i. Let v be ? ToPrimitive(value).
+        ii. If Type(v) is String, then
+            1. Let tv be the result of parsing v as a date, in exactly the same
+               manner as for the parse method (20.3.3.2). If the parse resulted
+               in an abrupt completion, tv is the Completion Record.
+
+  ToPrimitive ( input [ , PreferredType ] )
+
+  1. If PreferredType was not passed, let hint be "default".
+  2. Else if PreferredType is hint String, let hint be "string".
+  3. Else PreferredType is hint Number, let hint be "number".
+  4. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+  5. If exoticToPrim is not undefined, then
+     a. Let result be ? Call(exoticToPrim, input, « hint »).
+     b. If Type(result) is not Object, return result.
+features: [Symbol.toPrimitive]
+---*/
+
+var toPrimitive = {};
+var returnValue;
+toPrimitive[Symbol.toPrimitive] = function() {
+  return returnValue;
+};
+
+returnValue = 8;
+assert.sameValue(new Date(toPrimitive).getTime(), 8, 'number');
+
+returnValue = undefined;
+assert.sameValue(new Date(toPrimitive).getTime(), NaN, 'undefined');
+
+returnValue = true;
+assert.sameValue(new Date(toPrimitive).getTime(), 1, 'boolean `true`');
+
+returnValue = false;
+assert.sameValue(new Date(toPrimitive).getTime(), 0, 'boolean `false`');
+
+returnValue = null;
+assert.sameValue(new Date(toPrimitive).getTime(), 0, 'null');
+
+returnValue = Symbol.toPrimitive;
+assert.throws(TypeError, function() {
+  new Date(toPrimitive);
+}, 'symbol');

--- a/test/built-ins/Date/value-to-primitive-result-string.js
+++ b/test/built-ins/Date/value-to-primitive-result-string.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date-value
+es6id: 20.3.2.2
+description: Exotic `Symbol.toPrimitive` method returns a String value
+info: |
+  3. If NewTarget is not undefined, then
+     a. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+        i. Let tv be thisTimeValue(value).
+     b. Else,
+        i. Let v be ? ToPrimitive(value).
+        ii. If Type(v) is String, then
+            1. Let tv be the result of parsing v as a date, in exactly the same
+               manner as for the parse method (20.3.3.2). If the parse resulted
+               in an abrupt completion, tv is the Completion Record.
+
+  ToPrimitive ( input [ , PreferredType ] )
+
+  1. If PreferredType was not passed, let hint be "default".
+  2. Else if PreferredType is hint String, let hint be "string".
+  3. Else PreferredType is hint Number, let hint be "number".
+  4. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+  5. If exoticToPrim is not undefined, then
+     a. Let result be ? Call(exoticToPrim, input, « hint »).
+     b. If Type(result) is not Object, return result.
+features: [Symbol.toPrimitive]
+---*/
+
+var stringToPrimitive = {};
+stringToPrimitive[Symbol.toPrimitive] = function() {
+  return '2016-06-05T18:40:00.000Z';
+};
+
+assert.sameValue(new Date(stringToPrimitive).getTime(), 1465152000000);


### PR DESCRIPTION
This changeset increases test coverage for the semantics defined in [ECMA262
section 20](https://tc39.github.io/ecma262/#sec-numbers-and-dates).

There are additional methods of the Date.prototype methods that still need
coverage, but I felt this patch was getting a bit long in the tooth as it is.