### PR TITLE
Add Test262Error.name to check the kind of error easily by just looking up `error.name`

### DIFF
--- a/harness/sta.js
+++ b/harness/sta.js
@@ -6,11 +6,12 @@ var EarlyErrorRePat = "^((?!" + NotEarlyErrorString + ").)*$";
 var NotEarlyError = new Error(NotEarlyErrorString);
 
 function Test262Error(message) {
+    this.name = "Test262Error";
     this.message = message || "";
 }
 
 Test262Error.prototype.toString = function () {
-    return "Test262Error: " + this.message;
+    return this.name + ": " + this.message;
 };
 
 var $ERROR;


### PR DESCRIPTION
Add Test262Error.name property. This addition aligns Test262Error more to usual Error instance.
For example, JavaScriptCore engine[[1]] uses the uncaught error.name to check the expected error is thrown.

[1]: https://bugs.webkit.org/show_bug.cgi?id=159862