### PR TITLE
Tests for trailing commas in function arg lists

### DIFF
--- a/test/language/expressions/arrow-function/params-trailing-comma-length.js
+++ b/test/language/expressions/arrow-function/params-trailing-comma-length.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas don't affect the .length property of arrow
+  functions.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+
+assert.sameValue(
+  ((a,) => {}).length,
+  1,
+  "Arrow function with 1 arg + trailing comma reports incorrect .length!"
+);
+
+assert.sameValue(
+  ((a,b,) => {}).length,
+  2,
+  "Arrow function with 2 args + trailing comma reports incorrect .length!"
+);

--- a/test/language/expressions/arrow-function/params-trailing-comma.js
+++ b/test/language/expressions/arrow-function/params-trailing-comma.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Check that trailing commas are permitted in arrow function argument lists
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+((a,) => {});
+((a,b,) => {});

--- a/test/language/expressions/call/trailing-comma.js
+++ b/test/language/expressions/call/trailing-comma.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas are not permitted after spread arguments
+  in a call expression.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+negative: SyntaxError
+---*/
+
+function foo() {}
+foo(...[],);

--- a/test/language/expressions/function/params-trailing-comma-arguments.js
+++ b/test/language/expressions/function/params-trailing-comma-arguments.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas do not affect `arguments` in function
+  expression bodies.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+
+var f1 = function() {
+  assert.sameValue(
+    arguments.length,
+    1,
+    "Function expression called with 1 arg + trailing comma reports " +
+    "invalid arguments.length!"
+  );
+};
+f1(1,);
+
+var f2 = function() {
+  assert.sameValue(
+    arguments.length,
+    2,
+    "Function expression called with 2 arg + trailing comma reports " +
+    "invalid arguments.length!"
+  );
+};
+f2(1,2,);

--- a/test/language/expressions/function/params-trailing-comma-length.js
+++ b/test/language/expressions/function/params-trailing-comma-length.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas don't affect the .length property of
+  function expressions.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+
+assert.sameValue(
+  (function(a,) {}).length,
+  1,
+  "Function expression with 1 arg + trailing comma reports incorrect .length!"
+);
+
+assert.sameValue(
+  (function(a,b,) {}).length,
+  2,
+  "Function expression with 2 args + trailing comma reports incorrect .length!"
+);

--- a/test/language/expressions/function/params-trailing-comma.js
+++ b/test/language/expressions/function/params-trailing-comma.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas are permitted in function expression
+  argument lists.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+var one = (0, function(a,) {});
+var two = (0, function(a,b,) {});

--- a/test/language/expressions/generators/params-trailing-comma-arguments.js
+++ b/test/language/expressions/generators/params-trailing-comma-arguments.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas do not affect `arguments` in function
+  expression bodies.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+
+var f1 = function*() {
+  assert.sameValue(
+    arguments.length,
+    1,
+    "Function expression called with 1 arg + trailing comma reports " +
+    "invalid arguments.length!"
+  );
+};
+f1(1,).next();
+
+var f2 = function*() {
+  assert.sameValue(
+    arguments.length,
+    2,
+    "Function expression called with 2 arg + trailing comma reports " +
+    "invalid arguments.length!"
+  );
+};
+f2(1,2,).next();

--- a/test/language/expressions/generators/params-trailing-comma-length.js
+++ b/test/language/expressions/generators/params-trailing-comma-length.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas don't affect the .length property of generator
+  function expressions.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+
+assert.sameValue(
+  (function*(a,) {}).length,
+  1,
+  "Generator expression with 1 arg + trailing comma reports incorrect .length!"
+);
+
+assert.sameValue(
+  (function*(a,b,) {}).length,
+  2,
+  "Generator expression with 2 args + trailing comma reports incorrect .length!"
+);

--- a/test/language/expressions/generators/params-trailing-comma.js
+++ b/test/language/expressions/generators/params-trailing-comma.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Check that trailing commas are permitted in generator function argument lists
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+var one = (0, function*(a,) {});
+var two = (0, function*(a,b,) {});

--- a/test/language/expressions/object/method-definition/params-trailing-comma-arguments.js
+++ b/test/language/expressions/object/method-definition/params-trailing-comma-arguments.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing parameter commas do not affect `arguments` in object
+  method bodies.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+
+var obj = {
+  f1() {
+    assert.sameValue(
+      arguments.length,
+      1,
+      "Object method called with 1 arg + trailing comma reports " +
+      "invalid arguments.length!"
+    );
+  },
+
+  f2() {
+    assert.sameValue(
+      arguments.length,
+      2,
+      "Object method called with 2 arg + trailing comma reports " +
+      "invalid arguments.length!"
+    );
+  }
+};
+
+obj.f1(1,);
+obj.f2(1,2,);

--- a/test/language/expressions/object/method-definition/params-trailing-comma-length.js
+++ b/test/language/expressions/object/method-definition/params-trailing-comma-length.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas don't affect the .length property of
+  object methods.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+
+var obj = {
+  one(a,) {},
+  two(a,b,) {},
+};
+
+assert.sameValue(
+  obj.one.length,
+  1,
+  "Object method with 1 arg + trailing comma reports incorrect .length!"
+);
+
+assert.sameValue(
+  obj.two.length,
+  2,
+  "Object method with 2 args + trailing comma reports incorrect .length!"
+);

--- a/test/language/expressions/object/method-definition/params-trailing-comma-rest.js
+++ b/test/language/expressions/object/method-definition/params-trailing-comma-rest.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas are not permitted after rest params in
+  object method parameter lists.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+negative: SyntaxError
+---*/
+({
+  m(...[],) {}
+});

--- a/test/language/expressions/object/method-definition/params-trailing-comma.js
+++ b/test/language/expressions/object/method-definition/params-trailing-comma.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Check that trailing commas are permitted in object method argument lists
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+({
+  one(a,) {},
+  two(a,b,) {},
+});

--- a/test/language/rest-parameters/params-trailing-comma-rest.js
+++ b/test/language/rest-parameters/params-trailing-comma-rest.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas are not permitted permitted after rest
+  arguments in arrow function argument lists.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+negative: SyntaxError
+---*/
+
+((...a,) => {})

--- a/test/language/statements/class/definition/params-trailing-comma-arguments.js
+++ b/test/language/statements/class/definition/params-trailing-comma-arguments.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas in method parameter lists do not affect `arguments`
+  in class method bodies.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+
+class C {
+  f1() {
+    assert.sameValue(
+      arguments.length,
+      1,
+      "Class method called with 1 arg + trailing comma reports " +
+      "invalid arguments.length!"
+    );
+  },
+
+  f2() {
+    assert.sameValue(
+      arguments.length,
+      2,
+      "Class method called with 2 arg + trailing comma reports " +
+      "invalid arguments.length!"
+    );
+  }
+};
+
+(new C()).f1(1,);
+(new C()).f2(1,2,);

--- a/test/language/statements/class/definition/params-trailing-comma-length.js
+++ b/test/language/statements/class/definition/params-trailing-comma-length.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas don't affect the .length property of
+  class methods.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+
+class C {
+  one(a,) {}
+  two(a,b,) {}
+};
+
+assert.sameValue(
+  C.prototype.one.length,
+  1,
+  "Class method with 1 arg + trailing comma reports incorrect .length!"
+);
+
+assert.sameValue(
+  C.prototype.two.length,
+  2,
+  "Class method with 2 args + trailing comma reports incorrect .length!"
+);

--- a/test/language/statements/class/definition/params-trailing-comma-rest.js
+++ b/test/language/statements/class/definition/params-trailing-comma-rest.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas are not permitted after rest args in
+  class method parameter lists.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+negative: SyntaxError
+---*/
+class C {
+  m(...[],) {}
+}

--- a/test/language/statements/class/definition/params-trailing-comma.js
+++ b/test/language/statements/class/definition/params-trailing-comma.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Check that trailing commas are permitted in class method argument lists
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+class C {
+  one(a,) {},
+  two(a,b,) {},
+}

--- a/test/language/statements/function/params-trailing-comma-arguments.js
+++ b/test/language/statements/function/params-trailing-comma-arguments.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas do not affect `arguments` in function
+  declaration bodies.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+
+function f1() {
+  assert.sameValue(
+    arguments.length,
+    1,
+    "Function declaration called with 1 arg + trailing comma reports " +
+    "invalid arguments.length!"
+  );
+}
+
+function f2() {
+  assert.sameValue(
+    arguments.length,
+    2,
+    "Function declaration called with 2 arg + trailing comma reports " +
+    "invalid arguments.length!"
+  );
+}
+
+f1(1,);
+f2(1,2,);

--- a/test/language/statements/function/params-trailing-comma-length.js
+++ b/test/language/statements/function/params-trailing-comma-length.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas don't affect the .length property of
+  function declarations.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+
+function one(a,) {}
+function two(a,b,) {}
+
+assert.sameValue(
+  one.length,
+  1,
+  "Function expression with 1 arg + trailing comma reports incorrect .length!"
+);
+
+assert.sameValue(
+  two.length,
+  2,
+  "Function expression with 2 args + trailing comma reports incorrect .length!"
+);

--- a/test/language/statements/function/params-trailing-comma.js
+++ b/test/language/statements/function/params-trailing-comma.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Check that trailing commas are permitted in function declaration argument lists
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+function one(a,) {}
+function two(a,b,) {}

--- a/test/language/statements/generators/params-trailing-comma-length.js
+++ b/test/language/statements/generators/params-trailing-comma-length.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Check that trailing commas don't affect the .length property of
+  generator function declarations.
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+
+function one*(a,) {}
+function two*(a,b,) {}
+
+assert.sameValue(
+  one.length,
+  1,
+  "Function expression with 1 arg + trailing comma reports incorrect .length!"
+);
+
+assert.sameValue(
+  two.length,
+  2,
+  "Function expression with 2 args + trailing comma reports incorrect .length!"
+);

--- a/test/language/statements/generators/params-trailing-comma.js
+++ b/test/language/statements/generators/params-trailing-comma.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 Jeff Morrison. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Check that trailing commas are permitted in generator function argument lists
+info: http://jeffmo.github.io/es-trailing-function-commas/
+author: Jeff Morrison <lbljeffmo@gmail.com>
+---*/
+function* one(a,) {}
+function* two(a,b,) {}


### PR DESCRIPTION
Adds tests for the proposal as described here:
http://jeffmo.github.io/es-trailing-function-commas/

cc @bterlson @ljharb 