### PR TITLE
Add DateTimeFormat.prototype.formatToParts tests

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/formatToParts/date-is-infinity-throws.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/date-is-infinity-throws.js
@@ -1,0 +1,33 @@
+// Copyright 2016 Leonardo Balter. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: >
+  Throws a RangeError if date arg is cast to an Infinity value
+info: |
+  Intl.DateTimeFormat.prototype.formatToParts ([ date ])
+
+  4. If _date_ is not provided or is *undefined*, then
+    a. Let _x_ be *%Date_now%*().
+  5. Else,
+    a. Let _x_ be ? ToNumber(_date_).
+  6. Return ? FormatDateTimeToParts(_dtf_, _x_).
+
+  FormatDateTimeToParts(dateTimeFormat, x)
+
+  1. Let _parts_ be ? PartitionDateTimePattern(_dateTimeFormat_, _x_).
+
+  PartitionDateTimePattern (dateTimeFormat, x)
+
+  1. If _x_ is not a finite Number, throw a *RangeError* exception.
+---*/
+
+var dtf = new Intl.DateTimeFormat(["pt-BR"]);
+
+assert.throws(RangeError, function() {
+  dtf.formatToParts(Infinity);
+}, "+Infinity");
+
+assert.throws(RangeError, function() {
+  dtf.formatToParts(-Infinity);
+}, "-Infinity");

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/date-is-nan-throws.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/date-is-nan-throws.js
@@ -1,0 +1,33 @@
+// Copyright 2016 Leonardo Balter. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: >
+  Throws a RangeError if date arg is cast to NaN
+info: |
+  Intl.DateTimeFormat.prototype.formatToParts ([ date ])
+
+  4. If _date_ is not provided or is *undefined*, then
+    a. Let _x_ be *%Date_now%*().
+  5. Else,
+    a. Let _x_ be ? ToNumber(_date_).
+  6. Return ? FormatDateTimeToParts(_dtf_, _x_).
+
+  FormatDateTimeToParts(dateTimeFormat, x)
+
+  1. Let _parts_ be ? PartitionDateTimePattern(_dateTimeFormat_, _x_).
+
+  PartitionDateTimePattern (dateTimeFormat, x)
+
+  1. If _x_ is not a finite Number, throw a *RangeError* exception.
+---*/
+
+var dtf = new Intl.DateTimeFormat(["pt-BR"]);
+
+assert.throws(RangeError, function() {
+  dtf.formatToParts(NaN);
+});
+
+assert.throws(RangeError, function() {
+  dtf.formatToParts("lol");
+});

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/formatToParts.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/formatToParts.js
@@ -1,0 +1,17 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: Property type and descriptor. 
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  typeof Intl.DateTimeFormat.prototype.formatToParts,
+  'function',
+  '`typeof Intl.DateTimeFormat.prototype.formatToParts` is `function`'
+);
+
+verifyNotEnumerable(Intl.DateTimeFormat.prototype, 'formatToParts');
+verifyWritable(Intl.DateTimeFormat.prototype, 'formatToParts');
+verifyConfigurable(Intl.DateTimeFormat.prototype, 'formatToParts');

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/length.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/length.js
@@ -1,0 +1,13 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: Intl.DateTimeFormat.prototype.formatToParts.length. 
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Intl.DateTimeFormat.prototype.formatToParts.length, 0);
+
+verifyNotEnumerable(Intl.DateTimeFormat.prototype.formatToParts, "length");
+verifyNotWritable(Intl.DateTimeFormat.prototype.formatToParts, "length");
+verifyConfigurable(Intl.DateTimeFormat.prototype.formatToParts, "length");

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/main.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/main.js
@@ -1,0 +1,40 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: Tests for existance and behavior of Intl.DateTimeFormat.prototype.formatToParts
+---*/
+
+function reduce(parts) {
+  return parts.map(part => part.value).join('');
+}
+
+function compareFTPtoFormat(locales, options, value) {
+  const dtf = new Intl.DateTimeFormat(locales, options);
+  assert.sameValue(
+    dtf.format(value),
+    reduce(dtf.formatToParts(value)),
+    `Expected the same value for value ${value},
+     locales: ${locales} and options: ${options}`
+  );
+}
+
+compareFTPtoFormat();
+compareFTPtoFormat('pl');
+compareFTPtoFormat(['pl']);
+compareFTPtoFormat([]);
+compareFTPtoFormat(['de'], undefined, 0);
+compareFTPtoFormat(['de'], undefined, -10);
+compareFTPtoFormat(['de'], undefined, 25324234235);
+compareFTPtoFormat(['de'], {
+  day: '2-digit'
+}, Date.now());
+compareFTPtoFormat(['de'], {
+  day: 'numeric',
+  year: '2-digit'
+}, Date.now());
+compareFTPtoFormat(['ar'], {
+  month: 'numeric',
+  day: 'numeric',
+  year: '2-digit'
+}, Date.now());

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/name.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/name.js
@@ -1,0 +1,15 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: Intl.DateTimeFormat.prototype.formatToParts.name value and descriptor. 
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Intl.DateTimeFormat.prototype.formatToParts.name, 'formatToParts',
+  'The value of `Intl.DateTimeFormat.prototype.formatToParts.name` is `"formatToParts"`'
+);
+
+verifyNotEnumerable(Intl.DateTimeFormat.prototype.formatToParts, 'name');
+verifyNotWritable(Intl.DateTimeFormat.prototype.formatToParts, 'name');
+verifyConfigurable(Intl.DateTimeFormat.prototype.formatToParts, 'name');

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/return-abrupt-tonumber-date.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/return-abrupt-tonumber-date.js
@@ -1,0 +1,42 @@
+// Copyright 2016 Leonardo Balter. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: >
+  Return abrupt completions from ToNumber(date)
+info: |
+  Intl.DateTimeFormat.prototype.formatToParts ([ date ])
+
+  4. If _date_ is not provided or is *undefined*, then
+    a. Let _x_ be *%Date_now%*().
+  5. Else,
+    a. Let _x_ be ? ToNumber(_date_).
+features: [Symbol]
+---*/
+
+var obj1 = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+
+var obj2 = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+var dtf = new Intl.DateTimeFormat(["pt-BR"]);
+
+assert.throws(Test262Error, function() {
+  dtf.formatToParts(obj1);
+}, "valueOf");
+
+assert.throws(Test262Error, function() {
+  dtf.formatToParts(obj2);
+}, "toString");
+
+var s = Symbol('1');
+assert.throws(TypeError, function() {
+  dtf.formatToParts(s);
+}, "symbol");

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/this-has-not-internal-throws.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/this-has-not-internal-throws.js
@@ -1,0 +1,17 @@
+// Copyright 2016 Leonardo Balter. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: >
+  Throws a TypeError if this is not a DateTimeFormat object
+---*/
+
+var formatToParts = Intl.DateTimeFormat.prototype.formatToParts;
+
+assert.throws(TypeError, function() {
+  formatToParts.call({});
+}, "{}");
+
+assert.throws(TypeError, function() {
+  formatToParts.call(new Date());
+}, "new Date()");

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/this-is-not-object-throws.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/this-is-not-object-throws.js
@@ -1,0 +1,38 @@
+// Copyright 2016 Leonardo Balter. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: Throws a TypeError if this is not Object
+features: [Symbol]
+---*/
+
+var formatToParts = Intl.DateTimeFormat.prototype.formatToParts;
+
+assert.throws(TypeError, function() {
+  formatToParts.call(undefined);
+}, "undefined");
+
+assert.throws(TypeError, function() {
+  formatToParts.call(null);
+}, "null");
+
+assert.throws(TypeError, function() {
+  formatToParts.call(42);
+}, "number");
+
+assert.throws(TypeError, function() {
+  formatToParts.call("foo");
+}, "string");
+
+assert.throws(TypeError, function() {
+  formatToParts.call(false);
+}, "false");
+
+assert.throws(TypeError, function() {
+  formatToParts.call(true);
+}, "true");
+
+var s = Symbol('1');
+assert.throws(TypeError, function() {
+  formatToParts.call(s);
+}, "symbol");


### PR DESCRIPTION
This is a set of tests for https://github.com/tc39/ecma402/pull/64 which we'd like to land in the spec soon.

I'd like to get the test262 tests for this change ready to land as part of the getting the proposal to stage 4.

I'm not sure how much more testing is required since most of the feature is tested in `DateTimeFormat.prototype.format` tests, and this is just a different representation of the output.

I'd like to get the PR to be ready to land once we land the feature in the spec, so would like to get it reviewed now.

@leobalter, @jugglinmike - can you review this?