### PR TITLE
NumberFormat.prototype.formatToParts tests

### DIFF
--- a/test/intl402/NumberFormat/prototype/formatToParts/formatToParts.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/formatToParts.js
@@ -1,0 +1,17 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: Property type and descriptor. 
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  typeof Intl.NumberFormat.prototype.formatToParts,
+  'function',
+  '`typeof Intl.NumberFormat.prototype.formatToParts` is `function`'
+);
+
+verifyNotEnumerable(Intl.NumberFormat.prototype, 'formatToParts');
+verifyWritable(Intl.NumberFormat.prototype, 'formatToParts');
+verifyConfigurable(Intl.NumberFormat.prototype, 'formatToParts');

--- a/test/intl402/NumberFormat/prototype/formatToParts/length.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/length.js
@@ -1,0 +1,13 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: Intl.NumberFormat.prototype.formatToParts.length. 
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Intl.NumberFormat.prototype.formatToParts.length, 0);
+
+verifyNotEnumerable(Intl.NumberFormat.prototype.formatToParts, "length");
+verifyNotWritable(Intl.NumberFormat.prototype.formatToParts, "length");
+verifyConfigurable(Intl.NumberFormat.prototype.formatToParts, "length");

--- a/test/intl402/NumberFormat/prototype/formatToParts/main.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/main.js
@@ -1,0 +1,65 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: Tests for existance and behavior of Intl.NumberFormat.prototype.formatToParts
+---*/
+
+function reduce(parts) {
+  return parts.map(part => part.value).join('');
+}
+
+function compareFTPtoFormat(locales, options, value) {
+  const nf = new Intl.NumberFormat(locales, options);
+  assert.sameValue(
+    nf.format(value),
+    reduce(nf.formatToParts(value)),
+    `Expected the same value for value ${value},
+     locales: ${locales} and options: ${options}`
+  );
+}
+
+const num1 = 123456.789;
+const num2 = 0.123;
+
+compareFTPtoFormat();
+compareFTPtoFormat('pl');
+compareFTPtoFormat(['pl']);
+compareFTPtoFormat([]);
+compareFTPtoFormat(['de'], undefined, 0);
+compareFTPtoFormat(['de'], undefined, -10);
+compareFTPtoFormat(['de'], undefined, 25324234235);
+compareFTPtoFormat(['de'], undefined, num1);
+compareFTPtoFormat(['de'], {
+  style: 'percent'
+}, num2);
+compareFTPtoFormat(['de'], {
+  style: 'currency',
+  currency: 'EUR'
+}, num1);
+compareFTPtoFormat(['de'], {
+  style: 'currency',
+  currency: 'EUR',
+  currencyDisplay: 'code'
+}, num1);
+compareFTPtoFormat(['de'], {
+  useGrouping: true
+}, num1);
+compareFTPtoFormat(['de'], {
+  useGrouping: false
+}, num1);
+compareFTPtoFormat(['de'], {
+  minimumIntegerDigits: 2
+}, num2);
+compareFTPtoFormat(['de'], {
+  minimumFractionDigits: 6
+}, num2);
+compareFTPtoFormat(['de'], {
+  maximumFractionDigits: 1
+}, num2);
+compareFTPtoFormat(['de'], {
+  maximumSignificantDigits: 3
+}, num1);
+compareFTPtoFormat(['de'], {
+  maximumSignificantDigits: 5
+}, num1);

--- a/test/intl402/NumberFormat/prototype/formatToParts/name.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/name.js
@@ -1,0 +1,15 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: Intl.NumberFormat.prototype.formatToParts.name value and descriptor. 
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Intl.NumberFormat.prototype.formatToParts.name, 'formatToParts',
+  'The value of `Intl.NumberFormat.prototype.formatToParts.name` is `"formatToParts"`'
+);
+
+verifyNotEnumerable(Intl.NumberFormat.prototype.formatToParts, 'name');
+verifyNotWritable(Intl.NumberFormat.prototype.formatToParts, 'name');
+verifyConfigurable(Intl.NumberFormat.prototype.formatToParts, 'name');


### PR DESCRIPTION
This is similar to #734 but for `NumberFormat.prototype.formatToParts`.  I think I could use some help deciding which parts of the spec should be covered. Thanks!