### PR TITLE
add PropertyDefinitionList evaluation order test

### DIFF
--- a/test/language/expressions/object/computed-property-evaluation-order.js
+++ b/test/language/expressions/object/computed-property-evaluation-order.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2016 Michael Ficarra. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object-initializer-runtime-semantics-propertydefinitionevaluation
+description: >
+    Evaluation of PropertyDefinitionList occurs in order, and each
+    PropertyDefinition's PropertyName is evaluated before its
+    AssignmentExpression.
+---*/
+
+var counter = 0;
+var o = {
+  [++counter]: ++counter,
+  [++counter]: ++counter,
+  [++counter]: ++counter,
+}
+
+var keys = Object.keys(o);
+
+assert.sameValue(keys.length, 3, '3 PropertyDefinitions should result in 3 properties');
+assert.sameValue(keys[0], '1');
+assert.sameValue(o[keys[0]], 2);
+assert.sameValue(keys[1], '3');
+assert.sameValue(o[keys[1]], 4);
+assert.sameValue(keys[2], '5');
+assert.sameValue(o[keys[2]], 6);


### PR DESCRIPTION
This test is being added because the committee is considering changing this evaluation order (as discussed at the May 2016 Munich meeting). The consequences of this spec change will be more clear as a test change than a simple test addition.

/cc @leobalter 