### PR TITLE
NumberFormat.prototype.formatToParts tests

### DIFF
--- a/test/intl402/NumberFormat/prototype/formatToParts/formatToParts.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/formatToParts.js
@@ -1,0 +1,17 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: Property type and descriptor. 
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  typeof Intl.NumberFormat.prototype.formatToParts,
+  'function',
+  '`typeof Intl.NumberFormat.prototype.formatToParts` is `function`'
+);
+
+verifyNotEnumerable(Intl.NumberFormat.prototype, 'formatToParts');
+verifyWritable(Intl.NumberFormat.prototype, 'formatToParts');
+verifyConfigurable(Intl.NumberFormat.prototype, 'formatToParts');

--- a/test/intl402/NumberFormat/prototype/formatToParts/length.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/length.js
@@ -1,0 +1,13 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: Intl.NumberFormat.prototype.formatToParts.length. 
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Intl.NumberFormat.prototype.formatToParts.length, 0);
+
+verifyNotEnumerable(Intl.NumberFormat.prototype.formatToParts, "length");
+verifyNotWritable(Intl.NumberFormat.prototype.formatToParts, "length");
+verifyConfigurable(Intl.NumberFormat.prototype.formatToParts, "length");

--- a/test/intl402/NumberFormat/prototype/formatToParts/main.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/main.js
@@ -1,0 +1,65 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: Tests for existance and behavior of Intl.NumberFormat.prototype.formatToParts
+---*/
+
+function reduce(parts) {
+  return parts.map(part => part.value).join('');
+}
+
+function compareFTPtoFormat(locales, options, value) {
+  const nf = new Intl.NumberFormat(locales, options);
+  assert.sameValue(
+    nf.format(value),
+    reduce(nf.formatToParts(value)),
+    `Expected the same value for value ${value},
+     locales: ${locales} and options: ${options}`
+  );
+}
+
+const num1 = 123456.789;
+const num2 = 0.123;
+
+compareFTPtoFormat();
+compareFTPtoFormat('pl');
+compareFTPtoFormat(['pl']);
+compareFTPtoFormat([]);
+compareFTPtoFormat(['de'], undefined, 0);
+compareFTPtoFormat(['de'], undefined, -10);
+compareFTPtoFormat(['de'], undefined, 25324234235);
+compareFTPtoFormat(['de'], undefined, num1);
+compareFTPtoFormat(['de'], {
+  style: 'percent'
+}, num2);
+compareFTPtoFormat(['de'], {
+  style: 'currency',
+  currency: 'EUR'
+}, num1);
+compareFTPtoFormat(['de'], {
+  style: 'currency',
+  currency: 'EUR',
+  currencyDisplay: 'code'
+}, num1);
+compareFTPtoFormat(['de'], {
+  useGrouping: true
+}, num1);
+compareFTPtoFormat(['de'], {
+  useGrouping: false
+}, num1);
+compareFTPtoFormat(['de'], {
+  minimumIntegerDigits: 2
+}, num2);
+compareFTPtoFormat(['de'], {
+  minimumFractionDigits: 6
+}, num2);
+compareFTPtoFormat(['de'], {
+  maximumFractionDigits: 1
+}, num2);
+compareFTPtoFormat(['de'], {
+  maximumSignificantDigits: 3
+}, num1);
+compareFTPtoFormat(['de'], {
+  maximumSignificantDigits: 5
+}, num1);

--- a/test/intl402/NumberFormat/prototype/formatToParts/name.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/name.js
@@ -1,0 +1,15 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: Intl.NumberFormat.prototype.formatToParts.name value and descriptor. 
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Intl.NumberFormat.prototype.formatToParts.name, 'formatToParts',
+  'The value of `Intl.NumberFormat.prototype.formatToParts.name` is `"formatToParts"`'
+);
+
+verifyNotEnumerable(Intl.NumberFormat.prototype.formatToParts, 'name');
+verifyNotWritable(Intl.NumberFormat.prototype.formatToParts, 'name');
+verifyConfigurable(Intl.NumberFormat.prototype.formatToParts, 'name');

--- a/test/intl402/NumberFormat/prototype/formatToParts/return-abrupt-tonumber.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/return-abrupt-tonumber.js
@@ -1,0 +1,40 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+//
+/*---
+description: >
+  Return abrupt completions from ToNumber(date)
+info: |
+  Intl.NumberFormat.prototype.formatToParts ([ value ])
+
+  5. Let _x_ be ? ToNumber(_value_).
+features: [Symbol]
+---*/
+
+var obj1 = {
+  valueOf: function() {
+    throw new Test262Error();
+  }
+};
+
+var obj2 = {
+  toString: function() {
+    throw new Test262Error();
+  }
+};
+
+var nf = new Intl.NumberFormat(["pt-BR"]);
+
+assert.throws(Test262Error, function() {
+  nf.formatToParts(obj1);
+}, "valueOf");
+
+assert.throws(Test262Error, function() {
+  nf.formatToParts(obj2);
+}, "toString");
+
+var s = Symbol('1');
+assert.throws(TypeError, function() {
+  nf.formatToParts(s);
+}, "symbol");
+

--- a/test/intl402/NumberFormat/prototype/formatToParts/this-has-not-internal-throws.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/this-has-not-internal-throws.js
@@ -1,0 +1,17 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: >
+  Throws a TypeError if this is not a NumberFormat object
+---*/
+
+var formatToParts = Intl.NumberFormat.prototype.formatToParts;
+
+assert.throws(TypeError, function() {
+  formatToParts.call({});
+}, "{}");
+
+assert.throws(TypeError, function() {
+  formatToParts.call(new Number());
+}, "new Number()");

--- a/test/intl402/NumberFormat/prototype/formatToParts/this-is-not-object-throws.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/this-is-not-object-throws.js
@@ -1,0 +1,39 @@
+// Copyright 2016 Mozilla Corporation. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+description: Throws a TypeError if this is not Object
+features: [Symbol]
+---*/
+
+var formatToParts = Intl.NumberFormat.prototype.formatToParts;
+
+assert.throws(TypeError, function() {
+  formatToParts.call(undefined);
+}, "undefined");
+
+assert.throws(TypeError, function() {
+  formatToParts.call(null);
+}, "null");
+
+assert.throws(TypeError, function() {
+  formatToParts.call(42);
+}, "number");
+
+assert.throws(TypeError, function() {
+  formatToParts.call("foo");
+}, "string");
+
+assert.throws(TypeError, function() {
+  formatToParts.call(false);
+}, "false");
+
+assert.throws(TypeError, function() {
+  formatToParts.call(true);
+}, "true");
+
+var s = Symbol('1');
+assert.throws(TypeError, function() {
+  formatToParts.call(s);
+}, "symbol");
+


### PR DESCRIPTION
This is an updated pull request based on https://github.com/tc39/test262/pull/736 - I added relevant tests from DTF.prototype.formatToParts tests.

@leobalter - can you take a look and tell me if that's enough?