### PR TITLE
Remove duplicate description keys

### DIFF
--- a/test/built-ins/Date/prototype/setTime/new-value-time-clip.js
+++ b/test/built-ins/Date/prototype/setTime/new-value-time-clip.js
@@ -5,7 +5,6 @@ esid: sec-date.prototype.settime
 es6id: 20.3.4.27
 description: Behavior when new value exceeds [[DateValue]] limits
 info: |
-info: |
   1. Perform ? thisTimeValue(this value).
   2. Let t be ? ToNumber(time).
   3. Let v be TimeClip(t).

--- a/test/built-ins/Date/prototype/setTime/this-value-invalid-date.js
+++ b/test/built-ins/Date/prototype/setTime/this-value-invalid-date.js
@@ -6,7 +6,6 @@ es6id: 20.3.4.27
 description: >
   Behavior when the "this" value is a Date object describing an invald date
 info: |
-info: |
   1. Perform ? thisTimeValue(this value).
   2. Let t be ? ToNumber(time).
   3. Let v be TimeClip(t).


### PR DESCRIPTION
Fixing some tests that caused https://github.com/bterlson/test262-harness to crash due to yaml formatting.