### PR TITLE
Update return-values.js (Number#toExponential bug in Firefox)

### DIFF
--- a/test/built-ins/Number/prototype/toExponential/return-values.js
+++ b/test/built-ins/Number/prototype/toExponential/return-values.js
@@ -52,6 +52,5 @@ assert.sameValue((0.9999).toExponential(18), "9.999000000000000110e-1");
 assert.sameValue((0.9999).toExponential(19), "9.9990000000000001101e-1");
 assert.sameValue((0.9999).toExponential(20), "9.99900000000000011013e-1");
 
-// https://bugzilla.mozilla.org/show_bug.cgi?id=944846
 assert.sameValue((25).toExponential(0), "3e+1");
 assert.sameValue((12345).toExponential(3), "1.235e+4");

--- a/test/built-ins/Number/prototype/toExponential/return-values.js
+++ b/test/built-ins/Number/prototype/toExponential/return-values.js
@@ -51,3 +51,7 @@ assert.sameValue((0.9999).toExponential(17), "9.99900000000000011e-1");
 assert.sameValue((0.9999).toExponential(18), "9.999000000000000110e-1");
 assert.sameValue((0.9999).toExponential(19), "9.9990000000000001101e-1");
 assert.sameValue((0.9999).toExponential(20), "9.99900000000000011013e-1");
+
+// https://bugzilla.mozilla.org/show_bug.cgi?id=944846
+assert.sameValue((25).toExponential(0), "3e+1");
+assert.sameValue((12345).toExponential(3), "1.235e+4");


### PR DESCRIPTION
extra values to test (without them Number#toExponential looks fine in Firefox)