### PR TITLE
Fix operator precedence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,7 +233,7 @@ p.then(function () {
 
     return "Expected exception to be thrown";
 }).then($DONE, function (e) {
-   if (!e instanceof TypeError) {
+   if (!(e instanceof TypeError)) {
       $ERROR("Expected TypeError but got " + e);
    }
 


### PR DESCRIPTION
Unlike PHP, in JavaScript `!` has higher precedence than `instanceof`, thus `!smth instanceof TypeError` will never (unless `@@hasInstance` is defined) be `true`.