### PR TITLE
Add tests to handle revised template literals

### DIFF
--- a/test/language/expressions/tagged-template/invalid-escape-sequences.js
+++ b/test/language/expressions/tagged-template/invalid-escape-sequences.js
@@ -1,0 +1,70 @@
+// Copyright (C) 2016 Tim Disney. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Invalid unicode escape sequence in tagged template literals are allowed
+esid: sec-template-literal-lexical-components
+---*/
+
+(strs => {
+  assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
+  assert.sameValue(strs.raw[0], '\\01');
+})`\01`;
+
+(strs => {
+  assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
+  assert.sameValue(strs.raw[0], '\\1');
+})`\1`;
+
+(strs => {
+  assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
+  assert.sameValue(strs.raw[0], '\\1');
+})`\xg`;
+
+(strs => {
+  assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
+  assert.sameValue(strs.raw[0], '\\1');
+})`\xAg`;
+
+(strs => {
+  assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
+  assert.sameValue(strs.raw[0], '\\u0');
+})`\u0`;
+
+(strs => {
+  assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
+  assert.sameValue(strs.raw[0], '\\u0g');
+})`\u0g`;
+
+(strs => {
+  assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
+  assert.sameValue(strs.raw[0], '\\u00g');
+})`\u00g`;
+
+(strs => {
+  assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
+  assert.sameValue(strs.raw[0], '\\u000g');
+})`\u000g`;
+
+(strs => {
+  assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
+  assert.sameValue(strs.raw[0], '\\u{g');
+})`\u{g`;
+
+(strs => {
+  assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
+  assert.sameValue(strs.raw[0], '\\u{0');
+})`\u{0`;
+
+(strs => {
+  assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
+  assert.sameValue(strs.raw[0], '\\u{10FFFFF}');
+})`\u{10FFFFF}`;
+
+((strs, val) => {
+  assert.sameValue(val, 'inner');
+  assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
+  assert.sameValue(strs.raw[0], '\\u{10FFFFF}');
+
+  assert.sameValue(strs[1], 'right');
+  assert.sameValue(strs.raw[1], 'right');
+})`\u{10FFFFF}${'inner'}right`;

--- a/test/language/expressions/template-literal/invalid-hexidecimal-character-escape-sequence-truncated-1.js
+++ b/test/language/expressions/template-literal/invalid-hexidecimal-character-escape-sequence-truncated-1.js
@@ -1,11 +1,8 @@
 // Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-es6id: 11.8.6.1
+esid: sec-template-literal-lexical-components
 description: Invalid hexidecimal character escape sequence
-info: >
-    The TV of TemplateCharacter :: \ EscapeSequence is the SV of
-    EscapeSequence.
 negative: SyntaxError
 ---*/
 

--- a/test/language/expressions/template-literal/invalid-hexidecimal-character-escape-sequence-truncated-2.js
+++ b/test/language/expressions/template-literal/invalid-hexidecimal-character-escape-sequence-truncated-2.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 Tim Disney. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-template-literal-lexical-components
+description: Invalid hexidecimal character escape sequence
+negative: SyntaxError
+---*/
+
+`\x0G`;

--- a/test/language/expressions/template-literal/invalid-hexidecimal-character-escape-sequence-truncated-3.js
+++ b/test/language/expressions/template-literal/invalid-hexidecimal-character-escape-sequence-truncated-3.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 Tim Disney. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-template-literal-lexical-components
+description: Invalid hexidecimal character escape sequence
+negative: SyntaxError
+---*/
+
+`\xG`;

--- a/test/language/expressions/template-literal/invalid-unicode-escape-sequence-1.js
+++ b/test/language/expressions/template-literal/invalid-unicode-escape-sequence-1.js
@@ -1,11 +1,8 @@
 // Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-es6id: 11.8.6
+esid: sec-template-literal-lexical-components
 description: Invalid unicode escape sequence
-info: >
-    The TV of TemplateCharacter :: \ EscapeSequence is the SV of
-    EscapeSequence.
 negative: SyntaxError
 ---*/
 

--- a/test/language/expressions/template-literal/invalid-unicode-escape-sequence-2.js
+++ b/test/language/expressions/template-literal/invalid-unicode-escape-sequence-2.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 Tim Disney. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-template-literal-lexical-components
+description: Invalid unicode escape sequence
+negative: SyntaxError
+---*/
+
+`\u0g`;

--- a/test/language/expressions/template-literal/invalid-unicode-escape-sequence-3.js
+++ b/test/language/expressions/template-literal/invalid-unicode-escape-sequence-3.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 Tim Disney. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-template-literal-lexical-components
+description: Invalid unicode escape sequence
+negative: SyntaxError
+---*/
+
+`\u00g`;

--- a/test/language/expressions/template-literal/invalid-unicode-escape-sequence-4.js
+++ b/test/language/expressions/template-literal/invalid-unicode-escape-sequence-4.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 Tim Disney. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-template-literal-lexical-components
+description: Invalid unicode escape sequence
+negative: SyntaxError
+---*/
+
+`\u000g`;

--- a/test/language/expressions/template-literal/invalid-unicode-escape-sequence-5.js
+++ b/test/language/expressions/template-literal/invalid-unicode-escape-sequence-5.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 Tim Disney. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-template-literal-lexical-components
+description: Invalid unicode escape sequence
+negative: SyntaxError
+---*/
+
+`\u{g`;

--- a/test/language/expressions/template-literal/invalid-unicode-escape-sequence-6.js
+++ b/test/language/expressions/template-literal/invalid-unicode-escape-sequence-6.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 Tim Disney. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-template-literal-lexical-components
+description: Invalid unicode escape sequence
+negative: SyntaxError
+---*/
+
+`\u{0`;

--- a/test/language/expressions/template-literal/invalid-unicode-escape-sequence-7.js
+++ b/test/language/expressions/template-literal/invalid-unicode-escape-sequence-7.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 Tim Disney. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-template-literal-lexical-components
+description: Invalid unicode escape sequence
+negative: SyntaxError
+---*/
+
+`\u{10FFFFF}`;

--- a/test/language/expressions/template-literal/invalid-unicode-escape-sequence-8.js
+++ b/test/language/expressions/template-literal/invalid-unicode-escape-sequence-8.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 Tim Disney. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-template-literal-lexical-components
+description: Invalid unicode escape sequence
+negative: SyntaxError
+---*/
+
+`\u{10FFFFF}${'inner'}right`;


### PR DESCRIPTION
Add tests for the template literal revision [proposal](https://github.com/tc39/proposal-template-literal-revision) (the proposal is currently at stage 3). The proposal allows tagged template literals to use previously disallowed escape sequences.

