### PR TITLE
Add tests for non-optional arguments of Date.UTC()

### DIFF
--- a/test/built-ins/Date/UTC/infinity-make-day.js
+++ b/test/built-ins/Date/UTC/infinity-make-day.js
@@ -6,13 +6,16 @@ es6id: 20.3.3.4
 description: Infinite values specified to MakeDay produce NaN
 info: |
   [...]
-  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))). 
+  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))).
 
   MakeDay (year, month, date)
 
   1. If year is not finite or month is not finite or date is not finite, return
      NaN.
 ---*/
+
+assert.sameValue(Date.UTC(Infinity), NaN, 'year: Infinity - single arg');
+assert.sameValue(Date.UTC(-Infinity), NaN, 'year: -Infinity - single arg');
 
 assert.sameValue(Date.UTC(Infinity, 0), NaN, 'year: Infinity');
 assert.sameValue(Date.UTC(-Infinity, 0), NaN, 'year: -Infinity');
@@ -22,3 +25,4 @@ assert.sameValue(Date.UTC(0, -Infinity), NaN, 'month: -Infinity');
 
 assert.sameValue(Date.UTC(0, 0, Infinity), NaN, 'date: Infinity');
 assert.sameValue(Date.UTC(0, 0, -Infinity), NaN, 'date: -Infinity');
+

--- a/test/built-ins/Date/UTC/nans.js
+++ b/test/built-ins/Date/UTC/nans.js
@@ -17,6 +17,7 @@ info: |
   9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))).
 ---*/
 
+assert.sameValue(Date.UTC(NaN), NaN, 'year');
 assert.sameValue(Date.UTC(NaN, 0), NaN, 'year');
 assert.sameValue(Date.UTC(1970, NaN), NaN, 'month');
 assert.sameValue(Date.UTC(1970, 0, NaN), NaN, 'date');

--- a/test/built-ins/Date/UTC/nans.js
+++ b/test/built-ins/Date/UTC/nans.js
@@ -14,13 +14,16 @@ info: |
   7. If ms is supplied, let milli be ? ToNumber(ms); else let milli be 0.
   8. If y is not NaN and 0 ≤ ToInteger(y) ≤ 99, let yr be 1900+ToInteger(y);
      otherwise, let yr be y.
-  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))). 
+  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))).
 ---*/
 
-assert.sameValue(new Date(NaN, 0).getTime(), NaN, 'year');
-assert.sameValue(new Date(1970, NaN).getTime(), NaN, 'month');
-assert.sameValue(new Date(1970, 0, NaN).getTime(), NaN, 'date');
-assert.sameValue(new Date(1970, 0, 1, NaN).getTime(), NaN, 'hours');
-assert.sameValue(new Date(1970, 0, 1, 0, NaN).getTime(), NaN, 'minutes');
-assert.sameValue(new Date(1970, 0, 1, 0, 0, NaN).getTime(), NaN, 'seconds');
-assert.sameValue(new Date(1970, 0, 1, 0, 0, 0, NaN).getTime(), NaN, 'ms');
+assert.sameValue(Date.UTC(NaN, 0), NaN, 'year');
+assert.sameValue(Date.UTC(1970, NaN), NaN, 'month');
+assert.sameValue(Date.UTC(1970, 0, NaN), NaN, 'date');
+assert.sameValue(Date.UTC(1970, 0, 1, NaN), NaN, 'hours');
+assert.sameValue(Date.UTC(1970, 0, 1, 0, NaN), NaN, 'minutes');
+assert.sameValue(Date.UTC(1970, 0, 1, 0, 0, NaN), NaN, 'seconds');
+assert.sameValue(Date.UTC(1970, 0, 1, 0, 0, 0, NaN), NaN, 'ms');
+
+// Tests for non optional arguments
+assert.sameValue(Date.UTC(), NaN, 'missing year');

--- a/test/built-ins/Date/UTC/no-arg.js
+++ b/test/built-ins/Date/UTC/no-arg.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-date.utc
 es6id: 20.3.3.4
-description: NaN value handling
+description: Tests for non optional arguments
 info: |
   1. Let y be ? ToNumber(year).
   2. Let m be ? ToNumber(month).
@@ -17,11 +17,4 @@ info: |
   9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))).
 ---*/
 
-assert.sameValue(Date.UTC(NaN), NaN, 'year');
-assert.sameValue(Date.UTC(NaN, 0), NaN, 'year');
-assert.sameValue(Date.UTC(1970, NaN), NaN, 'month');
-assert.sameValue(Date.UTC(1970, 0, NaN), NaN, 'date');
-assert.sameValue(Date.UTC(1970, 0, 1, NaN), NaN, 'hours');
-assert.sameValue(Date.UTC(1970, 0, 1, 0, NaN), NaN, 'minutes');
-assert.sameValue(Date.UTC(1970, 0, 1, 0, 0, NaN), NaN, 'seconds');
-assert.sameValue(Date.UTC(1970, 0, 1, 0, 0, 0, NaN), NaN, 'ms');
+assert.sameValue(Date.UTC(), NaN, 'missing non-optional year argument');

--- a/test/built-ins/Date/UTC/return-value.js
+++ b/test/built-ins/Date/UTC/return-value.js
@@ -14,8 +14,10 @@ info: |
   7. If ms is supplied, let milli be ? ToNumber(ms); else let milli be 0.
   8. If y is not NaN and 0 ≤ ToInteger(y) ≤ 99, let yr be 1900+ToInteger(y);
      otherwise, let yr be y.
-  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))). 
+  9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))).
 ---*/
+
+assert.sameValue(Date.UTC(1970), 0, '1970');
 
 assert.sameValue(Date.UTC(1970, 0), 0, '1970, 0');
 assert.sameValue(Date.UTC(2016, 0), 1451606400000, '2016, 0');


### PR DESCRIPTION
Are these actually necessary? I'm tempted to add them just to be able to change them in the future (new default for month).

@bterlson 
