### PR TITLE
Add test for inequality of RegExps created from the same source

### DIFF
--- a/test/language/literals/regexp/inequality.js
+++ b/test/language/literals/regexp/inequality.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Regular expression literals should not compare as equal even if they appear in the same source position.
+esid: sec-regular-expression-literals-runtime-semantics-evaluation
+---*/
+
+function makeRegExp() {
+  return /(?:)/;
+}
+
+assert.notSameValue(makeRegExp(), makeRegExp());
+
+var values = [];
+for (var i = 0; i < 2; ++i) {
+  values[i] = /(?:)/;
+}
+
+assert.notSameValue(values[0], values[1]);


### PR DESCRIPTION
We already have [a single test](https://github.com/bakkot/test262/blob/master/test/language/literals/regexp/S7.8.5_A4.2.js) (that I could find) which tests that two identical regular expression literals create distinct objects, but we don't test that the same literal source, evaluated at different times, creates distinct objects.