### PR TITLE
fix incorrect tests for trailing commas

### DIFF
--- a/test/language/expressions/call/trailing-comma.js
+++ b/test/language/expressions/call/trailing-comma.js
@@ -2,13 +2,10 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: >
-  Check that trailing commas are not permitted after spread arguments
+  Check that trailing commas are permitted after spread arguments
   in a call expression.
 info: http://jeffmo.github.io/es-trailing-function-commas/
 author: Jeff Morrison <lbljeffmo@gmail.com>
-negative:
-  phase: early
-  type: SyntaxError
 ---*/
 
 function foo() {}

--- a/test/language/statements/class/definition/params-trailing-comma-arguments.js
+++ b/test/language/statements/class/definition/params-trailing-comma-arguments.js
@@ -16,7 +16,7 @@ class C {
       "Class method called with 1 arg + trailing comma reports " +
       "invalid arguments.length!"
     );
-  },
+  }
 
   f2() {
     assert.sameValue(

--- a/test/language/statements/class/definition/params-trailing-comma.js
+++ b/test/language/statements/class/definition/params-trailing-comma.js
@@ -6,6 +6,6 @@ info: http://jeffmo.github.io/es-trailing-function-commas/
 author: Jeff Morrison <lbljeffmo@gmail.com>
 ---*/
 class C {
-  one(a,) {},
-  two(a,b,) {},
+  one(a,) {}
+  two(a,b,) {}
 }


### PR DESCRIPTION
* Method declarations should not be followed by a comma.
* A comma after a spread parameter is actually allowed.