### PR TITLE
Fix 'negative' frontmatter key in yield tests

### DIFF
--- a/test/language/expressions/yield/in-iteration-stmt.js
+++ b/test/language/expressions/yield/in-iteration-stmt.js
@@ -10,7 +10,9 @@ info: |
   Syntax
 
   yield [no LineTerminator here] AssignmentExpression[?In, +Yield]
-negative: SyntaxError
+negative:
+  phase: early
+  type: SyntaxError
 ---*/
 
 function* g() {

--- a/test/language/expressions/yield/star-in-iteration-stmt.js
+++ b/test/language/expressions/yield/star-in-iteration-stmt.js
@@ -10,7 +10,9 @@ info: |
   Syntax
 
   yield [no LineTerminator here] * AssignmentExpression[?In, +Yield]
-negative: SyntaxError
+negative:
+  phase: early
+  type: SyntaxError
 ---*/
 
 function* g() {


### PR DESCRIPTION
This commit corrects the 'negative' frontmatter key in
test/language/expressions/yield/in-iteration-stmt.js and
test/language/expressions/yield/star-in-iteration-stmt.js.