### PR TITLE
Replace islamicc with islamic-umalqura in getCanonicalLocales/main.js (Intl402)

### DIFF
--- a/test/intl402/Intl/getCanonicalLocales/main.js
+++ b/test/intl402/Intl/getCanonicalLocales/main.js
@@ -29,6 +29,4 @@ assertArray(gCL({'a': 0}), []);
 
 assertArray(gCL({}), []);
 
-assertArray(gCL(['ar-ma-u-ca-islamic-umalqura']), ['ar-MA-u-ca-islamic-umalqura']);
-
 assertArray(gCL(['th-th-u-nu-thai']), ['th-TH-u-nu-thai']);

--- a/test/intl402/Intl/getCanonicalLocales/main.js
+++ b/test/intl402/Intl/getCanonicalLocales/main.js
@@ -29,6 +29,6 @@ assertArray(gCL({'a': 0}), []);
 
 assertArray(gCL({}), []);
 
-assertArray(gCL(['ar-ma-u-ca-islamicc']), ['ar-MA-u-ca-islamicc']);
+assertArray(gCL(['ar-ma-u-ca-islamic-umalqura']), ['ar-MA-u-ca-islamic-umalqura']);
 
 assertArray(gCL(['th-th-u-nu-thai']), ['th-TH-u-nu-thai']);


### PR DESCRIPTION
Per discussion in #743, it's implementation-dependent how ismalicc is
canonicalized. However, 'islamic-umalqura' should be treated the same
way by all implementations.