### PR TITLE
Avoid writing to top-level vars named "top", for browser compat

### DIFF
--- a/test/language/statements/function/S13.2.2_A5_T1.js
+++ b/test/language/statements/function/S13.2.2_A5_T1.js
@@ -11,26 +11,26 @@ es5id: 13.2.2_A5_T1
 description: Declaring a function with "function __FACTORY(arg1, arg2)"
 ---*/
 
-var __VOLUME, __RED, __ID, __TOP, __BOTTOM, __LEFT, color, top, left, __device;
+var __VOLUME, __RED, __ID, __BOTTOM, __TOP, __LEFT, color, bottom, left, __device;
 
 __VOLUME=8;
 __RED="red";
 __ID=12342;
-__TOP=1.1;
-__BOTTOM=0.0;
-__LEFT=0.0;
+__BOTTOM=1.1;
+__TOP=0.1;
+__LEFT=0.5;
 
 
 function __FACTORY(arg1, arg2){
 	this.volume=__VOLUME;
 	color=__RED;
 	this.id=arg1;
-	top=arg2;
-	this.bottom=arguments[3];
-	left=arguments[4];
+	bottom=arg2;
+	this.top=arguments[2];
+	left=arguments[3];
 };
 
-__device = new __FACTORY(__ID, __TOP, __BOTTOM, __LEFT);
+__device = new __FACTORY(__ID, __BOTTOM, __TOP, __LEFT);
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
@@ -50,8 +50,8 @@ if (__device.volume !== __VOLUME) {
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#3
-if (__device.top !== undefined) {
-	$ERROR('#3: __device.top === undefined. Actual: __device.top ==='+__device.top);
+if (__device.bottom !== undefined) {
+	$ERROR('#3: __device.bottom === undefined. Actual: __device.bottom ==='+__device.bottom);
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -74,8 +74,8 @@ if (__device.left !== undefined) {
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#6
-if (__device.bottom !== __BOTTOM) {
-	$ERROR('#6: __device.bottom === __BOTTOM. Actual: __device.bottom ==='+__device.bottom);
+if (__device.top !== __TOP) {
+	$ERROR('#6: __device.top === __TOP. Actual: __device.top ==='+__device.top);
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/language/statements/function/S13.2.2_A5_T2.js
+++ b/test/language/statements/function/S13.2.2_A5_T2.js
@@ -11,26 +11,26 @@ es5id: 13.2.2_A5_T2
 description: Declaring a function with "__FACTORY = function(arg1, arg2)"
 ---*/
 
-var __VOLUME, __RED, __ID, __TOP, __BOTTOM, __LEFT, __FACTORY, color, top, left, __device;
+var __VOLUME, __RED, __ID, __BOTTOM, __TOP, __LEFT, __FACTORY, color, bottom, left, __device;
 
 __VOLUME=8;
 __RED="red";
 __ID=12342;
-__TOP=1.1;
-__BOTTOM=0.0;
-__LEFT=0.0;
+__BOTTOM=1.1;
+__TOP=0.1;
+__LEFT=0.5;
 
 
 __FACTORY = function(arg1, arg2){
 	this.volume=__VOLUME;
 	color=__RED;
 	this.id=arg1;
-	top=arg2;
-	this.bottom=arguments[3];
-	left=arguments[4];
+	bottom=arg2;
+	this.top=arguments[2];
+	left=arguments[3];
 };
 
-__device = new __FACTORY(__ID, __TOP, __BOTTOM, __LEFT);
+__device = new __FACTORY(__ID, __BOTTOM, __TOP, __LEFT);
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
@@ -50,8 +50,8 @@ if (__device.volume !== __VOLUME) {
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#3
-if (__device.top !== undefined) {
-	$ERROR('#3: __device.top === undefined. Actual: __device.top ==='+__device.top);
+if (__device.bottom !== undefined) {
+	$ERROR('#3: __device.bottom === undefined. Actual: __device.bottom ==='+__device.bottom);
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -74,8 +74,8 @@ if (__device.left !== undefined) {
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#6
-if (__device.bottom !== __BOTTOM) {
-	$ERROR('#6: __device.bottom === __BOTTOM. Actual: __device.bottom ==='+__device.bottom);
+if (__device.top !== __TOP) {
+	$ERROR('#6: __device.top === __TOP. Actual: __device.top ==='+__device.top);
 }
 //
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The HTML spec requires browsers to define a non-configurable property of the global (window) object named "top". (See [attributes of the window object](https://html.spec.whatwg.org/multipage/browsers.html#the-window-object) and [the definition of "[Unforgeable]"](https://www.w3.org/TR/WebIDL/#Unforgeable).) This makes it impossible for a browser to successfully run a test in strict mode (as is [required](https://github.com/tc39/test262/blob/master/INTERPRETING.md#strict-mode)) if said test attempts to write to a global variable named "top".

This patch switches variable names around in two tests so that they don't try to do that. It also incidentally fixes an off-by-one error which was only not causing failure due to two variables having the same value, and modifies those variables to be distinct.

Having these tests be runnable in a browser isn't an explicit goal, but it still seems worth it for such an easy fix. Other tests also make assumptions about properties of the global object (e.g. that `length` [does not exist](https://github.com/tc39/test262/blob/bef7f988d2a954c44fb4c8f99e91d9122ef275e3/test/language/expressions/function/dstr-ary-ptrn-rest-obj-prop-id.js#L64-L66) or that setting `name` to a Symbol [will succeed](https://github.com/tc39/test262/blob/bef7f988d2a954c44fb4c8f99e91d9122ef275e3/test/language/expressions/object/method-definition/generator-name-prop-symbol.js#L13)) which are by default violated in a browser context, but generally those conditions be arranged by deleting the relevant properties of the global object. `top` is an exception in that it is explicitly non-configurable.