### PR TITLE
Use $.detachArrayBuffer API instead of throwing

### DIFF
--- a/harness/detachArrayBuffer.js
+++ b/harness/detachArrayBuffer.js
@@ -1,3 +1,6 @@
 function $DETACHBUFFER(buffer) {
-  throw new Test262Error("No method available to detach an ArrayBuffer");
+  if (!$ || typeof $.detachArrayBuffer !== "function") {
+    throw new Test262Error("No method available to detach an ArrayBuffer");
+  }
+  $.detachArrayBuffer(buffer);
 }


### PR DESCRIPTION
INTERRPETING.md [requires](https://github.com/tc39/test262/blob/master/INTERPRETING.md#host-defined-functions) hosts to expose a `$.detachArrayBuffer` method, but nothing is using it; relevant tests call `$DETACHBUFFER`, which unconditionally throws. This PR simply modifies that function to defer to `$.detachArrayBuffer`.

If hosts don't have a way to expose the relevant abstract operation, they can choose to define `$.detachArrayBuffer` such that it throws. We don't need to decided that for them.

(They could of course also just monkey-patch `$DETACHBUFFER`, but that goes against INTERRPETING.md. The less special knowledge required the better, I should think.)

ref #784; ping @leobalter and @bterlson in light of that discussion.