### PR TITLE
Ensure that tests calling $DONE have the async flag

### DIFF
--- a/test/built-ins/Promise/prototype/then/ctor-access-count.js
+++ b/test/built-ins/Promise/prototype/then/ctor-access-count.js
@@ -25,6 +25,7 @@ info: >
     8. If S is either undefined or null, return defaultConstructor.
     9. If IsConstructor(S) is true, return S.
     10. Throw a TypeError exception.
+flags: [async]
 ---*/
 
 var callCount = 0;

--- a/test/built-ins/Promise/prototype/then/resolve-pending-fulfilled-prms-cstm-then.js
+++ b/test/built-ins/Promise/prototype/then/resolve-pending-fulfilled-prms-cstm-then.js
@@ -25,6 +25,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/resolve-pending-rejected-prms-cstm-then.js
+++ b/test/built-ins/Promise/prototype/then/resolve-pending-rejected-prms-cstm-then.js
@@ -26,6 +26,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/resolve-settled-fulfilled-prms-cstm-then.js
+++ b/test/built-ins/Promise/prototype/then/resolve-settled-fulfilled-prms-cstm-then.js
@@ -32,6 +32,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/prototype/then/resolve-settled-rejected-prms-cstm-then.js
+++ b/test/built-ins/Promise/prototype/then/resolve-settled-rejected-prms-cstm-then.js
@@ -32,6 +32,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/race/resolve-prms-cstm-then.js
+++ b/test/built-ins/Promise/race/resolve-prms-cstm-then.js
@@ -26,6 +26,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/resolve-prms-cstm-then-deferred.js
+++ b/test/built-ins/Promise/resolve-prms-cstm-then-deferred.js
@@ -21,6 +21,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var returnValue = null;

--- a/test/built-ins/Promise/resolve-prms-cstm-then-immed.js
+++ b/test/built-ins/Promise/resolve-prms-cstm-then-immed.js
@@ -21,6 +21,7 @@ info: >
         [...]
     12. Perform EnqueueJob ("PromiseJobs", PromiseResolveThenableJob,
         «promise, resolution, thenAction»)
+flags: [async]
 ---*/
 
 var returnValue = null;


### PR DESCRIPTION
`$DONE` is defined in [harness/doneprintHandle.js](https://github.com/tc39/test262/blob/bef7f988d2a954c44fb4c8f99e91d9122ef275e3/harness/doneprintHandle.js), and INTERPRETING.md only [requires](https://github.com/tc39/test262/blob/master/INTERPRETING.md#flags) that doneprintHandle.js (modulo [naming inconsistency](https://github.com/tc39/test262/issues/791)) be included when the `async` flag is set, but several tests referenced it without setting that flag. This PR adds that flag to those tests.