### PR TITLE
Add link to web-based runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ There are a number of volunteer-maintained projects that may be used to execute 
 
 - https://github.com/bterlson/test262-harness (platform: Node.js)
 - https://github.com/test262-utils/test262-harness-py (platform: Python)
+- https://bakkot.github.io/test262-web-runner/ (platform: web)


### PR DESCRIPTION
Page is [here](https://bakkot.github.io/test262-web-runner/), source is [here](https://github.com/bakkot/test262-web-runner).

This project is incidentally the origin of my recent handful of fixes.