### PR TITLE
add line feeds following `{` of F.p.toString output for dynamic functions

### DIFF
--- a/test/built-ins/Function/prototype/toString/Function.js
+++ b/test/built-ins/Function/prototype/toString/Function.js
@@ -8,4 +8,4 @@ description: Function.prototype.toString on a function created with the Function
 
 let f = /* before */Function("a", " /* a */ b, c /* b */ //", "/* c */ ; /* d */ //")/* after */;
 
-assert.sameValue(f.toString(), "function anonymous(a, /* a */ b, c /* b */ //\n) {/* c */ ; /* d */ //\n}");
+assert.sameValue(f.toString(), "function anonymous(a, /* a */ b, c /* b */ //\n) {\n/* c */ ; /* d */ //\n}");

--- a/test/built-ins/Function/prototype/toString/GeneratorFunction.js
+++ b/test/built-ins/Function/prototype/toString/GeneratorFunction.js
@@ -9,4 +9,4 @@ description: Function.prototype.toString on a generator function created with th
 let GeneratorFunction = Object.getPrototypeOf(function*(){}).constructor;
 let g = /* before */GeneratorFunction("a", " /* a */ b, c /* b */ //", "/* c */ yield yield; /* d */ //")/* after */;
 
-assert.sameValue(g.toString(), "function* anonymous(a, /* a */ b, c /* b */ //\n) {/* c */ yield yield; /* d */ //\n}");
+assert.sameValue(g.toString(), "function* anonymous(a, /* a */ b, c /* b */ //\n) {\n/* c */ yield yield; /* d */ //\n}");


### PR DESCRIPTION
This aligns the tests with this recent change to the F.p.toString proposal:
https://github.com/tc39/Function-prototype-toString-revision/commit/7432ded0e6c465fb53a95fddc7a08608401bd413