### PR TITLE
Add missing operator in test

### DIFF
--- a/test/built-ins/Function/prototype/bind/15.3.4.5.1-4-14.js
+++ b/test/built-ins/Function/prototype/bind/15.3.4.5.1-4-14.js
@@ -11,7 +11,7 @@ description: >
         var obj = { prop: "abc" };
 
         var func = function (x) {
-            return this === obj && x === 1 && arguments[1] === 2
+            return this === obj && x === 1 && arguments[1] === 2 &&
                 arguments[0] === 1 && arguments.length === 2 && this.prop === "abc";
         };
 


### PR DESCRIPTION
Automatic Semicolon Insertion hides an error here by transforming a long
ReturnStatement into a ReturnStatement followed by an ExpressionStatement
that is never reached. The conditions on the second line are thus never
tested.