### PR TITLE
Add test for setting a module namespace object's prototype to null

### DIFF
--- a/test/language/module-code/namespace/internals/set-prototype-of-null.js
+++ b/test/language/module-code/namespace/internals/set-prototype-of-null.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-module-namespace-exotic-objects-setprototypeof-v
+description: >
+  The [[SetPrototypeOf]] internal method returns `true` if
+  passed `null`
+flags: [module]
+---*/
+
+import * as ns from './set-prototype-of-null.js';
+
+assert.sameValue(typeof Object.setPrototypeOf, 'function');
+assert.sameValue(ns, Object.setPrototypeOf(ns, null);


### PR DESCRIPTION
The behavior changed from returning false to true in
https://github.com/tc39/ecma262/commit/13906140a