### PR TITLE
Add test for extending a constructor with null .prototype

### DIFF
--- a/test/language/statements/class/constructor-inferred-observable-iteration.js
+++ b/test/language/statements/class/constructor-inferred-observable-iteration.js
@@ -8,7 +8,7 @@ description: >
 info: |
   [...]
   10. If constructor is empty, then
-      a. If ClassHeritageopt is present and protoParent is not null, then
+      a. If ClassHeritageopt is present and superclass is not null, then
          i. Let constructor be the result of parsing the source text
 
              constructor(... args){ super (...args);}

--- a/test/language/statements/class/subclass/class-definition-null-proto-missing-return-override.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto-missing-return-override.js
@@ -16,11 +16,9 @@ info: |
      [...]
   6. Else,
      [...]
-     e. If superclass is null, then
-        i. Let protoParent be null.
-        ii. Let constructorParent be the intrinsic object %FunctionPrototype%.
+     b. Let superclass be the result of evaluating ClassHeritage.
   [...]
-  15. If ClassHeritageopt is present and protoParent is not null, then set F's
+  15. If ClassHeritageopt is present and superclass is not null, then set F's
       [[ConstructorKind]] internal slot to "derived".
   [...]
 

--- a/test/language/statements/class/subclass/class-definition-null-proto-super.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto-super.js
@@ -13,11 +13,9 @@ info: |
      [...]
   6. Else,
      [...]
-     e. If superclass is null, then
-        i. Let protoParent be null.
-        ii. Let constructorParent be the intrinsic object %FunctionPrototype%.
+     b. Let superclass be the result of evaluating ClassHeritage.
   [...]
-  15. If ClassHeritageopt is present and protoParent is not null, then set F's
+  15. If ClassHeritageopt is present and superclass is not null, then set F's
       [[ConstructorKind]] internal slot to "derived".
   [...]
 

--- a/test/language/statements/class/subclass/class-definition-null-proto-this.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto-this.js
@@ -15,11 +15,9 @@ info: |
      [...]
   6. Else,
      [...]
-     e. If superclass is null, then
-        i. Let protoParent be null.
-        ii. Let constructorParent be the intrinsic object %FunctionPrototype%.
+     b. Let superclass be the result of evaluating ClassHeritage.
   [...]
-  15. If ClassHeritageopt is present and protoParent is not null, then set F's
+  15. If ClassHeritageopt is present and superclass is not null, then set F's
       [[ConstructorKind]] internal slot to "derived".
   [...]
 

--- a/test/language/statements/class/subclass/class-definition-null-proto.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto.js
@@ -16,15 +16,13 @@ info: |
      [...]
   6. Else,
      [...]
-     e. If superclass is null, then
-        i. Let protoParent be null.
-        ii. Let constructorParent be the intrinsic object %FunctionPrototype%.
+     b. Let superclass be the result of evaluating ClassHeritage.
      [...]
   7. Let proto be ObjectCreate(protoParent).
   8. If ClassBodyopt is not present, let constructor be empty.
   9. Else, let constructor be ConstructorMethod of ClassBody.
   10. If constructor is empty, then
-      a. If ClassHeritageopt is present and protoParent is not null, then
+      a. If ClassHeritageopt is present and superclass is not null, then
          [...]
       b. Else,
          i. Let constructor be the result of parsing the source text

--- a/test/language/statements/class/subclass/class-definition-parent-proto-null.js
+++ b/test/language/statements/class/subclass/class-definition-parent-proto-null.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2016 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-runtime-semantics-classdefinitionevaluation
+description: A class which extends a constructor with null .prototype is a derived class.
+---*/
+
+var invoked = false;
+var instance, savedArg;
+
+function A(arg) {
+  invoked = true;
+  savedArg = arg;
+  this.prop = 0;
+}
+A.prototype = null;
+
+class C extends A {}
+
+instance = new C(1);
+
+assert.sameValue(invoked, true);
+assert.sameValue(savedArg, 1);
+assert.sameValue(instance.prop, 0);


### PR DESCRIPTION
This tests for the behavior being proposed in https://github.com/tc39/ecma262/pull/755.

Don't merge until we have consensus to merge that PR.