### PR TITLE
Mark namespace object toStringTag as non-configurable

### DIFF
--- a/test/language/module-code/namespace/Symbol.toStringTag.js
+++ b/test/language/module-code/namespace/Symbol.toStringTag.js
@@ -10,7 +10,7 @@ info: >
     "Module".
 
     This property has the attributes { [[Writable]]: false, [[Enumerable]]:
-    false, [[Configurable]]: true }.
+    false, [[Configurable]]: false }.
 flags: [module]
 features: [Symbol.toStringTag]
 ---*/
@@ -26,4 +26,4 @@ var desc = Object.getOwnPropertyDescriptor(ns, Symbol.toStringTag);
 
 assert.sameValue(desc.enumerable, false, 'reports as non-enumerable');
 assert.sameValue(desc.writable, false, 'reports as non-writable');
-assert.sameValue(desc.configurable, true, 'reports as configurable');
+assert.sameValue(desc.configurable, false, 'reports as non-configurable');

--- a/test/language/module-code/namespace/internals/get-own-property-sym.js
+++ b/test/language/module-code/namespace/internals/get-own-property-sym.js
@@ -28,7 +28,7 @@ desc = Object.getOwnPropertyDescriptor(ns, Symbol.toStringTag);
 assert.sameValue(desc.value, ns[Symbol.toStringTag]);
 assert.sameValue(desc.enumerable, false, 'Symbol.toStringTag enumerable');
 assert.sameValue(desc.writable, false, 'Symbol.toStringTag writable');
-assert.sameValue(desc.configurable, true, 'Symbol.toStringTag configurable');
+assert.sameValue(desc.configurable, false, 'Symbol.toStringTag configurable');
 
 assert.sameValue(Object.prototype.hasOwnProperty.call(ns, notFound), false);
 desc = Object.getOwnPropertyDescriptor(ns, notFound);


### PR DESCRIPTION
It [was changed](https://github.com/tc39/ecma262/pull/747) from configurable to non-configurable at the November 2016 meeting.