### PR TITLE
Remove last usage of arguments.caller

### DIFF
--- a/test/language/statements/class/strict-mode/arguments-callee.js
+++ b/test/language/statements/class/strict-mode/arguments-callee.js
@@ -6,7 +6,7 @@ description: >
     class strict mode
 ---*/
 var D = class extends function() {
-  arguments.caller;
+  arguments.callee;
 } {};
 assert.throws(TypeError, function() {
   Object.getPrototypeOf(D).arguments;


### PR DESCRIPTION
I missed this in https://github.com/tc39/test262/pull/797.

I've checked more thoroughly now; I think this was the only one overlooked.