### PR TITLE
Fix test for instantiating a class extending null

### DIFF
--- a/test/language/statements/class/subclass/class-definition-null-proto-missing-return-override.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto-missing-return-override.js
@@ -38,4 +38,4 @@ class Foo extends null {
 
 var foo = new Foo();
 
-assert.sameValue(Object.getPrototypeOf(foo), Foo);
+assert.sameValue(Object.getPrototypeOf(foo), Foo.prototype);


### PR DESCRIPTION
The sameValue assertion should be that the [[Prototype]] is
equal to the class's prototype, not the constructor.