### PR TITLE
Remove BYR currency code which has been removed from ISO 4217

### DIFF
--- a/test/intl402/NumberFormat/11.1.1_20_c.js
+++ b/test/intl402/NumberFormat/11.1.1_20_c.js
@@ -36,7 +36,6 @@ var currencyDigits = {
     BSD: 2,
     BTN: 2,
     BWP: 2,
-    BYR: 0,
     BZD: 2,
     CAD: 2,
     CDF: 2,


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=843758#c12

> 11.1.1_20_c.js expects BYR (Belarusian ruble) is still a valid currency code, but the latest currency update removed BYR (cf. ISO 4217 AMENDMENT NUMBER 161).