### PR TITLE
Test for case-insensitivity in invalid BCP 47 usage

### DIFF
--- a/test/intl402/6.2.2_b.js
+++ b/test/intl402/6.2.2_b.js
@@ -18,7 +18,9 @@ var invalidLanguageTags = [
     "i_klingon",
     "cmn-hans-cn-t-ca-u-ca-x_t-u",
     "enochian_enochian",
-    "de-gregory_u-ca-gregory"
+    "de-gregory_u-ca-gregory",
+    "de-tester-Tester",  // Case-insensitive duplicate variant subtag
+    "de-DE-u-kn-true-U-kn-true",  // Case-insensitive duplicate singleton subtag
 ];
 
 testWithIntlConstructors(function (Constructor) {


### PR DESCRIPTION
This patch adds a regression test for a previous V8 bug reported originally at
https://bugs.chromium.org/p/v8/issues/detail?id=4215