### PR TITLE
Add tests for known violation of invariants v2

### DIFF
--- a/test/built-ins/Object/internals/DefineOwnProperty/consistent-value-function-arguments.js
+++ b/test/built-ins/Object/internals/DefineOwnProperty/consistent-value-function-arguments.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2017 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-invariants-of-the-essential-internal-methods
+es6id: 6.1.7.3
+description: >
+  Value of non-writable, non-configurable data property must not change
+  ("arguments" property of a non-strict function)
+info: |
+  [[GetOwnProperty]] (P)
+  [...]
+  - If a property P is described as a data property with Desc.[[Value]] equal
+    to v and Desc.[[Writable]] and Desc.[[Configurable]] are both false, then
+    the SameValue must be returned for the Desc.[[Value]] attribute of the
+    property on all future calls to [[GetOwnProperty]] ( P ).
+  [...]
+  (This invariant was violated for the specific property under test by a number
+  of implementations as of January 2017.)
+---*/
+
+function f() {
+    return Reflect.getOwnPropertyDescriptor(f, 'arguments');
+}
+
+Reflect.defineProperty(f, 'arguments', { writable: false, configurable: false });
+
+var desc = Reflect.getOwnPropertyDescriptor(f, 'arguments');
+if (desc && desc.configurable === false && desc.writable === false) {
+    var desc2 = f();
+    assert.sameValue(desc.value, desc2.value);
+}

--- a/test/built-ins/Object/internals/DefineOwnProperty/consistent-value-function-caller.js
+++ b/test/built-ins/Object/internals/DefineOwnProperty/consistent-value-function-caller.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2017 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-invariants-of-the-essential-internal-methods
+es6id: 6.1.7.3
+description: >
+  Value of non-writable, non-configurable data property must not change
+  ("caller" property of a non-strict function)
+info: |
+  [[GetOwnProperty]] (P)
+  [...]
+  - If a property P is described as a data property with Desc.[[Value]] equal
+    to v and Desc.[[Writable]] and Desc.[[Configurable]] are both false, then
+    the SameValue must be returned for the Desc.[[Value]] attribute of the
+    property on all future calls to [[GetOwnProperty]] ( P ).
+  [...]
+  (This invariant was violated for the specific property under test by a number
+  of implementations as of January 2017.)
+---*/
+
+function f() {
+    return Reflect.getOwnPropertyDescriptor(f, 'caller');
+}
+
+function g() {
+    return f();
+}
+
+Reflect.defineProperty(f, 'caller', { writable: false, configurable: false });
+
+var desc = Reflect.getOwnPropertyDescriptor(f, 'caller');
+if (desc && desc.configurable === false && desc.writable === false) {
+    var desc2 = g();
+    assert.sameValue(desc.value, desc2.value);
+}

--- a/test/built-ins/Object/internals/DefineOwnProperty/consistent-value-regexp-$1.js
+++ b/test/built-ins/Object/internals/DefineOwnProperty/consistent-value-regexp-$1.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2017 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-invariants-of-the-essential-internal-methods
+es6id: 6.1.7.3
+description: >
+  Value of non-writable, non-configurable data property must not change
+  ("$1" property of the RegExp built-in)
+info: |
+  [[GetOwnProperty]] (P)
+  [...]
+  - If a property P is described as a data property with Desc.[[Value]] equal
+    to v and Desc.[[Writable]] and Desc.[[Configurable]] are both false, then
+    the SameValue must be returned for the Desc.[[Value]] attribute of the
+    property on all future calls to [[GetOwnProperty]] ( P ).
+  [...]
+  (This invariant was violated for the specific property under test by at least
+  one implementation as of January 2017.)
+---*/
+
+Reflect.defineProperty(RegExp, '$1', { writable: false, configurable: false });
+
+var desc = Reflect.getOwnPropertyDescriptor(RegExp, '$1');
+if (desc && desc.configurable === false && desc.writable === false) {
+    /(x)/.exec('x');
+    var desc2 = Reflect.getOwnPropertyDescriptor(RegExp, '$1');
+    assert.sameValue(desc.value, desc2.value);
+}

--- a/test/built-ins/Object/internals/DefineOwnProperty/consistent-writable-regexp-$1.js
+++ b/test/built-ins/Object/internals/DefineOwnProperty/consistent-writable-regexp-$1.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2017 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-invariants-of-the-essential-internal-methods
+es6id: 6.1.7.3
+description: >
+  A property made non-writable, non-configurable must not be reported as writable
+  ("$1" property of the RegExp built-in)
+info: |
+  [[GetOwnProperty]] (P)
+  [...]
+  - If the [[Writable]] attribute may change from false to true,
+    then the [[Configurable]] attribute must be true..
+  [...]
+  (This invariant was violated for the specific property under test by at least
+  one implementation as of January 2017.)
+---*/
+
+if (Reflect.defineProperty(RegExp, '$1', { writable: false, configurable: false })) {
+    var desc = Reflect.getOwnPropertyDescriptor(RegExp, '$1');
+    assert.sameValue(desc.writable, false);
+}


### PR DESCRIPTION
Subsumes #653 (issue with copyright/licence).
Resolves #649.
Also, add a test against a observed bug in Chakra: RegExp.$1 claims to successfully become non-writable, non-configurable, but remains writable.
