### PR TITLE
Add tests for accessor names

### DIFF
--- a/src/accessor-names/computed-err-evaluation.case
+++ b/src/accessor-names/computed-err-evaluation.case
@@ -1,0 +1,23 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Abrupt completion when evaluating expression
+template: error
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+---*/
+
+//- setup
+var thrower = function() {
+  throw new Test262Error();
+};
+
+//- error
+Test262Error
+//- name
+thrower()

--- a/src/accessor-names/computed-err-to-prop-key.case
+++ b/src/accessor-names/computed-err-to-prop-key.case
@@ -1,0 +1,39 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Abrupt completion when coercing to property key value
+template: error
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+
+  7.1.14 ToPropertyKey
+
+  1. Let key be ? ToPrimitive(argument, hint String).
+
+  7.1.1 ToPrimitive
+
+  [...]
+  7. Return ? OrdinaryToPrimitive(input, hint).
+
+  7.1.1.1 OrdinaryToPrimitive
+
+  5. For each name in methodNames in List order, do
+     [...]
+  6. Throw a TypeError exception.
+---*/
+
+//- setup
+var badKey = Object.create(null);
+
+//- error
+TypeError
+//- name
+badKey

--- a/src/accessor-names/computed-err-unresolvable.case
+++ b/src/accessor-names/computed-err-unresolvable.case
@@ -1,0 +1,20 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Abrupt completion when resolving reference value
+template: error
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+---*/
+
+//- error
+ReferenceError
+//- name
+test262unresolvable

--- a/src/accessor-names/computed.case
+++ b/src/accessor-names/computed.case
@@ -1,0 +1,24 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (AssignmentExpression)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- setup
+var _;
+
+//- declareWith
+[_ = 'str' + 'ing']
+//- referenceWith
+'string'

--- a/src/accessor-names/default/cls-decl-inst.template
+++ b/src/accessor-names/default/cls-decl-inst.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/class/accessor-name-inst-
+name: Class declaration, instance method
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         i. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments proto and false.
+---*/
+
+var stringSet;
+
+class C {
+  get /*{ declareWith }*/() { return 'get string'; }
+  set /*{ declareWith }*/(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype[/*{ referenceWith }*/], 'get string');
+
+C.prototype[/*{ referenceWith }*/] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/src/accessor-names/default/cls-decl-static.template
+++ b/src/accessor-names/default/cls-decl-static.template
@@ -1,0 +1,28 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/class/accessor-name-static-
+name: Class declaration, static method
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         [...]
+      b. Else,
+         a. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments F and false.
+---*/
+
+var stringSet;
+
+class C {
+  static get /*{ declareWith }*/() { return 'get string'; }
+  static set /*{ declareWith }*/(param) { stringSet = param; }
+}
+
+assert.sameValue(C[/*{ referenceWith }*/], 'get string');
+
+C[/*{ referenceWith }*/] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/src/accessor-names/default/cls-expr-inst.template
+++ b/src/accessor-names/default/cls-expr-inst.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/class/accessor-name-inst-
+name: Class expression, instance method
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         i. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments proto and false.
+---*/
+
+var stringSet;
+
+var C = class {
+  get /*{ declareWith }*/() { return 'get string'; }
+  set /*{ declareWith }*/(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype[/*{ referenceWith }*/], 'get string');
+
+C.prototype[/*{ referenceWith }*/] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/src/accessor-names/default/cls-expr-static.template
+++ b/src/accessor-names/default/cls-expr-static.template
@@ -1,0 +1,28 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/class/accessor-name-static-
+name: Class expression, static method
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         [...]
+      b. Else,
+         a. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments F and false.
+---*/
+
+var stringSet;
+
+var C = class {
+  static get /*{ declareWith }*/() { return 'get string'; }
+  static set /*{ declareWith }*/(param) { stringSet = param; }
+};
+
+assert.sameValue(C[/*{ referenceWith }*/], 'get string');
+
+C[/*{ referenceWith }*/] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/src/accessor-names/default/obj.template
+++ b/src/accessor-names/default/obj.template
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/object/accessor-name-
+name: Object initializer
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+info: |
+  ObjectLiteral :
+    { PropertyDefinitionList }
+    { PropertyDefinitionList , }
+
+  1. Let obj be ObjectCreate(%ObjectPrototype%).
+  2. Let status be the result of performing PropertyDefinitionEvaluation of
+     PropertyDefinitionList with arguments obj and true.
+---*/
+
+var stringSet;
+var obj = {
+  get [/*{ declareWith }*/]() { return 'get string'; },
+  set [/*{ declareWith }*/](param) { stringSet = param; }
+};
+
+assert.sameValue(obj[/*{ referenceWith }*/], 'get string');
+
+obj[/*{ referenceWith }*/] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/src/accessor-names/error/cls-decl-inst.template
+++ b/src/accessor-names/error/cls-decl-inst.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/class/accessor-name-inst-
+name: Class declaration, instance method
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         i. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments proto and false.
+---*/
+
+assert.throws(/*{ error }*/, function() {
+  class C {
+    get [/*{ name }*/]() {}
+  }
+}, '`get` accessor');
+
+assert.throws(/*{ error }*/, function() {
+  class C {
+    set [/*{ name }*/](_) {}
+  }
+}, '`set` accessor');

--- a/src/accessor-names/error/cls-decl-static.template
+++ b/src/accessor-names/error/cls-decl-static.template
@@ -1,0 +1,28 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/class/accessor-name-static-
+name: Class declaration, static method
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         [...]
+      b. Else,
+         a. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments F and false.
+---*/
+
+assert.throws(/*{ error }*/, function() {
+  class C {
+    static get [/*{ name }*/]() {}
+  }
+}, '`get` accessor');
+
+assert.throws(/*{ error }*/, function() {
+  class C {
+    static set [/*{ name }*/](_) {}
+  }
+}, '`set` accessor');

--- a/src/accessor-names/error/cls-expr-inst.template
+++ b/src/accessor-names/error/cls-expr-inst.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/class/accessor-name-inst-
+name: Class expression, instance method
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         i. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments proto and false.
+---*/
+
+assert.throws(/*{ error }*/, function() {
+  0, class {
+    get [/*{ name }*/]() {}
+  };
+}, '`get` accessor');
+
+assert.throws(/*{ error }*/, function() {
+  0, class {
+    set [/*{ name }*/](_) {}
+  };
+}, '`set` accessor');

--- a/src/accessor-names/error/cls-expr-static.template
+++ b/src/accessor-names/error/cls-expr-static.template
@@ -1,0 +1,28 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/class/accessor-name-static-
+name: Class expression, static method
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         [...]
+      b. Else,
+         a. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments F and false.
+---*/
+
+assert.throws(/*{ error }*/, function() {
+  0, class {
+    static get [/*{ name }*/]() {}
+  };
+}, '`get` accessor');
+
+assert.throws(/*{ error }*/, function() {
+  0, class {
+    static set [/*{ name }*/](_) {}
+  };
+}, '`set` accessor');

--- a/src/accessor-names/error/obj.template
+++ b/src/accessor-names/error/obj.template
@@ -1,0 +1,28 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/object/accessor-name-
+name: Object initializer
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+info: |
+  ObjectLiteral :
+    { PropertyDefinitionList }
+    { PropertyDefinitionList , }
+
+  1. Let obj be ObjectCreate(%ObjectPrototype%).
+  2. Let status be the result of performing PropertyDefinitionEvaluation of
+     PropertyDefinitionList with arguments obj and true.
+---*/
+
+assert.throws(/*{ error }*/, function() {
+  ({
+    get [/*{ name }*/]() {}
+  });
+}, '`get` accessor');
+
+assert.throws(/*{ error }*/, function() {
+  ({
+    set [/*{ name }*/](_) {}
+  });
+}, '`set` accessor');

--- a/src/accessor-names/literal-numeric-binary.case
+++ b/src/accessor-names/literal-numeric-binary.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (numeric literal in binary notation)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- declareWith
+0b10
+//- referenceWith
+'2'

--- a/src/accessor-names/literal-numeric-exponent.case
+++ b/src/accessor-names/literal-numeric-exponent.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (numeric literal in exponent notation)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- declareWith
+1E+9
+//- referenceWith
+'1000000000'

--- a/src/accessor-names/literal-numeric-hex.case
+++ b/src/accessor-names/literal-numeric-hex.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (numeric literal in hexadecimal notation)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- declareWith
+0x10
+//- referenceWith
+'16'

--- a/src/accessor-names/literal-numeric-leading-decimal.case
+++ b/src/accessor-names/literal-numeric-leading-decimal.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (numeric literal with leading decimal point)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- declareWith
+.1
+//- referenceWith
+'0.1'

--- a/src/accessor-names/literal-numeric-non-canonical.case
+++ b/src/accessor-names/literal-numeric-non-canonical.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (numeric literal with non-canonical representation)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- declareWith
+0.0000001
+//- referenceWith
+'1e-7'

--- a/src/accessor-names/literal-numeric-octal.case
+++ b/src/accessor-names/literal-numeric-octal.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (numeric literal in octal notation)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- declareWith
+0o10
+//- referenceWith
+'8'

--- a/src/accessor-names/literal-numeric-zero.case
+++ b/src/accessor-names/literal-numeric-zero.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (numeric literal zero)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- declareWith
+0
+//- referenceWith
+'0'

--- a/src/accessor-names/literal-string-char-escape.case
+++ b/src/accessor-names/literal-string-char-escape.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (string literal containing a character escape sequence)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- declareWith
+'character\tescape'
+//- referenceWith
+'character	escape'

--- a/src/accessor-names/literal-string-double-quote.case
+++ b/src/accessor-names/literal-string-double-quote.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (string literal using double quotes)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- declareWith
+"singleQuote"
+//- referenceWith
+"singleQuote"

--- a/src/accessor-names/literal-string-double-quote.case
+++ b/src/accessor-names/literal-string-double-quote.case
@@ -16,6 +16,6 @@ info: |
 ---*/
 
 //- declareWith
-"singleQuote"
+"doubleQuote"
 //- referenceWith
-"singleQuote"
+"doubleQuote"

--- a/src/accessor-names/literal-string-empty.case
+++ b/src/accessor-names/literal-string-empty.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (string literal, the empty string)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- declareWith
+''
+//- referenceWith
+''

--- a/src/accessor-names/literal-string-hex-escape.case
+++ b/src/accessor-names/literal-string-hex-escape.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (string literal containing a hexadecimal escape sequence)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- declareWith
+'hex\x45scape'
+//- referenceWith
+'hexEscape'

--- a/src/accessor-names/literal-string-single-quote.case
+++ b/src/accessor-names/literal-string-single-quote.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (string literal using single quotes)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- declareWith
+'singleQuote'
+//- referenceWith
+'singleQuote'

--- a/src/accessor-names/literal-string-unicode-escape.case
+++ b/src/accessor-names/literal-string-unicode-escape.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (string literal containing a Unicode escape sequence)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- declareWith
+'unicod\u{000065}Escape'
+//- referenceWith
+'unicodeEscape'

--- a/test/language/expressions/class/accessor-name-inst-computed-err-evaluation.js
+++ b/test/language/expressions/class/accessor-name-inst-computed-err-evaluation.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-evaluation.case
+// - src/accessor-names/error/cls-expr-inst.template
+/*---
+description: Abrupt completion when evaluating expression (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+---*/
+var thrower = function() {
+  throw new Test262Error();
+};
+
+
+assert.throws(Test262Error, function() {
+  0, class {
+    get [thrower()]() {}
+  };
+}, '`get` accessor');
+
+assert.throws(Test262Error, function() {
+  0, class {
+    set [thrower()](_) {}
+  };
+}, '`set` accessor');

--- a/test/language/expressions/class/accessor-name-inst-computed-err-to-prop-key.js
+++ b/test/language/expressions/class/accessor-name-inst-computed-err-to-prop-key.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-to-prop-key.case
+// - src/accessor-names/error/cls-expr-inst.template
+/*---
+description: Abrupt completion when coercing to property key value (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+
+    7.1.14 ToPropertyKey
+
+    1. Let key be ? ToPrimitive(argument, hint String).
+
+    7.1.1 ToPrimitive
+
+    [...]
+    7. Return ? OrdinaryToPrimitive(input, hint).
+
+    7.1.1.1 OrdinaryToPrimitive
+
+    5. For each name in methodNames in List order, do
+       [...]
+    6. Throw a TypeError exception.
+---*/
+var badKey = Object.create(null);
+
+
+assert.throws(TypeError, function() {
+  0, class {
+    get [badKey]() {}
+  };
+}, '`get` accessor');
+
+assert.throws(TypeError, function() {
+  0, class {
+    set [badKey](_) {}
+  };
+}, '`set` accessor');

--- a/test/language/expressions/class/accessor-name-inst-computed-err-unresolvable.js
+++ b/test/language/expressions/class/accessor-name-inst-computed-err-unresolvable.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-unresolvable.case
+// - src/accessor-names/error/cls-expr-inst.template
+/*---
+description: Abrupt completion when resolving reference value (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+---*/
+
+assert.throws(ReferenceError, function() {
+  0, class {
+    get [test262unresolvable]() {}
+  };
+}, '`get` accessor');
+
+assert.throws(ReferenceError, function() {
+  0, class {
+    set [test262unresolvable](_) {}
+  };
+}, '`set` accessor');

--- a/test/language/expressions/class/accessor-name-inst-computed-in.js
+++ b/test/language/expressions/class/accessor-name-inst-computed-in.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+description: >
+  AssignmentExpression may contain `in` keyword regardless of outer context
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         i. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments proto and false.
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+var empty = Object.create(null);
+var C, value;
+
+for (C = class { get ['x' in empty]() { return 'via get'; } }; ; ) {
+  value = C.prototype.false;
+  break;
+}
+
+assert.sameValue(value, 'via get');
+
+for (C = class { set ['x' in empty](param) { value = param; } }; ; ) {
+  C.prototype.false = 'via set';
+  break;
+}
+
+assert.sameValue(value, 'via set');

--- a/test/language/expressions/class/accessor-name-inst-computed-yield-expr.js
+++ b/test/language/expressions/class/accessor-name-inst-computed-yield-expr.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+description: >
+  The `yield` keyword behaves as a YieldExpression within a generator function
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         i. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments proto and false.
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+features: [generators]
+---*/
+
+var yieldSet, C, iter;
+function* g() {
+  C = class {
+    get [yield]() { return 'get yield'; }
+    set [yield](param) { yieldSet = param; }
+  };
+}
+
+iter = g();
+
+iter.next();
+iter.next('first');
+iter.next('second');
+
+assert.sameValue(C.prototype.first, 'get yield');
+
+C.prototype.second = 'set yield';
+
+assert.sameValue(yieldSet, 'set yield');

--- a/test/language/expressions/class/accessor-name-inst-computed.js
+++ b/test/language/expressions/class/accessor-name-inst-computed.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed.case
+// - src/accessor-names/default/cls-expr-inst.template
+/*---
+description: Computed values as accessor property names (AssignmentExpression) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+var _;
+
+
+var stringSet;
+
+var C = class {
+  get [_ = 'str' + 'ing']() { return 'get string'; }
+  set [_ = 'str' + 'ing'](param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype['string'], 'get string');
+
+C.prototype['string'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-numeric-binary.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-numeric-binary.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-binary.case
+// - src/accessor-names/default/cls-expr-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in binary notation) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get 0b10() { return 'get string'; }
+  set 0b10(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype['2'], 'get string');
+
+C.prototype['2'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-numeric-exponent.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-numeric-exponent.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-exponent.case
+// - src/accessor-names/default/cls-expr-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in exponent notation) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get 1E+9() { return 'get string'; }
+  set 1E+9(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype['1000000000'], 'get string');
+
+C.prototype['1000000000'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-numeric-hex.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-numeric-hex.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-hex.case
+// - src/accessor-names/default/cls-expr-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in hexadecimal notation) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get 0x10() { return 'get string'; }
+  set 0x10(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype['16'], 'get string');
+
+C.prototype['16'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-numeric-leading-decimal.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-numeric-leading-decimal.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-leading-decimal.case
+// - src/accessor-names/default/cls-expr-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal with leading decimal point) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get .1() { return 'get string'; }
+  set .1(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype['0.1'], 'get string');
+
+C.prototype['0.1'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-numeric-non-canonical.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-numeric-non-canonical.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-non-canonical.case
+// - src/accessor-names/default/cls-expr-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal with non-canonical representation) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get 0.0000001() { return 'get string'; }
+  set 0.0000001(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype['1e-7'], 'get string');
+
+C.prototype['1e-7'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-numeric-octal.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-numeric-octal.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-octal.case
+// - src/accessor-names/default/cls-expr-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in octal notation) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get 0o10() { return 'get string'; }
+  set 0o10(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype['8'], 'get string');
+
+C.prototype['8'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-numeric-zero.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-numeric-zero.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-zero.case
+// - src/accessor-names/default/cls-expr-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal zero) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get 0() { return 'get string'; }
+  set 0(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype['0'], 'get string');
+
+C.prototype['0'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-string-char-escape.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-string-char-escape.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-char-escape.case
+// - src/accessor-names/default/cls-expr-inst.template
+/*---
+description: Computed values as accessor property names (string literal containing a character escape sequence) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get 'character\tescape'() { return 'get string'; }
+  set 'character\tescape'(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype['character	escape'], 'get string');
+
+C.prototype['character	escape'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-string-double-quote.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-string-double-quote.js
@@ -27,11 +27,11 @@ info: |
 var stringSet;
 
 var C = class {
-  get "singleQuote"() { return 'get string'; }
-  set "singleQuote"(param) { stringSet = param; }
+  get "doubleQuote"() { return 'get string'; }
+  set "doubleQuote"(param) { stringSet = param; }
 };
 
-assert.sameValue(C.prototype["singleQuote"], 'get string');
+assert.sameValue(C.prototype["doubleQuote"], 'get string');
 
-C.prototype["singleQuote"] = 'set string';
+C.prototype["doubleQuote"] = 'set string';
 assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-string-double-quote.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-string-double-quote.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-double-quote.case
+// - src/accessor-names/default/cls-expr-inst.template
+/*---
+description: Computed values as accessor property names (string literal using double quotes) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get "singleQuote"() { return 'get string'; }
+  set "singleQuote"(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype["singleQuote"], 'get string');
+
+C.prototype["singleQuote"] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-string-empty.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-string-empty.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-empty.case
+// - src/accessor-names/default/cls-expr-inst.template
+/*---
+description: Computed values as accessor property names (string literal, the empty string) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get ''() { return 'get string'; }
+  set ''(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype[''], 'get string');
+
+C.prototype[''] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-string-hex-escape.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-string-hex-escape.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-hex-escape.case
+// - src/accessor-names/default/cls-expr-inst.template
+/*---
+description: Computed values as accessor property names (string literal containing a hexadecimal escape sequence) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get 'hex\x45scape'() { return 'get string'; }
+  set 'hex\x45scape'(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype['hexEscape'], 'get string');
+
+C.prototype['hexEscape'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-string-line-terminator.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-string-line-terminator.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Computed values as accessor property names (string literal containing a line terminator) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get 'line\
+Terminator'
+() { return 'get string'; }
+  set 'line\
+Terminator'
+(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype['lineTerminator'], 'get string');
+
+C.prototype['lineTerminator'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-string-single-quote.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-string-single-quote.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-single-quote.case
+// - src/accessor-names/default/cls-expr-inst.template
+/*---
+description: Computed values as accessor property names (string literal using single quotes) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get 'singleQuote'() { return 'get string'; }
+  set 'singleQuote'(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype['singleQuote'], 'get string');
+
+C.prototype['singleQuote'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-inst-literal-string-unicode-escape.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-string-unicode-escape.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-unicode-escape.case
+// - src/accessor-names/default/cls-expr-inst.template
+/*---
+description: Computed values as accessor property names (string literal containing a Unicode escape sequence) (Class expression, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get 'unicod\u{000065}Escape'() { return 'get string'; }
+  set 'unicod\u{000065}Escape'(param) { stringSet = param; }
+};
+
+assert.sameValue(C.prototype['unicodeEscape'], 'get string');
+
+C.prototype['unicodeEscape'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-computed-err-evaluation.js
+++ b/test/language/expressions/class/accessor-name-static-computed-err-evaluation.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-evaluation.case
+// - src/accessor-names/error/cls-expr-static.template
+/*---
+description: Abrupt completion when evaluating expression (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+---*/
+var thrower = function() {
+  throw new Test262Error();
+};
+
+
+assert.throws(Test262Error, function() {
+  0, class {
+    static get [thrower()]() {}
+  };
+}, '`get` accessor');
+
+assert.throws(Test262Error, function() {
+  0, class {
+    static set [thrower()](_) {}
+  };
+}, '`set` accessor');

--- a/test/language/expressions/class/accessor-name-static-computed-err-to-prop-key.js
+++ b/test/language/expressions/class/accessor-name-static-computed-err-to-prop-key.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-to-prop-key.case
+// - src/accessor-names/error/cls-expr-static.template
+/*---
+description: Abrupt completion when coercing to property key value (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+
+    7.1.14 ToPropertyKey
+
+    1. Let key be ? ToPrimitive(argument, hint String).
+
+    7.1.1 ToPrimitive
+
+    [...]
+    7. Return ? OrdinaryToPrimitive(input, hint).
+
+    7.1.1.1 OrdinaryToPrimitive
+
+    5. For each name in methodNames in List order, do
+       [...]
+    6. Throw a TypeError exception.
+---*/
+var badKey = Object.create(null);
+
+
+assert.throws(TypeError, function() {
+  0, class {
+    static get [badKey]() {}
+  };
+}, '`get` accessor');
+
+assert.throws(TypeError, function() {
+  0, class {
+    static set [badKey](_) {}
+  };
+}, '`set` accessor');

--- a/test/language/expressions/class/accessor-name-static-computed-err-unresolvable.js
+++ b/test/language/expressions/class/accessor-name-static-computed-err-unresolvable.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-unresolvable.case
+// - src/accessor-names/error/cls-expr-static.template
+/*---
+description: Abrupt completion when resolving reference value (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+---*/
+
+assert.throws(ReferenceError, function() {
+  0, class {
+    static get [test262unresolvable]() {}
+  };
+}, '`get` accessor');
+
+assert.throws(ReferenceError, function() {
+  0, class {
+    static set [test262unresolvable](_) {}
+  };
+}, '`set` accessor');

--- a/test/language/expressions/class/accessor-name-static-computed-in.js
+++ b/test/language/expressions/class/accessor-name-static-computed-in.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+description: >
+  AssignmentExpression may contain `in` keyword regardless of outer context
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         [...]
+      b. Else,
+         a. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments F and false.
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+var empty = Object.create(null);
+var C, value;
+
+for (C = class { static get ['x' in empty]() { return 'via get'; } }; ; ) {
+  value = C.false;
+  break;
+}
+
+assert.sameValue(value, 'via get');
+
+for (C = class { static set ['x' in empty](param) { value = param; } }; ; ) {
+  C.false = 'via set';
+  break;
+}
+
+assert.sameValue(value, 'via set');

--- a/test/language/expressions/class/accessor-name-static-computed-yield-expr.js
+++ b/test/language/expressions/class/accessor-name-static-computed-yield-expr.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+description: >
+  The `yield` keyword behaves as a YieldExpression within a generator function
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         [...]
+      b. Else,
+         a. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments F and false.
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+features: [generators]
+---*/
+
+var yieldSet, C, iter;
+function* g() {
+  C = class {
+    static get [yield]() { return 'get yield'; }
+    static set [yield](param) { yieldSet = param; }
+  };
+}
+
+iter = g();
+
+iter.next();
+iter.next('first');
+iter.next('second');
+
+assert.sameValue(C.first, 'get yield');
+
+C.second = 'set yield';
+
+assert.sameValue(yieldSet, 'set yield');

--- a/test/language/expressions/class/accessor-name-static-computed.js
+++ b/test/language/expressions/class/accessor-name-static-computed.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed.case
+// - src/accessor-names/default/cls-expr-static.template
+/*---
+description: Computed values as accessor property names (AssignmentExpression) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+var _;
+
+
+var stringSet;
+
+var C = class {
+  static get [_ = 'str' + 'ing']() { return 'get string'; }
+  static set [_ = 'str' + 'ing'](param) { stringSet = param; }
+};
+
+assert.sameValue(C['string'], 'get string');
+
+C['string'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-numeric-binary.js
+++ b/test/language/expressions/class/accessor-name-static-literal-numeric-binary.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-binary.case
+// - src/accessor-names/default/cls-expr-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in binary notation) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get 0b10() { return 'get string'; }
+  static set 0b10(param) { stringSet = param; }
+};
+
+assert.sameValue(C['2'], 'get string');
+
+C['2'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-numeric-exponent.js
+++ b/test/language/expressions/class/accessor-name-static-literal-numeric-exponent.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-exponent.case
+// - src/accessor-names/default/cls-expr-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in exponent notation) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get 1E+9() { return 'get string'; }
+  static set 1E+9(param) { stringSet = param; }
+};
+
+assert.sameValue(C['1000000000'], 'get string');
+
+C['1000000000'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-numeric-hex.js
+++ b/test/language/expressions/class/accessor-name-static-literal-numeric-hex.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-hex.case
+// - src/accessor-names/default/cls-expr-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in hexadecimal notation) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get 0x10() { return 'get string'; }
+  static set 0x10(param) { stringSet = param; }
+};
+
+assert.sameValue(C['16'], 'get string');
+
+C['16'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-numeric-leading-decimal.js
+++ b/test/language/expressions/class/accessor-name-static-literal-numeric-leading-decimal.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-leading-decimal.case
+// - src/accessor-names/default/cls-expr-static.template
+/*---
+description: Computed values as accessor property names (numeric literal with leading decimal point) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get .1() { return 'get string'; }
+  static set .1(param) { stringSet = param; }
+};
+
+assert.sameValue(C['0.1'], 'get string');
+
+C['0.1'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-numeric-non-canonical.js
+++ b/test/language/expressions/class/accessor-name-static-literal-numeric-non-canonical.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-non-canonical.case
+// - src/accessor-names/default/cls-expr-static.template
+/*---
+description: Computed values as accessor property names (numeric literal with non-canonical representation) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get 0.0000001() { return 'get string'; }
+  static set 0.0000001(param) { stringSet = param; }
+};
+
+assert.sameValue(C['1e-7'], 'get string');
+
+C['1e-7'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-numeric-octal.js
+++ b/test/language/expressions/class/accessor-name-static-literal-numeric-octal.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-octal.case
+// - src/accessor-names/default/cls-expr-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in octal notation) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get 0o10() { return 'get string'; }
+  static set 0o10(param) { stringSet = param; }
+};
+
+assert.sameValue(C['8'], 'get string');
+
+C['8'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-numeric-zero.js
+++ b/test/language/expressions/class/accessor-name-static-literal-numeric-zero.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-zero.case
+// - src/accessor-names/default/cls-expr-static.template
+/*---
+description: Computed values as accessor property names (numeric literal zero) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get 0() { return 'get string'; }
+  static set 0(param) { stringSet = param; }
+};
+
+assert.sameValue(C['0'], 'get string');
+
+C['0'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-string-char-escape.js
+++ b/test/language/expressions/class/accessor-name-static-literal-string-char-escape.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-char-escape.case
+// - src/accessor-names/default/cls-expr-static.template
+/*---
+description: Computed values as accessor property names (string literal containing a character escape sequence) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get 'character\tescape'() { return 'get string'; }
+  static set 'character\tescape'(param) { stringSet = param; }
+};
+
+assert.sameValue(C['character	escape'], 'get string');
+
+C['character	escape'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-string-double-quote.js
+++ b/test/language/expressions/class/accessor-name-static-literal-string-double-quote.js
@@ -29,11 +29,11 @@ info: |
 var stringSet;
 
 var C = class {
-  static get "singleQuote"() { return 'get string'; }
-  static set "singleQuote"(param) { stringSet = param; }
+  static get "doubleQuote"() { return 'get string'; }
+  static set "doubleQuote"(param) { stringSet = param; }
 };
 
-assert.sameValue(C["singleQuote"], 'get string');
+assert.sameValue(C["doubleQuote"], 'get string');
 
-C["singleQuote"] = 'set string';
+C["doubleQuote"] = 'set string';
 assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-string-double-quote.js
+++ b/test/language/expressions/class/accessor-name-static-literal-string-double-quote.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-double-quote.case
+// - src/accessor-names/default/cls-expr-static.template
+/*---
+description: Computed values as accessor property names (string literal using double quotes) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get "singleQuote"() { return 'get string'; }
+  static set "singleQuote"(param) { stringSet = param; }
+};
+
+assert.sameValue(C["singleQuote"], 'get string');
+
+C["singleQuote"] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-string-empty.js
+++ b/test/language/expressions/class/accessor-name-static-literal-string-empty.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-empty.case
+// - src/accessor-names/default/cls-expr-static.template
+/*---
+description: Computed values as accessor property names (string literal, the empty string) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get ''() { return 'get string'; }
+  static set ''(param) { stringSet = param; }
+};
+
+assert.sameValue(C[''], 'get string');
+
+C[''] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-string-hex-escape.js
+++ b/test/language/expressions/class/accessor-name-static-literal-string-hex-escape.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-hex-escape.case
+// - src/accessor-names/default/cls-expr-static.template
+/*---
+description: Computed values as accessor property names (string literal containing a hexadecimal escape sequence) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get 'hex\x45scape'() { return 'get string'; }
+  static set 'hex\x45scape'(param) { stringSet = param; }
+};
+
+assert.sameValue(C['hexEscape'], 'get string');
+
+C['hexEscape'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-string-line-terminator.js
+++ b/test/language/expressions/class/accessor-name-static-literal-string-line-terminator.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Computed values as accessor property names (string literal containing a line terminator) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get 'line\
+Terminator'
+() { return 'get string'; }
+  static set 'line\
+Terminator'
+(param) { stringSet = param; }
+};
+
+assert.sameValue(C['lineTerminator'], 'get string');
+
+C['lineTerminator'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-string-single-quote.js
+++ b/test/language/expressions/class/accessor-name-static-literal-string-single-quote.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-single-quote.case
+// - src/accessor-names/default/cls-expr-static.template
+/*---
+description: Computed values as accessor property names (string literal using single quotes) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get 'singleQuote'() { return 'get string'; }
+  static set 'singleQuote'(param) { stringSet = param; }
+};
+
+assert.sameValue(C['singleQuote'], 'get string');
+
+C['singleQuote'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-string-unicode-escape.js
+++ b/test/language/expressions/class/accessor-name-static-literal-string-unicode-escape.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-unicode-escape.case
+// - src/accessor-names/default/cls-expr-static.template
+/*---
+description: Computed values as accessor property names (string literal containing a Unicode escape sequence) (Class expression, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get 'unicod\u{000065}Escape'() { return 'get string'; }
+  static set 'unicod\u{000065}Escape'(param) { stringSet = param; }
+};
+
+assert.sameValue(C['unicodeEscape'], 'get string');
+
+C['unicodeEscape'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-computed-err-evaluation.js
+++ b/test/language/expressions/object/accessor-name-computed-err-evaluation.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-evaluation.case
+// - src/accessor-names/error/obj.template
+/*---
+description: Abrupt completion when evaluating expression (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+---*/
+var thrower = function() {
+  throw new Test262Error();
+};
+
+
+assert.throws(Test262Error, function() {
+  ({
+    get [thrower()]() {}
+  });
+}, '`get` accessor');
+
+assert.throws(Test262Error, function() {
+  ({
+    set [thrower()](_) {}
+  });
+}, '`set` accessor');

--- a/test/language/expressions/object/accessor-name-computed-err-to-prop-key.js
+++ b/test/language/expressions/object/accessor-name-computed-err-to-prop-key.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-to-prop-key.case
+// - src/accessor-names/error/obj.template
+/*---
+description: Abrupt completion when coercing to property key value (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+
+    7.1.14 ToPropertyKey
+
+    1. Let key be ? ToPrimitive(argument, hint String).
+
+    7.1.1 ToPrimitive
+
+    [...]
+    7. Return ? OrdinaryToPrimitive(input, hint).
+
+    7.1.1.1 OrdinaryToPrimitive
+
+    5. For each name in methodNames in List order, do
+       [...]
+    6. Throw a TypeError exception.
+---*/
+var badKey = Object.create(null);
+
+
+assert.throws(TypeError, function() {
+  ({
+    get [badKey]() {}
+  });
+}, '`get` accessor');
+
+assert.throws(TypeError, function() {
+  ({
+    set [badKey](_) {}
+  });
+}, '`set` accessor');

--- a/test/language/expressions/object/accessor-name-computed-err-unresolvable.js
+++ b/test/language/expressions/object/accessor-name-computed-err-unresolvable.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-unresolvable.case
+// - src/accessor-names/error/obj.template
+/*---
+description: Abrupt completion when resolving reference value (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+---*/
+
+assert.throws(ReferenceError, function() {
+  ({
+    get [test262unresolvable]() {}
+  });
+}, '`get` accessor');
+
+assert.throws(ReferenceError, function() {
+  ({
+    set [test262unresolvable](_) {}
+  });
+}, '`set` accessor');

--- a/test/language/expressions/object/accessor-name-computed-in.js
+++ b/test/language/expressions/object/accessor-name-computed-in.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+description: >
+  AssignmentExpression may contain `in` keyword regardless of outer context
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+var empty = Object.create(null);
+var obj, value;
+
+for (obj = { get ['x' in empty]() { return 'via get'; } }; ; ) {
+  value = obj.false;
+  break;
+}
+
+assert.sameValue(value, 'via get');
+
+for (obj = { set ['x' in empty](param) { value = param; } }; ; ) {
+  obj.false = 'via set';
+  break;
+}
+
+assert.sameValue(value, 'via set');

--- a/test/language/expressions/object/accessor-name-computed-yield-expr.js
+++ b/test/language/expressions/object/accessor-name-computed-yield-expr.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+description: >
+  The `yield` keyword behaves as a YieldExpression within a generator function
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+features: [generators]
+---*/
+
+var yieldSet, obj, iter;
+function* g() {
+  obj = {
+    get [yield]() { return 'get yield'; },
+    set [yield](param) { yieldSet = param; }
+  };
+}
+
+iter = g();
+
+iter.next();
+iter.next('first');
+iter.next('second');
+
+assert.sameValue(obj.first, 'get yield');
+
+obj.second = 'set yield';
+
+assert.sameValue(yieldSet, 'set yield');

--- a/test/language/expressions/object/accessor-name-computed-yield-id.js
+++ b/test/language/expressions/object/accessor-name-computed-yield-id.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+description: >
+  The `yield` keyword behaves as an Identifier outside of a generator function
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+flags: [noStrict]
+---*/
+
+var yield = 'y';
+var yieldSet;
+var obj = {
+  get [yield]() { return 'get yield'; },
+  set [yield](param) { yieldSet = param; }
+};
+
+assert.sameValue(obj.y, 'get yield');
+
+obj.y = 'set yield';
+
+assert.sameValue(yieldSet, 'set yield');

--- a/test/language/expressions/object/accessor-name-computed.js
+++ b/test/language/expressions/object/accessor-name-computed.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed.case
+// - src/accessor-names/default/obj.template
+/*---
+description: Computed values as accessor property names (AssignmentExpression) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+var _;
+
+
+var stringSet;
+var obj = {
+  get [[_ = 'str' + 'ing']]() { return 'get string'; },
+  set [[_ = 'str' + 'ing']](param) { stringSet = param; }
+};
+
+assert.sameValue(obj['string'], 'get string');
+
+obj['string'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-numeric-binary.js
+++ b/test/language/expressions/object/accessor-name-literal-numeric-binary.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-binary.case
+// - src/accessor-names/default/obj.template
+/*---
+description: Computed values as accessor property names (numeric literal in binary notation) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+var obj = {
+  get [0b10]() { return 'get string'; },
+  set [0b10](param) { stringSet = param; }
+};
+
+assert.sameValue(obj['2'], 'get string');
+
+obj['2'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-numeric-exponent.js
+++ b/test/language/expressions/object/accessor-name-literal-numeric-exponent.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-exponent.case
+// - src/accessor-names/default/obj.template
+/*---
+description: Computed values as accessor property names (numeric literal in exponent notation) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+var obj = {
+  get [1E+9]() { return 'get string'; },
+  set [1E+9](param) { stringSet = param; }
+};
+
+assert.sameValue(obj['1000000000'], 'get string');
+
+obj['1000000000'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-numeric-hex.js
+++ b/test/language/expressions/object/accessor-name-literal-numeric-hex.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-hex.case
+// - src/accessor-names/default/obj.template
+/*---
+description: Computed values as accessor property names (numeric literal in hexadecimal notation) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+var obj = {
+  get [0x10]() { return 'get string'; },
+  set [0x10](param) { stringSet = param; }
+};
+
+assert.sameValue(obj['16'], 'get string');
+
+obj['16'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-numeric-leading-decimal.js
+++ b/test/language/expressions/object/accessor-name-literal-numeric-leading-decimal.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-leading-decimal.case
+// - src/accessor-names/default/obj.template
+/*---
+description: Computed values as accessor property names (numeric literal with leading decimal point) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+var obj = {
+  get [.1]() { return 'get string'; },
+  set [.1](param) { stringSet = param; }
+};
+
+assert.sameValue(obj['0.1'], 'get string');
+
+obj['0.1'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-numeric-non-canonical.js
+++ b/test/language/expressions/object/accessor-name-literal-numeric-non-canonical.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-non-canonical.case
+// - src/accessor-names/default/obj.template
+/*---
+description: Computed values as accessor property names (numeric literal with non-canonical representation) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+var obj = {
+  get [0.0000001]() { return 'get string'; },
+  set [0.0000001](param) { stringSet = param; }
+};
+
+assert.sameValue(obj['1e-7'], 'get string');
+
+obj['1e-7'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-numeric-octal.js
+++ b/test/language/expressions/object/accessor-name-literal-numeric-octal.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-octal.case
+// - src/accessor-names/default/obj.template
+/*---
+description: Computed values as accessor property names (numeric literal in octal notation) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+var obj = {
+  get [0o10]() { return 'get string'; },
+  set [0o10](param) { stringSet = param; }
+};
+
+assert.sameValue(obj['8'], 'get string');
+
+obj['8'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-numeric-zero.js
+++ b/test/language/expressions/object/accessor-name-literal-numeric-zero.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-zero.case
+// - src/accessor-names/default/obj.template
+/*---
+description: Computed values as accessor property names (numeric literal zero) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+var obj = {
+  get [0]() { return 'get string'; },
+  set [0](param) { stringSet = param; }
+};
+
+assert.sameValue(obj['0'], 'get string');
+
+obj['0'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-string-char-escape.js
+++ b/test/language/expressions/object/accessor-name-literal-string-char-escape.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-char-escape.case
+// - src/accessor-names/default/obj.template
+/*---
+description: Computed values as accessor property names (string literal containing a character escape sequence) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+var obj = {
+  get ['character\tescape']() { return 'get string'; },
+  set ['character\tescape'](param) { stringSet = param; }
+};
+
+assert.sameValue(obj['character	escape'], 'get string');
+
+obj['character	escape'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-string-double-quote.js
+++ b/test/language/expressions/object/accessor-name-literal-string-double-quote.js
@@ -28,11 +28,11 @@ info: |
 
 var stringSet;
 var obj = {
-  get ["singleQuote"]() { return 'get string'; },
-  set ["singleQuote"](param) { stringSet = param; }
+  get ["doubleQuote"]() { return 'get string'; },
+  set ["doubleQuote"](param) { stringSet = param; }
 };
 
-assert.sameValue(obj["singleQuote"], 'get string');
+assert.sameValue(obj["doubleQuote"], 'get string');
 
-obj["singleQuote"] = 'set string';
+obj["doubleQuote"] = 'set string';
 assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-string-double-quote.js
+++ b/test/language/expressions/object/accessor-name-literal-string-double-quote.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-double-quote.case
+// - src/accessor-names/default/obj.template
+/*---
+description: Computed values as accessor property names (string literal using double quotes) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+var obj = {
+  get ["singleQuote"]() { return 'get string'; },
+  set ["singleQuote"](param) { stringSet = param; }
+};
+
+assert.sameValue(obj["singleQuote"], 'get string');
+
+obj["singleQuote"] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-string-empty.js
+++ b/test/language/expressions/object/accessor-name-literal-string-empty.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-empty.case
+// - src/accessor-names/default/obj.template
+/*---
+description: Computed values as accessor property names (string literal, the empty string) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+var obj = {
+  get ['']() { return 'get string'; },
+  set [''](param) { stringSet = param; }
+};
+
+assert.sameValue(obj[''], 'get string');
+
+obj[''] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-string-hex-escape.js
+++ b/test/language/expressions/object/accessor-name-literal-string-hex-escape.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-hex-escape.case
+// - src/accessor-names/default/obj.template
+/*---
+description: Computed values as accessor property names (string literal containing a hexadecimal escape sequence) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+var obj = {
+  get ['hex\x45scape']() { return 'get string'; },
+  set ['hex\x45scape'](param) { stringSet = param; }
+};
+
+assert.sameValue(obj['hexEscape'], 'get string');
+
+obj['hexEscape'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-string-line-terminator.js
+++ b/test/language/expressions/object/accessor-name-literal-string-line-terminator.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Computed values as accessor property names (string literal containing a line terminator) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+var obj = {
+  get ['line\
+Terminator'
+]() { return 'get string'; },
+  set ['line\
+Terminator'
+](param) { stringSet = param; }
+};
+
+assert.sameValue(obj['lineTerminator'], 'get string');
+
+obj['lineTerminator'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-string-single-quote.js
+++ b/test/language/expressions/object/accessor-name-literal-string-single-quote.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-single-quote.case
+// - src/accessor-names/default/obj.template
+/*---
+description: Computed values as accessor property names (string literal using single quotes) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+var obj = {
+  get ['singleQuote']() { return 'get string'; },
+  set ['singleQuote'](param) { stringSet = param; }
+};
+
+assert.sameValue(obj['singleQuote'], 'get string');
+
+obj['singleQuote'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-string-unicode-escape.js
+++ b/test/language/expressions/object/accessor-name-literal-string-unicode-escape.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-unicode-escape.case
+// - src/accessor-names/default/obj.template
+/*---
+description: Computed values as accessor property names (string literal containing a Unicode escape sequence) (Object initializer)
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+flags: [generated]
+info: |
+    ObjectLiteral :
+      { PropertyDefinitionList }
+      { PropertyDefinitionList , }
+
+    1. Let obj be ObjectCreate(%ObjectPrototype%).
+    2. Let status be the result of performing PropertyDefinitionEvaluation of
+       PropertyDefinitionList with arguments obj and true.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+var obj = {
+  get ['unicod\u{000065}Escape']() { return 'get string'; },
+  set ['unicod\u{000065}Escape'](param) { stringSet = param; }
+};
+
+assert.sameValue(obj['unicodeEscape'], 'get string');
+
+obj['unicodeEscape'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-computed-err-evaluation.js
+++ b/test/language/statements/class/accessor-name-inst-computed-err-evaluation.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-evaluation.case
+// - src/accessor-names/error/cls-decl-inst.template
+/*---
+description: Abrupt completion when evaluating expression (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+---*/
+var thrower = function() {
+  throw new Test262Error();
+};
+
+
+assert.throws(Test262Error, function() {
+  class C {
+    get [thrower()]() {}
+  }
+}, '`get` accessor');
+
+assert.throws(Test262Error, function() {
+  class C {
+    set [thrower()](_) {}
+  }
+}, '`set` accessor');

--- a/test/language/statements/class/accessor-name-inst-computed-err-to-prop-key.js
+++ b/test/language/statements/class/accessor-name-inst-computed-err-to-prop-key.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-to-prop-key.case
+// - src/accessor-names/error/cls-decl-inst.template
+/*---
+description: Abrupt completion when coercing to property key value (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+
+    7.1.14 ToPropertyKey
+
+    1. Let key be ? ToPrimitive(argument, hint String).
+
+    7.1.1 ToPrimitive
+
+    [...]
+    7. Return ? OrdinaryToPrimitive(input, hint).
+
+    7.1.1.1 OrdinaryToPrimitive
+
+    5. For each name in methodNames in List order, do
+       [...]
+    6. Throw a TypeError exception.
+---*/
+var badKey = Object.create(null);
+
+
+assert.throws(TypeError, function() {
+  class C {
+    get [badKey]() {}
+  }
+}, '`get` accessor');
+
+assert.throws(TypeError, function() {
+  class C {
+    set [badKey](_) {}
+  }
+}, '`set` accessor');

--- a/test/language/statements/class/accessor-name-inst-computed-err-unresolvable.js
+++ b/test/language/statements/class/accessor-name-inst-computed-err-unresolvable.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-unresolvable.case
+// - src/accessor-names/error/cls-decl-inst.template
+/*---
+description: Abrupt completion when resolving reference value (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+---*/
+
+assert.throws(ReferenceError, function() {
+  class C {
+    get [test262unresolvable]() {}
+  }
+}, '`get` accessor');
+
+assert.throws(ReferenceError, function() {
+  class C {
+    set [test262unresolvable](_) {}
+  }
+}, '`set` accessor');

--- a/test/language/statements/class/accessor-name-inst-computed-yield-expr.js
+++ b/test/language/statements/class/accessor-name-inst-computed-yield-expr.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+description: >
+  The `yield` keyword behaves as a YieldExpression within a generator function
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         i. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments proto and false.
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+features: [generators]
+---*/
+
+var yieldSet, C, iter;
+function* g() {
+  class C_ {
+    get [yield]() { return 'get yield'; }
+    set [yield](param) { yieldSet = param; }
+  }
+
+  C = C_;
+}
+
+iter = g();
+
+iter.next();
+iter.next('first');
+iter.next('second');
+
+assert.sameValue(C.prototype.first, 'get yield');
+
+C.prototype.second = 'set yield';
+
+assert.sameValue(yieldSet, 'set yield');

--- a/test/language/statements/class/accessor-name-inst-computed.js
+++ b/test/language/statements/class/accessor-name-inst-computed.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed.case
+// - src/accessor-names/default/cls-decl-inst.template
+/*---
+description: Computed values as accessor property names (AssignmentExpression) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+var _;
+
+
+var stringSet;
+
+class C {
+  get [_ = 'str' + 'ing']() { return 'get string'; }
+  set [_ = 'str' + 'ing'](param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype['string'], 'get string');
+
+C.prototype['string'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-numeric-binary.js
+++ b/test/language/statements/class/accessor-name-inst-literal-numeric-binary.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-binary.case
+// - src/accessor-names/default/cls-decl-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in binary notation) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get 0b10() { return 'get string'; }
+  set 0b10(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype['2'], 'get string');
+
+C.prototype['2'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-numeric-exponent.js
+++ b/test/language/statements/class/accessor-name-inst-literal-numeric-exponent.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-exponent.case
+// - src/accessor-names/default/cls-decl-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in exponent notation) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get 1E+9() { return 'get string'; }
+  set 1E+9(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype['1000000000'], 'get string');
+
+C.prototype['1000000000'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-numeric-hex.js
+++ b/test/language/statements/class/accessor-name-inst-literal-numeric-hex.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-hex.case
+// - src/accessor-names/default/cls-decl-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in hexadecimal notation) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get 0x10() { return 'get string'; }
+  set 0x10(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype['16'], 'get string');
+
+C.prototype['16'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-numeric-leading-decimal.js
+++ b/test/language/statements/class/accessor-name-inst-literal-numeric-leading-decimal.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-leading-decimal.case
+// - src/accessor-names/default/cls-decl-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal with leading decimal point) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get .1() { return 'get string'; }
+  set .1(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype['0.1'], 'get string');
+
+C.prototype['0.1'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-numeric-non-canonical.js
+++ b/test/language/statements/class/accessor-name-inst-literal-numeric-non-canonical.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-non-canonical.case
+// - src/accessor-names/default/cls-decl-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal with non-canonical representation) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get 0.0000001() { return 'get string'; }
+  set 0.0000001(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype['1e-7'], 'get string');
+
+C.prototype['1e-7'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-numeric-octal.js
+++ b/test/language/statements/class/accessor-name-inst-literal-numeric-octal.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-octal.case
+// - src/accessor-names/default/cls-decl-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in octal notation) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get 0o10() { return 'get string'; }
+  set 0o10(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype['8'], 'get string');
+
+C.prototype['8'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-numeric-zero.js
+++ b/test/language/statements/class/accessor-name-inst-literal-numeric-zero.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-zero.case
+// - src/accessor-names/default/cls-decl-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal zero) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get 0() { return 'get string'; }
+  set 0(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype['0'], 'get string');
+
+C.prototype['0'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-string-char-escape.js
+++ b/test/language/statements/class/accessor-name-inst-literal-string-char-escape.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-char-escape.case
+// - src/accessor-names/default/cls-decl-inst.template
+/*---
+description: Computed values as accessor property names (string literal containing a character escape sequence) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get 'character\tescape'() { return 'get string'; }
+  set 'character\tescape'(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype['character	escape'], 'get string');
+
+C.prototype['character	escape'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-string-double-quote.js
+++ b/test/language/statements/class/accessor-name-inst-literal-string-double-quote.js
@@ -27,11 +27,11 @@ info: |
 var stringSet;
 
 class C {
-  get "singleQuote"() { return 'get string'; }
-  set "singleQuote"(param) { stringSet = param; }
+  get "doubleQuote"() { return 'get string'; }
+  set "doubleQuote"(param) { stringSet = param; }
 }
 
-assert.sameValue(C.prototype["singleQuote"], 'get string');
+assert.sameValue(C.prototype["doubleQuote"], 'get string');
 
-C.prototype["singleQuote"] = 'set string';
+C.prototype["doubleQuote"] = 'set string';
 assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-string-double-quote.js
+++ b/test/language/statements/class/accessor-name-inst-literal-string-double-quote.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-double-quote.case
+// - src/accessor-names/default/cls-decl-inst.template
+/*---
+description: Computed values as accessor property names (string literal using double quotes) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get "singleQuote"() { return 'get string'; }
+  set "singleQuote"(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype["singleQuote"], 'get string');
+
+C.prototype["singleQuote"] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-string-empty.js
+++ b/test/language/statements/class/accessor-name-inst-literal-string-empty.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-empty.case
+// - src/accessor-names/default/cls-decl-inst.template
+/*---
+description: Computed values as accessor property names (string literal, the empty string) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get ''() { return 'get string'; }
+  set ''(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype[''], 'get string');
+
+C.prototype[''] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-string-hex-escape.js
+++ b/test/language/statements/class/accessor-name-inst-literal-string-hex-escape.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-hex-escape.case
+// - src/accessor-names/default/cls-decl-inst.template
+/*---
+description: Computed values as accessor property names (string literal containing a hexadecimal escape sequence) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get 'hex\x45scape'() { return 'get string'; }
+  set 'hex\x45scape'(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype['hexEscape'], 'get string');
+
+C.prototype['hexEscape'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-string-line-terminator.js
+++ b/test/language/statements/class/accessor-name-inst-literal-string-line-terminator.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Computed values as accessor property names (string literal containing a line terminator) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get 'line\
+Terminator'
+() { return 'get string'; }
+  set 'line\
+Terminator'
+(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype['lineTerminator'], 'get string');
+
+C.prototype['lineTerminator'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-string-single-quote.js
+++ b/test/language/statements/class/accessor-name-inst-literal-string-single-quote.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-single-quote.case
+// - src/accessor-names/default/cls-decl-inst.template
+/*---
+description: Computed values as accessor property names (string literal using single quotes) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get 'singleQuote'() { return 'get string'; }
+  set 'singleQuote'(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype['singleQuote'], 'get string');
+
+C.prototype['singleQuote'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-string-unicode-escape.js
+++ b/test/language/statements/class/accessor-name-inst-literal-string-unicode-escape.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-unicode-escape.case
+// - src/accessor-names/default/cls-decl-inst.template
+/*---
+description: Computed values as accessor property names (string literal containing a Unicode escape sequence) (Class declaration, instance method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments proto and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get 'unicod\u{000065}Escape'() { return 'get string'; }
+  set 'unicod\u{000065}Escape'(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype['unicodeEscape'], 'get string');
+
+C.prototype['unicodeEscape'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-computed-err-evaluation.js
+++ b/test/language/statements/class/accessor-name-static-computed-err-evaluation.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-evaluation.case
+// - src/accessor-names/error/cls-decl-static.template
+/*---
+description: Abrupt completion when evaluating expression (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+---*/
+var thrower = function() {
+  throw new Test262Error();
+};
+
+
+assert.throws(Test262Error, function() {
+  class C {
+    static get [thrower()]() {}
+  }
+}, '`get` accessor');
+
+assert.throws(Test262Error, function() {
+  class C {
+    static set [thrower()](_) {}
+  }
+}, '`set` accessor');

--- a/test/language/statements/class/accessor-name-static-computed-err-to-prop-key.js
+++ b/test/language/statements/class/accessor-name-static-computed-err-to-prop-key.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-to-prop-key.case
+// - src/accessor-names/error/cls-decl-static.template
+/*---
+description: Abrupt completion when coercing to property key value (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+
+    7.1.14 ToPropertyKey
+
+    1. Let key be ? ToPrimitive(argument, hint String).
+
+    7.1.1 ToPrimitive
+
+    [...]
+    7. Return ? OrdinaryToPrimitive(input, hint).
+
+    7.1.1.1 OrdinaryToPrimitive
+
+    5. For each name in methodNames in List order, do
+       [...]
+    6. Throw a TypeError exception.
+---*/
+var badKey = Object.create(null);
+
+
+assert.throws(TypeError, function() {
+  class C {
+    static get [badKey]() {}
+  }
+}, '`get` accessor');
+
+assert.throws(TypeError, function() {
+  class C {
+    static set [badKey](_) {}
+  }
+}, '`set` accessor');

--- a/test/language/statements/class/accessor-name-static-computed-err-unresolvable.js
+++ b/test/language/statements/class/accessor-name-static-computed-err-unresolvable.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed-err-unresolvable.case
+// - src/accessor-names/error/cls-decl-static.template
+/*---
+description: Abrupt completion when resolving reference value (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+---*/
+
+assert.throws(ReferenceError, function() {
+  class C {
+    static get [test262unresolvable]() {}
+  }
+}, '`get` accessor');
+
+assert.throws(ReferenceError, function() {
+  class C {
+    static set [test262unresolvable](_) {}
+  }
+}, '`set` accessor');

--- a/test/language/statements/class/accessor-name-static-computed-yield-expr.js
+++ b/test/language/statements/class/accessor-name-static-computed-yield-expr.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object-initializer-runtime-semantics-evaluation
+es6id: 12.2.6.8
+description: >
+  The `yield` keyword behaves as a YieldExpression within a generator function
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         [...]
+      b. Else,
+         a. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments F and false.
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+features: [generators]
+---*/
+
+var yieldSet, C, iter;
+function* g() {
+  class C_ {
+    static get [yield]() { return 'get yield'; }
+    static set [yield](param) { yieldSet = param; }
+  }
+
+  C = C_;
+}
+
+iter = g();
+
+iter.next();
+iter.next('first');
+iter.next('second');
+
+assert.sameValue(C.first, 'get yield');
+
+C.second = 'set yield';
+
+assert.sameValue(yieldSet, 'set yield');

--- a/test/language/statements/class/accessor-name-static-computed.js
+++ b/test/language/statements/class/accessor-name-static-computed.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed.case
+// - src/accessor-names/default/cls-decl-static.template
+/*---
+description: Computed values as accessor property names (AssignmentExpression) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+var _;
+
+
+var stringSet;
+
+class C {
+  static get [_ = 'str' + 'ing']() { return 'get string'; }
+  static set [_ = 'str' + 'ing'](param) { stringSet = param; }
+}
+
+assert.sameValue(C['string'], 'get string');
+
+C['string'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-numeric-binary.js
+++ b/test/language/statements/class/accessor-name-static-literal-numeric-binary.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-binary.case
+// - src/accessor-names/default/cls-decl-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in binary notation) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get 0b10() { return 'get string'; }
+  static set 0b10(param) { stringSet = param; }
+}
+
+assert.sameValue(C['2'], 'get string');
+
+C['2'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-numeric-exponent.js
+++ b/test/language/statements/class/accessor-name-static-literal-numeric-exponent.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-exponent.case
+// - src/accessor-names/default/cls-decl-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in exponent notation) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get 1E+9() { return 'get string'; }
+  static set 1E+9(param) { stringSet = param; }
+}
+
+assert.sameValue(C['1000000000'], 'get string');
+
+C['1000000000'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-numeric-hex.js
+++ b/test/language/statements/class/accessor-name-static-literal-numeric-hex.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-hex.case
+// - src/accessor-names/default/cls-decl-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in hexadecimal notation) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get 0x10() { return 'get string'; }
+  static set 0x10(param) { stringSet = param; }
+}
+
+assert.sameValue(C['16'], 'get string');
+
+C['16'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-numeric-leading-decimal.js
+++ b/test/language/statements/class/accessor-name-static-literal-numeric-leading-decimal.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-leading-decimal.case
+// - src/accessor-names/default/cls-decl-static.template
+/*---
+description: Computed values as accessor property names (numeric literal with leading decimal point) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get .1() { return 'get string'; }
+  static set .1(param) { stringSet = param; }
+}
+
+assert.sameValue(C['0.1'], 'get string');
+
+C['0.1'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-numeric-non-canonical.js
+++ b/test/language/statements/class/accessor-name-static-literal-numeric-non-canonical.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-non-canonical.case
+// - src/accessor-names/default/cls-decl-static.template
+/*---
+description: Computed values as accessor property names (numeric literal with non-canonical representation) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get 0.0000001() { return 'get string'; }
+  static set 0.0000001(param) { stringSet = param; }
+}
+
+assert.sameValue(C['1e-7'], 'get string');
+
+C['1e-7'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-numeric-octal.js
+++ b/test/language/statements/class/accessor-name-static-literal-numeric-octal.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-octal.case
+// - src/accessor-names/default/cls-decl-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in octal notation) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get 0o10() { return 'get string'; }
+  static set 0o10(param) { stringSet = param; }
+}
+
+assert.sameValue(C['8'], 'get string');
+
+C['8'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-numeric-zero.js
+++ b/test/language/statements/class/accessor-name-static-literal-numeric-zero.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-zero.case
+// - src/accessor-names/default/cls-decl-static.template
+/*---
+description: Computed values as accessor property names (numeric literal zero) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get 0() { return 'get string'; }
+  static set 0(param) { stringSet = param; }
+}
+
+assert.sameValue(C['0'], 'get string');
+
+C['0'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-string-char-escape.js
+++ b/test/language/statements/class/accessor-name-static-literal-string-char-escape.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-char-escape.case
+// - src/accessor-names/default/cls-decl-static.template
+/*---
+description: Computed values as accessor property names (string literal containing a character escape sequence) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get 'character\tescape'() { return 'get string'; }
+  static set 'character\tescape'(param) { stringSet = param; }
+}
+
+assert.sameValue(C['character	escape'], 'get string');
+
+C['character	escape'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-string-double-quote.js
+++ b/test/language/statements/class/accessor-name-static-literal-string-double-quote.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-double-quote.case
+// - src/accessor-names/default/cls-decl-static.template
+/*---
+description: Computed values as accessor property names (string literal using double quotes) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get "singleQuote"() { return 'get string'; }
+  static set "singleQuote"(param) { stringSet = param; }
+}
+
+assert.sameValue(C["singleQuote"], 'get string');
+
+C["singleQuote"] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-string-double-quote.js
+++ b/test/language/statements/class/accessor-name-static-literal-string-double-quote.js
@@ -29,11 +29,11 @@ info: |
 var stringSet;
 
 class C {
-  static get "singleQuote"() { return 'get string'; }
-  static set "singleQuote"(param) { stringSet = param; }
+  static get "doubleQuote"() { return 'get string'; }
+  static set "doubleQuote"(param) { stringSet = param; }
 }
 
-assert.sameValue(C["singleQuote"], 'get string');
+assert.sameValue(C["doubleQuote"], 'get string');
 
-C["singleQuote"] = 'set string';
+C["doubleQuote"] = 'set string';
 assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-string-empty.js
+++ b/test/language/statements/class/accessor-name-static-literal-string-empty.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-empty.case
+// - src/accessor-names/default/cls-decl-static.template
+/*---
+description: Computed values as accessor property names (string literal, the empty string) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get ''() { return 'get string'; }
+  static set ''(param) { stringSet = param; }
+}
+
+assert.sameValue(C[''], 'get string');
+
+C[''] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-string-hex-escape.js
+++ b/test/language/statements/class/accessor-name-static-literal-string-hex-escape.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-hex-escape.case
+// - src/accessor-names/default/cls-decl-static.template
+/*---
+description: Computed values as accessor property names (string literal containing a hexadecimal escape sequence) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get 'hex\x45scape'() { return 'get string'; }
+  static set 'hex\x45scape'(param) { stringSet = param; }
+}
+
+assert.sameValue(C['hexEscape'], 'get string');
+
+C['hexEscape'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-string-line-terminator.js
+++ b/test/language/statements/class/accessor-name-static-literal-string-line-terminator.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Computed values as accessor property names (string literal containing a line terminator) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get 'line\
+Terminator'
+() { return 'get string'; }
+  static set 'line\
+Terminator'
+(param) { stringSet = param; }
+}
+
+assert.sameValue(C['lineTerminator'], 'get string');
+
+C['lineTerminator'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-string-single-quote.js
+++ b/test/language/statements/class/accessor-name-static-literal-string-single-quote.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-single-quote.case
+// - src/accessor-names/default/cls-decl-static.template
+/*---
+description: Computed values as accessor property names (string literal using single quotes) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get 'singleQuote'() { return 'get string'; }
+  static set 'singleQuote'(param) { stringSet = param; }
+}
+
+assert.sameValue(C['singleQuote'], 'get string');
+
+C['singleQuote'] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-string-unicode-escape.js
+++ b/test/language/statements/class/accessor-name-static-literal-string-unicode-escape.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-unicode-escape.case
+// - src/accessor-names/default/cls-decl-static.template
+/*---
+description: Computed values as accessor property names (string literal containing a Unicode escape sequence) (Class declaration, static method)
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+flags: [generated]
+info: |
+    [...]
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           [...]
+        b. Else,
+           a. Let status be the result of performing PropertyDefinitionEvaluation
+              for m with arguments F and false.
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get 'unicod\u{000065}Escape'() { return 'get string'; }
+  static set 'unicod\u{000065}Escape'(param) { stringSet = param; }
+}
+
+assert.sameValue(C['unicodeEscape'], 'get string');
+
+C['unicodeEscape'] = 'set string';
+assert.sameValue(stringSet, 'set string');


### PR DESCRIPTION
These tests for accessor names were originally submitted in gh-706, but that
change set only concerned their use within object initializers. At @avdg's
recommendation, I have expanded coverage to include class definitions. Because
this generally concerns four additional syntactic forms (instance accessors
within class expressions, static accessors within class expressions, instance
accessors within class declarations, and static accessors within class
declarations), I've made use of the test generation tool to promote consistent
coverage. Not all tests were suitable subjects for procedural generation,
however (there is only one interesting case for the use of the `in` keyword,
for example, making the "case/template" formatting needlessly indirect), so
this patch also includes some traditional non-generated test material. In all
cases, file meta-data and license information accurately describes the
provenance.