### PR TITLE
Add tests for try/finally in async functions

### DIFF
--- a/test/language/expressions/async-arrow-function/try-reject-finally-reject.js
+++ b/test/language/expressions/async-arrow-function/try-reject-finally-reject.js
@@ -1,0 +1,27 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async() => {
+  try {
+    await new Promise(function(resolve, reject) {
+      reject("early-reject");
+    });
+  } finally {
+    await new Promise(function(resolve, reject) {
+      reject("override");
+    });
+  }
+};
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Awaited rejection in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-arrow-function/try-reject-finally-return.js
+++ b/test/language/expressions/async-arrow-function/try-reject-finally-return.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async() => {
+  try {
+    await new Promise(function(resolve, reject) {
+      reject("early-reject");
+    });
+  } finally {
+    return "override";
+  }
+};
+
+f().then(function(value) {
+  assert.sameValue(value, "override", "Return in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-arrow-function/try-reject-finally-throw.js
+++ b/test/language/expressions/async-arrow-function/try-reject-finally-throw.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async() => {
+  try {
+    await new Promise(function(resolve, reject) {
+      reject("early-reject");
+    });
+  } finally {
+    throw "override";
+  }
+};
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Exception thrown in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-arrow-function/try-return-finally-reject.js
+++ b/test/language/expressions/async-arrow-function/try-return-finally-reject.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer resolving an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async() => {
+  try {
+    return "early-return";
+  } finally {
+    await new Promise(function(resolve, reject) {
+      reject("override");
+    });
+  }
+};
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Awaited rejection in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-arrow-function/try-return-finally-return.js
+++ b/test/language/expressions/async-arrow-function/try-return-finally-return.js
@@ -21,5 +21,5 @@ var f = async() => {
 };
 
 f().then(function(value) {
-    assert.sameValue(value, "override", "Return in finally block");
+  assert.sameValue(value, "override", "Return in finally block");
 }).then($DONE, $DONE);

--- a/test/language/expressions/async-arrow-function/try-return-finally-return.js
+++ b/test/language/expressions/async-arrow-function/try-return-finally-return.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer resolving an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async() => {
+  try {
+    return "early-return";
+  } finally {
+    return await new Promise(function(resolve, reject) {
+      resolve("override");
+    });
+  }
+};
+
+f().then(function(value) {
+    assert.sameValue(value, "override", "Return in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-arrow-function/try-return-finally-throw.js
+++ b/test/language/expressions/async-arrow-function/try-return-finally-throw.js
@@ -1,0 +1,23 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer resolving an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async() => {
+  try {
+    return "early-return";
+  } finally {
+    throw "override";
+  }
+};
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Exception thrown in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-arrow-function/try-throw-finally-reject.js
+++ b/test/language/expressions/async-arrow-function/try-throw-finally-reject.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async() => {
+  try {
+    throw "early-throw";
+  } finally {
+    await new Promise(function(resolve, reject) {
+      reject("override");
+    });
+  }
+};
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Awaited rejection in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-arrow-function/try-throw-finally-return.js
+++ b/test/language/expressions/async-arrow-function/try-throw-finally-return.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async() => {
+  try {
+    throw "early-throw";
+  } finally {
+    return await new Promise(function(resolve, reject) {
+      resolve("override");
+    });
+  }
+};
+
+f().then(function(value) {
+  assert.sameValue(value, "override", "Return in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-arrow-function/try-throw-finally-throw.js
+++ b/test/language/expressions/async-arrow-function/try-throw-finally-throw.js
@@ -1,0 +1,23 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async() => {
+  try {
+    throw "early-throw";
+  } finally {
+    throw "override";
+  }
+};
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Exception thrown in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-function/try-reject-finally-reject.js
+++ b/test/language/expressions/async-function/try-reject-finally-reject.js
@@ -1,0 +1,27 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async function() {
+  try {
+    await new Promise(function(resolve, reject) {
+      reject("early-reject");
+    });
+  } finally {
+    await new Promise(function(resolve, reject) {
+      reject("override");
+    });
+  }
+};
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Awaited rejection in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-function/try-reject-finally-return.js
+++ b/test/language/expressions/async-function/try-reject-finally-return.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async function() {
+  try {
+    await new Promise(function(resolve, reject) {
+      reject("early-reject");
+    });
+  } finally {
+    return "override";
+  }
+};
+
+f().then(function(value) {
+  assert.sameValue(value, "override", "Return in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-function/try-reject-finally-throw.js
+++ b/test/language/expressions/async-function/try-reject-finally-throw.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async function() {
+  try {
+    await new Promise(function(resolve, reject) {
+      reject("early-reject");
+    });
+  } finally {
+    throw "override";
+  }
+};
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Exception thrown in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-function/try-return-finally-reject.js
+++ b/test/language/expressions/async-function/try-return-finally-reject.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer resolving an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async function() {
+  try {
+    return "early-return";
+  } finally {
+    await new Promise(function(resolve, reject) {
+      reject("override");
+    });
+  }
+};
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Awaited rejection in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-function/try-return-finally-return.js
+++ b/test/language/expressions/async-function/try-return-finally-return.js
@@ -21,5 +21,5 @@ var f = async function() {
 };
 
 f().then(function(value) {
-    assert.sameValue(value, "override", "Return in finally block");
+  assert.sameValue(value, "override", "Return in finally block");
 }).then($DONE, $DONE);

--- a/test/language/expressions/async-function/try-return-finally-return.js
+++ b/test/language/expressions/async-function/try-return-finally-return.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer resolving an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async function() {
+  try {
+    return "early-return";
+  } finally {
+    return await new Promise(function(resolve, reject) {
+      resolve("override");
+    });
+  }
+};
+
+f().then(function(value) {
+    assert.sameValue(value, "override", "Return in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-function/try-return-finally-throw.js
+++ b/test/language/expressions/async-function/try-return-finally-throw.js
@@ -1,0 +1,23 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer resolving an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async function() {
+  try {
+    return "early-return";
+  } finally {
+    throw "override";
+  }
+};
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Exception thrown in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-function/try-throw-finally-reject.js
+++ b/test/language/expressions/async-function/try-throw-finally-reject.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async function() {
+  try {
+    throw "early-throw";
+  } finally {
+    await new Promise(function(resolve, reject) {
+      reject("override");
+    });
+  }
+};
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Awaited rejection in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-function/try-throw-finally-return.js
+++ b/test/language/expressions/async-function/try-throw-finally-return.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async function() {
+  try {
+    throw "early-throw";
+  } finally {
+    return await new Promise(function(resolve, reject) {
+      resolve("override");
+    });
+  }
+};
+
+f().then(function(value) {
+  assert.sameValue(value, "override", "Return in finally block");
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-function/try-throw-finally-throw.js
+++ b/test/language/expressions/async-function/try-throw-finally-throw.js
@@ -1,0 +1,23 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+var f = async function() {
+  try {
+    throw "early-throw";
+  } finally {
+    throw "override";
+  }
+};
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Exception thrown in finally block");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-function/try-reject-finally-reject.js
+++ b/test/language/statements/async-function/try-reject-finally-reject.js
@@ -1,0 +1,27 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+async function f() {
+  try {
+    await new Promise(function(resolve, reject) {
+      reject("early-reject");
+    });
+  } finally {
+    await new Promise(function(resolve, reject) {
+      reject("override");
+    });
+  }
+}
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Awaited rejection in finally block");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-function/try-reject-finally-return.js
+++ b/test/language/statements/async-function/try-reject-finally-return.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+async function f() {
+  try {
+    await new Promise(function(resolve, reject) {
+      reject("early-reject");
+    });
+  } finally {
+    return "override";
+  }
+}
+
+f().then(function(value) {
+  assert.sameValue(value, "override", "Return in finally block");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-function/try-reject-finally-throw.js
+++ b/test/language/statements/async-function/try-reject-finally-throw.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+async function f() {
+  try {
+    await new Promise(function(resolve, reject) {
+      reject("early-reject");
+    });
+  } finally {
+    throw "override";
+  }
+}
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Exception thrown in finally block");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-function/try-return-finally-reject.js
+++ b/test/language/statements/async-function/try-return-finally-reject.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer resolving an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+async function f() {
+  try {
+    return "early-return";
+  } finally {
+    await new Promise(function(resolve, reject) {
+      reject("override");
+    });
+  }
+}
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Aaited rejection in finally block");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-function/try-return-finally-reject.js
+++ b/test/language/statements/async-function/try-return-finally-reject.js
@@ -21,5 +21,5 @@ async function f() {
 }
 
 f().then($DONE, function(value) {
-  assert.sameValue(value, "override", "Aaited rejection in finally block");
+  assert.sameValue(value, "override", "Awaited rejection in finally block");
 }).then($DONE, $DONE);

--- a/test/language/statements/async-function/try-return-finally-return.js
+++ b/test/language/statements/async-function/try-return-finally-return.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer resolving an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+async function f() {
+  try {
+    return "early-return";
+  } finally {
+    return await new Promise(function(resolve, reject) {
+      resolve("override");
+    });
+  }
+}
+
+f().then(function(value) {
+    assert.sameValue(value, "override", "Return in finally block");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-function/try-return-finally-return.js
+++ b/test/language/statements/async-function/try-return-finally-return.js
@@ -21,5 +21,5 @@ async function f() {
 }
 
 f().then(function(value) {
-    assert.sameValue(value, "override", "Return in finally block");
+  assert.sameValue(value, "override", "Return in finally block");
 }).then($DONE, $DONE);

--- a/test/language/statements/async-function/try-return-finally-throw.js
+++ b/test/language/statements/async-function/try-return-finally-throw.js
@@ -1,0 +1,23 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer resolving an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+async function f() {
+  try {
+    return "early-return";
+  } finally {
+    throw "override";
+  }
+}
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Exception thrown in finally block");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-function/try-throw-finally-reject.js
+++ b/test/language/statements/async-function/try-throw-finally-reject.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+async function f() {
+  try {
+    throw "early-throw";
+  } finally {
+    await new Promise(function(resolve, reject) {
+      reject("override");
+    });
+  }
+}
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Awaited rejection in finally block");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-function/try-throw-finally-return.js
+++ b/test/language/statements/async-function/try-throw-finally-return.js
@@ -1,0 +1,25 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+async function f() {
+  try {
+    throw "early-throw";
+  } finally {
+    return await new Promise(function(resolve, reject) {
+      resolve("override");
+    });
+  }
+}
+
+f().then(function(value) {
+  assert.sameValue(value, "override", "Return in finally block");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-function/try-throw-finally-throw.js
+++ b/test/language/statements/async-function/try-throw-finally-throw.js
@@ -1,0 +1,23 @@
+// Copyright 2017 Caitlin Potter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  Implementations must defer rejecting an async function's Promise until after
+  all finally blocks have been evaluated.
+flags: [async]
+---*/
+
+async function f() {
+  try {
+    throw "early-throw";
+  } finally {
+    throw "override";
+  }
+}
+
+f().then($DONE, function(value) {
+  assert.sameValue(value, "override", "Exception thrown in finally block");
+}).then($DONE, $DONE);


### PR DESCRIPTION
Add tests to verify that try/finally defers execution of promise resolution for return statements and throw statements. This guards against a pattern which implementations may be tempted to use, such as rewriting return/throw statements at parse time like so:

From:
```js
return return_value;
```

To:
```js
return ResolvePromise(async_function_promise_, return_value), async_function_promise_;
```

v8 currently fails these tests, though a fix is in the pipeline.