### PR TITLE
Remove empty info section from a SharedArrayBuffer test

### DIFF
--- a/test/built-ins/SharedArrayBuffer/prototype/slice/context-is-not-arraybuffer-object.js
+++ b/test/built-ins/SharedArrayBuffer/prototype/slice/context-is-not-arraybuffer-object.js
@@ -5,7 +5,6 @@
 /*---
 description: >
   Throws a TypeError if `this` does not have an [[ArrayBufferData]] internal slot.
-info: >
 ---*/
 
 assert.throws(TypeError, function() {


### PR DESCRIPTION
This section is useless (and also trips up the YAML parser V8 uses)

cc @binji @syg 