### PR TITLE
Update RegExp tests for the semantics change

### DIFF
--- a/test/built-ins/RegExp/prototype/exec/failure-lastindex-access.js
+++ b/test/built-ins/RegExp/prototype/exec/failure-lastindex-access.js
@@ -2,13 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: lastIndex is not accessed when global and sticky are unset.
+description: lastIndex is read but not written when global and sticky are unset.
 es6id: 21.2.5.2.2
 info: >
     21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
 
+    4. Let lastIndex be ? ToLength(? Get(R, "lastIndex")).
     [...]
-    7. If global is false and sticky is false, let lastIndex be 0.
+    8. If global is false and sticky is false, let lastIndex be 0.
     [...]
     12. Repeat, while matchSucceeded is false
         [...]
@@ -18,16 +19,18 @@ info: >
               2. Return null.
 ---*/
 
-var thrower = {
+var gets = 0;
+var counter = {
   valueOf: function() {
-    throw new Test262Error();
+    gets++;
+    return 0;
   }
 };
 
 var r = /a/;
-r.lastIndex = thrower;
+r.lastIndex = counter;
 
 var result = r.exec('nbc');
 assert.sameValue(result, null);
-assert.sameValue(r.lastIndex, thrower);
-
+assert.sameValue(r.lastIndex, counter);
+assert.sameValue(gets, 1);

--- a/test/built-ins/RegExp/prototype/exec/success-lastindex-access.js
+++ b/test/built-ins/RegExp/prototype/exec/success-lastindex-access.js
@@ -2,32 +2,35 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: lastIndex is not accessed when global and sticky are unset.
+description: lastIndex read but not written when global and sticky are unset.
 es6id: 21.2.5.2.2
 info: >
     21.2.5.2.2 Runtime Semantics: RegExpBuiltinExec ( R, S )
 
     [...]
-    4. Let flags be R.[[OriginalFlags]].
-    5. If flags contains "g", let global be true, else let global be false.
+    4. Let lastIndex be ? ToLength(? Get(R, "lastIndex")).
+    5. Let flags be R.[[OriginalFlags]].
+    6. If flags contains "g", let global be true, else let global be false.
     [...]
     15. If global is true or sticky is true, then
         a. Perform ? Set(R, "lastIndex", e, true).
 ---*/
 
-var thrower = {
+var gets = 0;
+var counter = {
   valueOf: function() {
-    throw new Test262Error();
+    gets++;
+    return 0;
   }
 };
 
 var r = /./;
-r.lastIndex = thrower;
+r.lastIndex = counter;
 
 var result = r.exec('abc');
 
 assert.notSameValue(result, null);
 assert.sameValue(result.length, 1);
 assert.sameValue(result[0], 'a');
-assert.sameValue(r.lastIndex, thrower);
-
+assert.sameValue(r.lastIndex, counter);
+assert.sameValue(gets, 1);


### PR DESCRIPTION
Spec change at https://github.com/tc39/ecma262/pull/798

Tested on V8's implementation of the new semantics.

cc @schuay @bterlson @anba @claudepache