### PR TITLE
Change tests for `extends null` and Intl legacy constructor semantics

### DIFF
--- a/test/built-ins/TypedArray/prototype/copyWithin/negative-out-of-bounds-end.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/negative-out-of-bounds-end.js
@@ -41,7 +41,7 @@ testWithTypedArrayConstructors(function(TA) {
     compareArray(
       new TA([1, 2, 3, 4, 5]).copyWithin(0, 1, -Infinity),
       [1, 2, 3, 4, 5]
-    )
+    ),
     '[1, 2, 3, 4, 5].copyWithin(0, 1, -Infinity) -> [1, 2, 3, 4, 5]'
   );
 
@@ -57,7 +57,7 @@ testWithTypedArrayConstructors(function(TA) {
     compareArray(
       new TA([1, 2, 3, 4, 5]).copyWithin(0, -2, -Infinity),
       [1, 2, 3, 4, 5]
-    )
+    ),
     '[1, 2, 3, 4, 5].copyWithin(0, -2, -Infinity) -> [1, 2, 3, 4, 5]'
   );
 
@@ -73,7 +73,7 @@ testWithTypedArrayConstructors(function(TA) {
     compareArray(
       new TA([1, 2, 3, 4, 5]).copyWithin(0, -9, -Infinity),
       [1, 2, 3, 4, 5]
-    )
+    ),
     '[1, 2, 3, 4, 5].copyWithin(0, -9, -Infinity) -> [1, 2, 3, 4, 5]'
   );
 
@@ -89,7 +89,7 @@ testWithTypedArrayConstructors(function(TA) {
     compareArray(
       new TA([1, 2, 3, 4, 5]).copyWithin(-3, -2, -Infinity),
       [1, 2, 3, 4, 5]
-    )
+    ),
     '[1, 2, 3, 4, 5].copyWithin(-3, -2, -Infinity) -> [1, 2, 3, 4, 5]'
   );
 
@@ -105,7 +105,7 @@ testWithTypedArrayConstructors(function(TA) {
     compareArray(
       new TA([1, 2, 3, 4, 5]).copyWithin(-7, -8, -Infinity),
       [1, 2, 3, 4, 5]
-    )
+    ),
     '[1, 2, 3, 4, 5].copyWithin(-7, -8, -Infinity) -> [1, 2, 3, 4, 5]'
   );
 });

--- a/test/built-ins/TypedArray/prototype/copyWithin/negative-out-of-bounds-start.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/negative-out-of-bounds-start.js
@@ -38,7 +38,7 @@ testWithTypedArrayConstructors(function(TA) {
   assert(
     compareArray(
       new TA([1, 2, 3, 4, 5]).copyWithin(0, -Infinity),
-      [0, 1, 2, 3]
+      [1, 2, 3, 4, 5]
     ),
     '[1, 2, 3, 4, 5]).copyWithin(0, -Infinity) -> [1, 2, 3, 4, 5]'
   );

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js
@@ -69,7 +69,7 @@ testWithTypedArrayConstructors(function(TA) {
   assert(compareArray(sample, [1, 2, 42, 43]), "sample is SAB-backed, offset: 2, result: " + sample);
   assert.sameValue(result, undefined, "returns undefined");
 
-  var sab1 = new SharedArrayBuffer(2 * TA.BYTES_PER_ELEMENT);
+  var sab1 = new SharedArrayBuffer(2 * other.BYTES_PER_ELEMENT);
   src = new other(sab1);
   src[0] = 42;
   src[1] = 43;

--- a/test/intl402/DateTimeFormat/12.1.1_1.js
+++ b/test/intl402/DateTimeFormat/12.1.1_1.js
@@ -3,12 +3,17 @@
 
 /*---
 es5id: 12.1.1_1
-description: Tests that the this-value is ignored in DateTimeFormat.
+description: >
+    Tests that the this-value is ignored in DateTimeFormat, if the this-value
+    isn't a DateTimeFormat instance.
 author: Norbert Lindenberg
 includes: [testIntl.js]
 ---*/
 
 testWithIntlConstructors(function (Constructor) {
+    if (Constructor === Intl.DateTimeFormat)
+        return true;
+
     var obj, newObj;
 
     // variant 1: use constructor in a "new" expression

--- a/test/intl402/DateTimeFormat/prototype/format/12.3.2_1_a_L15.js
+++ b/test/intl402/DateTimeFormat/prototype/format/12.3.2_1_a_L15.js
@@ -12,4 +12,4 @@ author: Norbert Lindenberg
 includes: [testBuiltInObject.js]
 ---*/
 
-testBuiltInObject(new Intl.DateTimeFormat().format, true, false, [], 0);
+testBuiltInObject(new Intl.DateTimeFormat().format, true, false, [], 1);

--- a/test/intl402/NumberFormat/11.1.1_1.js
+++ b/test/intl402/NumberFormat/11.1.1_1.js
@@ -3,12 +3,17 @@
 
 /*---
 es5id: 11.1.1_1
-description: Tests that the this-value is ignored in NumberFormat.
+description: >
+    Tests that the this-value is ignored in NumberFormat, if the this-value
+    isn't a NumberFormat instance.
 author: Norbert Lindenberg
 includes: [testIntl.js]
 ---*/
 
 testWithIntlConstructors(function (Constructor) {
+    if (Constructor === Intl.NumberFormat)
+        return true;
+
     var obj, newObj;
 
     // variant 1: use constructor in a "new" expression

--- a/test/language/expressions/object/method-definition/async-super-call-body.js
+++ b/test/language/expressions/object/method-definition/async-super-call-body.js
@@ -16,11 +16,12 @@ var sup = {
 }
 
 var child = {
-  __proto__: sup,
   async method() {
     var x = await super.method();
     assert.sameValue(x, 'sup');
   }
 }
+
+Object.setPrototypeOf(child, sup);
 
 child.method().then($DONE, $DONE);

--- a/test/language/expressions/object/method-definition/async-super-call-param.js
+++ b/test/language/expressions/object/method-definition/async-super-call-param.js
@@ -16,12 +16,13 @@ var sup = {
 }
 
 var child = {
-  __proto__: sup,
   async method(x = super.method()) {
     var y = await x;
     assert.sameValue(y, 'sup');
   }
 }
+
+Object.setPrototypeOf(child, sup);
 
 child.method().then($DONE, $DONE);
 

--- a/test/language/statements/class/subclass/builtin-objects/Promise/regular-subclassing.js
+++ b/test/language/statements/class/subclass/builtin-objects/Promise/regular-subclassing.js
@@ -23,12 +23,14 @@ assert.throws(TypeError, function() {
 });
 
 var calledExecutor = false;
+var executorArguments;
 
-var prom1 = new Prom(function(resolve) {
+var prom1 = new Prom(function() {
   calledExecutor = true;
-  assert.sameValue(arguments.length, 2);
-  assert(arguments[0] === Promise.resolve);
-  assert(arguments[1] === Promise.reject);
+  executorArguments = arguments;
 });
 
 assert(calledExecutor);
+assert.sameValue(executorArguments.length, 2);
+assert.sameValue(typeof executorArguments[0], "function");
+assert.sameValue(typeof executorArguments[1], "function");

--- a/test/language/statements/class/subclass/class-definition-null-proto-contains-return-override.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto-contains-return-override.js
@@ -4,18 +4,30 @@
 esid: sec-runtime-semantics-classdefinitionevaluation
 es6id: 14.5.14
 description: >
-    Runtime Semantics: ClassDefinitionEvaluation
+    The constructor of a null-extending class can contain an explicit return value.
+info: |
+  Runtime Semantics: ClassDefinitionEvaluation
 
-    If superclass is null, then
-      Let protoParent be null.
-      Let constructorParent be the intrinsic object %FunctionPrototype%.
+  [...]
+  15. If ClassHeritageopt is present, then set F's [[ConstructorKind]] internal slot to "derived".
+  [...]
+
+  9.2.2 [[Construct]]
+
+  [...]
+  13. If result.[[Type]] is return, then
+     a. If Type(result.[[Value]]) is Object, return NormalCompletion(result.[[Value]]).
+  [...]
 ---*/
+var obj;
+
 class Foo extends null {
   constructor() {
-    return {};
+    return obj = {};
   }
 }
 
 var f = new Foo();
 
+assert.sameValue(f, obj);
 assert.sameValue(Object.getPrototypeOf(f), Object.prototype);

--- a/test/language/statements/class/subclass/class-definition-null-proto-missing-return-override.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto-missing-return-override.js
@@ -3,12 +3,9 @@
 /*---
 esid: sec-runtime-semantics-classdefinitionevaluation
 description: >
-  The `this` value of a null-extending class is automatically initialized,
-  obviating the need for an explicit return value in the constructor.
+  The `this` value of a null-extending class isn't automatically initialized,
+  which makes it necessary to have an explicit return value in the constructor.
 info: |
-  The behavior under test was introduced in the "ES2017" revision of the
-  specification and conflicts with prior editions.
-
   Runtime Semantics: ClassDefinitionEvaluation
 
   [...]
@@ -18,24 +15,25 @@ info: |
      [...]
      b. Let superclass be the result of evaluating ClassHeritage.
   [...]
-  15. If ClassHeritageopt is present and superclass is not null, then set F's
-      [[ConstructorKind]] internal slot to "derived".
+  15. If ClassHeritageopt is present, then set F's [[ConstructorKind]] internal slot to "derived".
   [...]
 
   9.2.2 [[Construct]]
 
   [...]
-  5. If kind is "base", then
-     a. Let thisArgument be ? OrdinaryCreateFromConstructor(newTarget,
-        "%ObjectPrototype%").
-  [...]
   15. Return ? envRec.GetThisBinding().
+
+  8.1.1.3.4 GetThisBinding ( )
+  [...]
+  3. If envRec.[[ThisBindingStatus]] is "uninitialized", throw a ReferenceError exception.
+  [...]
 ---*/
 
 class Foo extends null {
-  constructor() {}
+  constructor() {
+  }
 }
 
-var foo = new Foo();
-
-assert.sameValue(Object.getPrototypeOf(foo), Foo.prototype);
+assert.throws(ReferenceError, function() {
+  new C();
+});

--- a/test/language/statements/class/subclass/class-definition-null-proto-super.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto-super.js
@@ -3,8 +3,8 @@
 /*---
 esid: sec-runtime-semantics-classdefinitionevaluation
 description: >
-  The `this` value of a null-extending class is automatically initialized,
-  preventing the use of `super` from within the constructor.
+  Attempting to call `super()` in a null-extending class throws a TypeError,
+  because %FunctionPrototype% cannot be called as constructor function.
 info: |
   Runtime Semantics: ClassDefinitionEvaluation
 
@@ -14,17 +14,12 @@ info: |
   6. Else,
      [...]
      b. Let superclass be the result of evaluating ClassHeritage.
+     [...]
+     e. If superclass is null, then
+        [...]
+        ii. Let constructorParent be the intrinsic object %FunctionPrototype%.
   [...]
-  15. If ClassHeritageopt is present and superclass is not null, then set F's
-      [[ConstructorKind]] internal slot to "derived".
-  [...]
-
-  9.2.2 [[Construct]]
-
-  [...]
-  5. If kind is "base", then
-     a. Let thisArgument be ? OrdinaryCreateFromConstructor(newTarget,
-        "%ObjectPrototype%").
+  15. Let constructorInfo be the result of performing DefineMethod for constructor with arguments proto and constructorParent as the optional functionPrototype argument.
   [...]
 
   12.3.5.1 Runtime Semantics: Evaluation
@@ -32,17 +27,15 @@ info: |
   SuperCall : super Arguments
 
   [...]
-  6. Let result be ? Construct(func, argList, newTarget).
-  7. Let thisER be GetThisEnvironment( ).
-  8. Return ? thisER.BindThisValue(result).
+  3. Let func be ? GetSuperConstructor().
+  4. Let argList be ArgumentListEvaluation of Arguments.
+  [...]
 
-  8.1.1.3.1 BindThisValue
+  12.3.5.2 Runtime Semantics: GetSuperConstructor ( )
 
   [...]
-  3. If envRec.[[ThisBindingStatus]] is "initialized", throw a ReferenceError
-     exception.
-  4. Set envRec.[[ThisValue]] to V.
-  5. Set envRec.[[ThisBindingStatus]] to "initialized".
+  5. Let superConstructor be ! activeFunction.[[GetPrototypeOf]]().
+  6. If IsConstructor(superConstructor) is false, throw a TypeError exception.
   [...]
 ---*/
 
@@ -52,7 +45,7 @@ var reachable = 0;
 class C extends null {
   constructor() {
     reachable += 1;
-    super();
+    super(unreachable += 1);
     unreachable += 1;
   }
 }

--- a/test/language/statements/class/subclass/class-definition-null-proto-this.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto-this.js
@@ -3,42 +3,37 @@
 /*---
 esid: sec-runtime-semantics-classdefinitionevaluation
 description: >
-  The `this` value of a null-extending class is automatically initialized
+  The `this` value of a null-extending class isn't automatically initialized
 info: |
-  The behavior under test was introduced in the "ES2017" revision of the
-  specification and conflicts with prior editions.
-
   Runtime Semantics: ClassDefinitionEvaluation
 
   [...]
-  5. If ClassHeritageopt is not present, then
-     [...]
-  6. Else,
-     [...]
-     b. Let superclass be the result of evaluating ClassHeritage.
-  [...]
-  15. If ClassHeritageopt is present and superclass is not null, then set F's
-      [[ConstructorKind]] internal slot to "derived".
+  15. If ClassHeritageopt is present, then set F's [[ConstructorKind]] internal slot to "derived".
   [...]
 
-  9.2.2 [[Construct]]
+  12.2.2.1 Runtime Semantics: Evaluation
+  PrimaryExpression : this
+  1. Return ? ResolveThisBinding( ).
 
+  8.3.4 ResolveThisBinding ( )
   [...]
-  5. If kind is "base", then
-     a. Let thisArgument be ? OrdinaryCreateFromConstructor(newTarget,
-        "%ObjectPrototype%").
+  2. Return ? envRec.GetThisBinding().
+  
+  8.1.1.3.4 GetThisBinding ( )
+  [...]
+  3. If envRec.[[ThisBindingStatus]] is "uninitialized", throw a ReferenceError exception.
   [...]
 ---*/
 
-var thisVal, instance;
-
 class C extends null {
   constructor() {
-    thisVal = this;
+    // Use an arrow function to access the `this` binding of the class constructor.
+    assert.throws(ReferenceError, () => {
+      this;
+    });
   }
 }
 
-instance = new C();
-
-assert.sameValue(instance instanceof C, true);
-assert.sameValue(instance, thisVal);
+assert.throws(ReferenceError, function() {
+  new C();
+});

--- a/test/language/statements/class/subclass/class-definition-null-proto.js
+++ b/test/language/statements/class/subclass/class-definition-null-proto.js
@@ -4,32 +4,21 @@
 esid: sec-runtime-semantics-classdefinitionevaluation
 es6id: 14.5.14
 description: >
-  When a null-extending class does not specify a `constructor` method
-  definition, a method with zero parameters and an empty body is used
+  The prototype of a null-extending class is %FunctionPrototype%, the prototype of
+  its "prototype" property is `null`.
 info: |
-  The behavior under test was introduced in the "ES2017" revision of the
-  specification and conflicts with prior editions.
-
   Runtime Semantics: ClassDefinitionEvaluation
 
+  [...]
   5. If ClassHeritageopt is not present, then
      [...]
   6. Else,
      [...]
      b. Let superclass be the result of evaluating ClassHeritage.
      [...]
-  7. Let proto be ObjectCreate(protoParent).
-  8. If ClassBodyopt is not present, let constructor be empty.
-  9. Else, let constructor be ConstructorMethod of ClassBody.
-  10. If constructor is empty, then
-      a. If ClassHeritageopt is present and superclass is not null, then
-         [...]
-      b. Else,
-         i. Let constructor be the result of parsing the source text
-
-              constructor( ){ }
-
-            using the syntactic grammar with the goal symbol MethodDefinition.
+     e. If superclass is null, then
+         i. Let protoParent be null.
+        ii. Let constructorParent be the intrinsic object %FunctionPrototype%.
   [...]
 ---*/
 
@@ -37,3 +26,4 @@ class Foo extends null {}
 
 assert.sameValue(Object.getPrototypeOf(Foo.prototype), null);
 assert.sameValue(Object.getPrototypeOf(Foo.prototype.constructor), Function.prototype);
+assert.sameValue(Foo, Foo.prototype.constructor);


### PR DESCRIPTION
The main changes are for tc39/ecma262#781 and tc39/ecma402#84, plus some other small bug fixes. 

tc39/ecma402#84 also needs new tests, but I'd like to fix the failing tests first.