### PR TITLE
Test for parameters with default expressions in Annex B FiB tests

### DIFF
--- a/test/annexB/language/function-code/block-decl-func-skip-param.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-param.js
@@ -27,5 +27,18 @@ var init, after;
   after = f;
 }(123));
 
-assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
-assert.sameValue(after, 123, 'value is not updated following evaluation');
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (without default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (without default expr)');
+
+(function(f = 123) {
+  init = f;
+
+  {
+    function f() {  }
+  }
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (with default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (with default expr)');

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-param.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-param.js
@@ -34,5 +34,16 @@ var init, after;
   after = f;
 }(123));
 
-assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
-assert.sameValue(after, 123, 'value is not updated following evaluation');
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (without default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (without default expr)');
+
+(function(f = 123) {
+  init = f;
+
+  if (true) function f() {  } else function _f() {}
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (with default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (with default expr)');

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-param.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-param.js
@@ -34,5 +34,16 @@ var init, after;
   after = f;
 }(123));
 
-assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
-assert.sameValue(after, 123, 'value is not updated following evaluation');
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (without default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (without default expr)');
+
+(function(f = 123) {
+  init = f;
+
+  if (false) function _f() {} else function f() {  }
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (with default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (with default expr)');

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-param.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-param.js
@@ -34,5 +34,16 @@ var init, after;
   after = f;
 }(123));
 
-assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
-assert.sameValue(after, 123, 'value is not updated following evaluation');
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (without default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (without default expr)');
+
+(function(f = 123) {
+  init = f;
+
+  if (true) function f() {  } else ;
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (with default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (with default expr)');

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-param.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-param.js
@@ -34,5 +34,16 @@ var init, after;
   after = f;
 }(123));
 
-assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
-assert.sameValue(after, 123, 'value is not updated following evaluation');
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (without default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (without default expr)');
+
+(function(f = 123) {
+  init = f;
+
+  if (true) function f() {  }
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (with default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (with default expr)');

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-param.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-param.js
@@ -34,5 +34,16 @@ var init, after;
   after = f;
 }(123));
 
-assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
-assert.sameValue(after, 123, 'value is not updated following evaluation');
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (without default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (without default expr)');
+
+(function(f = 123) {
+  init = f;
+
+  if (false) ; else function f() {  }
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (with default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (with default expr)');

--- a/test/annexB/language/function-code/switch-case-func-skip-param.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-param.js
@@ -28,5 +28,19 @@ var init, after;
   after = f;
 }(123));
 
-assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
-assert.sameValue(after, 123, 'value is not updated following evaluation');
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (without default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (without default expr)');
+
+(function(f = 123) {
+  init = f;
+
+  switch (1) {
+    case 1:
+      function f() {  }
+  }
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (with default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (with default expr)');

--- a/test/annexB/language/function-code/switch-dflt-func-skip-param.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-param.js
@@ -28,5 +28,19 @@ var init, after;
   after = f;
 }(123));
 
-assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
-assert.sameValue(after, 123, 'value is not updated following evaluation');
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (without default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (without default expr)');
+
+(function(f = 123) {
+  init = f;
+
+  switch (1) {
+    default:
+      function f() {  }
+  }
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined` (with default expr)');
+assert.sameValue(after, 123, 'value is not updated following evaluation (with default expr)');


### PR DESCRIPTION
@anba found this bug in Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1339123

This is worth testing because engines may implement the extra scope needed for function parameter expressions only if there are expressions.