### PR TITLE
Update YAML frontmatter of some tests to be compatible with monkeyYaml

### DIFF
--- a/test/built-ins/RegExp/prototype/Symbol.split/str-adv-thru-empty-match.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/str-adv-thru-empty-match.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description:
+description: >
     lastIndex is explicitly advanced following an empty match
 es6id: 21.2.5.11
 info: >

--- a/test/built-ins/RegExp/prototype/Symbol.split/u-lastindex-adv-thru-match.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/u-lastindex-adv-thru-match.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description:
+description: >
     lastIndex is advanced according to width of astral symbols following match success
 es6id: 21.2.5.11
 info: >

--- a/test/intl402/PluralRules/prototype/select/non-finite.js
+++ b/test/intl402/PluralRules/prototype/select/non-finite.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-Intl.PluralRules.prototype.select
 description: Tests that select function returns "other" for non finite values.
-info:
+info: |
   1.1.4. ResolvePlural (pluralRules, n)
   (...)
   1.1.4_3. If isFinite(n) is false, then

--- a/test/intl402/PluralRules/prototype/select/tainting.js
+++ b/test/intl402/PluralRules/prototype/select/tainting.js
@@ -6,7 +6,7 @@ esid: sec-intl-pluralrules-abstracts
 description: >
     Tests that the behavior of a Record is not affected by
     adversarial  changes to Object.prototype.
-info:
+info: |
   1.1.1. InitializePluralRules (pluralRules, locales, options)
   (...)
   1.1.1_6. Let t be ? GetOption(options, "type", "string", « "cardinal", "ordinal" », "cardinal").

--- a/test/language/module-code/instn-named-bndng-dflt-expr.js
+++ b/test/language/module-code/instn-named-bndng-dflt-expr.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-description:
+description: >
     Imported binding reflects state of exported default binding (expressions)
 esid: sec-moduledeclarationinstantiation
 info: |

--- a/test/language/module-code/instn-star-ambiguous.js
+++ b/test/language/module-code/instn-star-ambiguous.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-description:
+description: >
     Ambiguous exports are not reflected in module namespace objects, nor do
     they trigger an error upon resolution
 esid: sec-moduledeclarationinstantiation

--- a/test/language/module-code/instn-star-props-circular.js
+++ b/test/language/module-code/instn-star-props-circular.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-description:
+description: >
     Circular "star" imports do not trigger infinite recursion during name
     enumeration.
 esid: sec-moduledeclarationinstantiation

--- a/test/language/module-code/instn-star-props-dflt-keep-indirect.js
+++ b/test/language/module-code/instn-star-props-dflt-keep-indirect.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-description:
+description: >
     Indirect default exports are included in the module namespace object
 esid: sec-moduledeclarationinstantiation
 info: |

--- a/test/language/module-code/instn-star-props-dflt-keep-local.js
+++ b/test/language/module-code/instn-star-props-dflt-keep-local.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-description:
+description: >
     Local default exports are included in the module namespace object
 esid: sec-moduledeclarationinstantiation
 info: |

--- a/test/language/module-code/instn-star-props-dflt-skip.js
+++ b/test/language/module-code/instn-star-props-dflt-skip.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-description:
+description: >
     Default exports are not included in the module namespace object
 esid: sec-moduledeclarationinstantiation
 info: |

--- a/test/language/statements/for-of/array-contract.js
+++ b/test/language/statements/for-of/array-contract.js
@@ -3,7 +3,7 @@
 
 /*---
 description: Array entry removal during traversal using for..of
-info:
+info: >
     Entries removed from an Array instance during traversal should not be
     visited.
 es6id: 13.6.4

--- a/test/language/statements/if/cptn-else-false-abrupt-empty.js
+++ b/test/language/statements/if/cptn-else-false-abrupt-empty.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-if-statement-runtime-semantics-evaluation
-description:
+description: >
     Completion value when expression is false with an `else` clause and body
     returns an empty abrupt completion
 info: >

--- a/test/language/statements/with/labelled-fn-stmt.js
+++ b/test/language/statements/with/labelled-fn-stmt.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-with-statement-static-semantics-early-errors
 es6id: 13.11.1
-description:
+description: >
   A labelled function declaration is never permitted in the Statement position
 info: |
   WithStatementa: with ( Expression ) Statement


### PR DESCRIPTION
MonkeyYaml can't parse the YAML meta data when the mapping value is written in the next line without either `>` or `|`.