### PR TITLE
NumberFormat default minimumSignificantDigits

### DIFF
--- a/test/intl402/NumberFormat/default-minimum-singificant-digits.js
+++ b/test/intl402/NumberFormat/default-minimum-singificant-digits.js
@@ -13,6 +13,9 @@ assert.throws(RangeError, function() {
   Intl.NumberFormat(undefined, {maximumSignificantDigits: 0});
 });
 
-// For similar reasons, the following statement is checking that
-// minimumSignificantDigits is at most 1.
-assert.notSameValue(Intl.NumberFormat(undefined, {maximumSignificantDigits: 1}), undefined);
+// If nothing is thrown, check that the options are resolved appropriately.
+var res = Intl.NumberFormat(undefined, {maximumSignificantDigits: 1})
+
+assert.sameValue(Object.getPrototypeOf(res), Intl.NumberFormat.prototype, 'result is an instance of NumberFormat')
+assert.sameValue(res.resolvedOptions().minimumSignificantDigits, 1, 'default minimumSignificantDigits')
+assert.sameValue(res.resolvedOptions().maximumSignificantDigits, 1, 'sets maximumSignificantDigits')

--- a/test/intl402/NumberFormat/default-minimum-singificant-digits.js
+++ b/test/intl402/NumberFormat/default-minimum-singificant-digits.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Tests that the default value of minimumSignificantDigits is 1.
+---*/
+
+// maximumSignificantDigits needs to be in range from minimumSignificantDigits
+// to 21 (both inclusive). Setting maximumSignificantDigits to 0 will throw a
+// RangeError if the (default) minimumSignificantDigits is at least 1.
+assert.throws(RangeError, function() {
+  Intl.NumberFormat(undefined, {maximumSignificantDigits: 0});
+});
+
+// For similar reasons, the following statement is checking that
+// minimumSignificantDigits is at most 1.
+Intl.NumberFormat(undefined, {maximumSignificantDigits: 1});

--- a/test/intl402/NumberFormat/default-minimum-singificant-digits.js
+++ b/test/intl402/NumberFormat/default-minimum-singificant-digits.js
@@ -3,6 +3,7 @@
 
 /*---
 description: Tests that the default value of minimumSignificantDigits is 1.
+esid: sec-setnfdigitoptions
 ---*/
 
 // maximumSignificantDigits needs to be in range from minimumSignificantDigits
@@ -14,4 +15,4 @@ assert.throws(RangeError, function() {
 
 // For similar reasons, the following statement is checking that
 // minimumSignificantDigits is at most 1.
-Intl.NumberFormat(undefined, {maximumSignificantDigits: 1});
+assert.notSameValue(Intl.NumberFormat(undefined, {maximumSignificantDigits: 1}), undefined);


### PR DESCRIPTION
Adds a test for NumberFormat default minimumSignificantDigits.

This originates from the V8 bugfix https://bugs.chromium.org/p/v8/issues/detail?id=5554.