### PR TITLE
Implementing initial set test cases for object rest deconstruction

### DIFF
--- a/src/dstr-assignment/obj-rest-descriptors.case
+++ b/src/dstr-assignment/obj-rest-descriptors.case
@@ -1,0 +1,33 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    Object created from rest deconstruction doesn't copy source
+    object property descriptors.
+template: default
+esid: pending
+includes: [propertyHelper.js]
+---*/
+
+//- setup
+var rest;
+var obj = {};
+Object.defineProperty(obj, "a", { value: 3, configurable: false, enumerable: true });
+Object.defineProperty(obj, "b", { value: 4, writable: false, enumerable: true });
+//- elems
+{...rest}
+//- vals
+obj
+//- body
+assert.sameValue(rest.a, 3);
+assert.sameValue(rest.b, 4);
+
+verifyEnumerable(rest, "a");
+verifyWritable(rest, "a");
+verifyConfigurable(rest, "a");
+
+verifyEnumerable(rest, "b");
+verifyWritable(rest, "b");
+verifyConfigurable(rest, "b");
+

--- a/src/dstr-assignment/obj-rest-empty-obj.case
+++ b/src/dstr-assignment/obj-rest-empty-obj.case
@@ -1,0 +1,22 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    RestBindingInitialization creates a new object even if lhs is an empty object
+template: default
+esid: pending
+---*/
+
+//- setup
+var rest;
+
+//- elems
+{...rest}
+//- vals
+{}
+//- body
+assert.notSameValue(rest, undefined);
+assert.notSameValue(rest, null);
+assert.sameValue(typeof rest, "object");
+

--- a/src/dstr-assignment/obj-rest-getter-abrupt-get-error.case
+++ b/src/dstr-assignment/obj-rest-getter-abrupt-get-error.case
@@ -1,0 +1,22 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    Rest deconstruction doesn't happen if getter return is abrupt
+template: error
+esid: pending
+---*/
+
+//- setup
+var x;
+var count = 0;
+//- elems
+{...x}
+//- vals
+{ get v() { count++; throw new Test262Error(); } }
+//- error
+Test262Error
+//- teardown
+assert.sameValue(count, 1);
+

--- a/src/dstr-assignment/obj-rest-getter.case
+++ b/src/dstr-assignment/obj-rest-getter.case
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    Getter is called when obj is being deconstructed to a rest Object
+template: default
+esid: pending
+includes: [propertyHelper.js]
+---*/
+
+//- setup
+var x;
+var count = 0;
+//- elems
+{...x}
+//- vals
+{ get v() { count++; return 2; } }
+//- body
+assert.sameValue(x.v, 2);
+assert.sameValue(count, 1);
+
+verifyEnumerable(x, "v");
+verifyWritable(x, "v");
+verifyConfigurable(x, "v");
+

--- a/src/dstr-assignment/obj-rest-nested-obj-nested-rest.case
+++ b/src/dstr-assignment/obj-rest-nested-obj-nested-rest.case
@@ -1,0 +1,35 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    When DestructuringAssignmentTarget is an object literal, it should be parsed
+    parsed as a DestructuringAssignmentPattern and evaluated as a destructuring
+    assignment and object rest desconstruction is allowed in that case.
+template: default
+esid: pending
+includes: [propertyHelper.js]
+---*/
+
+//- setup
+var a, b, c, rest;
+//- elems
+{a, b, ...{c, ...rest}}
+//- vals
+{a: 1, b: 2, c: 3, d: 4, e: 5}
+//- body
+assert.sameValue(a, 1);
+assert.sameValue(b, 2);
+assert.sameValue(c, 3);
+
+assert.sameValue(rest.d, 4);
+assert.sameValue(rest.e, 5);
+
+verifyEnumerable(rest, "d");
+verifyWritable(rest, "d");
+verifyConfigurable(rest, "d");
+
+verifyEnumerable(rest, "e");
+verifyWritable(rest, "e");
+verifyConfigurable(rest, "e");
+

--- a/src/dstr-assignment/obj-rest-nested-obj.case
+++ b/src/dstr-assignment/obj-rest-nested-obj.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    When DestructuringAssignmentTarget is an object literal, it should be parsed
+    parsed as a DestructuringAssignmentPattern and evaluated as a destructuring
+    assignment.
+template: default
+esid: pending
+---*/
+
+//- setup
+var a, b, c, d, e;
+//- elems
+{a, b, ...{c, e}}
+//- vals
+{a: 1, b: 2, c: 3, d: 4, e: 5}
+//- body
+assert.sameValue(a, 1);
+assert.sameValue(b, 2);
+assert.sameValue(c, 3);
+assert.sameValue(e, 5);
+assert.sameValue(d, undefined);
+

--- a/src/dstr-assignment/obj-rest-not-last-element-invalid.case
+++ b/src/dstr-assignment/obj-rest-not-last-element-invalid.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    Object rest element needs to be the last AssignmenProperty
+    in ObjectAssignmentPattern.
+template: syntax
+esid: pending
+negative:
+  phase: early
+  type: SyntaxError
+---*/
+
+//- setup
+var rest, b;
+//- elems
+{...rest, b}
+//- vals
+{}
+

--- a/src/dstr-assignment/obj-rest-number.case
+++ b/src/dstr-assignment/obj-rest-number.case
@@ -1,0 +1,22 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    RestBindingInitialization creates a new object even if lhs is a Number
+template: default
+esid: pending
+---*/
+
+//- setup
+var rest;
+
+//- elems
+{...rest}
+//- vals
+51
+//- body
+assert.notSameValue(rest, undefined);
+assert.notSameValue(rest, null);
+assert(rest instanceof Object);
+

--- a/src/dstr-assignment/obj-rest-obj-own-property.case
+++ b/src/dstr-assignment/obj-rest-obj-own-property.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    Rest object contains just soruce object's own properties
+template: default
+esid: pending
+includes: [propertyHelper.js]
+---*/
+
+//- setup
+var o = Object.create({ x: 1, y: 2 });
+o.z = 3;
+
+var x, y, z;
+//- elems
+{ x, ...{y , z} }
+//- vals
+o
+//- body
+assert.sameValue(x, 1);
+assert.sameValue(y, undefined);
+assert.sameValue(z, 3);
+

--- a/src/dstr-assignment/obj-rest-put-const.case
+++ b/src/dstr-assignment/obj-rest-put-const.case
@@ -1,0 +1,20 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    The object rest deconstruction assignment target should obey `const` semantics.
+template: error
+esid: pending
+features: [const]
+---*/
+
+//- setup
+const rest = null;
+//- error
+TypeError
+//- elems
+{...rest}
+//- vals
+{}
+

--- a/src/dstr-assignment/obj-rest-skip-non-enumerable.case
+++ b/src/dstr-assignment/obj-rest-skip-non-enumerable.case
@@ -1,0 +1,32 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    Rest object doesn't contain non-enumerable properties
+template: default
+esid: pending
+includes: [propertyHelper.js]
+---*/
+
+//- setup
+var rest;
+var obj = {a: 3, b: 4};
+Object.defineProperty(obj, "x", { value: 4, enumerable: false });
+//- elems
+{...rest}
+//- vals
+obj
+//- body
+assert.sameValue(rest.a, 3);
+assert.sameValue(rest.b, 4);
+assert.sameValue(Object.getOwnPropertyDescriptor(rest, "x"), undefined);
+
+verifyEnumerable(rest, "a");
+verifyWritable(rest, "a");
+verifyConfigurable(rest, "a");
+
+verifyEnumerable(rest, "b");
+verifyWritable(rest, "b");
+verifyConfigurable(rest, "b");
+

--- a/src/dstr-assignment/obj-rest-str-val.case
+++ b/src/dstr-assignment/obj-rest-str-val.case
@@ -1,0 +1,23 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    RestBindingInitialization creats an object with indexes as property name
+template: default
+esid: pending
+---*/
+
+//- setup
+var rest;
+
+//- elems
+{...rest}
+//- vals
+"foo"
+//- body
+assert.sameValue(rest["0"], "f");
+assert.sameValue(rest["1"], "o");
+assert.sameValue(rest["2"], "o");
+assert(rest instanceof Object);
+

--- a/src/dstr-assignment/obj-rest-symbol-val.case
+++ b/src/dstr-assignment/obj-rest-symbol-val.case
@@ -1,0 +1,22 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    RestBindingInitialization creates a new object if lhs is a Symbol
+template: default
+esid: pending
+---*/
+
+//- setup
+var rest;
+
+//- elems
+{...rest}
+//- vals
+Symbol("foo")
+//- body
+assert.notSameValue(rest, undefined);
+assert.notSameValue(rest, null);
+assert(rest instanceof Object);
+

--- a/src/dstr-assignment/obj-rest-to-property-with-setter.case
+++ b/src/dstr-assignment/obj-rest-to-property-with-setter.case
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    When DestructuringAssignmentTarget is an object property setter, its value should be
+    binded as rest object.
+template: default
+esid: pending
+---*/
+
+//- setup
+var settedValue;
+var executedGetter = false;
+var src = {
+    get y() { executedGetter = true; },
+    set y(v) {
+        settedValue = v;
+    }
+}
+src.y = undefined;
+//- elems
+{...src.y}
+//- vals
+{ x: 1, y: 2}
+//- body
+assert.sameValue(settedValue.x, 1);
+assert.sameValue(settedValue.y, 2);
+assert(!executedGetter, "The property should not be accessed");
+

--- a/src/dstr-assignment/obj-rest-to-property.case
+++ b/src/dstr-assignment/obj-rest-to-property.case
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    When DestructuringAssignmentTarget is an object property, its value should be binded
+    as rest object.
+template: default
+esid: pending
+includes: [propertyHelper.js]
+---*/
+
+//- setup
+var src = {};
+//- elems
+{...src.y}
+//- vals
+{ x: 1, y: 2}
+//- body
+assert.sameValue(src.y.x, 1);
+assert.sameValue(src.y.y, 2);
+
+verifyEnumerable(src, "y");
+verifyWritable(src, "y");
+verifyConfigurable(src, "y");
+

--- a/src/dstr-assignment/obj-rest-val-null.case
+++ b/src/dstr-assignment/obj-rest-val-null.case
@@ -1,0 +1,20 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    TypeError is thrown when rhs is null because of 7.1.13 ToObject ( argument )
+    used by CopyDataProperties
+template: error
+esid: pending
+---*/
+
+//- error
+TypeError
+//- setup
+var rest;
+//- elems
+{...rest}
+//- vals
+null
+

--- a/src/dstr-assignment/obj-rest-val-undefined.case
+++ b/src/dstr-assignment/obj-rest-val-undefined.case
@@ -1,0 +1,20 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    TypeError is thrown when rhs is ```undefined``` because of 7.1.13 ToObject ( argument )
+    used by CopyDataProperties
+template: error
+esid: pending
+---*/
+
+//- error
+TypeError
+//- setup
+var rest;
+//- elems
+{...rest}
+//- vals
+undefined
+

--- a/src/dstr-assignment/obj-rest-valid-object.case
+++ b/src/dstr-assignment/obj-rest-valid-object.case
@@ -1,0 +1,32 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    Rest object contains just unextracted data
+template: default
+esid: pending
+includes: [propertyHelper.js]
+---*/
+
+//- setup
+var rest, a, b;
+
+//- elems
+{a, b, ...rest}
+//- vals
+{x: 1, y: 2, a: 5, b: 3}
+//- body
+assert.sameValue(rest.x, 1);
+assert.sameValue(rest.y, 2);
+assert.sameValue(rest.a, undefined);
+assert.sameValue(rest.b, undefined);
+
+verifyEnumerable(rest, "x");
+verifyWritable(rest, "x");
+verifyConfigurable(rest, "x");
+
+verifyEnumerable(rest, "y");
+verifyWritable(rest, "y");
+verifyConfigurable(rest, "y");
+

--- a/src/dstr-binding/obj-ptrn-rest-getter.case
+++ b/src/dstr-binding/obj-ptrn-rest-getter.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    Getter is called when obj is being deconstructed to a rest Object
+template: default
+esid: pending
+includes: [propertyHelper.js]
+---*/
+
+//- setup
+var count = 0;
+//- elems
+{...x}
+//- vals
+{ get v() { count++; return 2; } }
+//- body
+assert.sameValue(x.v, 2);
+assert.sameValue(count, 1);
+
+verifyEnumerable(x, "v");
+verifyWritable(x, "v");
+verifyConfigurable(x, "v");
+

--- a/src/dstr-binding/obj-ptrn-rest-nested-obj.case
+++ b/src/dstr-binding/obj-ptrn-rest-nested-obj.case
@@ -1,0 +1,24 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    When DestructuringAssignmentTarget is an object literal, it should be parsed
+    parsed as a DestructuringAssignmentPattern and evaluated as a destructuring
+    assignment.
+template: default
+esid: pending
+---*/
+
+//- setup
+var obj = {a: 3, b: 4};
+//- elems
+{a, b, ...{c, e}}
+//- vals
+{a: 1, b: 2, c: 3, d: 4, e: 5}
+//- body
+assert.sameValue(a, 1);
+assert.sameValue(b, 2);
+assert.sameValue(c, 3);
+assert.sameValue(e, 5);
+

--- a/src/dstr-binding/obj-ptrn-rest-obj-nested-rest.case
+++ b/src/dstr-binding/obj-ptrn-rest-obj-nested-rest.case
@@ -1,0 +1,33 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    When DestructuringAssignmentTarget is an object literal, it should be parsed
+    parsed as a DestructuringAssignmentPattern and evaluated as a destructuring
+    assignment and object rest desconstruction is allowed in that case.
+template: default
+esid: pending
+includes: [propertyHelper.js]
+---*/
+
+//- elems
+{a, b, ...{c, ...rest}}
+//- vals
+{a: 1, b: 2, c: 3, d: 4, e: 5}
+//- body
+assert.sameValue(a, 1);
+assert.sameValue(b, 2);
+assert.sameValue(c, 3);
+
+assert.sameValue(rest.d, 4);
+assert.sameValue(rest.e, 5);
+
+verifyEnumerable(rest, "d");
+verifyWritable(rest, "d");
+verifyConfigurable(rest, "d");
+
+verifyEnumerable(rest, "e");
+verifyWritable(rest, "e");
+verifyConfigurable(rest, "e");
+

--- a/src/dstr-binding/obj-ptrn-rest-obj-own-property.case
+++ b/src/dstr-binding/obj-ptrn-rest-obj-own-property.case
@@ -1,0 +1,23 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    Rest object contains just soruce object's own properties
+template: default
+esid: pending
+includes: [propertyHelper.js]
+---*/
+
+//- setup
+var o = Object.create({ x: 1, y: 2 });
+o.z = 3;
+//- elems
+{ x, ...{y , z} }
+//- vals
+o
+//- body
+assert.sameValue(x, 1);
+assert.sameValue(y, undefined);
+assert.sameValue(z, 3);
+

--- a/src/dstr-binding/obj-ptrn-rest-skip-non-enumerable.case
+++ b/src/dstr-binding/obj-ptrn-rest-skip-non-enumerable.case
@@ -1,0 +1,31 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    Rest object doesn't contain non-enumerable properties
+template: default
+esid: pending
+includes: [propertyHelper.js]
+---*/
+
+//- setup
+var o = {a: 3, b: 4};
+Object.defineProperty(o, "x", { value: 4, enumerable: false });
+//- elems
+{...rest}
+//- vals
+o
+//- body
+assert.sameValue(rest.a, 3);
+assert.sameValue(rest.b, 4);
+assert.sameValue(rest.x, undefined);
+
+verifyEnumerable(rest, "a");
+verifyWritable(rest, "a");
+verifyConfigurable(rest, "a");
+
+verifyEnumerable(rest, "b");
+verifyWritable(rest, "b");
+verifyConfigurable(rest, "b");
+

--- a/src/dstr-binding/obj-ptrn-rest-val-obj.case
+++ b/src/dstr-binding/obj-ptrn-rest-val-obj.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    Rest object contains just unextracted data
+template: default
+esid: pending
+includes: [propertyHelper.js]
+---*/
+
+//- elems
+{a, b, ...rest}
+//- vals
+{x: 1, y: 2, a: 5, b: 3}
+//- body
+assert.sameValue(rest.x, 1);
+assert.sameValue(rest.y, 2);
+assert.sameValue(rest.a, undefined);
+assert.sameValue(rest.b, undefined);
+
+verifyEnumerable(rest, "x");
+verifyWritable(rest, "x");
+verifyConfigurable(rest, "x");
+
+verifyEnumerable(rest, "y");
+verifyWritable(rest, "y");
+verifyConfigurable(rest, "y");
+


### PR DESCRIPTION
This PR is an initial set for Object Properties Rest Deconstruction proposal. To run these tests is necessary generate test cases using make.py script. To run them, an agent harness is required. v8 is already implementing it behind ```--harmony_object_rest_spreas``` and a proposed Patch in JavaScriptCore is ongoing [1]. I ran these tests using JavaScriptCore's Patch applied.

Some tests around the syntax is also coming.

[1] - https://bugs.webkit.org/show_bug.cgi?id=167962