### PR TITLE
Update tests for cyclic module dependencies through export*

### DIFF
--- a/test/language/module-code/instn-iee-star-cycle-indirect-x_FIXTURE.js
+++ b/test/language/module-code/instn-iee-star-cycle-indirect-x_FIXTURE.js
@@ -1,7 +1,8 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-// This module should be visited exactly one time during resolution of the "x"
-// binding.
+// This module is visited two times:
+// First when resolving the "x" binding and then another time to resolve the
+// "y" binding.
 export { y as x } from './instn-iee-star-cycle-2_FIXTURE.js';
 export var y = 45;

--- a/test/language/module-code/instn-iee-star-cycle.js
+++ b/test/language/module-code/instn-iee-star-cycle.js
@@ -2,26 +2,42 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: >
-    Modules are visited no more than one time when resolving bindings through
-    "star" exports.
+    Modules can be visited more than once when resolving bindings through
+    "star" exports as long as the exportName is different each time.
 esid: sec-moduledeclarationinstantiation
 info: |
     [...]
     9. For each ExportEntry Record e in module.[[IndirectExportEntries]], do
        a. Let resolution be ? module.ResolveExport(e.[[ExportName]], « », « »).
-       b. If resolution is null or resolution is "ambiguous", throw a
-          SyntaxError exception.
+       [...]
 
-    15.2.1.16.3 ResolveExport( exportName, resolveSet, exportStarSet )
+    15.2.1.16.3 ResolveExport( exportName, resolveSet )
 
     [...]
-    7. If exportStarSet contains module, return null.
-    8. Append module to exportStarSet.
+    3. Append the Record {[[Module]]: module, [[ExportName]]: exportName} to resolveSet.
+    4. For each ExportEntry Record e in module.[[LocalExportEntries]], do
+       a. If SameValue(exportName, e.[[ExportName]]) is true, then
+          i.  Assert: module provides the direct binding for this export.
+          ii. Return Record{[[Module]]: module, [[BindingName]]: e.[[LocalName]]}.
+    5. For each ExportEntry Record e in module.[[IndirectExportEntries]], do
+       a. If SameValue(exportName, e.[[ExportName]]) is true, then
+          i.   Assert: module imports a specific binding for this export.
+          ii.  Let importedModule be ? HostResolveImportedModule(module, e.[[ModuleRequest]]).
+          iii. Return ? importedModule.ResolveExport(e.[[ImportName]], resolveSet).
     [...]
-negative:
-  phase: early
-  type: SyntaxError
+    8. For each ExportEntry Record e in module.[[StarExportEntries]], do
+       a. Let importedModule be ? HostResolveImportedModule(module, e.[[ModuleRequest]]).
+       b. Let resolution be ? importedModule.ResolveExport(exportName, resolveSet).
+       [...]
+       d. If resolution is not null, then
+          i.  If starResolution is null, let starResolution be resolution.
+          [...]
+    9. Return starResolution.
 flags: [module]
 ---*/
 
 export { x } from './instn-iee-star-cycle-2_FIXTURE.js';
+
+import * as self from './instn-iee-star-cycle.js';
+
+assert.sameValue(self.x, 45);

--- a/test/language/module-code/instn-named-star-cycle-indirect-x_FIXTURE.js
+++ b/test/language/module-code/instn-named-star-cycle-indirect-x_FIXTURE.js
@@ -1,7 +1,8 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-// This module should be visited exactly one time during resolution of the "x"
-// binding.
+// This module is visited two times:
+// First when resolving the "x" binding and then another time to resolve the
+// "y" binding.
 export { y as x } from './instn-named-star-cycle-2_FIXTURE.js';
 export var y = 45;

--- a/test/language/module-code/instn-named-star-cycle.js
+++ b/test/language/module-code/instn-named-star-cycle.js
@@ -2,8 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: >
-    Modules are visited no more than one time when resolving bindings through
-    "star" exports.
+    Modules can be visited more than once when resolving bindings through
+    "star" exports as long as the exportName is different each time.
 esid: sec-moduledeclarationinstantiation
 info: |
     [...]
@@ -15,22 +15,36 @@ info: |
         c. Else,
            i. Let resolution be ?
               importedModule.ResolveExport(in.[[ImportName]], « », « »).
-           ii. If resolution is null or resolution is "ambiguous", throw a
-               SyntaxError exception.
+           [...]
            iii. Call envRec.CreateImportBinding(in.[[LocalName]],
                 resolution.[[Module]], resolution.[[BindingName]]).
     [...]
 
-    15.2.1.16.3 ResolveExport( exportName, resolveSet, exportStarSet )
+    15.2.1.16.3 ResolveExport( exportName, resolveSet )
 
     [...]
-    7. If exportStarSet contains module, return null.
-    8. Append module to exportStarSet.
+    3. Append the Record {[[Module]]: module, [[ExportName]]: exportName} to resolveSet.
+    4. For each ExportEntry Record e in module.[[LocalExportEntries]], do
+       a. If SameValue(exportName, e.[[ExportName]]) is true, then
+          i.  Assert: module provides the direct binding for this export.
+          ii. Return Record{[[Module]]: module, [[BindingName]]: e.[[LocalName]]}.
+    5. For each ExportEntry Record e in module.[[IndirectExportEntries]], do
+       a. If SameValue(exportName, e.[[ExportName]]) is true, then
+          i.   Assert: module imports a specific binding for this export.
+          ii.  Let importedModule be ? HostResolveImportedModule(module, e.[[ModuleRequest]]).
+          iii. Return ? importedModule.ResolveExport(e.[[ImportName]], resolveSet).
     [...]
-negative:
-  phase: early
-  type: SyntaxError
+    8. For each ExportEntry Record e in module.[[StarExportEntries]], do
+       a. Let importedModule be ? HostResolveImportedModule(module, e.[[ModuleRequest]]).
+       b. Let resolution be ? importedModule.ResolveExport(exportName, resolveSet).
+       [...]
+       d. If resolution is not null, then
+          i.  If starResolution is null, let starResolution be resolution.
+          [...]
+    9. Return starResolution.
 flags: [module]
 ---*/
 
 import { x } from './instn-named-star-cycle-2_FIXTURE.js';
+
+assert.sameValue(x, 45);

--- a/test/language/module-code/instn-star-star-cycle-indirect-x_FIXTURE.js
+++ b/test/language/module-code/instn-star-star-cycle-indirect-x_FIXTURE.js
@@ -1,7 +1,8 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-// This module should be visited exactly one time during resolution of the "x"
-// binding.
+// This module is visited two times:
+// First when resolving the "x" binding and then another time to resolve the
+// "y" binding.
 export { y as x } from './instn-star-star-cycle-2_FIXTURE.js';
 export var y = 45;

--- a/test/language/module-code/instn-star-star-cycle.js
+++ b/test/language/module-code/instn-star-star-cycle.js
@@ -2,8 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: >
-    Modules are visited no more than one time when resolving bindings through
-    "star" exports.
+    Modules can be visited more than once when resolving bindings through
+    "star" exports as long as the exportName is different each time.
 esid: sec-moduledeclarationinstantiation
 info: |
     [...]
@@ -16,16 +16,32 @@ info: |
            iii. Call envRec.InitializeBinding(in.[[LocalName]], namespace).
         [...]
 
-    15.2.1.16.3 ResolveExport( exportName, resolveSet, exportStarSet )
+    15.2.1.16.3 ResolveExport( exportName, resolveSet )
 
     [...]
-    7. If exportStarSet contains module, return null.
-    8. Append module to exportStarSet.
+    3. Append the Record {[[Module]]: module, [[ExportName]]: exportName} to resolveSet.
+    4. For each ExportEntry Record e in module.[[LocalExportEntries]], do
+       a. If SameValue(exportName, e.[[ExportName]]) is true, then
+          i.  Assert: module provides the direct binding for this export.
+          ii. Return Record{[[Module]]: module, [[BindingName]]: e.[[LocalName]]}.
+    5. For each ExportEntry Record e in module.[[IndirectExportEntries]], do
+       a. If SameValue(exportName, e.[[ExportName]]) is true, then
+          i.   Assert: module imports a specific binding for this export.
+          ii.  Let importedModule be ? HostResolveImportedModule(module, e.[[ModuleRequest]]).
+          iii. Return ? importedModule.ResolveExport(e.[[ImportName]], resolveSet).
     [...]
-negative:
-  phase: early
-  type: SyntaxError
+    8. For each ExportEntry Record e in module.[[StarExportEntries]], do
+       a. Let importedModule be ? HostResolveImportedModule(module, e.[[ModuleRequest]]).
+       b. Let resolution be ? importedModule.ResolveExport(exportName, resolveSet).
+       [...]
+       d. If resolution is not null, then
+          i.  If starResolution is null, let starResolution be resolution.
+          [...]
+    9. Return starResolution.
 flags: [module]
 ---*/
 
 import * as ns from './instn-star-star-cycle-2_FIXTURE.js';
+
+assert.sameValue(ns.x, 45);
+assert.sameValue(ns.y, 45);


### PR DESCRIPTION
Cyclic dependencies are no longer an error per https://github.com/tc39/ecma262/pull/783.