### PR TITLE
Async Generator flow control tests

### DIFF
--- a/test/language/expressions/async-generators/return-suspendedStart-promise.js
+++ b/test/language/expressions/async-generators/return-suspendedStart-promise.js
@@ -1,0 +1,36 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is return, and generator.[[AsyncGeneratorState]] is
+  "suspendedStart", generator is closed without being resumed.
+
+  AsyncGeneratorResolve will unwrap Promise values (steps 6-10)
+flags: [async]
+---*/
+
+var g = async function*() {
+  throw new Test262Error('Generator must not be resumed.');
+};
+
+var it = g();
+var resolve;
+var promise = new Promise(function(resolver) {
+  resolve = resolver;
+});
+
+it.return(promise).then(function(ret) {
+  assert.sameValue(ret.value, 'unwrapped-value', 'AsyncGeneratorResolve(generator, completion.[[Value]], true)');
+  assert.sameValue(ret.done, true, 'AsyncGeneratorResolve(generator, completion.[[Value]], true)');
+
+  it.next().then(function(ret) {
+    assert.sameValue(ret.value, undefined, 'Generator is closed');
+    assert.sameValue(ret.done, true, 'Generator is closed');
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+resolve('unwrapped-value');

--- a/test/language/expressions/async-generators/return-suspendedStart.js
+++ b/test/language/expressions/async-generators/return-suspendedStart.js
@@ -1,0 +1,27 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is return, and generator.[[AsyncGeneratorState]] is
+  "suspendedStart", generator is closed without being resumed.
+flags: [async]
+---*/
+
+var g = async function*() {
+  throw new Test262Error('Generator must not be resumed.');
+};
+
+var it = g();
+it.return('sent-value').then(function(ret) {
+  assert.sameValue(ret.value, 'sent-value', 'AsyncGeneratorResolve(generator, completion.[[Value]], true)');
+  assert.sameValue(ret.done, true, 'AsyncGeneratorResolve(generator, completion.[[Value]], true)');
+
+  it.next().then(function(ret) {
+    assert.sameValue(ret.value, undefined, 'Generator is closed');
+    assert.sameValue(ret.done, true, 'Generator is closed');
+  }).then($DONE, $DONE);
+}).catch($DONE);

--- a/test/language/expressions/async-generators/return-suspendedYield-promise.js
+++ b/test/language/expressions/async-generators/return-suspendedYield-promise.js
@@ -1,0 +1,41 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is return, and generator.[[AsyncGeneratorState]] is
+  "suspendedYield", generator is resumed and immediately closes the generator
+  and returns completion.
+flags: [async]
+---*/
+
+var g = async function*() {
+  yield 1;
+  throw new Test262Error('Generator must not be resumed.');
+};
+
+var it = g();
+var resolve;
+var promise = new Promise(function(resolver) {
+  resolve = resolver;
+});
+it.next().then(function(ret) {
+  assert.sameValue(ret.value, 1, 'Initial yield');
+  assert.sameValue(ret.done, false, 'Initial yield');
+
+  it.return(promise).then(function(ret) {
+    assert.sameValue(ret.value, 'unwrapped-value', 'AsyncGeneratorResolve(generator, resultValue, true)');
+    assert.sameValue(ret.done, true, 'AsyncGeneratorResolve(generator, resultValue, true)');
+
+    it.next().then(function(ret) {
+      assert.sameValue(ret.value, undefined, 'Generator is closed');
+      assert.sameValue(ret.done, true, 'Generator is closed');
+    }).then($DONE, $DONE);
+    
+  }).catch($DONE);
+
+  resolve('unwrapped-value');
+}).catch($DONE);

--- a/test/language/expressions/async-generators/return-suspendedYield-try-finally-return.js
+++ b/test/language/expressions/async-generators/return-suspendedYield-try-finally-return.js
@@ -1,0 +1,40 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is return, and generator.[[AsyncGeneratorState]] is
+  "suspendedYield", and generator is resumed within a try-block with an
+  associated finally block, resume execution within finally.
+flags: [async]
+---*/
+
+var g = async function*() {
+  try {
+    yield 1;
+    throw new Test262Error('Generator must be resumed in finally block.');
+  } finally {
+    return 'done';
+  }
+};
+
+var it = g();
+it.next().then(function(ret) {
+  assert.sameValue(ret.value, 1, 'Initial yield');
+  assert.sameValue(ret.done, false, 'Initial yield');
+
+  it.return('sent-value').then(function(ret) {
+    assert.sameValue(ret.value, 'done', 'AsyncGeneratorResolve(generator, resultValue, true)');
+    assert.sameValue(ret.done, true, 'AsyncGeneratorResolve(generator, resultValue, true)');
+
+    it.next().then(function(ret) {
+      assert.sameValue(ret.value, undefined, 'Generator is closed');
+      assert.sameValue(ret.done, true, 'Generator is closed');
+    }).then($DONE, $DONE);
+    
+  }).catch($DONE);
+
+}).catch($DONE);

--- a/test/language/expressions/async-generators/return-suspendedYield-try-finally-throw.js
+++ b/test/language/expressions/async-generators/return-suspendedYield-try-finally-throw.js
@@ -1,0 +1,41 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is return, and generator.[[AsyncGeneratorState]] is
+  "suspendedYield", and generator is resumed within a try-block with an
+  associated finally block, resume execution within finally.
+flags: [async]
+---*/
+
+var error = new Error("boop");
+var g = async function*() {
+  try {
+    yield 1;
+    throw new Test262Error('Generator must be resumed in finally block.');
+  } finally {
+    throw error;
+    throw new Test262Error('Generator must not be resumed.');
+  }
+};
+
+var it = g();
+it.next().then(function(ret) {
+  assert.sameValue(ret.value, 1, 'Initial yield');
+  assert.sameValue(ret.done, false, 'Initial yield');
+
+  it.return('sent-value').then($DONE, function(err) {
+    assert.sameValue(err, error, 'AsyncGeneratorReject(generator, resultValue)');
+
+    it.next().then(function(ret) {
+      assert.sameValue(ret.value, undefined, 'Generator is closed');
+      assert.sameValue(ret.done, true, 'Generator is closed');
+    }).then($DONE, $DONE);
+    
+  }).catch($DONE);
+
+}).catch($DONE);

--- a/test/language/expressions/async-generators/return-suspendedYield-try-finally.js
+++ b/test/language/expressions/async-generators/return-suspendedYield-try-finally.js
@@ -1,0 +1,46 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is return, and generator.[[AsyncGeneratorState]] is
+  "suspendedYield", and generator is resumed within a try-block with an
+  associated finally block, resume execution within finally.
+flags: [async]
+---*/
+
+var g = async function*() {
+  try {
+    yield 1;
+    throw new Test262Error('Generator must be resumed in finally block.');
+  } finally {
+    yield 2;
+  }
+};
+
+var it = g();
+it.next().then(function(ret) {
+  assert.sameValue(ret.value, 1, 'Initial yield');
+  assert.sameValue(ret.done, false, 'Initial yield');
+
+  it.return('sent-value').then(function(ret) {
+    assert.sameValue(ret.value, 2, 'Yield in finally block');
+    assert.sameValue(ret.done, false, 'Yield in finally block');
+
+    it.next().then(function(ret) {
+      assert.sameValue(ret.value, 'sent-value', 'AsyncGeneratorResolve(generator, resultValue, true)');
+      assert.sameValue(ret.done, true, 'AsyncGeneratorResolve(generator, resultValue, true)');
+
+      it.next().then(function(ret) {
+        assert.sameValue(ret.value, undefined, 'Generator is closed');
+        assert.sameValue(ret.done, true, 'Generator is closed');
+      }).then($DONE, $DONE);
+
+    }).catch($DONE);
+    
+  }).catch($DONE);
+
+}).catch($DONE);

--- a/test/language/expressions/async-generators/return-suspendedYield.js
+++ b/test/language/expressions/async-generators/return-suspendedYield.js
@@ -1,0 +1,36 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is return, and generator.[[AsyncGeneratorState]] is
+  "suspendedYield", generator is resumed and immediately closes the generator
+  and returns completion.
+flags: [async]
+---*/
+
+var g = async function*() {
+  yield 1;
+  throw new Test262Error('Generator must not be resumed.');
+};
+
+var it = g();
+it.next().then(function(ret) {
+  assert.sameValue(ret.value, 1, 'Initial yield');
+  assert.sameValue(ret.done, false, 'Initial yield');
+
+  it.return('sent-value').then(function(ret) {
+    assert.sameValue(ret.value, 'sent-value', 'AsyncGeneratorResolve(generator, resultValue, true)');
+    assert.sameValue(ret.done, true, 'AsyncGeneratorResolve(generator, resultValue, true)');
+
+    it.next().then(function(ret) {
+      assert.sameValue(ret.value, undefined, 'Generator is closed');
+      assert.sameValue(ret.done, true, 'Generator is closed');
+    }).then($DONE, $DONE);
+    
+  }).catch($DONE);
+
+}).catch($DONE);

--- a/test/language/expressions/async-generators/throw-suspendedStart-promise.js
+++ b/test/language/expressions/async-generators/throw-suspendedStart-promise.js
@@ -1,0 +1,30 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is throw, and generator.[[AsyncGeneratorState]] is
+  "suspendedStart", generator is closed without being resumed.
+
+  AsyncGeneratorReject will not unwrap Promise values
+flags: [async]
+---*/
+
+var g = async function*() {
+  throw new Test262Error('Generator must not be resumed.');
+};
+
+var it = g();
+var promise = new Promise(function() {});
+
+it.throw(promise).then($DONE, function(err) {
+  assert.sameValue(err, promise, 'AsyncGeneratorReject(generator, completion.[[Value]])');
+
+  it.next().then(function(ret) {
+    assert.sameValue(ret.value, undefined, 'Generator is closed');
+    assert.sameValue(ret.done, true, 'Generator is closed');
+  }).then($DONE, $DONE);
+}).catch($DONE);

--- a/test/language/expressions/async-generators/throw-suspendedStart.js
+++ b/test/language/expressions/async-generators/throw-suspendedStart.js
@@ -1,0 +1,27 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is throw, and generator.[[AsyncGeneratorState]] is
+  "suspendedStart", generator is closed without being resumed.
+flags: [async]
+---*/
+
+var error = new Error('boop');
+var g = async function*() {
+  throw new Test262Error('Generator must not be resumed.');
+};
+
+var it = g();
+it.throw(error).then($DONE, function(err) {
+  assert.sameValue(err, error, 'AsyncGeneratorReject(generator, completion.[[Value]])');
+
+  it.next().then(function(ret) {
+    assert.sameValue(ret.value, undefined, 'Generator is closed');
+    assert.sameValue(ret.done, true, 'Generator is closed');
+  }).then($DONE, $DONE);
+}).catch($DONE);

--- a/test/language/expressions/async-generators/throw-suspendedYield-promise.js
+++ b/test/language/expressions/async-generators/throw-suspendedYield-promise.js
@@ -1,0 +1,39 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is throw, and generator.[[AsyncGeneratorState]] is
+  "suspendedYield", generator is resumed and immediately and
+  closes the generator and returns completion.
+
+  AsyncGeneratorReject will not unwrap Promise values
+flags: [async]
+---*/
+
+var g = async function*() {
+  yield 1;
+  throw new Test262Error('Generator must not be resumed.');
+};
+
+var it = g();
+var promise = new Promise(function() {});
+
+it.next().then(function(ret) {
+  assert.sameValue(ret.value, 1, 'Initial yield');
+  assert.sameValue(ret.done, false, 'Initial yield');
+
+  it.throw(promise).then($DONE, function(err) {
+    assert.sameValue(err, promise, 'AsyncGeneratorReject(generator, resultValue)');
+
+    it.next().then(function(ret) {
+      assert.sameValue(ret.value, undefined, 'Generator is closed');
+      assert.sameValue(ret.done, true, 'Generator is closed');
+    }).then($DONE, $DONE);
+    
+  }).catch($DONE);
+
+}).catch($DONE);

--- a/test/language/expressions/async-generators/throw-suspendedYield-try-catch.js
+++ b/test/language/expressions/async-generators/throw-suspendedYield-try-catch.js
@@ -1,0 +1,42 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is throw, and generator.[[AsyncGeneratorState]] is
+  "suspendedYield", and generator is resumed within a try-block with an
+  associated catch block, resume execution within catch-block.
+flags: [async]
+---*/
+
+var error = new Error('boop');
+var g = async function*() {
+  try {
+    yield 1;
+    throw new Test262Error('Generator must be resumed in catch block.');
+  } catch (err) {
+    assert.sameValue(err, error);
+    return 'done';
+  }
+};
+
+var it = g();
+it.next().then(function(ret) {
+  assert.sameValue(ret.value, 1, 'Initial yield');
+  assert.sameValue(ret.done, false, 'Initial yield');
+
+  it.throw(error).then(function(ret) {
+    assert.sameValue(ret.value, 'done', 'AsyncGeneratorResolve(generator, resultValue, true)');
+    assert.sameValue(ret.done, true, 'AsyncGeneratorResolve(generator, resultValue, true)');
+
+    it.next().then(function(ret) {
+      assert.sameValue(ret.value, undefined, 'Generator is closed');
+      assert.sameValue(ret.done, true, 'Generator is closed');
+    }).then($DONE, $DONE);
+    
+  }).catch($DONE);
+
+}).catch($DONE);

--- a/test/language/expressions/async-generators/throw-suspendedYield-try-finally-return.js
+++ b/test/language/expressions/async-generators/throw-suspendedYield-try-finally-return.js
@@ -1,0 +1,42 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is throw, and generator.[[AsyncGeneratorState]] is
+  "suspendedYield", and generator is resumed within a try-block with an
+  associated finally block, resume execution within finally.
+flags: [async]
+---*/
+
+class Err extends Error {};
+var g = async function*() {
+  try {
+    yield 1;
+    throw new Test262Error('Generator must be resumed in finally block.');
+  } finally {
+    return 'done';
+    throw new Test262Error('Generator must not be resumed.');
+  }
+};
+
+var it = g();
+it.next().then(function(ret) {
+  assert.sameValue(ret.value, 1, 'Initial yield');
+  assert.sameValue(ret.done, false, 'Initial yield');
+
+  it.throw(new Err).then(function(ret) {
+    assert.sameValue(ret.value, 'done', 'AsyncGeneratorResolve(generator, resultValue, true)');
+    assert.sameValue(ret.done, true, 'AsyncGeneratorResolve(generator, resultValue, true)');
+
+    it.next().then(function(ret) {
+      assert.sameValue(ret.value, undefined, 'Generator is closed');
+      assert.sameValue(ret.done, true, 'Generator is closed');
+    }).then($DONE, $DONE);
+
+  }).catch($DONE);
+
+}).catch($DONE);

--- a/test/language/expressions/async-generators/throw-suspendedYield-try-finally-throw.js
+++ b/test/language/expressions/async-generators/throw-suspendedYield-try-finally-throw.js
@@ -1,0 +1,41 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is throw, and generator.[[AsyncGeneratorState]] is
+  "suspendedYield", and generator is resumed within a try-block with an
+  associated finally block, resume execution within finally.
+flags: [async]
+---*/
+
+var error = new Error('boop');
+var g = async function*() {
+  try {
+    yield 1;
+    throw new Test262Error('Generator must be resumed in finally block.');
+  } finally {
+    throw error;
+    throw new Test262Error('Generator must not be resumed.');
+  }
+};
+
+var it = g();
+it.next().then(function(ret) {
+  assert.sameValue(ret.value, 1, 'Initial yield');
+  assert.sameValue(ret.done, false, 'Initial yield');
+
+  it.throw(new Error('superceded')).then($DONE, function(err) {
+    assert.sameValue(err, error, 'AsyncGeneratorReject(generator, resultValue)');
+
+    it.next().then(function(ret) {
+      assert.sameValue(ret.value, undefined, 'Generator is closed');
+      assert.sameValue(ret.done, true, 'Generator is closed');
+    }).then($DONE, $DONE);
+
+  }).catch($DONE);
+
+}).catch($DONE);

--- a/test/language/expressions/async-generators/throw-suspendedYield-try-finally.js
+++ b/test/language/expressions/async-generators/throw-suspendedYield-try-finally.js
@@ -1,0 +1,46 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is throw, and generator.[[AsyncGeneratorState]] is
+  "suspendedYield", and generator is resumed within a try-block with an
+  associated finally block, resume execution within finally.
+flags: [async]
+---*/
+
+var error = new Error('boop');
+var g = async function*() {
+  try {
+    yield 1;
+    throw new Test262Error('Generator must be resumed in finally block.');
+  } finally {
+    yield 2;
+  }
+};
+
+var it = g();
+it.next().then(function(ret) {
+  assert.sameValue(ret.value, 1, 'Initial yield');
+  assert.sameValue(ret.done, false, 'Initial yield');
+
+  it.throw(error).then(function(ret) {
+    assert.sameValue(ret.value, 2, 'Yield in finally block');
+    assert.sameValue(ret.done, false, 'Yield in finally block');
+
+    it.next().then($DONE, function(err) {
+      assert.sameValue(err, error, 'AsyncGeneratorReject(generator, returnValue)');
+
+      it.next().then(function(ret) {
+        assert.sameValue(ret.value, undefined, 'Generator is closed');
+        assert.sameValue(ret.done, true, 'Generator is closed');
+      }).then($DONE, $DONE);
+
+    }).catch($DONE);
+    
+  }).catch($DONE);
+
+}).catch($DONE);

--- a/test/language/expressions/async-generators/throw-suspendedYield.js
+++ b/test/language/expressions/async-generators/throw-suspendedYield.js
@@ -1,0 +1,36 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Caitlin Potter <caitp@igalia.com>
+esid: pending
+description: >
+  AsyncGeneratorResumeNext:
+  If completion.[[Type]] is throw, and generator.[[AsyncGeneratorState]] is
+  "suspendedYield", generator is resumed and immediately and
+  closes the generator and returns completion.
+flags: [async]
+---*/
+
+var error = new Error('boop');
+var g = async function*() {
+  yield 1;
+  throw new Test262Error('Generator must not be resumed.');
+};
+
+var it = g();
+it.next().then(function(ret) {
+  assert.sameValue(ret.value, 1, 'Initial yield');
+  assert.sameValue(ret.done, false, 'Initial yield');
+
+  it.throw(error).then($DONE, function(err) {
+    assert.sameValue(err, error, 'AsyncGeneratorReject(generator, resultValue)');
+
+    it.next().then(function(ret) {
+      assert.sameValue(ret.value, undefined, 'Generator is closed');
+      assert.sameValue(ret.done, true, 'Generator is closed');
+    }).then($DONE, $DONE);
+    
+  }).catch($DONE);
+
+}).catch($DONE);


### PR DESCRIPTION
Here's a starter suite of tests for basic flow control in Async Generators.

This relates primarily to the behaviour of AsyncGeneratorResumeNext, AsyncGeneratorStart, AsyncGeneratorResolve and AsyncGeneratorReject, as well as some coverage of changes to GeneratorYield.

There is stuff missing, as I haven't exhaustively written tests for all of the variations that are necessary.