### PR TITLE
Top-level `let undefined` is a runtime error, not an early error.

### DIFF
--- a/test/language/global-code/decl-lex-restricted-global.js
+++ b/test/language/global-code/decl-lex-restricted-global.js
@@ -11,7 +11,7 @@ info: |
      c. Let hasRestrictedGlobal be ? envRec.HasRestrictedGlobalProperty(name).
      d. If hasRestrictedGlobal is true, throw a SyntaxError exception.
 negative:
-  phase: early
+  phase: runtime
   type: SyntaxError
 ---*/
 


### PR DESCRIPTION
The error occurs in [GlobalDeclarationInstantiation](https://tc39.github.io/ecma262/#sec-globaldeclarationinstantiation), which is runtime semantics.

INTERPRETING.md is kind of unclear on what phase GlobalDeclarationInstantiation corresponds to, so I'm not entirely sure if this change is correct.

Ping @jugglinmike