### PR TITLE
Add tests for abrupt case in yield* in async generator - getting iterator

### DIFF
--- a/test/language/statements/async-generator/yield-star-expr-abrupt.js
+++ b/test/language/statements/async-generator/yield-star-expr-abrupt.js
@@ -1,0 +1,49 @@
+/*---
+ author: Tooru Fujisawa [:arai] <arai_a@mac.com>
+ esid: pending
+ description: Abrupt completion while getting yield* operand
+ info: >
+    YieldExpression: yield * AssignmentExpression
+
+    1. Let exprRef be the result of evaluating AssignmentExpression.
+    2. Let value be ? GetValue(exprRef).
+    ...
+
+ flags: [async]
+---*/
+
+var log = [];
+var rejectReason = new Proxy({}, {
+  get() {
+    // No operation should be done on reject reason.
+    log.push({ name: "rejectReason get" });
+  },
+  has() {
+    log.push({ name: "rejectReason has" });
+  }
+});
+var abrupt = function() {
+  log.push({ name: "before throw" });
+  throw rejectReason;
+  log.push({ name: "after throw" });
+};
+var asyncIterator = (async function*() {
+  log.push({ name: "before yield*" });
+  yield* abrupt();
+  log.push({ name: "after yield*" });
+  return "return-value";
+})();
+
+assert.sameValue(log.length, 0, "log.length");
+
+asyncIterator.next("next-arg-1").then(() => {
+  $ERROR('Promise incorrectly fulfilled.');
+}, v => {
+  assert.sameValue(log[0].name, "before yield*");
+
+  assert.sameValue(log[1].name, "before throw");
+
+  assert.sameValue(v, rejectReason, "reject reason");
+
+  assert.sameValue(log.length, 2, "log.length");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-generator/yield-star-getIterator-async-call-abrupt.js
+++ b/test/language/statements/async-generator/yield-star-getIterator-async-call-abrupt.js
@@ -1,0 +1,75 @@
+/*---
+ author: Tooru Fujisawa [:arai] <arai_a@mac.com>
+ esid: pending
+ description: Abrupt completion while calling [Symbol.asyncIterator]
+ info: >
+    YieldExpression: yield * AssignmentExpression
+
+    1. Let exprRef be the result of evaluating AssignmentExpression.
+    2. Let value be ? GetValue(exprRef).
+    3. Let generatorKind be ! GetGeneratorKind().
+    4. Let iterator be ? GetIterator(value, generatorKind).
+    ...
+
+    GetIterator ( obj [ , hint ] )
+
+    ...
+    3. If hint is async,
+      a. Set method to ? GetMethod(obj, @@asyncIterator).
+    ...
+    6. Let iterator be ? Call(method, obj).
+    ...
+
+ flags: [async]
+---*/
+
+var log = [];
+var rejectReason = new Proxy({}, {
+  get() {
+    // No operation should be done on reject reason.
+    log.push({ name: "rejectReason get" });
+  },
+  has() {
+    log.push({ name: "rejectReason has" });
+  }
+});
+var iter = {
+  get [Symbol.iterator]() {
+    log.push({ name: "get [Symbol.iterator]" });
+  },
+  get [Symbol.asyncIterator]() {
+    log.push({ name: "get [Symbol.asyncIterator]" });
+
+    return function() {
+      log.push({ name: "call [Symbol.asyncIterator]" });
+
+      log.push({ name: "before throw" });
+      throw rejectReason;
+      log.push({ name: "after throw" });
+    };
+  }
+};
+var asyncIterator = (async function*() {
+  log.push({ name: "before yield*" });
+  yield* iter;
+  log.push({ name: "after yield*" });
+  return "return-value";
+})();
+
+assert.sameValue(log.length, 0, "log.length");
+
+asyncIterator.next("next-arg-1").then(() => {
+  $ERROR('Promise incorrectly fulfilled.');
+}, v => {
+  assert.sameValue(log[0].name, "before yield*");
+
+  assert.sameValue(log[1].name, "get [Symbol.asyncIterator]");
+
+  assert.sameValue(log[2].name, "call [Symbol.asyncIterator]");
+
+  assert.sameValue(log[3].name, "before throw");
+
+  assert.sameValue(v, rejectReason, "reject reason");
+
+  assert.sameValue(log.length, 4, "log.length");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-generator/yield-star-getIterator-async-get-abrupt.js
+++ b/test/language/statements/async-generator/yield-star-getIterator-async-get-abrupt.js
@@ -1,0 +1,73 @@
+/*---
+ author: Tooru Fujisawa [:arai] <arai_a@mac.com>
+ esid: pending
+ description: Abrupt completion while getting [Symbol.asyncIterator]
+ info: >
+    YieldExpression: yield * AssignmentExpression
+
+    1. Let exprRef be the result of evaluating AssignmentExpression.
+    2. Let value be ? GetValue(exprRef).
+    3. Let generatorKind be ! GetGeneratorKind().
+    4. Let iterator be ? GetIterator(value, generatorKind).
+    ...
+
+    GetIterator ( obj [ , hint ] )
+
+    ...
+    3. If hint is async,
+      a. Set method to ? GetMethod(obj, @@asyncIterator).
+    ...
+
+    GetMethod ( V, P )
+
+    ...
+    2. Let func be ? GetV(V, P).
+    ...
+
+ flags: [async]
+---*/
+
+var log = [];
+var rejectReason = new Proxy({}, {
+  get() {
+    // No operation should be done on reject reason.
+    log.push({ name: "rejectReason get" });
+  },
+  has() {
+    log.push({ name: "rejectReason has" });
+  }
+});
+var iter = {
+  get [Symbol.iterator]() {
+    log.push({ name: "get [Symbol.iterator]" });
+  },
+  get [Symbol.asyncIterator]() {
+    log.push({ name: "get [Symbol.asyncIterator]" });
+
+    log.push({ name: "before throw" });
+    throw rejectReason;
+    log.push({ name: "after throw" });
+  }
+};
+var asyncIterator = (async function*() {
+  log.push({ name: "before yield*" });
+  yield* iter;
+  log.push({ name: "after yield*" });
+  return "return-value";
+})();
+
+assert.sameValue(log.length, 0, "log.length");
+
+asyncIterator.next("next-arg-1").then(() => {
+  $ERROR('Promise incorrectly fulfilled.');
+}, v => {
+  assert.sameValue(log[0].name, "before yield*");
+
+  assert.sameValue(log[1].name, "get [Symbol.asyncIterator]");
+
+  assert.sameValue(log[2].name, "before throw");
+
+  assert.sameValue(v, rejectReason, "reject reason");
+
+  assert.sameValue(log.length, 3, "log.length");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-generator/yield-star-getIterator-async-non-object.js
+++ b/test/language/statements/async-generator/yield-star-getIterator-async-non-object.js
@@ -1,0 +1,65 @@
+/*---
+ author: Tooru Fujisawa [:arai] <arai_a@mac.com>
+ esid: pending
+ description: Non object returned by [Symbol.asyncIterator]()
+ info: >
+    YieldExpression: yield * AssignmentExpression
+
+    1. Let exprRef be the result of evaluating AssignmentExpression.
+    2. Let value be ? GetValue(exprRef).
+    3. Let generatorKind be ! GetGeneratorKind().
+    4. Let iterator be ? GetIterator(value, generatorKind).
+    ...
+
+    GetIterator ( obj [ , hint ] )
+
+    ...
+    3. If hint is async,
+      a. Set method to ? GetMethod(obj, @@asyncIterator).
+    ...
+    6. Let iterator be ? Call(method, obj).
+    7. If Type(iterator) is not Object, throw a TypeError exception.
+    ...
+
+ flags: [async]
+---*/
+
+var log = [];
+var iter = {
+  get [Symbol.iterator]() {
+    log.push({ name: "get [Symbol.iterator]" });
+  },
+  get [Symbol.asyncIterator]() {
+    log.push({ name: "get [Symbol.asyncIterator]" });
+
+    return function() {
+      log.push({ name: "call [Symbol.asyncIterator]" });
+
+      return "non object";
+    };
+  }
+};
+var asyncIterator = (async function*() {
+  log.push({ name: "before yield*" });
+  yield* iter;
+  log.push({ name: "after yield*" });
+  return "return-value";
+})();
+
+assert.sameValue(log.length, 0, "log.length");
+
+asyncIterator.next("next-arg-1").then(() => {
+  $ERROR('Promise incorrectly fulfilled.');
+}, v => {
+  assert.sameValue(log[0].name, "before yield*");
+
+  assert.sameValue(log[1].name, "get [Symbol.asyncIterator]");
+
+  assert.sameValue(log[2].name, "call [Symbol.asyncIterator]");
+
+  if (!(v instanceof TypeError)) {
+    $ERROR('Expected TypeError but got ' + v);
+  }
+
+  assert.sameValue(log.length, 3, "log.length");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-generator/yield-star-getIterator-async-not-callable.js
+++ b/test/language/statements/async-generator/yield-star-getIterator-async-not-callable.js
@@ -1,0 +1,64 @@
+/*---
+ author: Tooru Fujisawa [:arai] <arai_a@mac.com>
+ esid: pending
+ description: Non callable returned by [Symbol.asyncIterator]
+ info: >
+    YieldExpression: yield * AssignmentExpression
+
+    1. Let exprRef be the result of evaluating AssignmentExpression.
+    2. Let value be ? GetValue(exprRef).
+    3. Let generatorKind be ! GetGeneratorKind().
+    4. Let iterator be ? GetIterator(value, generatorKind).
+    ...
+
+    GetIterator ( obj [ , hint ] )
+
+    ...
+    3. If hint is async,
+      a. Set method to ? GetMethod(obj, @@asyncIterator).
+    ...
+
+    GetMethod ( V, P )
+
+    ...
+    2. Let func be ? GetV(V, P).
+    ...
+    4. If IsCallable(func) is false, throw a TypeError exception.
+    ...
+
+ flags: [async]
+---*/
+
+var log = [];
+var iter = {
+  get [Symbol.iterator]() {
+    log.push({ name: "get [Symbol.iterator]" });
+  },
+  get [Symbol.asyncIterator]() {
+    log.push({ name: "get [Symbol.asyncIterator]" });
+
+    return "non callable";
+  }
+};
+var asyncIterator = (async function*() {
+  log.push({ name: "before yield*" });
+  yield* iter;
+  log.push({ name: "after yield*" });
+  return "return-value";
+})();
+
+assert.sameValue(log.length, 0, "log.length");
+
+asyncIterator.next("next-arg-1").then(() => {
+  $ERROR('Promise incorrectly fulfilled.');
+}, v => {
+  assert.sameValue(log[0].name, "before yield*");
+
+  assert.sameValue(log[1].name, "get [Symbol.asyncIterator]");
+
+  if (!(v instanceof TypeError)) {
+    $ERROR('Expected TypeError but got ' + v);
+  }
+
+  assert.sameValue(log.length, 2, "log.length");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-generator/yield-star-getIterator-sync-call-abrupt.js
+++ b/test/language/statements/async-generator/yield-star-getIterator-sync-call-abrupt.js
@@ -1,0 +1,79 @@
+/*---
+ author: Tooru Fujisawa [:arai] <arai_a@mac.com>
+ esid: pending
+ description: Abrupt completion while calling [Symbol.iterator]
+ info: >
+    YieldExpression: yield * AssignmentExpression
+
+    1. Let exprRef be the result of evaluating AssignmentExpression.
+    2. Let value be ? GetValue(exprRef).
+    3. Let generatorKind be ! GetGeneratorKind().
+    4. Let iterator be ? GetIterator(value, generatorKind).
+    ...
+
+    GetIterator ( obj [ , hint ] )
+
+    ...
+    3. If hint is async,
+      a. Set method to ? GetMethod(obj, @@asyncIterator).
+        i. Let syncMethod be ? GetMethod(obj, @@iterator).
+        ii. Let syncIterator be ? Call(syncMethod, obj).
+    ...
+
+ flags: [async]
+---*/
+
+var log = [];
+var rejectReason = new Proxy({}, {
+  get() {
+    // No operation should be done on reject reason.
+    log.push({ name: "rejectReason get" });
+  },
+  has() {
+    log.push({ name: "rejectReason has" });
+  }
+});
+var iter = {
+  get [Symbol.iterator]() {
+    log.push({ name: "get [Symbol.iterator]" });
+
+    return function() {
+      log.push({ name: "call [Symbol.iterator]" });
+
+      log.push({ name: "before throw" });
+      throw rejectReason;
+      log.push({ name: "after throw" });
+    };
+  },
+  get [Symbol.asyncIterator]() {
+    log.push({ name: "get [Symbol.asyncIterator]" });
+
+    return undefined;
+  }
+};
+var asyncIterator = (async function*() {
+  log.push({ name: "before yield*" });
+  yield* iter;
+  log.push({ name: "after yield*" });
+  return "return-value";
+})();
+
+assert.sameValue(log.length, 0, "log.length");
+
+asyncIterator.next("next-arg-1").then(() => {
+  $ERROR('Promise incorrectly fulfilled.');
+}, v => {
+  assert.sameValue(log[0].name, "before yield*");
+
+  assert.sameValue(log[1].name, "get [Symbol.asyncIterator]");
+
+  assert.sameValue(log[2].name, "get [Symbol.iterator]");
+
+  assert.sameValue(log[3].name, "call [Symbol.iterator]");
+
+  assert.sameValue(log[4].name, "before throw");
+
+  assert.sameValue(v, rejectReason, "reject reason");
+
+  assert.sameValue(log.length, 5, "log.length");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-generator/yield-star-getIterator-sync-get-abrupt.js
+++ b/test/language/statements/async-generator/yield-star-getIterator-sync-get-abrupt.js
@@ -1,0 +1,79 @@
+/*---
+ author: Tooru Fujisawa [:arai] <arai_a@mac.com>
+ esid: pending
+ description: Abrupt completion while getting [Symbol.iterator]
+ info: >
+    YieldExpression: yield * AssignmentExpression
+
+    1. Let exprRef be the result of evaluating AssignmentExpression.
+    2. Let value be ? GetValue(exprRef).
+    3. Let generatorKind be ! GetGeneratorKind().
+    4. Let iterator be ? GetIterator(value, generatorKind).
+    ...
+
+    GetIterator ( obj [ , hint ] )
+
+    ...
+    3. If hint is async,
+      a. Set method to ? GetMethod(obj, @@asyncIterator).
+      b. If method is undefined,
+        i. Let syncMethod be ? GetMethod(obj, @@iterator).
+    ...
+
+    GetMethod ( V, P )
+
+    ...
+    2. Let func be ? GetV(V, P).
+    ...
+
+ flags: [async]
+---*/
+
+var log = [];
+var rejectReason = new Proxy({}, {
+  get() {
+    // No operation should be done on reject reason.
+    log.push({ name: "rejectReason get" });
+  },
+  has() {
+    log.push({ name: "rejectReason has" });
+  }
+});
+var iter = {
+  get [Symbol.iterator]() {
+    log.push({ name: "get [Symbol.iterator]" });
+
+    log.push({ name: "before throw" });
+    throw rejectReason;
+    log.push({ name: "after throw" });
+  },
+  get [Symbol.asyncIterator]() {
+    log.push({ name: "get [Symbol.asyncIterator]" });
+
+    return undefined;
+  }
+};
+var asyncIterator = (async function*() {
+  log.push({ name: "before yield*" });
+  yield* iter;
+  log.push({ name: "after yield*" });
+  return "return-value";
+})();
+
+assert.sameValue(log.length, 0, "log.length");
+
+asyncIterator.next("next-arg-1").then(() => {
+  $ERROR('Promise incorrectly fulfilled.');
+}, v => {
+  assert.sameValue(log[0].name, "before yield*");
+
+  assert.sameValue(log[1].name, "get [Symbol.asyncIterator]");
+
+  assert.sameValue(log[2].name, "get [Symbol.iterator]");
+
+  assert.sameValue(log[3].name, "before throw");
+
+  assert.sameValue(v, rejectReason, "reject reason");
+
+  assert.sameValue(log.length, 4, "log.length");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-generator/yield-star-getIterator-sync-non-object.js
+++ b/test/language/statements/async-generator/yield-star-getIterator-sync-non-object.js
@@ -1,0 +1,74 @@
+/*---
+ author: Tooru Fujisawa [:arai] <arai_a@mac.com>
+ esid: pending
+ description: Non object returned by [Symbol.iterator]()
+ info: >
+    YieldExpression: yield * AssignmentExpression
+
+    1. Let exprRef be the result of evaluating AssignmentExpression.
+    2. Let value be ? GetValue(exprRef).
+    3. Let generatorKind be ! GetGeneratorKind().
+    4. Let iterator be ? GetIterator(value, generatorKind).
+    ...
+
+    GetIterator ( obj [ , hint ] )
+
+    ...
+    3. If hint is async,
+      a. Set method to ? GetMethod(obj, @@asyncIterator).
+        i. Let syncMethod be ? GetMethod(obj, @@iterator).
+        ii. Let syncIterator be ? Call(syncMethod, obj).
+        iii. Return ? CreateAsyncFromSyncIterator(syncIterator).
+    ...
+
+    CreateAsyncFromSyncIterator(syncIterator)
+
+    1. If Type(syncIterator) is not Object, throw a TypeError exception.
+    ...
+
+ flags: [async]
+---*/
+
+var log = [];
+var iter = {
+  get [Symbol.iterator]() {
+    log.push({ name: "get [Symbol.iterator]" });
+
+    return function() {
+      log.push({ name: "call [Symbol.iterator]" });
+
+      return "non object";
+    };
+  },
+  get [Symbol.asyncIterator]() {
+    log.push({ name: "get [Symbol.asyncIterator]" });
+
+    return undefined;
+  }
+};
+var asyncIterator = (async function*() {
+  log.push({ name: "before yield*" });
+  yield* iter;
+  log.push({ name: "after yield*" });
+  return "return-value";
+})();
+
+assert.sameValue(log.length, 0, "log.length");
+
+asyncIterator.next("next-arg-1").then(() => {
+  $ERROR('Promise incorrectly fulfilled.');
+}, v => {
+  assert.sameValue(log[0].name, "before yield*");
+
+  assert.sameValue(log[1].name, "get [Symbol.asyncIterator]");
+
+  assert.sameValue(log[2].name, "get [Symbol.iterator]");
+
+  assert.sameValue(log[3].name, "call [Symbol.iterator]");
+
+  if (!(v instanceof TypeError)) {
+    $ERROR('Expected TypeError but got ' + v);
+  }
+
+  assert.sameValue(log.length, 4, "log.length");
+}).then($DONE, $DONE);

--- a/test/language/statements/async-generator/yield-star-getIterator-sync-not-callable.js
+++ b/test/language/statements/async-generator/yield-star-getIterator-sync-not-callable.js
@@ -1,0 +1,70 @@
+/*---
+ author: Tooru Fujisawa [:arai] <arai_a@mac.com>
+ esid: pending
+ description: Non callable returned by [Symbol.iterator]
+ info: >
+    YieldExpression: yield * AssignmentExpression
+
+    1. Let exprRef be the result of evaluating AssignmentExpression.
+    2. Let value be ? GetValue(exprRef).
+    3. Let generatorKind be ! GetGeneratorKind().
+    4. Let iterator be ? GetIterator(value, generatorKind).
+    ...
+
+    GetIterator ( obj [ , hint ] )
+
+    ...
+    3. If hint is async,
+      a. Set method to ? GetMethod(obj, @@asyncIterator).
+      b. If method is undefined,
+        i. Let syncMethod be ? GetMethod(obj, @@iterator).
+    ...
+
+    GetMethod ( V, P )
+
+    ...
+    2. Let func be ? GetV(V, P).
+    ...
+    4. If IsCallable(func) is false, throw a TypeError exception.
+    ...
+
+ flags: [async]
+---*/
+
+var log = [];
+var iter = {
+  get [Symbol.iterator]() {
+    log.push({ name: "get [Symbol.iterator]" });
+
+    return "non callable";
+  },
+  get [Symbol.asyncIterator]() {
+    log.push({ name: "get [Symbol.asyncIterator]" });
+
+    return undefined;
+  }
+};
+var asyncIterator = (async function*() {
+  log.push({ name: "before yield*" });
+  yield* iter;
+  log.push({ name: "after yield*" });
+  return "return-value";
+})();
+
+assert.sameValue(log.length, 0, "log.length");
+
+asyncIterator.next("next-arg-1").then(() => {
+  $ERROR('Promise incorrectly fulfilled.');
+}, v => {
+  assert.sameValue(log[0].name, "before yield*");
+
+  assert.sameValue(log[1].name, "get [Symbol.asyncIterator]");
+
+  assert.sameValue(log[2].name, "get [Symbol.iterator]");
+
+  if (!(v instanceof TypeError)) {
+    $ERROR('Expected TypeError but got ' + v);
+  }
+
+  assert.sameValue(log.length, 3, "log.length");
+}).then($DONE, $DONE);


### PR DESCRIPTION
Here's first chunk of abrupt case for yield* in async generator.
from getting yield* operand to getting iterator from it.
