### PR TITLE
Improve isEnumerable check with a for-in loop for string names

### DIFF
--- a/harness/propertyHelper.js
+++ b/harness/propertyHelper.js
@@ -11,7 +11,22 @@ function isConfigurable(obj, name) {
 }
 
 function isEnumerable(obj, name) {
-    return Object.prototype.hasOwnProperty.call(obj, name) &&
+    var stringCheck;
+    
+    if (typeof name === "string") {
+        for (var x in obj) {
+            if (x === name) {
+                stringCheck = true;
+                break;
+            }
+        }
+    } else {
+        // skip it if name is not string, works for Symbol names.
+        stringCheck = true;
+    }
+
+    return stringCheck &&
+        Object.prototype.hasOwnProperty.call(obj, name) &&
         Object.prototype.propertyIsEnumerable.call(obj, name);
 }
 


### PR DESCRIPTION
Ref https://github.com/tc39/test262/pull/879#discussion_r104128520

cc @anba 

For the piece of mind, I'm comparing tests results using a new compiled version of d8.

```
test262-harness --hostPath=`which d8` --hostType=d8 $(git grep --name-only --extended-regexp 'verify(Not)?Enumerable' test/built-ins)
```