### PR TITLE
Extend test generation tool

### DIFF
--- a/src/accessor-names/literal-string-line-continuation.case
+++ b/src/accessor-names/literal-string-line-continuation.case
@@ -1,0 +1,22 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Computed values as accessor property names (string literal containing LineContinuation)
+template: default
+info: |
+  12.2.6.7 Runtime Semantics: Evaluation
+
+  [...]
+
+  ComputedPropertyName : [ AssignmentExpression ]
+
+  1. Let exprValue be the result of evaluating AssignmentExpression.
+  2. Let propName be ? GetValue(exprValue).
+  3. Return ? ToPropertyKey(propName).
+---*/
+
+//- declareWith
+'line\
+Continuation'
+//- referenceWith
+'lineContinuation'

--- a/test/language/expressions/class/accessor-name-inst-literal-string-line-continuation.js
+++ b/test/language/expressions/class/accessor-name-inst-literal-string-line-continuation.js
@@ -1,9 +1,11 @@
-// Copyright (C) 2017 Mike Pennisi. All rights reserved.
-// This code is governed by the BSD license found in the LICENSE file.
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-line-continuation.case
+// - src/accessor-names/default/cls-expr-inst.template
 /*---
-description: Computed values as accessor property names (string literal containing a line terminator) (Class declaration, instance method)
+description: Computed values as accessor property names (string literal containing LineContinuation) (Class expression, instance method)
 esid: sec-runtime-semantics-classdefinitionevaluation
 es6id: 14.5.14
+flags: [generated]
 info: |
     [...]
     21. For each ClassElement m in order from methods
@@ -24,16 +26,14 @@ info: |
 
 var stringSet;
 
-class C {
+var C = class {
   get 'line\
-Terminator'
-() { return 'get string'; }
+Continuation'() { return 'get string'; }
   set 'line\
-Terminator'
-(param) { stringSet = param; }
-}
+Continuation'(param) { stringSet = param; }
+};
 
-assert.sameValue(C.prototype['lineTerminator'], 'get string');
+assert.sameValue(C.prototype['lineContinuation'], 'get string');
 
-C.prototype['lineTerminator'] = 'set string';
+C.prototype['lineContinuation'] = 'set string';
 assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/accessor-name-static-literal-string-line-continuation.js
+++ b/test/language/expressions/class/accessor-name-static-literal-string-line-continuation.js
@@ -1,9 +1,11 @@
-// Copyright (C) 2017 Mike Pennisi. All rights reserved.
-// This code is governed by the BSD license found in the LICENSE file.
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-line-continuation.case
+// - src/accessor-names/default/cls-expr-static.template
 /*---
-description: Computed values as accessor property names (string literal containing a line terminator) (Class declaration, static method)
+description: Computed values as accessor property names (string literal containing LineContinuation) (Class expression, static method)
 esid: sec-runtime-semantics-classdefinitionevaluation
 es6id: 14.5.14
+flags: [generated]
 info: |
     [...]
     21. For each ClassElement m in order from methods
@@ -26,16 +28,14 @@ info: |
 
 var stringSet;
 
-class C {
+var C = class {
   static get 'line\
-Terminator'
-() { return 'get string'; }
+Continuation'() { return 'get string'; }
   static set 'line\
-Terminator'
-(param) { stringSet = param; }
-}
+Continuation'(param) { stringSet = param; }
+};
 
-assert.sameValue(C['lineTerminator'], 'get string');
+assert.sameValue(C['lineContinuation'], 'get string');
 
-C['lineTerminator'] = 'set string';
+C['lineContinuation'] = 'set string';
 assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/object/accessor-name-literal-string-line-continuation.js
+++ b/test/language/expressions/object/accessor-name-literal-string-line-continuation.js
@@ -1,9 +1,11 @@
-// Copyright (C) 2016 the V8 project authors. All rights reserved.
-// This code is governed by the BSD license found in the LICENSE file.
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-line-continuation.case
+// - src/accessor-names/default/obj.template
 /*---
-description: Computed values as accessor property names (string literal containing a line terminator) (Object initializer)
+description: Computed values as accessor property names (string literal containing LineContinuation) (Object initializer)
 esid: sec-object-initializer-runtime-semantics-evaluation
 es6id: 12.2.6.8
+flags: [generated]
 info: |
     ObjectLiteral :
       { PropertyDefinitionList }
@@ -27,14 +29,12 @@ info: |
 var stringSet;
 var obj = {
   get ['line\
-Terminator'
-]() { return 'get string'; },
+Continuation']() { return 'get string'; },
   set ['line\
-Terminator'
-](param) { stringSet = param; }
+Continuation'](param) { stringSet = param; }
 };
 
-assert.sameValue(obj['lineTerminator'], 'get string');
+assert.sameValue(obj['lineContinuation'], 'get string');
 
-obj['lineTerminator'] = 'set string';
+obj['lineContinuation'] = 'set string';
 assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-inst-literal-string-line-continuation.js
+++ b/test/language/statements/class/accessor-name-inst-literal-string-line-continuation.js
@@ -1,9 +1,11 @@
-// Copyright (C) 2017 Mike Pennisi. All rights reserved.
-// This code is governed by the BSD license found in the LICENSE file.
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-line-continuation.case
+// - src/accessor-names/default/cls-decl-inst.template
 /*---
-description: Computed values as accessor property names (string literal containing a line terminator) (Class expression, instance method)
+description: Computed values as accessor property names (string literal containing LineContinuation) (Class declaration, instance method)
 esid: sec-runtime-semantics-classdefinitionevaluation
 es6id: 14.5.14
+flags: [generated]
 info: |
     [...]
     21. For each ClassElement m in order from methods
@@ -24,16 +26,14 @@ info: |
 
 var stringSet;
 
-var C = class {
+class C {
   get 'line\
-Terminator'
-() { return 'get string'; }
+Continuation'() { return 'get string'; }
   set 'line\
-Terminator'
-(param) { stringSet = param; }
-};
+Continuation'(param) { stringSet = param; }
+}
 
-assert.sameValue(C.prototype['lineTerminator'], 'get string');
+assert.sameValue(C.prototype['lineContinuation'], 'get string');
 
-C.prototype['lineTerminator'] = 'set string';
+C.prototype['lineContinuation'] = 'set string';
 assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/accessor-name-static-literal-string-line-continuation.js
+++ b/test/language/statements/class/accessor-name-static-literal-string-line-continuation.js
@@ -1,9 +1,11 @@
-// Copyright (C) 2017 Mike Pennisi. All rights reserved.
-// This code is governed by the BSD license found in the LICENSE file.
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-line-continuation.case
+// - src/accessor-names/default/cls-decl-static.template
 /*---
-description: Computed values as accessor property names (string literal containing a line terminator) (Class expression, static method)
+description: Computed values as accessor property names (string literal containing LineContinuation) (Class declaration, static method)
 esid: sec-runtime-semantics-classdefinitionevaluation
 es6id: 14.5.14
+flags: [generated]
 info: |
     [...]
     21. For each ClassElement m in order from methods
@@ -26,16 +28,14 @@ info: |
 
 var stringSet;
 
-var C = class {
+class C {
   static get 'line\
-Terminator'
-() { return 'get string'; }
+Continuation'() { return 'get string'; }
   static set 'line\
-Terminator'
-(param) { stringSet = param; }
-};
+Continuation'(param) { stringSet = param; }
+}
 
-assert.sameValue(C['lineTerminator'], 'get string');
+assert.sameValue(C['lineContinuation'], 'get string');
 
-C['lineTerminator'] = 'set string';
+C['lineContinuation'] = 'set string';
 assert.sameValue(stringSet, 'set string');

--- a/tools/generation/test/expected/indentation/spaces-indent-code.js
+++ b/tools/generation/test/expected/indentation/spaces-indent-code.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/indent-code.case
+// - tools/generation/test/fixtures/indentation/spaces.template
+/*---
+description: Multiple lines of code (Preserving "soft" indentation across newlines)
+flags: [generated]
+---*/
+
+(function() {
+  'These literals are each contained on a single line...';
+  "...which means they may be indented...";
+  `...without effecting the semantics of the generated source code.`;
+
+  if (true) {
+    'These literals are each contained on a single line...';
+    "...which means they may be indented...";
+    `...without effecting the semantics of the generated source code.`;
+  }
+}());

--- a/tools/generation/test/expected/indentation/spaces-indent-string-continuation.js
+++ b/tools/generation/test/expected/indentation/spaces-indent-string-continuation.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/indent-string-continuation.case
+// - tools/generation/test/fixtures/indentation/spaces.template
+/*---
+description: Multiline string via a line continuation character (Preserving "soft" indentation across newlines)
+flags: [generated]
+---*/
+
+(function() {
+  'this string is declared across multiple lines\
+\
+which disqualifies it as a candidate for indentation';
+
+  if (true) {
+    'this string is declared across multiple lines\
+\
+which disqualifies it as a candidate for indentation';
+  }
+}());

--- a/tools/generation/test/expected/indentation/spaces-indent-string-template.js
+++ b/tools/generation/test/expected/indentation/spaces-indent-string-template.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/indent-string-template.case
+// - tools/generation/test/fixtures/indentation/spaces.template
+/*---
+description: String template spanning multiple lines (Preserving "soft" indentation across newlines)
+flags: [generated]
+---*/
+
+(function() {
+  `this string template is declared across multiple lines
+
+which disqualifies it as a candidate for indentation
+it also happens to contain ' and ".`;
+
+  if (true) {
+    `this string template is declared across multiple lines
+
+which disqualifies it as a candidate for indentation
+it also happens to contain ' and ".`;
+  }
+}());

--- a/tools/generation/test/expected/indentation/tabs-indent-code.js
+++ b/tools/generation/test/expected/indentation/tabs-indent-code.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/indent-code.case
+// - tools/generation/test/fixtures/indentation/tabs.template
+/*---
+description: Multiple lines of code (Preserving "hard" indentation across newlines)
+flags: [generated]
+---*/
+
+(function() {
+	'These literals are each contained on a single line...';
+	"...which means they may be indented...";
+	`...without effecting the semantics of the generated source code.`;
+
+	if (true) {
+		'These literals are each contained on a single line...';
+		"...which means they may be indented...";
+		`...without effecting the semantics of the generated source code.`;
+	}
+}());

--- a/tools/generation/test/expected/indentation/tabs-indent-string-continuation.js
+++ b/tools/generation/test/expected/indentation/tabs-indent-string-continuation.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/indent-string-continuation.case
+// - tools/generation/test/fixtures/indentation/tabs.template
+/*---
+description: Multiline string via a line continuation character (Preserving "hard" indentation across newlines)
+flags: [generated]
+---*/
+
+(function() {
+	'this string is declared across multiple lines\
+\
+which disqualifies it as a candidate for indentation';
+
+	if (true) {
+		'this string is declared across multiple lines\
+\
+which disqualifies it as a candidate for indentation';
+	}
+}());

--- a/tools/generation/test/expected/indentation/tabs-indent-string-template.js
+++ b/tools/generation/test/expected/indentation/tabs-indent-string-template.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/indent-string-template.case
+// - tools/generation/test/fixtures/indentation/tabs.template
+/*---
+description: String template spanning multiple lines (Preserving "hard" indentation across newlines)
+flags: [generated]
+---*/
+
+(function() {
+	`this string template is declared across multiple lines
+
+which disqualifies it as a candidate for indentation
+it also happens to contain ' and ".`;
+
+	if (true) {
+		`this string template is declared across multiple lines
+
+which disqualifies it as a candidate for indentation
+it also happens to contain ' and ".`;
+	}
+}());

--- a/tools/generation/test/fixtures/indent-code.case
+++ b/tools/generation/test/fixtures/indent-code.case
@@ -1,0 +1,11 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+template: indentation
+desc: Multiple lines of code
+---*/
+
+//- value
+'These literals are each contained on a single line...';
+"...which means they may be indented...";
+`...without effecting the semantics of the generated source code.`;

--- a/tools/generation/test/fixtures/indent-string-continuation.case
+++ b/tools/generation/test/fixtures/indent-string-continuation.case
@@ -1,0 +1,11 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+template: indentation
+desc: Multiline string via a line continuation character
+---*/
+
+//- value
+'this string is declared across multiple lines\
+\
+which disqualifies it as a candidate for indentation';

--- a/tools/generation/test/fixtures/indent-string-template.case
+++ b/tools/generation/test/fixtures/indent-string-template.case
@@ -1,0 +1,12 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+template: indentation
+desc: String template spanning multiple lines
+---*/
+
+//- value
+`this string template is declared across multiple lines
+
+which disqualifies it as a candidate for indentation
+it also happens to contain ' and ".`;

--- a/tools/generation/test/fixtures/indentation/spaces.template
+++ b/tools/generation/test/fixtures/indentation/spaces.template
@@ -1,0 +1,14 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+name: Preserving "soft" indentation across newlines
+path: indentation/spaces-
+---*/
+
+(function() {
+  /*{ value }*/
+
+  if (true) {
+    /*{ value }*/
+  }
+}());

--- a/tools/generation/test/fixtures/indentation/tabs.template
+++ b/tools/generation/test/fixtures/indentation/tabs.template
@@ -1,0 +1,14 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+name: Preserving "hard" indentation across newlines
+path: indentation/tabs-
+---*/
+
+(function() {
+	/*{ value }*/
+
+	if (true) {
+		/*{ value }*/
+	}
+}());

--- a/tools/generation/test/run.py
+++ b/tools/generation/test/run.py
@@ -59,5 +59,14 @@ class TestGeneration(unittest.TestCase):
         self.assertEqual(result['returncode'], 0)
         self.compareTrees('negative')
 
+    def test_indentation(self):
+        result = self.fixture('indent-code.case')
+        self.assertEqual(result['returncode'], 0)
+        result = self.fixture('indent-string-continuation.case')
+        self.assertEqual(result['returncode'], 0)
+        result = self.fixture('indent-string-template.case')
+        self.assertEqual(result['returncode'], 0)
+        self.compareTrees('indentation')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The test generation tool exhibited a bug that made it unable to produce valid
tests in some situations. I discovered this while working on a patch recently
and decided to manually duplicate tests as a short-term workaround. This patch
corrects the bug in the tool and re-formats those manually-duplicated tests to
a procedurally-generated form.