### PR TITLE
Test for parameters with default expressions in Annex B FiB tests

### DIFF
--- a/src/annex-b-fns/func-skip-dft-param.case
+++ b/src/annex-b-fns/func-skip-dft-param.case
@@ -1,0 +1,28 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: >
+    Extension not observed when there is a default parameter with the same name
+template: func
+info: |
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
+    [...]
+---*/
+
+//- setup
+var init, after;
+//- params
+f = 123
+//- before
+init = f;
+//- after
+after = f;
+//- teardown
+assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
+assert.sameValue(after, 123, 'value is not updated following evaluation');

--- a/test/annexB/language/function-code/block-decl-func-skip-dft-param.js
+++ b/test/annexB/language/function-code/block-decl-func-skip-dft-param.js
@@ -1,0 +1,31 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-dft-param.case
+// - src/annex-b-fns/func/block.template
+/*---
+description: Extension not observed when there is a default parameter with the same name (Block statement in function scope containing a function declaration)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
+    [...]
+---*/
+var init, after;
+
+(function(f = 123) {
+  init = f;
+
+  {
+    function f() {  }
+  }
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
+assert.sameValue(after, 123, 'value is not updated following evaluation');

--- a/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-dft-param.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-dft-param.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-dft-param.case
+// - src/annex-b-fns/func/if-decl-else-decl-a.template
+/*---
+description: Extension not observed when there is a default parameter with the same name (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
+    [...]
+---*/
+var init, after;
+
+(function(f = 123) {
+  init = f;
+
+  if (true) function f() {  } else function _f() {}
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
+assert.sameValue(after, 123, 'value is not updated following evaluation');

--- a/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-dft-param.js
+++ b/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-dft-param.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-dft-param.case
+// - src/annex-b-fns/func/if-decl-else-decl-b.template
+/*---
+description: Extension not observed when there is a default parameter with the same name (IfStatement with a declaration in both statement positions in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
+    [...]
+---*/
+var init, after;
+
+(function(f = 123) {
+  init = f;
+
+  if (false) function _f() {} else function f() {  }
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
+assert.sameValue(after, 123, 'value is not updated following evaluation');

--- a/test/annexB/language/function-code/if-decl-else-stmt-func-skip-dft-param.js
+++ b/test/annexB/language/function-code/if-decl-else-stmt-func-skip-dft-param.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-dft-param.case
+// - src/annex-b-fns/func/if-decl-else-stmt.template
+/*---
+description: Extension not observed when there is a default parameter with the same name (IfStatement with a declaration in the first statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
+    [...]
+---*/
+var init, after;
+
+(function(f = 123) {
+  init = f;
+
+  if (true) function f() {  } else ;
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
+assert.sameValue(after, 123, 'value is not updated following evaluation');

--- a/test/annexB/language/function-code/if-decl-no-else-func-skip-dft-param.js
+++ b/test/annexB/language/function-code/if-decl-no-else-func-skip-dft-param.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-dft-param.case
+// - src/annex-b-fns/func/if-decl-no-else.template
+/*---
+description: Extension not observed when there is a default parameter with the same name (IfStatement without an else clause in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
+    [...]
+---*/
+var init, after;
+
+(function(f = 123) {
+  init = f;
+
+  if (true) function f() {  }
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
+assert.sameValue(after, 123, 'value is not updated following evaluation');

--- a/test/annexB/language/function-code/if-stmt-else-decl-func-skip-dft-param.js
+++ b/test/annexB/language/function-code/if-stmt-else-decl-func-skip-dft-param.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-dft-param.case
+// - src/annex-b-fns/func/if-stmt-else-decl.template
+/*---
+description: Extension not observed when there is a default parameter with the same name (IfStatement with a declaration in the second statement position in function scope)
+esid: sec-functiondeclarations-in-ifstatement-statement-clauses
+es6id: B.3.4
+flags: [generated, noStrict]
+info: |
+    The following rules for IfStatement augment those in 13.6:
+
+    IfStatement[Yield, Return]:
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else Statement[?Yield, ?Return]
+        if ( Expression[In, ?Yield] ) Statement[?Yield, ?Return] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield] else FunctionDeclaration[?Yield]
+        if ( Expression[In, ?Yield] ) FunctionDeclaration[?Yield]
+
+
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
+    [...]
+---*/
+var init, after;
+
+(function(f = 123) {
+  init = f;
+
+  if (false) ; else function f() {  }
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
+assert.sameValue(after, 123, 'value is not updated following evaluation');

--- a/test/annexB/language/function-code/switch-case-func-skip-dft-param.js
+++ b/test/annexB/language/function-code/switch-case-func-skip-dft-param.js
@@ -1,0 +1,32 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-dft-param.case
+// - src/annex-b-fns/func/switch-case.template
+/*---
+description: Extension not observed when there is a default parameter with the same name (Function declaration in the `case` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
+    [...]
+---*/
+var init, after;
+
+(function(f = 123) {
+  init = f;
+
+  switch (1) {
+    case 1:
+      function f() {  }
+  }
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
+assert.sameValue(after, 123, 'value is not updated following evaluation');

--- a/test/annexB/language/function-code/switch-dflt-func-skip-dft-param.js
+++ b/test/annexB/language/function-code/switch-dflt-func-skip-dft-param.js
@@ -1,0 +1,32 @@
+// This file was procedurally generated from the following sources:
+// - src/annex-b-fns/func-skip-dft-param.case
+// - src/annex-b-fns/func/switch-dflt.template
+/*---
+description: Extension not observed when there is a default parameter with the same name (Funtion declaration in the `default` clause of a `switch` statement in function scope)
+esid: sec-web-compat-functiondeclarationinstantiation
+es6id: B.3.3.1
+flags: [generated, noStrict]
+info: |
+    B.3.3.1 Changes to FunctionDeclarationInstantiation
+
+    [...]
+    ii. If replacing the FunctionDeclaration f with a VariableStatement that
+        has F as a BindingIdentifier would not produce any Early Errors for
+        func and F is not an element of BoundNames of argumentsList, then
+    [...]
+---*/
+var init, after;
+
+(function(f = 123) {
+  init = f;
+
+  switch (1) {
+    default:
+      function f() {  }
+  }
+
+  after = f;
+}());
+
+assert.sameValue(init, 123, 'binding is not initialized to `undefined`');
+assert.sameValue(after, 123, 'value is not updated following evaluation');


### PR DESCRIPTION
Closes gh-860

cc @syg @jugglinmike 

This is my first try to fix #860 using the test generation tool.

As you can see in [the new code](https://github.com/tc39/test262/compare/master...leobalter:860-block-dft-params?expand=1#diff-44c8f167f3b6d4d7f5e745fa3727baaf), I used both the previous copyright from V8 and included an extra line for Mozilla for the new change.

I'm not sure this is the best way to handle this case (wrt copyrights) but I'm willing to fix it if necessary.