### PR TITLE
Add missing test cases for set __proto__

### DIFF
--- a/test/annexB/built-ins/Object/prototype/__proto__/set-non-object.js
+++ b/test/annexB/built-ins/Object/prototype/__proto__/set-non-object.js
@@ -12,8 +12,24 @@ features: [Symbol]
 ---*/
 
 var set = Object.getOwnPropertyDescriptor(Object.prototype, '__proto__').set;
+var subject = {};
 
 assert.sameValue(set.call(true), undefined, 'boolean');
+assert.sameValue(
+  Object.getPrototypeOf(subject), Object.prototype, 'following boolean'
+);
+
 assert.sameValue(set.call(1), undefined, 'number');
+assert.sameValue(
+  Object.getPrototypeOf(subject), Object.prototype, 'following number'
+);
+
 assert.sameValue(set.call('string'), undefined, 'string');
+assert.sameValue(
+  Object.getPrototypeOf(subject), Object.prototype, 'following string'
+);
+
 assert.sameValue(set.call(Symbol('')), undefined, 'symbol');
+assert.sameValue(
+  Object.getPrototypeOf(subject), Object.prototype, 'following symbol'
+);


### PR DESCRIPTION
Fixes #887

Stolen from the sibling file `set-invalid-value.js`.