### PR TITLE
Avoid top level name and length bindings

### DIFF
--- a/src/dstr-assignment/array-rest-nested-obj-undefined-hole.case
+++ b/src/dstr-assignment/array-rest-nested-obj-undefined-hole.case
@@ -12,7 +12,9 @@ es6id: 12.14.5.3
 
 //- setup
 var x = null;
-var length;
+// Use the the top-level lexical scope for 'length' to provide compatibility with browsers
+// where length and name are properties of WindowProxy
+let length;
 //- elems
 [...{ 0: x, length }]
 //- vals

--- a/src/dstr-assignment/array-rest-nested-obj-undefined-own.case
+++ b/src/dstr-assignment/array-rest-nested-obj-undefined-own.case
@@ -12,7 +12,9 @@ es6id: 12.14.5.3
 
 //- setup
 var x = null;
-var length;
+// Use the the top-level lexical scope for 'length' to provide compatibility with browsers
+// where length and name are properties of WindowProxy
+let length;
 //- elems
 [...{ 0: x, length }]
 //- vals

--- a/src/dstr-assignment/array-rest-nested-obj-undefined.case
+++ b/src/dstr-assignment/array-rest-nested-obj-undefined.case
@@ -12,7 +12,9 @@ es6id: 12.14.5.3
 
 //- setup
 var x = null;
-var length;
+// Use the the top-level lexical scope for 'length' to provide compatibility with browsers
+// where length and name are properties of WindowProxy
+let length;
 //- elems
 [...{ 0: x, length }]
 //- vals

--- a/test/annexB/built-ins/String/prototype/substr/length-to-int-err.js
+++ b/test/annexB/built-ins/String/prototype/substr/length-to-int-err.js
@@ -12,14 +12,14 @@ features: [Symbol]
 ---*/
 
 var symbol = Symbol('');
-var length = {
+var len = {
   valueOf: function() {
     throw new Test262Error();
   }
 };
 
 assert.throws(Test262Error, function() {
-  ''.substr(0, length);
+  ''.substr(0, len);
 });
 
 assert.throws(TypeError, function() {

--- a/test/annexB/built-ins/String/prototype/substr/start-to-int-err.js
+++ b/test/annexB/built-ins/String/prototype/substr/start-to-int-err.js
@@ -18,18 +18,18 @@ var start = {
     throw new Test262Error();
   }
 };
-var length = {
+var len = {
   valueOf: function() {
     lengthCallCount += 1;
   }
 };
 
 assert.throws(Test262Error, function() {
-  ''.substr(start, length);
+  ''.substr(start, len);
 });
 
 assert.throws(TypeError, function() {
-  ''.substr(symbol, length);
+  ''.substr(symbol, len);
 });
 
 assert.sameValue(lengthCallCount, 0);

--- a/test/built-ins/Array/of/construct-this-with-the-number-of-arguments.js
+++ b/test/built-ins/Array/of/construct-this-with-the-number-of-arguments.js
@@ -14,25 +14,25 @@ info: >
   ...
 ---*/
 
-var length;
+var len;
 var hits = 0;
 
-function C(len) {
-  length = len;
+function C(length) {
+  len = length;
   hits++;
 }
 
 Array.of.call(C);
-assert.sameValue(length, 0, '`Array.of.call(C);` called `new C(0)`');
+assert.sameValue(len, 0, '`Array.of.call(C);` called `new C(0)`');
 assert.sameValue(hits, 1, 'Called constructor once per call');
 
 Array.of.call(C, 'a', 'b')
-assert.sameValue(length, 2, '`Array.of.call(C, "a", "b"));` called `new C(2)`');
+assert.sameValue(len, 2, '`Array.of.call(C, "a", "b"));` called `new C(2)`');
 assert.sameValue(hits, 2, 'Called constructor once per call');
 
 Array.of.call(C, false, null, undefined);
 assert.sameValue(
-  length, 3,
+  len, 3,
   '`Array.of.call(C, false, null, undefined);` called `new C(3)`'
 );
 assert.sameValue(hits, 3, 'Called constructor once per call');

--- a/test/built-ins/DataView/return-abrupt-tonumber-bytelength-symbol-sab.js
+++ b/test/built-ins/DataView/return-abrupt-tonumber-bytelength-symbol-sab.js
@@ -20,8 +20,8 @@ features: [SharedArrayBuffer]
 ---*/
 
 var buffer = new SharedArrayBuffer(8);
-var length = Symbol("1");
+var s = Symbol("1");
 
 assert.throws(TypeError, function() {
-  new DataView(buffer, 0, length);
+  new DataView(buffer, 0, s);
 });

--- a/test/built-ins/DataView/return-abrupt-tonumber-bytelength-symbol.js
+++ b/test/built-ins/DataView/return-abrupt-tonumber-bytelength-symbol.js
@@ -19,8 +19,8 @@ features: [Symbol]
 ---*/
 
 var buffer = new ArrayBuffer(8);
-var length = Symbol("1");
+var s = Symbol("1");
 
 assert.throws(TypeError, function() {
-  new DataView(buffer, 0, length);
+  new DataView(buffer, 0, s);
 });

--- a/test/built-ins/Function/S15.3_A3_T2.js
+++ b/test/built-ins/Function/S15.3_A3_T2.js
@@ -10,7 +10,7 @@ description: First argument is string and null
 ---*/
 
 this.color="red";
-var name="mars";
+var planet="mars";
 
 var f = Function.call("blablastring", "return this.color;");
 
@@ -19,7 +19,7 @@ if (f() !== "red") {
   $ERROR('#1: ');
 }
 
-var g = Function.call(null, "return this.name;");
+var g = Function.call(null, "return this.planet;");
 
 //CHECK#2
 if (g() !== "mars") {

--- a/test/built-ins/Object/internals/DefineOwnProperty/nan-equivalence.js
+++ b/test/built-ins/Object/internals/DefineOwnProperty/nan-equivalence.js
@@ -43,7 +43,7 @@ includes: [nans.js]
 
 var float = new Float64Array(1);
 var ints = new Uint8Array(float.buffer);
-var length = distinctNaNs.length;
+var len = distinctNaNs.length;
 var idx, jdx, subject, first, second;
 function byteValue(value) {
   float[0] = value;
@@ -57,8 +57,8 @@ function byteValue(value) {
  * cannot be verified and this test is expected to pass without evaluating any
  * assertions.
  */
-for (idx = 0; idx < length; ++idx) {
-  for (jdx = 0 ; jdx < length; ++jdx) {
+for (idx = 0; idx < len; ++idx) {
+  for (jdx = 0 ; jdx < len; ++jdx) {
     first = distinctNaNs[idx];
     second = distinctNaNs[jdx];
     if (byteValue(first) === byteValue(second)) {

--- a/test/built-ins/TypedArrays/buffer-arg-length-access-throws-sab.js
+++ b/test/built-ins/TypedArrays/buffer-arg-length-access-throws-sab.js
@@ -21,7 +21,7 @@ features: [SharedArrayBuffer]
 ---*/
 
 var buffer = new SharedArrayBuffer(8);
-var length = {
+var len = {
   valueOf() {
     throw new Test262Error();
   }
@@ -29,6 +29,6 @@ var length = {
 
 testWithTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {
-    new TA(buffer, 0, length);
+    new TA(buffer, 0, len);
   });
 });

--- a/test/built-ins/TypedArrays/buffer-arg-length-access-throws.js
+++ b/test/built-ins/TypedArrays/buffer-arg-length-access-throws.js
@@ -19,7 +19,7 @@ includes: [testTypedArray.js]
 ---*/
 
 var buffer = new ArrayBuffer(8);
-var length = {
+var len = {
   valueOf() {
     throw new Test262Error();
   }
@@ -27,6 +27,6 @@ var length = {
 
 testWithTypedArrayConstructors(function(TA) {
   assert.throws(Test262Error, function() {
-    new TA(buffer, 0, length);
+    new TA(buffer, 0, len);
   });
 });

--- a/test/built-ins/TypedArrays/buffer-arg-length-is-symbol-throws-sab.js
+++ b/test/built-ins/TypedArrays/buffer-arg-length-is-symbol-throws-sab.js
@@ -21,10 +21,10 @@ features: [SharedArrayBuffer]
 ---*/
 
 var buffer = new SharedArrayBuffer(8);
-var length = Symbol("1");
+var s = Symbol("1");
 
 testWithTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
-    new TA(buffer, 0, length);
+    new TA(buffer, 0, s);
   });
 });

--- a/test/built-ins/TypedArrays/buffer-arg-length-is-symbol-throws.js
+++ b/test/built-ins/TypedArrays/buffer-arg-length-is-symbol-throws.js
@@ -20,10 +20,10 @@ features: [Symbol]
 ---*/
 
 var buffer = new ArrayBuffer(8);
-var length = Symbol("1");
+var s = Symbol("1");
 
 testWithTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
-    new TA(buffer, 0, length);
+    new TA(buffer, 0, s);
   });
 });

--- a/test/built-ins/TypedArrays/typedarray-arg-returns-new-instance.js
+++ b/test/built-ins/TypedArrays/typedarray-arg-returns-new-instance.js
@@ -17,14 +17,14 @@ info: >
 includes: [testTypedArray.js]
 ---*/
 
-var length = 10;
-var typedArraySample = new Int8Array(length);
+var len = 10;
+var typedArraySample = new Int8Array(len);
 
 testWithTypedArrayConstructors(function(TA) {
   var typedArray = new TA(typedArraySample);
 
   assert.notSameValue(typedArray, typedArraySample);
-  assert.sameValue(typedArray.length, length);
+  assert.sameValue(typedArray.length, len);
   assert.sameValue(typedArray.constructor, TA);
   assert.sameValue(Object.getPrototypeOf(typedArray), TA.prototype);
 });

--- a/test/language/expressions/assignment/dstr-array-rest-nested-obj-undefined-hole.js
+++ b/test/language/expressions/assignment/dstr-array-rest-nested-obj-undefined-hole.js
@@ -17,7 +17,9 @@ info: |
        BindingPattern passing rval and undefined as arguments.
 ---*/
 var x = null;
-var length;
+// Use the the top-level lexical scope for 'length' to provide compatibility with browsers
+// where length and name are properties of WindowProxy
+let length;
 
 var result;
 var vals = [ , ];

--- a/test/language/expressions/assignment/dstr-array-rest-nested-obj-undefined-own.js
+++ b/test/language/expressions/assignment/dstr-array-rest-nested-obj-undefined-own.js
@@ -17,7 +17,9 @@ info: |
        BindingPattern passing rval and undefined as arguments.
 ---*/
 var x = null;
-var length;
+// Use the the top-level lexical scope for 'length' to provide compatibility with browsers
+// where length and name are properties of WindowProxy
+let length;
 
 var result;
 var vals = [undefined];

--- a/test/language/expressions/assignment/dstr-array-rest-nested-obj-undefined.js
+++ b/test/language/expressions/assignment/dstr-array-rest-nested-obj-undefined.js
@@ -17,7 +17,9 @@ info: |
        BindingPattern passing rval and undefined as arguments.
 ---*/
 var x = null;
-var length;
+// Use the the top-level lexical scope for 'length' to provide compatibility with browsers
+// where length and name are properties of WindowProxy
+let length;
 
 var result;
 var vals = [];

--- a/test/language/expressions/call/scope-lex-open.js
+++ b/test/language/expressions/call/scope-lex-open.js
@@ -21,16 +21,16 @@ info: |
 features: [let]
 ---*/
 
-var name = 'outside';
-var probeBefore = function() { return name; };
+var n = 'outside';
+var probeBefore = function() { return n; };
 var probeInside;
 
 // This test intentionally elides parameter expressions because their presence
 // triggers the creation of an additional LexicalEnvironment dedicated to the
 // function body (see sec-functiondeclarationinstantiation)
-var func = function name() {
-  let name = 'inside';
-  probeInside = function() { return name; };
+var func = function n() {
+  let n = 'inside';
+  probeInside = function() { return n; };
 };
 
 func();

--- a/test/language/expressions/call/scope-var-open.js
+++ b/test/language/expressions/call/scope-var-open.js
@@ -20,19 +20,19 @@ info: |
     [...]
 ---*/
 
-var name = 'outside';
-var probeBefore = function() { return name; };
+var n = 'outside';
+var probeBefore = function() { return n; };
 var probeBody;
 
 // This test intentionally elides parameter expressions because their presence
 // triggers the creation of an additional LexicalEnvironment dedicated to the
 // function body (see sec-functiondeclarationinstantiation)
-var func = function name() {
+var func = function n() {
   // The initializer is intentionally omitted from the following
   // VariableStatement in order to demonstrate that a new binding is created
   // (and not simply re-used from the FunctionExpression's BindingIdentifier).
-  var name;
-  probeBody = function() { return name; };
+  var n;
+  probeBody = function() { return n; };
 };
 
 func();

--- a/test/language/expressions/object/method-definition/generator-name-prop-symbol.js
+++ b/test/language/expressions/object/method-definition/generator-name-prop-symbol.js
@@ -10,8 +10,8 @@ includes: [propertyHelper.js]
 features: [Symbol, generators]
 ---*/
 
-var name = Symbol('method');
-var method = { *[name]() {} }[name];
+var m = Symbol('method');
+var method = { *[m]() {} }[m];
 
 assert.sameValue(method.name, '[method]');
 verifyNotEnumerable(method, 'name');

--- a/test/language/expressions/object/method-definition/name-name-prop-symbol.js
+++ b/test/language/expressions/object/method-definition/name-name-prop-symbol.js
@@ -10,8 +10,8 @@ includes: [propertyHelper.js]
 features: [Symbol]
 ---*/
 
-var name = Symbol('method');
-var method = { [name]() {} }[name];
+var m = Symbol('method');
+var method = { [m]() {} }[m];
 
 assert.sameValue(method.name, '[method]');
 verifyNotEnumerable(method, 'name');

--- a/test/language/statements/for-of/dstr-array-rest-nested-obj-undefined-hole.js
+++ b/test/language/statements/for-of/dstr-array-rest-nested-obj-undefined-hole.js
@@ -26,7 +26,9 @@ info: |
     [...]
 ---*/
 var x = null;
-var length;
+// Use the the top-level lexical scope for 'length' to provide compatibility with browsers
+// where length and name are properties of WindowProxy
+let length;
 
 var counter = 0;
 

--- a/test/language/statements/for-of/dstr-array-rest-nested-obj-undefined-own.js
+++ b/test/language/statements/for-of/dstr-array-rest-nested-obj-undefined-own.js
@@ -26,7 +26,9 @@ info: |
     [...]
 ---*/
 var x = null;
-var length;
+// Use the the top-level lexical scope for 'length' to provide compatibility with browsers
+// where length and name are properties of WindowProxy
+let length;
 
 var counter = 0;
 

--- a/test/language/statements/for-of/dstr-array-rest-nested-obj-undefined.js
+++ b/test/language/statements/for-of/dstr-array-rest-nested-obj-undefined.js
@@ -26,7 +26,9 @@ info: |
     [...]
 ---*/
 var x = null;
-var length;
+// Use the the top-level lexical scope for 'length' to provide compatibility with browsers
+// where length and name are properties of WindowProxy
+let length;
 
 var counter = 0;
 


### PR DESCRIPTION
Closes #850 

cc @syg, this is the best I could do to fix. We need to add this as soon as we have some code style document (#297)

