### PR TITLE
Add async-gen templates for params in the test gen tool

### DIFF
--- a/src/params/default/async-gen-func-decl.template
+++ b/src/params/default/async-gen-func-decl.template
@@ -1,0 +1,29 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/async-generator/params-
+name: async generator function declaration
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+flags: [async]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+async function* ref(/*{ params }*/) {
+  /*{ body }*/
+  callCount = callCount + 1;
+}
+
+ref(/*{ args }*/).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);

--- a/src/params/default/async-gen-func-expr.template
+++ b/src/params/default/async-gen-func-expr.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/async-generator/params-
+name: async generator function expression
+esid: sec-asyncgenerator-definitions-evaluation
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+    
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+flags: [async]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+var ref;
+ref = async function*(/*{ params }*/) {
+  /*{ body }*/
+  callCount = callCount + 1;
+};
+
+ref(/*{ args }*/).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);

--- a/src/params/default/async-gen-meth.template
+++ b/src/params/default/async-gen-meth.template
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/object/method-definition/params-async-gen-meth-
+name: async generator method
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+flags: [async]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+var obj = {
+  async *method(/*{ params }*/) {
+    /*{ body }*/
+    callCount = callCount + 1;
+  }
+};
+
+// Stores a reference `ref` for case evaluation
+var ref = obj.method;
+
+ref(/*{ args }*/).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator method invoked exactly once');
+}).then($DONE, $DONE);

--- a/src/params/default/async-gen-named-func-expr.template
+++ b/src/params/default/async-gen-named-func-expr.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/async-generator/params-named-
+name: async generator named function expression
+esid: sec-asyncgenerator-definitions-evaluation
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+    
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+flags: [async]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+var ref;
+ref = async function* g(/*{ params }*/) {
+  /*{ body }*/
+  callCount = callCount + 1;
+};
+
+ref(/*{ args }*/).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);

--- a/src/params/default/cls-decl-async-gen-meth-static.template
+++ b/src/params/default/cls-decl-async-gen-meth-static.template
@@ -1,0 +1,56 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/params-async-gen-meth-static-
+name: static class expression generator method
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+flags: [async]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+class C {
+  static async *method(/*{ params }*/) {
+    /*{ body }*/
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.method;
+
+ref(/*{ args }*/).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);

--- a/src/params/default/cls-decl-async-gen-meth.template
+++ b/src/params/default/cls-decl-async-gen-meth.template
@@ -1,0 +1,55 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/class/params-async-gen-meth-
+name: class expression method
+esid: sec-class-definitions-runtime-semantics-evaluation
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+flags: [async]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+class C {
+  async *method(/*{ params }*/) {
+    /*{ body }*/
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.prototype.method;
+
+ref(/*{ args }*/).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);

--- a/src/params/default/cls-expr-async-gen-meth-static.template
+++ b/src/params/default/cls-expr-async-gen-meth-static.template
@@ -1,0 +1,56 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/class/params-async-gen-meth-static-
+name: static class expression async generator method
+esid: sec-class-definitions-runtime-semantics-evaluation
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+flags: [async]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+var C = class {
+  static async *method(/*{ params }*/) {
+    /*{ body }*/
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.method;
+
+ref(/*{ args }*/).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);

--- a/src/params/default/cls-expr-async-gen-meth.template
+++ b/src/params/default/cls-expr-async-gen-meth.template
@@ -1,0 +1,57 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/class/params-async-gen-meth-
+name: class expression async generator method
+esid: sec-class-definitions-runtime-semantics-evaluation
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+flags: [async]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+var C = class {
+  async *method(/*{ params }*/) {
+    /*{ body }*/
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.prototype.method;
+
+ref(/*{ args }*/).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+

--- a/src/params/error/async-gen-func-decl.template
+++ b/src/params/error/async-gen-func-decl.template
@@ -1,0 +1,29 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/async-generator/params-
+name: async generator function declaration
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+async function* f(/*{ params }*/) {
+  /*{ body }*/
+  callCount = callCount + 1;
+}
+
+assert.throws(/*{ error }*/, function() {
+  f(/*{ args }*/);
+});
+
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/src/params/error/async-gen-func-expr.template
+++ b/src/params/error/async-gen-func-expr.template
@@ -1,0 +1,29 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/async-generator/params-
+name: async generator function expression
+esid: sec-asyncgenerator-definitions-evaluation
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+    
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+var f;
+f = async function*(/*{ params }*/) {
+  /*{ body }*/
+  callCount = callCount + 1;
+};
+
+assert.throws(/*{ error }*/, function() {
+  f(/*{ args }*/);
+});
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/src/params/error/async-gen-meth.template
+++ b/src/params/error/async-gen-meth.template
@@ -1,0 +1,34 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/object/method-definition/params-async-gen-meth-
+name: async generator method
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+var obj = {
+  async *method(/*{ params }*/) {
+    /*{ body }*/
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(/*{ error }*/, function() {
+  obj.method(/*{ args }*/);
+});
+assert.sameValue(callCount, 0, 'generator method body not evaluated');

--- a/src/params/error/async-gen-named-func-expr.template
+++ b/src/params/error/async-gen-named-func-expr.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/async-generator/params-named-
+name: async generator named function expression
+esid: sec-asyncgenerator-definitions-evaluation
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+    
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+flags: [async]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+var f;
+f = async function* g(/*{ params }*/) {
+  /*{ body }*/
+  callCount = callCount + 1;
+};
+
+assert.throws(/*{ error }*/, function() {
+  f(/*{ args }*/);
+});
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/src/params/error/cls-decl-async-gen-meth-static.template
+++ b/src/params/error/cls-decl-async-gen-meth-static.template
@@ -1,0 +1,54 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/params-async-gen-meth-static-
+name: static class expression generator method
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+class C {
+  static async *method(/*{ params }*/) {
+    /*{ body }*/
+    callCount = callCount + 1;
+  }
+}
+
+assert.throws(/*{ error }*/, function() {
+  C.method(/*{ args }*/);
+});
+
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/src/params/error/cls-decl-async-gen-meth.template
+++ b/src/params/error/cls-decl-async-gen-meth.template
@@ -1,0 +1,52 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/class/params-async-gen-meth-
+name: class expression method
+esid: sec-class-definitions-runtime-semantics-evaluation
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+class C {
+  async *method(/*{ params }*/) {
+    /*{ body }*/
+    callCount = callCount + 1;
+  }
+}
+
+assert.throws(/*{ error }*/, function() {
+  C.prototype.method(/*{ args }*/);
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/src/params/error/cls-expr-async-gen-meth-static.template
+++ b/src/params/error/cls-expr-async-gen-meth-static.template
@@ -1,0 +1,53 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/class/params-async-gen-meth-static-
+name: static class expression async generator method
+esid: sec-class-definitions-runtime-semantics-evaluation
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+var C = class {
+  static async *method(/*{ params }*/) {
+    /*{ body }*/
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(/*{ error }*/, function() {
+  C.method(/*{ args }*/);
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/src/params/error/cls-expr-async-gen-meth.template
+++ b/src/params/error/cls-expr-async-gen-meth.template
@@ -1,0 +1,74 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/class/params-async-gen-meth-
+name: class expression async generator method
+esid: sec-class-definitions-runtime-semantics-evaluation
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+features: [async-iteration]
+---*/
+
+var callCount = 0;
+var C = class {
+  async *method(/*{ params }*/) {
+    /*{ body }*/
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(/*{ error }*/, function() {
+  C.prototype.method(/*{ args }*/);
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/src/params/syntax/async-gen-func-decl.template
+++ b/src/params/syntax/async-gen-func-decl.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/async-generator/params-
+name: async generator function declaration
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+features: [async-iteration]
+---*/
+
+async function* f(/*{ params }*/) {
+  /*{ body }*/
+}

--- a/src/params/syntax/async-gen-func-expr.template
+++ b/src/params/syntax/async-gen-func-expr.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/async-generator/params-
+name: async generator function expression
+esid: sec-asyncgenerator-definitions-evaluation
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+    
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+features: [async-iteration]
+---*/
+
+0, async function*(/*{ params }*/) {
+  /*{ body }*/
+};

--- a/src/params/syntax/async-gen-meth.template
+++ b/src/params/syntax/async-gen-meth.template
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/object/method-definition/params-async-gen-meth-
+name: async generator method
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+features: [async-iteration]
+---*/
+
+0, {
+  async *method(/*{ params }*/) {
+    /*{ body }*/
+  }
+};

--- a/src/params/syntax/async-gen-named-func-expr.template
+++ b/src/params/syntax/async-gen-named-func-expr.template
@@ -1,0 +1,22 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/async-generator/params-named-
+name: async generator named function expression
+esid: sec-asyncgenerator-definitions-evaluation
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+    
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+flags: [async]
+features: [async-iteration]
+---*/
+
+0, async function* g(/*{ params }*/) {
+  /*{ body }*/
+};

--- a/src/params/syntax/cls-decl-async-gen-meth-static.template
+++ b/src/params/syntax/cls-decl-async-gen-meth-static.template
@@ -1,0 +1,46 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/params-async-gen-meth-static-
+name: static class expression generator method
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+features: [async-iteration]
+---*/
+
+class C {
+  static async *method(/*{ params }*/) {
+    /*{ body }*/
+  }
+}

--- a/src/params/syntax/cls-decl-async-gen-meth.template
+++ b/src/params/syntax/cls-decl-async-gen-meth.template
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/class/params-async-gen-meth-
+name: class expression method
+esid: sec-class-definitions-runtime-semantics-evaluation
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+features: [async-iteration]
+---*/
+
+class C {
+  async *method(/*{ params }*/) {
+    /*{ body }*/
+  }
+}

--- a/src/params/syntax/cls-expr-async-gen-meth-static.template
+++ b/src/params/syntax/cls-expr-async-gen-meth-static.template
@@ -1,0 +1,46 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/class/params-async-gen-meth-static-
+name: static class expression async generator method
+esid: sec-class-definitions-runtime-semantics-evaluation
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+features: [async-iteration]
+---*/
+
+0, class {
+  static async *method(/*{ params }*/) {
+    /*{ body }*/
+  }
+};

--- a/src/params/syntax/cls-expr-async-gen-meth.template
+++ b/src/params/syntax/cls-expr-async-gen-meth.template
@@ -1,0 +1,46 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/class/params-async-gen-meth-
+name: class expression async generator method
+esid: sec-class-definitions-runtime-semantics-evaluation
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+features: [async-iteration]
+---*/
+
+0, class {
+  async *method(/*{ params }*/) {
+    /*{ body }*/
+  }
+};

--- a/test/language/expressions/async-generator/params-dflt-abrupt.js
+++ b/test/language/expressions/async-generator/params-dflt-abrupt.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-abrupt.case
+// - src/params/error/async-gen-func-expr.template
+/*---
+description: Abrupt completion returned by evaluation of initializer (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+
+
+var callCount = 0;
+var f;
+f = async function*(_ = (function() { throw new Test262Error(); }())) {
+  
+  callCount = callCount + 1;
+};
+
+assert.throws(Test262Error, function() {
+  f();
+});
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/test/language/expressions/async-generator/params-dflt-arg-val-not-undefined.js
+++ b/test/language/expressions/async-generator/params-dflt-arg-val-not-undefined.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-not-undefined.case
+// - src/params/default/async-gen-func-expr.template
+/*---
+description: Use of intializer when argument value is not `undefined` (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+var obj = {};
+var falseCount = 0;
+var stringCount = 0;
+var nanCount = 0;
+var zeroCount = 0;
+var nullCount = 0;
+var objCount = 0;
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+var ref;
+ref = async function*(aFalse = falseCount +=1, aString = stringCount += 1, aNaN = nanCount += 1, a0 = zeroCount += 1, aNull = nullCount += 1, aObj = objCount +=1) {
+  assert.sameValue(aFalse, false);
+  assert.sameValue(aString, '');
+  assert.sameValue(aNaN, NaN);
+  assert.sameValue(a0, 0);
+  assert.sameValue(aNull, null);
+  assert.sameValue(aObj, obj);
+  callCount = callCount + 1;
+};
+
+ref(false, '', NaN, 0, null, obj).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(falseCount, 0, 'initializer not evaluated: false');
+assert.sameValue(stringCount, 0, 'initializer not evaluated: string');
+assert.sameValue(nanCount, 0, 'initializer not evaluated: NaN');
+assert.sameValue(zeroCount, 0, 'initializer not evaluated: 0');
+assert.sameValue(nullCount, 0, 'initializer not evaluated: null');
+assert.sameValue(objCount, 0, 'initializer not evaluated: object');

--- a/test/language/expressions/async-generator/params-dflt-arg-val-undefined.js
+++ b/test/language/expressions/async-generator/params-dflt-arg-val-undefined.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-undefined.case
+// - src/params/default/async-gen-func-expr.template
+/*---
+description: Use of intializer when argument value is `undefined` (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+var ref;
+ref = async function*(fromLiteral = 23, fromExpr = 45, fromHole = 99) {
+  assert.sameValue(fromLiteral, 23);
+  assert.sameValue(fromExpr, 45);
+  assert.sameValue(fromHole, 99);
+  callCount = callCount + 1;
+};
+
+ref(undefined, void 0).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-generator/params-dflt-duplicates.js
+++ b/test/language/expressions/async-generator/params-dflt-duplicates.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-duplicates.case
+// - src/params/syntax/async-gen-func-expr.template
+/*---
+description: It is a Syntax Error if BoundNames of FormalParameters contains any duplicate elements. (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    14.1.2 Static Semantics: Early Errors
+
+    StrictFormalParameters : FormalParameters
+
+    - It is a Syntax Error if BoundNames of FormalParameters contains any
+      duplicate elements.
+
+    FormalParameters : FormalParameterList
+
+    - It is a Syntax Error if IsSimpleParameterList of FormalParameterList is
+      false and BoundNames of FormalParameterList contains any duplicate
+      elements.
+
+---*/
+
+
+0, async function*(x = 0, x) {
+  
+};

--- a/test/language/expressions/async-generator/params-dflt-ref-later.js
+++ b/test/language/expressions/async-generator/params-dflt-ref-later.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-later.case
+// - src/params/error/async-gen-func-expr.template
+/*---
+description: Referencing a parameter that occurs later in the ParameterList (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+
+var callCount = 0;
+var f;
+f = async function*(x = y, y) {
+  
+  callCount = callCount + 1;
+};
+
+assert.throws(ReferenceError, function() {
+  f();
+});
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/test/language/expressions/async-generator/params-dflt-ref-prior.js
+++ b/test/language/expressions/async-generator/params-dflt-ref-prior.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-prior.case
+// - src/params/default/async-gen-func-expr.template
+/*---
+description: Referencing a parameter that occurs earlier in the ParameterList (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+var ref;
+ref = async function*(x, y = x, z = y) {
+  assert.sameValue(x, 3, 'first argument value');
+  assert.sameValue(y, 3, 'second argument value');
+  assert.sameValue(z, 3, 'third argument value');
+  callCount = callCount + 1;
+};
+
+ref(3).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-generator/params-dflt-ref-self.js
+++ b/test/language/expressions/async-generator/params-dflt-ref-self.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-self.case
+// - src/params/error/async-gen-func-expr.template
+/*---
+description: Referencing a parameter from within its own initializer (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+
+var callCount = 0;
+var f;
+f = async function*(x = x) {
+  
+  callCount = callCount + 1;
+};
+
+assert.throws(ReferenceError, function() {
+  f();
+});
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/test/language/expressions/async-generator/params-dflt-rest.js
+++ b/test/language/expressions/async-generator/params-dflt-rest.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-rest.case
+// - src/params/syntax/async-gen-func-expr.template
+/*---
+description: RestParameter does not support an initializer (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    14.1 Function Definitions
+
+    Syntax
+
+    FunctionRestParameter[Yield] :
+
+      BindingRestElement[?Yield]
+
+    13.3.3 Destructuring Binding Patterns
+
+    Syntax
+
+    BindingRestElement[Yield] :
+
+      ...BindingIdentifier[?Yield]
+      ...BindingPattern[?Yield]
+
+---*/
+
+
+0, async function*(...x = []) {
+  
+};

--- a/test/language/expressions/async-generator/params-named-dflt-abrupt.js
+++ b/test/language/expressions/async-generator/params-named-dflt-abrupt.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-abrupt.case
+// - src/params/error/async-gen-named-func-expr.template
+/*---
+description: Abrupt completion returned by evaluation of initializer (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+
+
+var callCount = 0;
+var f;
+f = async function* g(_ = (function() { throw new Test262Error(); }())) {
+  
+  callCount = callCount + 1;
+};
+
+assert.throws(Test262Error, function() {
+  f();
+});
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/test/language/expressions/async-generator/params-named-dflt-arg-val-not-undefined.js
+++ b/test/language/expressions/async-generator/params-named-dflt-arg-val-not-undefined.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-not-undefined.case
+// - src/params/default/async-gen-named-func-expr.template
+/*---
+description: Use of intializer when argument value is not `undefined` (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+var obj = {};
+var falseCount = 0;
+var stringCount = 0;
+var nanCount = 0;
+var zeroCount = 0;
+var nullCount = 0;
+var objCount = 0;
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+var ref;
+ref = async function* g(aFalse = falseCount +=1, aString = stringCount += 1, aNaN = nanCount += 1, a0 = zeroCount += 1, aNull = nullCount += 1, aObj = objCount +=1) {
+  assert.sameValue(aFalse, false);
+  assert.sameValue(aString, '');
+  assert.sameValue(aNaN, NaN);
+  assert.sameValue(a0, 0);
+  assert.sameValue(aNull, null);
+  assert.sameValue(aObj, obj);
+  callCount = callCount + 1;
+};
+
+ref(false, '', NaN, 0, null, obj).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(falseCount, 0, 'initializer not evaluated: false');
+assert.sameValue(stringCount, 0, 'initializer not evaluated: string');
+assert.sameValue(nanCount, 0, 'initializer not evaluated: NaN');
+assert.sameValue(zeroCount, 0, 'initializer not evaluated: 0');
+assert.sameValue(nullCount, 0, 'initializer not evaluated: null');
+assert.sameValue(objCount, 0, 'initializer not evaluated: object');

--- a/test/language/expressions/async-generator/params-named-dflt-arg-val-undefined.js
+++ b/test/language/expressions/async-generator/params-named-dflt-arg-val-undefined.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-undefined.case
+// - src/params/default/async-gen-named-func-expr.template
+/*---
+description: Use of intializer when argument value is `undefined` (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+var ref;
+ref = async function* g(fromLiteral = 23, fromExpr = 45, fromHole = 99) {
+  assert.sameValue(fromLiteral, 23);
+  assert.sameValue(fromExpr, 45);
+  assert.sameValue(fromHole, 99);
+  callCount = callCount + 1;
+};
+
+ref(undefined, void 0).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-generator/params-named-dflt-duplicates.js
+++ b/test/language/expressions/async-generator/params-named-dflt-duplicates.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-duplicates.case
+// - src/params/syntax/async-gen-named-func-expr.template
+/*---
+description: It is a Syntax Error if BoundNames of FormalParameters contains any duplicate elements. (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    14.1.2 Static Semantics: Early Errors
+
+    StrictFormalParameters : FormalParameters
+
+    - It is a Syntax Error if BoundNames of FormalParameters contains any
+      duplicate elements.
+
+    FormalParameters : FormalParameterList
+
+    - It is a Syntax Error if IsSimpleParameterList of FormalParameterList is
+      false and BoundNames of FormalParameterList contains any duplicate
+      elements.
+
+---*/
+
+
+0, async function* g(x = 0, x) {
+  
+};

--- a/test/language/expressions/async-generator/params-named-dflt-ref-later.js
+++ b/test/language/expressions/async-generator/params-named-dflt-ref-later.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-later.case
+// - src/params/error/async-gen-named-func-expr.template
+/*---
+description: Referencing a parameter that occurs later in the ParameterList (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+
+var callCount = 0;
+var f;
+f = async function* g(x = y, y) {
+  
+  callCount = callCount + 1;
+};
+
+assert.throws(ReferenceError, function() {
+  f();
+});
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/test/language/expressions/async-generator/params-named-dflt-ref-prior.js
+++ b/test/language/expressions/async-generator/params-named-dflt-ref-prior.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-prior.case
+// - src/params/default/async-gen-named-func-expr.template
+/*---
+description: Referencing a parameter that occurs earlier in the ParameterList (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+var ref;
+ref = async function* g(x, y = x, z = y) {
+  assert.sameValue(x, 3, 'first argument value');
+  assert.sameValue(y, 3, 'second argument value');
+  assert.sameValue(z, 3, 'third argument value');
+  callCount = callCount + 1;
+};
+
+ref(3).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-generator/params-named-dflt-ref-self.js
+++ b/test/language/expressions/async-generator/params-named-dflt-ref-self.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-self.case
+// - src/params/error/async-gen-named-func-expr.template
+/*---
+description: Referencing a parameter from within its own initializer (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+
+var callCount = 0;
+var f;
+f = async function* g(x = x) {
+  
+  callCount = callCount + 1;
+};
+
+assert.throws(ReferenceError, function() {
+  f();
+});
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/test/language/expressions/async-generator/params-named-dflt-rest.js
+++ b/test/language/expressions/async-generator/params-named-dflt-rest.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-rest.case
+// - src/params/syntax/async-gen-named-func-expr.template
+/*---
+description: RestParameter does not support an initializer (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    14.1 Function Definitions
+
+    Syntax
+
+    FunctionRestParameter[Yield] :
+
+      BindingRestElement[?Yield]
+
+    13.3.3 Destructuring Binding Patterns
+
+    Syntax
+
+    BindingRestElement[Yield] :
+
+      ...BindingIdentifier[?Yield]
+      ...BindingPattern[?Yield]
+
+---*/
+
+
+0, async function* g(...x = []) {
+  
+};

--- a/test/language/expressions/async-generator/params-named-trailing-comma-dflt-param.js
+++ b/test/language/expressions/async-generator/params-named-trailing-comma-dflt-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-dflt-param.case
+// - src/params/default/async-gen-named-func-expr.template
+/*---
+description: A trailing comma should not increase the respective length, using default parameters (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+var ref;
+ref = async function* g(a, b = 39,) {
+  assert.sameValue(a, 42);
+  assert.sameValue(b, 39);
+  callCount = callCount + 1;
+};
+
+ref(42, undefined, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/expressions/async-generator/params-named-trailing-comma-multiple-param.js
+++ b/test/language/expressions/async-generator/params-named-trailing-comma-multiple-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-multiple-param.case
+// - src/params/default/async-gen-named-func-expr.template
+/*---
+description: A trailing comma should not increase the respective length, using multiple parameters (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+var ref;
+ref = async function* g(a, b,) {
+  assert.sameValue(a, 42);
+  assert.sameValue(b, 39);
+  callCount = callCount + 1;
+};
+
+ref(42, 39, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 2, 'length is properly set');

--- a/test/language/expressions/async-generator/params-named-trailing-comma-rest-early-error.js
+++ b/test/language/expressions/async-generator/params-named-trailing-comma-rest-early-error.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-rest-early-error.case
+// - src/params/syntax/async-gen-named-func-expr.template
+/*---
+description: It's a syntax error if a FunctionRestParameter is followed by a trailing comma (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] :
+        [empty]
+        FunctionRestParameter[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await] ,
+        FormalParameterList[?Yield, ?Await] , FunctionRestParameter[?Yield, ?Await]
+---*/
+
+
+0, async function* g(...a,) {
+  
+};

--- a/test/language/expressions/async-generator/params-named-trailing-comma-single-param.js
+++ b/test/language/expressions/async-generator/params-named-trailing-comma-single-param.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-single-param.case
+// - src/params/default/async-gen-named-func-expr.template
+/*---
+description: A trailing comma should not increase the respective length, using a single parameter (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+var ref;
+ref = async function* g(a,) {
+  assert.sameValue(a, 42);
+  callCount = callCount + 1;
+};
+
+ref(42, 39).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/expressions/async-generator/params-trailing-comma-dflt-param.js
+++ b/test/language/expressions/async-generator/params-trailing-comma-dflt-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-dflt-param.case
+// - src/params/default/async-gen-func-expr.template
+/*---
+description: A trailing comma should not increase the respective length, using default parameters (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+var ref;
+ref = async function*(a, b = 39,) {
+  assert.sameValue(a, 42);
+  assert.sameValue(b, 39);
+  callCount = callCount + 1;
+};
+
+ref(42, undefined, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/expressions/async-generator/params-trailing-comma-multiple-param.js
+++ b/test/language/expressions/async-generator/params-trailing-comma-multiple-param.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-multiple-param.case
+// - src/params/default/async-gen-func-expr.template
+/*---
+description: A trailing comma should not increase the respective length, using multiple parameters (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+var ref;
+ref = async function*(a, b,) {
+  assert.sameValue(a, 42);
+  assert.sameValue(b, 39);
+  callCount = callCount + 1;
+};
+
+ref(42, 39, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 2, 'length is properly set');

--- a/test/language/expressions/async-generator/params-trailing-comma-rest-early-error.js
+++ b/test/language/expressions/async-generator/params-trailing-comma-rest-early-error.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-rest-early-error.case
+// - src/params/syntax/async-gen-func-expr.template
+/*---
+description: It's a syntax error if a FunctionRestParameter is followed by a trailing comma (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] :
+        [empty]
+        FunctionRestParameter[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await] ,
+        FormalParameterList[?Yield, ?Await] , FunctionRestParameter[?Yield, ?Await]
+---*/
+
+
+0, async function*(...a,) {
+  
+};

--- a/test/language/expressions/async-generator/params-trailing-comma-single-param.js
+++ b/test/language/expressions/async-generator/params-trailing-comma-single-param.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-single-param.case
+// - src/params/default/async-gen-func-expr.template
+/*---
+description: A trailing comma should not increase the respective length, using a single parameter (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+var ref;
+ref = async function*(a,) {
+  assert.sameValue(a, 42);
+  callCount = callCount + 1;
+};
+
+ref(42, 39).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/expressions/class/params-async-gen-meth-dflt-abrupt.js
+++ b/test/language/expressions/class/params-async-gen-meth-dflt-abrupt.js
@@ -1,0 +1,87 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-abrupt.case
+// - src/params/error/cls-expr-async-gen-meth.template
+/*---
+description: Abrupt completion returned by evaluation of initializer (class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  async *method(_ = (function() { throw new Test262Error(); }())) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(Test262Error, function() {
+  C.prototype.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/expressions/class/params-async-gen-meth-dflt-arg-val-not-undefined.js
+++ b/test/language/expressions/class/params-async-gen-meth-dflt-arg-val-not-undefined.js
@@ -1,0 +1,92 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-not-undefined.case
+// - src/params/default/cls-expr-async-gen-meth.template
+/*---
+description: Use of intializer when argument value is not `undefined` (class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+var obj = {};
+var falseCount = 0;
+var stringCount = 0;
+var nanCount = 0;
+var zeroCount = 0;
+var nullCount = 0;
+var objCount = 0;
+
+var callCount = 0;
+var C = class {
+  async *method(aFalse = falseCount +=1, aString = stringCount += 1, aNaN = nanCount += 1, a0 = zeroCount += 1, aNull = nullCount += 1, aObj = objCount +=1) {
+    assert.sameValue(aFalse, false);
+    assert.sameValue(aString, '');
+    assert.sameValue(aNaN, NaN);
+    assert.sameValue(a0, 0);
+    assert.sameValue(aNull, null);
+    assert.sameValue(aObj, obj);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.prototype.method;
+
+ref(false, '', NaN, 0, null, obj).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+
+assert.sameValue(falseCount, 0, 'initializer not evaluated: false');
+assert.sameValue(stringCount, 0, 'initializer not evaluated: string');
+assert.sameValue(nanCount, 0, 'initializer not evaluated: NaN');
+assert.sameValue(zeroCount, 0, 'initializer not evaluated: 0');
+assert.sameValue(nullCount, 0, 'initializer not evaluated: null');
+assert.sameValue(objCount, 0, 'initializer not evaluated: object');

--- a/test/language/expressions/class/params-async-gen-meth-dflt-arg-val-undefined.js
+++ b/test/language/expressions/class/params-async-gen-meth-dflt-arg-val-undefined.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-undefined.case
+// - src/params/default/cls-expr-async-gen-meth.template
+/*---
+description: Use of intializer when argument value is `undefined` (class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+
+var callCount = 0;
+var C = class {
+  async *method(fromLiteral = 23, fromExpr = 45, fromHole = 99) {
+    assert.sameValue(fromLiteral, 23);
+    assert.sameValue(fromExpr, 45);
+    assert.sameValue(fromHole, 99);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.prototype.method;
+
+ref(undefined, void 0).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+

--- a/test/language/expressions/class/params-async-gen-meth-dflt-duplicates.js
+++ b/test/language/expressions/class/params-async-gen-meth-dflt-duplicates.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-duplicates.case
+// - src/params/syntax/cls-expr-async-gen-meth.template
+/*---
+description: It is a Syntax Error if BoundNames of FormalParameters contains any duplicate elements. (class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.2 Static Semantics: Early Errors
+
+    StrictFormalParameters : FormalParameters
+
+    - It is a Syntax Error if BoundNames of FormalParameters contains any
+      duplicate elements.
+
+    FormalParameters : FormalParameterList
+
+    - It is a Syntax Error if IsSimpleParameterList of FormalParameterList is
+      false and BoundNames of FormalParameterList contains any duplicate
+      elements.
+
+---*/
+
+0, class {
+  async *method(x = 0, x) {
+    
+  }
+};

--- a/test/language/expressions/class/params-async-gen-meth-dflt-ref-later.js
+++ b/test/language/expressions/class/params-async-gen-meth-dflt-ref-later.js
@@ -1,0 +1,88 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-later.case
+// - src/params/error/cls-expr-async-gen-meth.template
+/*---
+description: Referencing a parameter that occurs later in the ParameterList (class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+var callCount = 0;
+var C = class {
+  async *method(x = y, y) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(ReferenceError, function() {
+  C.prototype.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/expressions/class/params-async-gen-meth-dflt-ref-prior.js
+++ b/test/language/expressions/class/params-async-gen-meth-dflt-ref-prior.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-prior.case
+// - src/params/default/cls-expr-async-gen-meth.template
+/*---
+description: Referencing a parameter that occurs earlier in the ParameterList (class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+var callCount = 0;
+var C = class {
+  async *method(x, y = x, z = y) {
+    assert.sameValue(x, 3, 'first argument value');
+    assert.sameValue(y, 3, 'second argument value');
+    assert.sameValue(z, 3, 'third argument value');
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.prototype.method;
+
+ref(3).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+

--- a/test/language/expressions/class/params-async-gen-meth-dflt-ref-self.js
+++ b/test/language/expressions/class/params-async-gen-meth-dflt-ref-self.js
@@ -1,0 +1,88 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-self.case
+// - src/params/error/cls-expr-async-gen-meth.template
+/*---
+description: Referencing a parameter from within its own initializer (class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+var callCount = 0;
+var C = class {
+  async *method(x = x) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(ReferenceError, function() {
+  C.prototype.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/expressions/class/params-async-gen-meth-dflt-rest.js
+++ b/test/language/expressions/class/params-async-gen-meth-dflt-rest.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-rest.case
+// - src/params/syntax/cls-expr-async-gen-meth.template
+/*---
+description: RestParameter does not support an initializer (class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1 Function Definitions
+
+    Syntax
+
+    FunctionRestParameter[Yield] :
+
+      BindingRestElement[?Yield]
+
+    13.3.3 Destructuring Binding Patterns
+
+    Syntax
+
+    BindingRestElement[Yield] :
+
+      ...BindingIdentifier[?Yield]
+      ...BindingPattern[?Yield]
+
+---*/
+
+0, class {
+  async *method(...x = []) {
+    
+  }
+};

--- a/test/language/expressions/class/params-async-gen-meth-static-dflt-abrupt.js
+++ b/test/language/expressions/class/params-async-gen-meth-static-dflt-abrupt.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-abrupt.case
+// - src/params/error/cls-expr-async-gen-meth-static.template
+/*---
+description: Abrupt completion returned by evaluation of initializer (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  static async *method(_ = (function() { throw new Test262Error(); }())) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(Test262Error, function() {
+  C.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/expressions/class/params-async-gen-meth-static-dflt-arg-val-not-undefined.js
+++ b/test/language/expressions/class/params-async-gen-meth-static-dflt-arg-val-not-undefined.js
@@ -1,0 +1,91 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-not-undefined.case
+// - src/params/default/cls-expr-async-gen-meth-static.template
+/*---
+description: Use of intializer when argument value is not `undefined` (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+var obj = {};
+var falseCount = 0;
+var stringCount = 0;
+var nanCount = 0;
+var zeroCount = 0;
+var nullCount = 0;
+var objCount = 0;
+
+var callCount = 0;
+var C = class {
+  static async *method(aFalse = falseCount +=1, aString = stringCount += 1, aNaN = nanCount += 1, a0 = zeroCount += 1, aNull = nullCount += 1, aObj = objCount +=1) {
+    assert.sameValue(aFalse, false);
+    assert.sameValue(aString, '');
+    assert.sameValue(aNaN, NaN);
+    assert.sameValue(a0, 0);
+    assert.sameValue(aNull, null);
+    assert.sameValue(aObj, obj);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.method;
+
+ref(false, '', NaN, 0, null, obj).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(falseCount, 0, 'initializer not evaluated: false');
+assert.sameValue(stringCount, 0, 'initializer not evaluated: string');
+assert.sameValue(nanCount, 0, 'initializer not evaluated: NaN');
+assert.sameValue(zeroCount, 0, 'initializer not evaluated: 0');
+assert.sameValue(nullCount, 0, 'initializer not evaluated: null');
+assert.sameValue(objCount, 0, 'initializer not evaluated: object');

--- a/test/language/expressions/class/params-async-gen-meth-static-dflt-arg-val-undefined.js
+++ b/test/language/expressions/class/params-async-gen-meth-static-dflt-arg-val-undefined.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-undefined.case
+// - src/params/default/cls-expr-async-gen-meth-static.template
+/*---
+description: Use of intializer when argument value is `undefined` (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+
+var callCount = 0;
+var C = class {
+  static async *method(fromLiteral = 23, fromExpr = 45, fromHole = 99) {
+    assert.sameValue(fromLiteral, 23);
+    assert.sameValue(fromExpr, 45);
+    assert.sameValue(fromHole, 99);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.method;
+
+ref(undefined, void 0).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/params-async-gen-meth-static-dflt-duplicates.js
+++ b/test/language/expressions/class/params-async-gen-meth-static-dflt-duplicates.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-duplicates.case
+// - src/params/syntax/cls-expr-async-gen-meth-static.template
+/*---
+description: It is a Syntax Error if BoundNames of FormalParameters contains any duplicate elements. (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.2 Static Semantics: Early Errors
+
+    StrictFormalParameters : FormalParameters
+
+    - It is a Syntax Error if BoundNames of FormalParameters contains any
+      duplicate elements.
+
+    FormalParameters : FormalParameterList
+
+    - It is a Syntax Error if IsSimpleParameterList of FormalParameterList is
+      false and BoundNames of FormalParameterList contains any duplicate
+      elements.
+
+---*/
+
+0, class {
+  static async *method(x = 0, x) {
+    
+  }
+};

--- a/test/language/expressions/class/params-async-gen-meth-static-dflt-ref-later.js
+++ b/test/language/expressions/class/params-async-gen-meth-static-dflt-ref-later.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-later.case
+// - src/params/error/cls-expr-async-gen-meth-static.template
+/*---
+description: Referencing a parameter that occurs later in the ParameterList (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+var callCount = 0;
+var C = class {
+  static async *method(x = y, y) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(ReferenceError, function() {
+  C.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/expressions/class/params-async-gen-meth-static-dflt-ref-prior.js
+++ b/test/language/expressions/class/params-async-gen-meth-static-dflt-ref-prior.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-prior.case
+// - src/params/default/cls-expr-async-gen-meth-static.template
+/*---
+description: Referencing a parameter that occurs earlier in the ParameterList (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+var callCount = 0;
+var C = class {
+  static async *method(x, y = x, z = y) {
+    assert.sameValue(x, 3, 'first argument value');
+    assert.sameValue(y, 3, 'second argument value');
+    assert.sameValue(z, 3, 'third argument value');
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.method;
+
+ref(3).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/params-async-gen-meth-static-dflt-ref-self.js
+++ b/test/language/expressions/class/params-async-gen-meth-static-dflt-ref-self.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-self.case
+// - src/params/error/cls-expr-async-gen-meth-static.template
+/*---
+description: Referencing a parameter from within its own initializer (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+var callCount = 0;
+var C = class {
+  static async *method(x = x) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(ReferenceError, function() {
+  C.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/expressions/class/params-async-gen-meth-static-dflt-rest.js
+++ b/test/language/expressions/class/params-async-gen-meth-static-dflt-rest.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-rest.case
+// - src/params/syntax/cls-expr-async-gen-meth-static.template
+/*---
+description: RestParameter does not support an initializer (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1 Function Definitions
+
+    Syntax
+
+    FunctionRestParameter[Yield] :
+
+      BindingRestElement[?Yield]
+
+    13.3.3 Destructuring Binding Patterns
+
+    Syntax
+
+    BindingRestElement[Yield] :
+
+      ...BindingIdentifier[?Yield]
+      ...BindingPattern[?Yield]
+
+---*/
+
+0, class {
+  static async *method(...x = []) {
+    
+  }
+};

--- a/test/language/expressions/class/params-async-gen-meth-static-trailing-comma-dflt-param.js
+++ b/test/language/expressions/class/params-async-gen-meth-static-trailing-comma-dflt-param.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-dflt-param.case
+// - src/params/default/cls-expr-async-gen-meth-static.template
+/*---
+description: A trailing comma should not increase the respective length, using default parameters (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+var callCount = 0;
+var C = class {
+  static async *method(a, b = 39,) {
+    assert.sameValue(a, 42);
+    assert.sameValue(b, 39);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.method;
+
+ref(42, undefined, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/expressions/class/params-async-gen-meth-static-trailing-comma-multiple-param.js
+++ b/test/language/expressions/class/params-async-gen-meth-static-trailing-comma-multiple-param.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-multiple-param.case
+// - src/params/default/cls-expr-async-gen-meth-static.template
+/*---
+description: A trailing comma should not increase the respective length, using multiple parameters (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+var callCount = 0;
+var C = class {
+  static async *method(a, b,) {
+    assert.sameValue(a, 42);
+    assert.sameValue(b, 39);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.method;
+
+ref(42, 39, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 2, 'length is properly set');

--- a/test/language/expressions/class/params-async-gen-meth-static-trailing-comma-rest-early-error.js
+++ b/test/language/expressions/class/params-async-gen-meth-static-trailing-comma-rest-early-error.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-rest-early-error.case
+// - src/params/syntax/cls-expr-async-gen-meth-static.template
+/*---
+description: It's a syntax error if a FunctionRestParameter is followed by a trailing comma (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] :
+        [empty]
+        FunctionRestParameter[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await] ,
+        FormalParameterList[?Yield, ?Await] , FunctionRestParameter[?Yield, ?Await]
+---*/
+
+0, class {
+  static async *method(...a,) {
+    
+  }
+};

--- a/test/language/expressions/class/params-async-gen-meth-static-trailing-comma-single-param.js
+++ b/test/language/expressions/class/params-async-gen-meth-static-trailing-comma-single-param.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-single-param.case
+// - src/params/default/cls-expr-async-gen-meth-static.template
+/*---
+description: A trailing comma should not increase the respective length, using a single parameter (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+var callCount = 0;
+var C = class {
+  static async *method(a,) {
+    assert.sameValue(a, 42);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.method;
+
+ref(42, 39).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/expressions/class/params-async-gen-meth-trailing-comma-dflt-param.js
+++ b/test/language/expressions/class/params-async-gen-meth-trailing-comma-dflt-param.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-dflt-param.case
+// - src/params/default/cls-expr-async-gen-meth.template
+/*---
+description: A trailing comma should not increase the respective length, using default parameters (class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+var callCount = 0;
+var C = class {
+  async *method(a, b = 39,) {
+    assert.sameValue(a, 42);
+    assert.sameValue(b, 39);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.prototype.method;
+
+ref(42, undefined, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/expressions/class/params-async-gen-meth-trailing-comma-multiple-param.js
+++ b/test/language/expressions/class/params-async-gen-meth-trailing-comma-multiple-param.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-multiple-param.case
+// - src/params/default/cls-expr-async-gen-meth.template
+/*---
+description: A trailing comma should not increase the respective length, using multiple parameters (class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+var callCount = 0;
+var C = class {
+  async *method(a, b,) {
+    assert.sameValue(a, 42);
+    assert.sameValue(b, 39);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.prototype.method;
+
+ref(42, 39, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+
+assert.sameValue(ref.length, 2, 'length is properly set');

--- a/test/language/expressions/class/params-async-gen-meth-trailing-comma-rest-early-error.js
+++ b/test/language/expressions/class/params-async-gen-meth-trailing-comma-rest-early-error.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-rest-early-error.case
+// - src/params/syntax/cls-expr-async-gen-meth.template
+/*---
+description: It's a syntax error if a FunctionRestParameter is followed by a trailing comma (class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] :
+        [empty]
+        FunctionRestParameter[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await] ,
+        FormalParameterList[?Yield, ?Await] , FunctionRestParameter[?Yield, ?Await]
+---*/
+
+0, class {
+  async *method(...a,) {
+    
+  }
+};

--- a/test/language/expressions/class/params-async-gen-meth-trailing-comma-single-param.js
+++ b/test/language/expressions/class/params-async-gen-meth-trailing-comma-single-param.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-single-param.case
+// - src/params/default/cls-expr-async-gen-meth.template
+/*---
+description: A trailing comma should not increase the respective length, using a single parameter (class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+var callCount = 0;
+var C = class {
+  async *method(a,) {
+    assert.sameValue(a, 42);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.prototype.method;
+
+ref(42, 39).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-abrupt.js
+++ b/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-abrupt.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-abrupt.case
+// - src/params/error/async-gen-meth.template
+/*---
+description: Abrupt completion returned by evaluation of initializer (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+
+var callCount = 0;
+var obj = {
+  async *method(_ = (function() { throw new Test262Error(); }())) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(Test262Error, function() {
+  obj.method();
+});
+assert.sameValue(callCount, 0, 'generator method body not evaluated');

--- a/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-arg-val-not-undefined.js
+++ b/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-arg-val-not-undefined.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-not-undefined.case
+// - src/params/default/async-gen-meth.template
+/*---
+description: Use of intializer when argument value is not `undefined` (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+var obj = {};
+var falseCount = 0;
+var stringCount = 0;
+var nanCount = 0;
+var zeroCount = 0;
+var nullCount = 0;
+var objCount = 0;
+
+var callCount = 0;
+var obj = {
+  async *method(aFalse = falseCount +=1, aString = stringCount += 1, aNaN = nanCount += 1, a0 = zeroCount += 1, aNull = nullCount += 1, aObj = objCount +=1) {
+    assert.sameValue(aFalse, false);
+    assert.sameValue(aString, '');
+    assert.sameValue(aNaN, NaN);
+    assert.sameValue(a0, 0);
+    assert.sameValue(aNull, null);
+    assert.sameValue(aObj, obj);
+    callCount = callCount + 1;
+  }
+};
+
+// Stores a reference `ref` for case evaluation
+var ref = obj.method;
+
+ref(false, '', NaN, 0, null, obj).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(falseCount, 0, 'initializer not evaluated: false');
+assert.sameValue(stringCount, 0, 'initializer not evaluated: string');
+assert.sameValue(nanCount, 0, 'initializer not evaluated: NaN');
+assert.sameValue(zeroCount, 0, 'initializer not evaluated: 0');
+assert.sameValue(nullCount, 0, 'initializer not evaluated: null');
+assert.sameValue(objCount, 0, 'initializer not evaluated: object');

--- a/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-arg-val-undefined.js
+++ b/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-arg-val-undefined.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-undefined.case
+// - src/params/default/async-gen-meth.template
+/*---
+description: Use of intializer when argument value is `undefined` (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+
+var callCount = 0;
+var obj = {
+  async *method(fromLiteral = 23, fromExpr = 45, fromHole = 99) {
+    assert.sameValue(fromLiteral, 23);
+    assert.sameValue(fromExpr, 45);
+    assert.sameValue(fromHole, 99);
+    callCount = callCount + 1;
+  }
+};
+
+// Stores a reference `ref` for case evaluation
+var ref = obj.method;
+
+ref(undefined, void 0).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator method invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-duplicates.js
+++ b/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-duplicates.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-duplicates.case
+// - src/params/syntax/async-gen-meth.template
+/*---
+description: It is a Syntax Error if BoundNames of FormalParameters contains any duplicate elements. (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.2 Static Semantics: Early Errors
+
+    StrictFormalParameters : FormalParameters
+
+    - It is a Syntax Error if BoundNames of FormalParameters contains any
+      duplicate elements.
+
+    FormalParameters : FormalParameterList
+
+    - It is a Syntax Error if IsSimpleParameterList of FormalParameterList is
+      false and BoundNames of FormalParameterList contains any duplicate
+      elements.
+
+---*/
+
+0, {
+  async *method(x = 0, x) {
+    
+  }
+};

--- a/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-ref-later.js
+++ b/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-ref-later.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-later.case
+// - src/params/error/async-gen-meth.template
+/*---
+description: Referencing a parameter that occurs later in the ParameterList (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+var callCount = 0;
+var obj = {
+  async *method(x = y, y) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(ReferenceError, function() {
+  obj.method();
+});
+assert.sameValue(callCount, 0, 'generator method body not evaluated');

--- a/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-ref-prior.js
+++ b/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-ref-prior.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-prior.case
+// - src/params/default/async-gen-meth.template
+/*---
+description: Referencing a parameter that occurs earlier in the ParameterList (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+var callCount = 0;
+var obj = {
+  async *method(x, y = x, z = y) {
+    assert.sameValue(x, 3, 'first argument value');
+    assert.sameValue(y, 3, 'second argument value');
+    assert.sameValue(z, 3, 'third argument value');
+    callCount = callCount + 1;
+  }
+};
+
+// Stores a reference `ref` for case evaluation
+var ref = obj.method;
+
+ref(3).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator method invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-ref-self.js
+++ b/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-ref-self.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-self.case
+// - src/params/error/async-gen-meth.template
+/*---
+description: Referencing a parameter from within its own initializer (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+var callCount = 0;
+var obj = {
+  async *method(x = x) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(ReferenceError, function() {
+  obj.method();
+});
+assert.sameValue(callCount, 0, 'generator method body not evaluated');

--- a/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-rest.js
+++ b/test/language/expressions/object/method-definition/params-async-gen-meth-dflt-rest.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-rest.case
+// - src/params/syntax/async-gen-meth.template
+/*---
+description: RestParameter does not support an initializer (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1 Function Definitions
+
+    Syntax
+
+    FunctionRestParameter[Yield] :
+
+      BindingRestElement[?Yield]
+
+    13.3.3 Destructuring Binding Patterns
+
+    Syntax
+
+    BindingRestElement[Yield] :
+
+      ...BindingIdentifier[?Yield]
+      ...BindingPattern[?Yield]
+
+---*/
+
+0, {
+  async *method(...x = []) {
+    
+  }
+};

--- a/test/language/expressions/object/method-definition/params-async-gen-meth-trailing-comma-dflt-param.js
+++ b/test/language/expressions/object/method-definition/params-async-gen-meth-trailing-comma-dflt-param.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-dflt-param.case
+// - src/params/default/async-gen-meth.template
+/*---
+description: A trailing comma should not increase the respective length, using default parameters (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+var callCount = 0;
+var obj = {
+  async *method(a, b = 39,) {
+    assert.sameValue(a, 42);
+    assert.sameValue(b, 39);
+    callCount = callCount + 1;
+  }
+};
+
+// Stores a reference `ref` for case evaluation
+var ref = obj.method;
+
+ref(42, undefined, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/expressions/object/method-definition/params-async-gen-meth-trailing-comma-multiple-param.js
+++ b/test/language/expressions/object/method-definition/params-async-gen-meth-trailing-comma-multiple-param.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-multiple-param.case
+// - src/params/default/async-gen-meth.template
+/*---
+description: A trailing comma should not increase the respective length, using multiple parameters (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+var callCount = 0;
+var obj = {
+  async *method(a, b,) {
+    assert.sameValue(a, 42);
+    assert.sameValue(b, 39);
+    callCount = callCount + 1;
+  }
+};
+
+// Stores a reference `ref` for case evaluation
+var ref = obj.method;
+
+ref(42, 39, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 2, 'length is properly set');

--- a/test/language/expressions/object/method-definition/params-async-gen-meth-trailing-comma-rest-early-error.js
+++ b/test/language/expressions/object/method-definition/params-async-gen-meth-trailing-comma-rest-early-error.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-rest-early-error.case
+// - src/params/syntax/async-gen-meth.template
+/*---
+description: It's a syntax error if a FunctionRestParameter is followed by a trailing comma (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] :
+        [empty]
+        FunctionRestParameter[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await] ,
+        FormalParameterList[?Yield, ?Await] , FunctionRestParameter[?Yield, ?Await]
+---*/
+
+0, {
+  async *method(...a,) {
+    
+  }
+};

--- a/test/language/expressions/object/method-definition/params-async-gen-meth-trailing-comma-single-param.js
+++ b/test/language/expressions/object/method-definition/params-async-gen-meth-trailing-comma-single-param.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-single-param.case
+// - src/params/default/async-gen-meth.template
+/*---
+description: A trailing comma should not increase the respective length, using a single parameter (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+var callCount = 0;
+var obj = {
+  async *method(a,) {
+    assert.sameValue(a, 42);
+    callCount = callCount + 1;
+  }
+};
+
+// Stores a reference `ref` for case evaluation
+var ref = obj.method;
+
+ref(42, 39).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/statements/async-generator/params-dflt-abrupt.js
+++ b/test/language/statements/async-generator/params-dflt-abrupt.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-abrupt.case
+// - src/params/error/async-gen-func-decl.template
+/*---
+description: Abrupt completion returned by evaluation of initializer (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+
+
+var callCount = 0;
+async function* f(_ = (function() { throw new Test262Error(); }())) {
+  
+  callCount = callCount + 1;
+}
+
+assert.throws(Test262Error, function() {
+  f();
+});
+
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/test/language/statements/async-generator/params-dflt-arg-val-not-undefined.js
+++ b/test/language/statements/async-generator/params-dflt-arg-val-not-undefined.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-not-undefined.case
+// - src/params/default/async-gen-func-decl.template
+/*---
+description: Use of intializer when argument value is not `undefined` (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+var obj = {};
+var falseCount = 0;
+var stringCount = 0;
+var nanCount = 0;
+var zeroCount = 0;
+var nullCount = 0;
+var objCount = 0;
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+async function* ref(aFalse = falseCount +=1, aString = stringCount += 1, aNaN = nanCount += 1, a0 = zeroCount += 1, aNull = nullCount += 1, aObj = objCount +=1) {
+  assert.sameValue(aFalse, false);
+  assert.sameValue(aString, '');
+  assert.sameValue(aNaN, NaN);
+  assert.sameValue(a0, 0);
+  assert.sameValue(aNull, null);
+  assert.sameValue(aObj, obj);
+  callCount = callCount + 1;
+}
+
+ref(false, '', NaN, 0, null, obj).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(falseCount, 0, 'initializer not evaluated: false');
+assert.sameValue(stringCount, 0, 'initializer not evaluated: string');
+assert.sameValue(nanCount, 0, 'initializer not evaluated: NaN');
+assert.sameValue(zeroCount, 0, 'initializer not evaluated: 0');
+assert.sameValue(nullCount, 0, 'initializer not evaluated: null');
+assert.sameValue(objCount, 0, 'initializer not evaluated: object');

--- a/test/language/statements/async-generator/params-dflt-arg-val-undefined.js
+++ b/test/language/statements/async-generator/params-dflt-arg-val-undefined.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-undefined.case
+// - src/params/default/async-gen-func-decl.template
+/*---
+description: Use of intializer when argument value is `undefined` (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+async function* ref(fromLiteral = 23, fromExpr = 45, fromHole = 99) {
+  assert.sameValue(fromLiteral, 23);
+  assert.sameValue(fromExpr, 45);
+  assert.sameValue(fromHole, 99);
+  callCount = callCount + 1;
+}
+
+ref(undefined, void 0).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/statements/async-generator/params-dflt-duplicates.js
+++ b/test/language/statements/async-generator/params-dflt-duplicates.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-duplicates.case
+// - src/params/syntax/async-gen-func-decl.template
+/*---
+description: It is a Syntax Error if BoundNames of FormalParameters contains any duplicate elements. (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [default-parameters, async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    14.1.2 Static Semantics: Early Errors
+
+    StrictFormalParameters : FormalParameters
+
+    - It is a Syntax Error if BoundNames of FormalParameters contains any
+      duplicate elements.
+
+    FormalParameters : FormalParameterList
+
+    - It is a Syntax Error if IsSimpleParameterList of FormalParameterList is
+      false and BoundNames of FormalParameterList contains any duplicate
+      elements.
+
+---*/
+
+
+async function* f(x = 0, x) {
+  
+}

--- a/test/language/statements/async-generator/params-dflt-ref-later.js
+++ b/test/language/statements/async-generator/params-dflt-ref-later.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-later.case
+// - src/params/error/async-gen-func-decl.template
+/*---
+description: Referencing a parameter that occurs later in the ParameterList (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+
+var callCount = 0;
+async function* f(x = y, y) {
+  
+  callCount = callCount + 1;
+}
+
+assert.throws(ReferenceError, function() {
+  f();
+});
+
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/test/language/statements/async-generator/params-dflt-ref-prior.js
+++ b/test/language/statements/async-generator/params-dflt-ref-prior.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-prior.case
+// - src/params/default/async-gen-func-decl.template
+/*---
+description: Referencing a parameter that occurs earlier in the ParameterList (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+async function* ref(x, y = x, z = y) {
+  assert.sameValue(x, 3, 'first argument value');
+  assert.sameValue(y, 3, 'second argument value');
+  assert.sameValue(z, 3, 'third argument value');
+  callCount = callCount + 1;
+}
+
+ref(3).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/statements/async-generator/params-dflt-ref-self.js
+++ b/test/language/statements/async-generator/params-dflt-ref-self.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-self.case
+// - src/params/error/async-gen-func-decl.template
+/*---
+description: Referencing a parameter from within its own initializer (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+
+var callCount = 0;
+async function* f(x = x) {
+  
+  callCount = callCount + 1;
+}
+
+assert.throws(ReferenceError, function() {
+  f();
+});
+
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/test/language/statements/async-generator/params-dflt-rest.js
+++ b/test/language/statements/async-generator/params-dflt-rest.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-rest.case
+// - src/params/syntax/async-gen-func-decl.template
+/*---
+description: RestParameter does not support an initializer (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [default-parameters, async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    14.1 Function Definitions
+
+    Syntax
+
+    FunctionRestParameter[Yield] :
+
+      BindingRestElement[?Yield]
+
+    13.3.3 Destructuring Binding Patterns
+
+    Syntax
+
+    BindingRestElement[Yield] :
+
+      ...BindingIdentifier[?Yield]
+      ...BindingPattern[?Yield]
+
+---*/
+
+
+async function* f(...x = []) {
+  
+}

--- a/test/language/statements/async-generator/params-trailing-comma-dflt-param.js
+++ b/test/language/statements/async-generator/params-trailing-comma-dflt-param.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-dflt-param.case
+// - src/params/default/async-gen-func-decl.template
+/*---
+description: A trailing comma should not increase the respective length, using default parameters (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+async function* ref(a, b = 39,) {
+  assert.sameValue(a, 42);
+  assert.sameValue(b, 39);
+  callCount = callCount + 1;
+}
+
+ref(42, undefined, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/statements/async-generator/params-trailing-comma-multiple-param.js
+++ b/test/language/statements/async-generator/params-trailing-comma-multiple-param.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-multiple-param.case
+// - src/params/default/async-gen-func-decl.template
+/*---
+description: A trailing comma should not increase the respective length, using multiple parameters (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+async function* ref(a, b,) {
+  assert.sameValue(a, 42);
+  assert.sameValue(b, 39);
+  callCount = callCount + 1;
+}
+
+ref(42, 39, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 2, 'length is properly set');

--- a/test/language/statements/async-generator/params-trailing-comma-rest-early-error.js
+++ b/test/language/statements/async-generator/params-trailing-comma-rest-early-error.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-rest-early-error.case
+// - src/params/syntax/async-gen-func-decl.template
+/*---
+description: It's a syntax error if a FunctionRestParameter is followed by a trailing comma (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] :
+        [empty]
+        FunctionRestParameter[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await] ,
+        FormalParameterList[?Yield, ?Await] , FunctionRestParameter[?Yield, ?Await]
+---*/
+
+
+async function* f(...a,) {
+  
+}

--- a/test/language/statements/async-generator/params-trailing-comma-single-param.js
+++ b/test/language/statements/async-generator/params-trailing-comma-single-param.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-single-param.case
+// - src/params/default/async-gen-func-decl.template
+/*---
+description: A trailing comma should not increase the respective length, using a single parameter (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+
+var callCount = 0;
+// Stores a reference `ref` for case evaluation
+async function* ref(a,) {
+  assert.sameValue(a, 42);
+  callCount = callCount + 1;
+}
+
+ref(42, 39).next().then(() => {
+    assert.sameValue(callCount, 1, 'generator function invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/statements/class/params-async-gen-meth-dflt-abrupt.js
+++ b/test/language/statements/class/params-async-gen-meth-dflt-abrupt.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-abrupt.case
+// - src/params/error/cls-decl-async-gen-meth.template
+/*---
+description: Abrupt completion returned by evaluation of initializer (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+
+var callCount = 0;
+class C {
+  async *method(_ = (function() { throw new Test262Error(); }())) {
+    
+    callCount = callCount + 1;
+  }
+}
+
+assert.throws(Test262Error, function() {
+  C.prototype.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/statements/class/params-async-gen-meth-dflt-arg-val-not-undefined.js
+++ b/test/language/statements/class/params-async-gen-meth-dflt-arg-val-not-undefined.js
@@ -1,0 +1,90 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-not-undefined.case
+// - src/params/default/cls-decl-async-gen-meth.template
+/*---
+description: Use of intializer when argument value is not `undefined` (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+var obj = {};
+var falseCount = 0;
+var stringCount = 0;
+var nanCount = 0;
+var zeroCount = 0;
+var nullCount = 0;
+var objCount = 0;
+
+var callCount = 0;
+class C {
+  async *method(aFalse = falseCount +=1, aString = stringCount += 1, aNaN = nanCount += 1, a0 = zeroCount += 1, aNull = nullCount += 1, aObj = objCount +=1) {
+    assert.sameValue(aFalse, false);
+    assert.sameValue(aString, '');
+    assert.sameValue(aNaN, NaN);
+    assert.sameValue(a0, 0);
+    assert.sameValue(aNull, null);
+    assert.sameValue(aObj, obj);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.prototype.method;
+
+ref(false, '', NaN, 0, null, obj).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(falseCount, 0, 'initializer not evaluated: false');
+assert.sameValue(stringCount, 0, 'initializer not evaluated: string');
+assert.sameValue(nanCount, 0, 'initializer not evaluated: NaN');
+assert.sameValue(zeroCount, 0, 'initializer not evaluated: 0');
+assert.sameValue(nullCount, 0, 'initializer not evaluated: null');
+assert.sameValue(objCount, 0, 'initializer not evaluated: object');

--- a/test/language/statements/class/params-async-gen-meth-dflt-arg-val-undefined.js
+++ b/test/language/statements/class/params-async-gen-meth-dflt-arg-val-undefined.js
@@ -1,0 +1,73 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-undefined.case
+// - src/params/default/cls-decl-async-gen-meth.template
+/*---
+description: Use of intializer when argument value is `undefined` (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+
+var callCount = 0;
+class C {
+  async *method(fromLiteral = 23, fromExpr = 45, fromHole = 99) {
+    assert.sameValue(fromLiteral, 23);
+    assert.sameValue(fromExpr, 45);
+    assert.sameValue(fromHole, 99);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.prototype.method;
+
+ref(undefined, void 0).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/statements/class/params-async-gen-meth-dflt-duplicates.js
+++ b/test/language/statements/class/params-async-gen-meth-dflt-duplicates.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-duplicates.case
+// - src/params/syntax/cls-decl-async-gen-meth.template
+/*---
+description: It is a Syntax Error if BoundNames of FormalParameters contains any duplicate elements. (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.2 Static Semantics: Early Errors
+
+    StrictFormalParameters : FormalParameters
+
+    - It is a Syntax Error if BoundNames of FormalParameters contains any
+      duplicate elements.
+
+    FormalParameters : FormalParameterList
+
+    - It is a Syntax Error if IsSimpleParameterList of FormalParameterList is
+      false and BoundNames of FormalParameterList contains any duplicate
+      elements.
+
+---*/
+
+class C {
+  async *method(x = 0, x) {
+    
+  }
+}

--- a/test/language/statements/class/params-async-gen-meth-dflt-ref-later.js
+++ b/test/language/statements/class/params-async-gen-meth-dflt-ref-later.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-later.case
+// - src/params/error/cls-decl-async-gen-meth.template
+/*---
+description: Referencing a parameter that occurs later in the ParameterList (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+var callCount = 0;
+class C {
+  async *method(x = y, y) {
+    
+    callCount = callCount + 1;
+  }
+}
+
+assert.throws(ReferenceError, function() {
+  C.prototype.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/statements/class/params-async-gen-meth-dflt-ref-prior.js
+++ b/test/language/statements/class/params-async-gen-meth-dflt-ref-prior.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-prior.case
+// - src/params/default/cls-decl-async-gen-meth.template
+/*---
+description: Referencing a parameter that occurs earlier in the ParameterList (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+var callCount = 0;
+class C {
+  async *method(x, y = x, z = y) {
+    assert.sameValue(x, 3, 'first argument value');
+    assert.sameValue(y, 3, 'second argument value');
+    assert.sameValue(z, 3, 'third argument value');
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.prototype.method;
+
+ref(3).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/statements/class/params-async-gen-meth-dflt-ref-self.js
+++ b/test/language/statements/class/params-async-gen-meth-dflt-ref-self.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-self.case
+// - src/params/error/cls-decl-async-gen-meth.template
+/*---
+description: Referencing a parameter from within its own initializer (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+var callCount = 0;
+class C {
+  async *method(x = x) {
+    
+    callCount = callCount + 1;
+  }
+}
+
+assert.throws(ReferenceError, function() {
+  C.prototype.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/statements/class/params-async-gen-meth-dflt-rest.js
+++ b/test/language/statements/class/params-async-gen-meth-dflt-rest.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-rest.case
+// - src/params/syntax/cls-decl-async-gen-meth.template
+/*---
+description: RestParameter does not support an initializer (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1 Function Definitions
+
+    Syntax
+
+    FunctionRestParameter[Yield] :
+
+      BindingRestElement[?Yield]
+
+    13.3.3 Destructuring Binding Patterns
+
+    Syntax
+
+    BindingRestElement[Yield] :
+
+      ...BindingIdentifier[?Yield]
+      ...BindingPattern[?Yield]
+
+---*/
+
+class C {
+  async *method(...x = []) {
+    
+  }
+}

--- a/test/language/statements/class/params-async-gen-meth-static-dflt-abrupt.js
+++ b/test/language/statements/class/params-async-gen-meth-static-dflt-abrupt.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-abrupt.case
+// - src/params/error/cls-decl-async-gen-meth-static.template
+/*---
+description: Abrupt completion returned by evaluation of initializer (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+
+
+var callCount = 0;
+class C {
+  static async *method(_ = (function() { throw new Test262Error(); }())) {
+    
+    callCount = callCount + 1;
+  }
+}
+
+assert.throws(Test262Error, function() {
+  C.method();
+});
+
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/statements/class/params-async-gen-meth-static-dflt-arg-val-not-undefined.js
+++ b/test/language/statements/class/params-async-gen-meth-static-dflt-arg-val-not-undefined.js
@@ -1,0 +1,91 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-not-undefined.case
+// - src/params/default/cls-decl-async-gen-meth-static.template
+/*---
+description: Use of intializer when argument value is not `undefined` (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+var obj = {};
+var falseCount = 0;
+var stringCount = 0;
+var nanCount = 0;
+var zeroCount = 0;
+var nullCount = 0;
+var objCount = 0;
+
+
+var callCount = 0;
+class C {
+  static async *method(aFalse = falseCount +=1, aString = stringCount += 1, aNaN = nanCount += 1, a0 = zeroCount += 1, aNull = nullCount += 1, aObj = objCount +=1) {
+    assert.sameValue(aFalse, false);
+    assert.sameValue(aString, '');
+    assert.sameValue(aNaN, NaN);
+    assert.sameValue(a0, 0);
+    assert.sameValue(aNull, null);
+    assert.sameValue(aObj, obj);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.method;
+
+ref(false, '', NaN, 0, null, obj).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(falseCount, 0, 'initializer not evaluated: false');
+assert.sameValue(stringCount, 0, 'initializer not evaluated: string');
+assert.sameValue(nanCount, 0, 'initializer not evaluated: NaN');
+assert.sameValue(zeroCount, 0, 'initializer not evaluated: 0');
+assert.sameValue(nullCount, 0, 'initializer not evaluated: null');
+assert.sameValue(objCount, 0, 'initializer not evaluated: object');

--- a/test/language/statements/class/params-async-gen-meth-static-dflt-arg-val-undefined.js
+++ b/test/language/statements/class/params-async-gen-meth-static-dflt-arg-val-undefined.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-arg-val-undefined.case
+// - src/params/default/cls-decl-async-gen-meth-static.template
+/*---
+description: Use of intializer when argument value is `undefined` (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    [...]
+    23. Let iteratorRecord be Record {[[Iterator]]:
+        CreateListIterator(argumentsList), [[Done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        a. Perform ? IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+---*/
+
+
+var callCount = 0;
+class C {
+  static async *method(fromLiteral = 23, fromExpr = 45, fromHole = 99) {
+    assert.sameValue(fromLiteral, 23);
+    assert.sameValue(fromExpr, 45);
+    assert.sameValue(fromHole, 99);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.method;
+
+ref(undefined, void 0).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/statements/class/params-async-gen-meth-static-dflt-duplicates.js
+++ b/test/language/statements/class/params-async-gen-meth-static-dflt-duplicates.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-duplicates.case
+// - src/params/syntax/cls-decl-async-gen-meth-static.template
+/*---
+description: It is a Syntax Error if BoundNames of FormalParameters contains any duplicate elements. (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.2 Static Semantics: Early Errors
+
+    StrictFormalParameters : FormalParameters
+
+    - It is a Syntax Error if BoundNames of FormalParameters contains any
+      duplicate elements.
+
+    FormalParameters : FormalParameterList
+
+    - It is a Syntax Error if IsSimpleParameterList of FormalParameterList is
+      false and BoundNames of FormalParameterList contains any duplicate
+      elements.
+
+---*/
+
+
+class C {
+  static async *method(x = 0, x) {
+    
+  }
+}

--- a/test/language/statements/class/params-async-gen-meth-static-dflt-ref-later.js
+++ b/test/language/statements/class/params-async-gen-meth-static-dflt-ref-later.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-later.case
+// - src/params/error/cls-decl-async-gen-meth-static.template
+/*---
+description: Referencing a parameter that occurs later in the ParameterList (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+
+var callCount = 0;
+class C {
+  static async *method(x = y, y) {
+    
+    callCount = callCount + 1;
+  }
+}
+
+assert.throws(ReferenceError, function() {
+  C.method();
+});
+
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/statements/class/params-async-gen-meth-static-dflt-ref-prior.js
+++ b/test/language/statements/class/params-async-gen-meth-static-dflt-ref-prior.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-prior.case
+// - src/params/default/cls-decl-async-gen-meth-static.template
+/*---
+description: Referencing a parameter that occurs earlier in the ParameterList (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [default-parameters, async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+
+var callCount = 0;
+class C {
+  static async *method(x, y = x, z = y) {
+    assert.sameValue(x, 3, 'first argument value');
+    assert.sameValue(y, 3, 'second argument value');
+    assert.sameValue(z, 3, 'third argument value');
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.method;
+
+ref(3).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/statements/class/params-async-gen-meth-static-dflt-ref-self.js
+++ b/test/language/statements/class/params-async-gen-meth-static-dflt-ref-self.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-ref-self.case
+// - src/params/error/cls-decl-async-gen-meth-static.template
+/*---
+description: Referencing a parameter from within its own initializer (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1.19 Runtime Semantics: IteratorBindingInitialization
+
+    FormalsList : FormalsList , FormalParameter
+
+    1. Let status be the result of performing IteratorBindingInitialization for
+       FormalsList using iteratorRecord and environment as the arguments.
+    2. ReturnIfAbrupt(status).
+    3. Return the result of performing IteratorBindingInitialization for
+       FormalParameter using iteratorRecord and environment as the arguments.
+
+---*/
+var x = 0;
+
+
+var callCount = 0;
+class C {
+  static async *method(x = x) {
+    
+    callCount = callCount + 1;
+  }
+}
+
+assert.throws(ReferenceError, function() {
+  C.method();
+});
+
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/statements/class/params-async-gen-meth-static-dflt-rest.js
+++ b/test/language/statements/class/params-async-gen-meth-static-dflt-rest.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/params/dflt-rest.case
+// - src/params/syntax/cls-decl-async-gen-meth-static.template
+/*---
+description: RestParameter does not support an initializer (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    14.1 Function Definitions
+
+    Syntax
+
+    FunctionRestParameter[Yield] :
+
+      BindingRestElement[?Yield]
+
+    13.3.3 Destructuring Binding Patterns
+
+    Syntax
+
+    BindingRestElement[Yield] :
+
+      ...BindingIdentifier[?Yield]
+      ...BindingPattern[?Yield]
+
+---*/
+
+
+class C {
+  static async *method(...x = []) {
+    
+  }
+}

--- a/test/language/statements/class/params-async-gen-meth-static-trailing-comma-dflt-param.js
+++ b/test/language/statements/class/params-async-gen-meth-static-trailing-comma-dflt-param.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-dflt-param.case
+// - src/params/default/cls-decl-async-gen-meth-static.template
+/*---
+description: A trailing comma should not increase the respective length, using default parameters (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+
+var callCount = 0;
+class C {
+  static async *method(a, b = 39,) {
+    assert.sameValue(a, 42);
+    assert.sameValue(b, 39);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.method;
+
+ref(42, undefined, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/statements/class/params-async-gen-meth-static-trailing-comma-multiple-param.js
+++ b/test/language/statements/class/params-async-gen-meth-static-trailing-comma-multiple-param.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-multiple-param.case
+// - src/params/default/cls-decl-async-gen-meth-static.template
+/*---
+description: A trailing comma should not increase the respective length, using multiple parameters (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+
+var callCount = 0;
+class C {
+  static async *method(a, b,) {
+    assert.sameValue(a, 42);
+    assert.sameValue(b, 39);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.method;
+
+ref(42, 39, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 2, 'length is properly set');

--- a/test/language/statements/class/params-async-gen-meth-static-trailing-comma-rest-early-error.js
+++ b/test/language/statements/class/params-async-gen-meth-static-trailing-comma-rest-early-error.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-rest-early-error.case
+// - src/params/syntax/cls-decl-async-gen-meth-static.template
+/*---
+description: It's a syntax error if a FunctionRestParameter is followed by a trailing comma (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] :
+        [empty]
+        FunctionRestParameter[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await] ,
+        FormalParameterList[?Yield, ?Await] , FunctionRestParameter[?Yield, ?Await]
+---*/
+
+
+class C {
+  static async *method(...a,) {
+    
+  }
+}

--- a/test/language/statements/class/params-async-gen-meth-static-trailing-comma-single-param.js
+++ b/test/language/statements/class/params-async-gen-meth-static-trailing-comma-single-param.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-single-param.case
+// - src/params/default/cls-decl-async-gen-meth-static.template
+/*---
+description: A trailing comma should not increase the respective length, using a single parameter (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+
+var callCount = 0;
+class C {
+  static async *method(a,) {
+    assert.sameValue(a, 42);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.method;
+
+ref(42, 39).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/statements/class/params-async-gen-meth-trailing-comma-dflt-param.js
+++ b/test/language/statements/class/params-async-gen-meth-trailing-comma-dflt-param.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-dflt-param.case
+// - src/params/default/cls-decl-async-gen-meth.template
+/*---
+description: A trailing comma should not increase the respective length, using default parameters (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+var callCount = 0;
+class C {
+  async *method(a, b = 39,) {
+    assert.sameValue(a, 42);
+    assert.sameValue(b, 39);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.prototype.method;
+
+ref(42, undefined, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 1, 'length is properly set');

--- a/test/language/statements/class/params-async-gen-meth-trailing-comma-multiple-param.js
+++ b/test/language/statements/class/params-async-gen-meth-trailing-comma-multiple-param.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-multiple-param.case
+// - src/params/default/cls-decl-async-gen-meth.template
+/*---
+description: A trailing comma should not increase the respective length, using multiple parameters (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+var callCount = 0;
+class C {
+  async *method(a, b,) {
+    assert.sameValue(a, 42);
+    assert.sameValue(b, 39);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.prototype.method;
+
+ref(42, 39, 1).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 2, 'length is properly set');

--- a/test/language/statements/class/params-async-gen-meth-trailing-comma-rest-early-error.js
+++ b/test/language/statements/class/params-async-gen-meth-trailing-comma-rest-early-error.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-rest-early-error.case
+// - src/params/syntax/cls-decl-async-gen-meth.template
+/*---
+description: It's a syntax error if a FunctionRestParameter is followed by a trailing comma (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] :
+        [empty]
+        FunctionRestParameter[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await]
+        FormalParameterList[?Yield, ?Await] ,
+        FormalParameterList[?Yield, ?Await] , FunctionRestParameter[?Yield, ?Await]
+---*/
+
+class C {
+  async *method(...a,) {
+    
+  }
+}

--- a/test/language/statements/class/params-async-gen-meth-trailing-comma-single-param.js
+++ b/test/language/statements/class/params-async-gen-meth-trailing-comma-single-param.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/params/trailing-comma-single-param.case
+// - src/params/default/cls-decl-async-gen-meth.template
+/*---
+description: A trailing comma should not increase the respective length, using a single parameter (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Trailing comma in the parameters list
+
+    14.1 Function Definitions
+
+    FormalParameters[Yield, Await] : FormalParameterList[?Yield, ?Await] ,
+---*/
+
+var callCount = 0;
+class C {
+  async *method(a,) {
+    assert.sameValue(a, 42);
+    callCount = callCount + 1;
+  }
+}
+
+// Stores a reference `ref` for case evaluation
+var ref = C.prototype.method;
+
+ref(42, 39).next().then(() => {
+    assert.sameValue(callCount, 1, 'method invoked exactly once');
+}).then($DONE, $DONE);
+
+assert.sameValue(ref.length, 1, 'length is properly set');


### PR DESCRIPTION
Follow up for #918, this PR adds async-generator templates in the src/params folder

