### PR TITLE
Test that Date.prototype.toString throws for non-Date receiver

### DIFF
--- a/test/built-ins/Date/prototype/toString/invalid-date.js
+++ b/test/built-ins/Date/prototype/toString/invalid-date.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-todatestring
+description: Invalid Dates are rendered as "Invalid Date"
+info: >
+  ToDateString ( tv )
+
+  ...
+  2. If tv is NaN, return "Invalid Date".
+  ...
+---*/
+
+assert.sameValue(new Date(NaN).toString(), "Invalid Date");

--- a/test/built-ins/Date/prototype/toString/non-date-receiver.js
+++ b/test/built-ins/Date/prototype/toString/non-date-receiver.js
@@ -1,12 +1,20 @@
-// Copyright (C) 2017 V8 project authors. All rights reserved.
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: #sec-date.prototype.tostring
+esid: sec-date.prototype.tostring
 description: Date.prototype.toString throws a TypeError on non-Date receivers
+info: |
+  Date.prototype.toString ( )
+
+  1. Let tv be ? thisTimeValue(this value).
 ---*/
 
 assert.throws(TypeError, () => Date.prototype.toString());
 assert.throws(TypeError, () => Date.prototype.toString.call(undefined));
 assert.throws(TypeError, () => Date.prototype.toString.call(0));
 assert.throws(TypeError, () => Date.prototype.toString.call({}));
+assert.throws(TypeError, () =>
+    Date.prototype.toString.call("Tue Mar 21 2017 12:16:43 GMT-0400 (EDT)"));
+assert.throws(TypeError, () =>
+    Date.prototype.toString.call(1490113011493));

--- a/test/built-ins/Date/prototype/toString/non-date-receiver.js
+++ b/test/built-ins/Date/prototype/toString/non-date-receiver.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2017 V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: #sec-date.prototype.tostring
+description: Date.prototype.toString throws a TypeError on non-Date receivers
+---*/
+
+assert.throws(TypeError, () => Date.prototype.toString());
+assert.throws(TypeError, () => Date.prototype.toString.call(undefined));
+assert.throws(TypeError, () => Date.prototype.toString.call(0));
+assert.throws(TypeError, () => Date.prototype.toString.call({}));


### PR DESCRIPTION
Pending discussion of https://github.com/tc39/ecma262/issues/849. Not ready to merge yet!

Test passes in V8.