### PR TITLE
Tests for RegExp capture substitution out of bounds

### DIFF
--- a/test/built-ins/RegExp/prototype/Symbol.replace/subst-capture-idx-1.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/subst-capture-idx-1.js
@@ -28,8 +28,10 @@ info: >
     Replacement text:
     The nth element of captures, where n is a single digit in the range 1 to 9.
     If n≤m and the nth element of captures is undefined, use the empty String
-    instead. If n>m, the result is implementation-defined.
+    instead. If n>m, no replacement is done.
 features: [Symbol.replace]
 ---*/
 
 assert.sameValue(/b(c)(z)?(.)/[Symbol.replace]('abcde', '[$1$2$3]'), 'a[cd]e');
+
+assert.sameValue(/b(c)(z)?(.)/[Symbol.replace]('abcde', '[$1$2$3$4$0]'), 'a[cd$4$0]e');

--- a/test/built-ins/RegExp/prototype/Symbol.replace/subst-capture-idx-2.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/subst-capture-idx-2.js
@@ -28,11 +28,14 @@ info: >
     Replacement text:
     The nnth element of captures, where nn is a two-digit decimal number in the
     range 01 to 99. If nn≤m and the nnth element of captures is undefined, use
-    the empty String instead. If nn is 00 or nn>m, the result is
-    implementation-defined.
+    the empty String instead. If nn is 00 or nn>m, no replacement is done.
 features: [Symbol.replace]
 ---*/
 
 assert.sameValue(
   /b(c)(z)?(.)/[Symbol.replace]('abcde', '[$01$02$03]'), 'a[cd]e'
+);
+
+assert.sameValue(
+  /b(c)(z)?(.)/[Symbol.replace]('abcde', '[$01$02$03$04$00]'), 'a[cd$04$00]e'
 );


### PR DESCRIPTION
In https://github.com/tc39/ecma262/pull/853 , standard semantics
for this case are proposed. This patch tests the case.

This test was tested in V8 and passed there. The test should not
be merged until TC39 comes to agreement about the semantics change.