### PR TITLE
Test for TypedArray.prototype.fill semantics change

### DIFF
--- a/test/built-ins/TypedArray/prototype/fill/fill-values-conversion-once.js
+++ b/test/built-ins/TypedArray/prototype/fill/fill-values-conversion-once.js
@@ -2,7 +2,6 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-%typedarray%.prototype.fill
-es6id: 22.2.3.8
 description: >
   Fills all the elements with non numeric values values.
 info: >

--- a/test/built-ins/TypedArray/prototype/fill/fill-values-conversion-once.js
+++ b/test/built-ins/TypedArray/prototype/fill/fill-values-conversion-once.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.fill
+es6id: 22.2.3.8
+description: >
+  Fills all the elements with non numeric values values.
+info: >
+  22.2.3.8 %TypedArray%.prototype.fill (value [ , start [ , end ] ] )
+
+  ...
+  3. Let _value_ be ? ToNumber(_value_).
+  ...
+includes: [testTypedArray.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+
+  var n = 1;
+  sample.fill({ valueOf() { return n++; } });
+
+  assert.sameValue(n, 2, "additional unexpected ToNumber() calls");
+  assert.sameValue(sample[0], 1, "incorrect ToNumber result in index 0");
+  assert.sameValue(sample[1], 1, "incorrect ToNumber result in index 1");
+});
+


### PR DESCRIPTION
The change is proposed in https://github.com/tc39/ecma262/pull/856
as a fix to https://github.com/tc39/ecma262/issues/855

Here, the ToNumber coercion is done only once, rather than on each
iteration. It does not appear that there were previously any
tests against repeated coercion for this parameter previously.

Tested this test against V8, which failed, as V8 implements the
current spec rather than the proposed one.