### PR TITLE
Date toString tests

### DIFF
--- a/test/built-ins/Date/prototype/toDateString/format.js
+++ b/test/built-ins/Date/prototype/toDateString/format.js
@@ -15,5 +15,5 @@ let match = dateRegExp.exec(new Date().toDateString());
 assert.notSameValue(null, match);
 
 // Years are padded to the left with zeroes
-match = stringRegExp.exec(new Date('0020-01-01T00:00:00Z').toDateString());
+match = dateRegExp.exec(new Date('0020-01-01T00:00:00Z').toDateString());
 assert.notSameValue(null, match);

--- a/test/built-ins/Date/prototype/toDateString/format.js
+++ b/test/built-ins/Date/prototype/toDateString/format.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.prototype.todatestring
+description: Test the format of the date from toDateString
+info: >
+  Date.prototype.toDateString ( )
+
+  5. Return DateString(_t_).
+---*/
+
+let dateRegExp = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{2} [0-9]{4}$/
+let match = dateRegExp.exec(new Date().toDateString());
+assert.notSameValue(null, match);
+
+// Years are padded to the left with zeroes
+match = stringRegExp.exec(new Date('0020-01-01T00:00:00Z').toDateString());
+assert.notSameValue(null, match);

--- a/test/built-ins/Date/prototype/toDateString/invalid-date.js
+++ b/test/built-ins/Date/prototype/toDateString/invalid-date.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.prototype.todatestring
+description: Invalid Dates are rendered as "Invalid Date"
+info: >
+  Date.prototype.toDateString ( )
+
+  ...
+  3. If tv is NaN, return "Invalid Date".
+  ...
+---*/
+
+assert.sameValue(new Date(NaN).toDateString(), "Invalid Date");
+
+

--- a/test/built-ins/Date/prototype/toString/format.js
+++ b/test/built-ins/Date/prototype/toString/format.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.prototype.tostring
+description: Test the format of the time from toString
+info: >
+  Runtime Semantics: ToDateString( _tv_ )
+
+  4. Return the String value formed by concatenating DateString(_t_), `" "`, TimeString(_t_), and TimeZoneString(_tv_).
+
+---*/
+
+let stringRegExp = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{2} [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} GMT[+-][0-9]{4}( \(.+\))?$/
+let match = stringRegExp.exec(new Date().toString());
+assert.notSameValue(null, match);
+
+// Years are padded to the left with zeroes
+match = stringRegExp.exec(new Date('0020-01-01T00:00:00Z').toString());
+assert.notSameValue(null, match);

--- a/test/built-ins/Date/prototype/toTimeString/format.js
+++ b/test/built-ins/Date/prototype/toTimeString/format.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.prototype.totimestring
+description: Test the format of the time from toTimeString
+info: >
+  Date.prototype.toTimeString ( )
+
+  5. Return the String value formed by concatenating TimeString(_t_) and TimeZoneString(_tv_).
+---*/
+
+let timeRegExp = /^[0-9]{2}:[0-9]{2}:[0-9]{2} GMT[+-][0-9]{4}( \(.+\))?$/
+let match = timeRegExp.exec(new Date().toTimeString());
+assert.notSameValue(null, match);

--- a/test/built-ins/Date/prototype/toTimeString/invalid-date.js
+++ b/test/built-ins/Date/prototype/toTimeString/invalid-date.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.prototype.totimestring
+description: Invalid Dates are rendered as "Invalid Date"
+info: >
+  Date.prototype.toTimeString ( )
+
+  ...
+  3. If tv is NaN, return "Invalid Date".
+  ...
+---*/
+
+assert.sameValue(new Date(NaN).toTimeString(), "Invalid Date");
+
+

--- a/test/built-ins/Date/prototype/toUTCString/day-names.js
+++ b/test/built-ins/Date/prototype/toUTCString/day-names.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-todatestring-day-names
+description: Test the names of days
+---*/
+
+assert.sameValue("Sun, 23 Mar 2014 00:00:00 GMT",
+                 (new Date("2014-03-23T00:00:00Z")).toUTCString());
+assert.sameValue("Mon, 24 Mar 2014 00:00:00 GMT",
+                 (new Date("2014-03-24T00:00:00Z")).toUTCString());
+assert.sameValue("Tue, 25 Mar 2014 00:00:00 GMT",
+                 (new Date("2014-03-25T00:00:00Z")).toUTCString());
+assert.sameValue("Wed, 26 Mar 2014 00:00:00 GMT",
+                 (new Date("2014-03-26T00:00:00Z")).toUTCString());
+assert.sameValue("Thu, 27 Mar 2014 00:00:00 GMT",
+                 (new Date("2014-03-27T00:00:00Z")).toUTCString());
+assert.sameValue("Fri, 28 Mar 2014 00:00:00 GMT",
+                 (new Date("2014-03-28T00:00:00Z")).toUTCString());
+assert.sameValue("Sat, 29 Mar 2014 00:00:00 GMT",
+                 (new Date("2014-03-29T00:00:00Z")).toUTCString());

--- a/test/built-ins/Date/prototype/toUTCString/format.js
+++ b/test/built-ins/Date/prototype/toUTCString/format.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.prototype.toutcstring
+description: Test the format of the date from toUTCString
+info: >
+  Date.prototype.toUTCString ( )
+
+  4. Return the String value formed by concatenating DateString(_tv_, `", "`), `" "`, and TimeString(_tv_).
+---*/
+
+let utcRegExp = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat), [0-9]{2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} GMT$/
+let match = utcRegExp.exec(new Date().toUTCString());
+assert.notSameValue(null, match);
+
+// Years are padded to the left with zeroes
+assert.sameValue('Wed, 01 Jan 0020 00:00:00 GMT', new Date('0020-01-01T00:00:00Z').toUTCString());

--- a/test/built-ins/Date/prototype/toUTCString/invalid-date.js
+++ b/test/built-ins/Date/prototype/toUTCString/invalid-date.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.prototype.toutcstring
+description: Invalid Dates are rendered as "Invalid Date"
+info: >
+  Date.prototype.toUTCString ( )
+
+  ...
+  3. If tv is NaN, return "Invalid Date".
+  ...
+---*/
+
+assert.sameValue(new Date(NaN).toUTCString(), "Invalid Date");
+

--- a/test/built-ins/Date/prototype/toUTCString/month-names.js
+++ b/test/built-ins/Date/prototype/toUTCString/month-names.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-todatestring-month-names
+description: Test the names of months
+---*/
+
+assert.sameValue("Wed, 01 Jan 2014 00:00:00 GMT",
+                 (new Date("2014-01-01T00:00:00Z")).toUTCString());
+assert.sameValue("Sat, 01 Feb 2014 00:00:00 GMT",
+                 (new Date("2014-02-01T00:00:00Z")).toUTCString());
+assert.sameValue("Sat, 01 Mar 2014 00:00:00 GMT",
+                 (new Date("2014-03-01T00:00:00Z")).toUTCString());
+assert.sameValue("Tue, 01 Apr 2014 00:00:00 GMT",
+                 (new Date("2014-04-01T00:00:00Z")).toUTCString());
+assert.sameValue("Thu, 01 May 2014 00:00:00 GMT",
+                 (new Date("2014-05-01T00:00:00Z")).toUTCString());
+assert.sameValue("Sun, 01 Jun 2014 00:00:00 GMT",
+                 (new Date("2014-06-01T00:00:00Z")).toUTCString());
+assert.sameValue("Tue, 01 Jul 2014 00:00:00 GMT",
+                 (new Date("2014-07-01T00:00:00Z")).toUTCString());
+assert.sameValue("Fri, 01 Aug 2014 00:00:00 GMT",
+                 (new Date("2014-08-01T00:00:00Z")).toUTCString());
+assert.sameValue("Mon, 01 Sep 2014 00:00:00 GMT",
+                 (new Date("2014-09-01T00:00:00Z")).toUTCString());
+assert.sameValue("Wed, 01 Oct 2014 00:00:00 GMT",
+                 (new Date("2014-10-01T00:00:00Z")).toUTCString());
+assert.sameValue("Sat, 01 Nov 2014 00:00:00 GMT",
+                 (new Date("2014-11-01T00:00:00Z")).toUTCString());
+assert.sameValue("Mon, 01 Dec 2014 00:00:00 GMT",
+                 (new Date("2014-12-01T00:00:00Z")).toUTCString());


### PR DESCRIPTION
These tests check the semantics of Date.prototype.toString, Date.prototype.toTimeString,
Date.prototype.toDateString and Date.prototype.toUTCString. There are probably ways
to make the more specific, but this is a start. The semantics are currently implementation-defined,
but a spec pull request at https://github.com/tc39/ecma262/pull/848 gives them this behavior.