### PR TITLE
Add tests for Number printing precision ranges

### DIFF
--- a/test/built-ins/Number/prototype/toExponential/range.js
+++ b/test/built-ins/Number/prototype/toExponential/range.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-number.prototype.toexponential
+description: Number.prototype.toExponential permits fractionDigits from 0 to 100
+info: >
+  Number.prototype.toExponential ( fractionDigits )
+
+  ...
+  8. If _p_ &lt; 0 or _p_ &gt; 100, throw a *RangeError* exception.
+  ...
+---*/
+
+assert.sameValue((3).toExponential(0), "3e+0");
+assert.throws(RangeError, () => (3).toExponential(0));
+
+assert.sameValue((3).toExponential(100), "3.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e+0");
+assert.throws(RangeError, () => (3).toExponential(101));
+
+

--- a/test/built-ins/Number/prototype/toFixed/range.js
+++ b/test/built-ins/Number/prototype/toFixed/range.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-number.prototype.tofixed
+description: Number.prototype.toFixed permits fractionDigits from -20 to 100
+info: >
+  Number.prototype.toFixed ( fractionDigits )
+
+  ...
+  3. If _f_ &lt; -20 or _f_ &gt; 100, throw a *RangeError* exception.
+  ...
+---*/
+
+assert.sameValue((3).toFixed(-20), "0");
+assert.throws(RangeError, () => (3).toFixed(-21));
+
+assert.sameValue((3).toFixed(100), "3.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+assert.throws(RangeError, () => (3).toFixed(101));

--- a/test/built-ins/Number/prototype/toPrecision/range.js
+++ b/test/built-ins/Number/prototype/toPrecision/range.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-number.prototype.toprecision
+description: Number.prototype.toPrecision permits fractionDigits from 1 to 100
+info: >
+  Number.prototype.toPrecision ( fractionDigits )
+
+  ...
+  8. If _p_ &lt; 1 or _p_ &gt; 100, throw a *RangeError* exception.
+  ...
+---*/
+
+assert.sameValue((3).toPrecision(1), "3");
+assert.throws(RangeError, () => (3).toPrecision(0));
+assert.throws(RangeError, () => (3).toPrecision(-10));
+
+assert.sameValue((3).toPrecision(100), "3.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+assert.throws(RangeError, () => (3).toPrecision(101));
+


### PR DESCRIPTION
These tests are against the needs-consensus pull request at
https://github.com/tc39/ecma262/pull/857