### PR TITLE
Add feature flags for tests on object rest spread

### DIFF
--- a/src/dstr-assignment/obj-rest-descriptors.case
+++ b/src/dstr-assignment/obj-rest-descriptors.case
@@ -8,6 +8,7 @@ desc: >
 template: default
 esid: pending
 includes: [propertyHelper.js]
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-empty-obj.case
+++ b/src/dstr-assignment/obj-rest-empty-obj.case
@@ -6,6 +6,7 @@ desc: >
     RestBindingInitialization creates a new object even if lhs is an empty object
 template: default
 esid: pending
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-getter-abrupt-get-error.case
+++ b/src/dstr-assignment/obj-rest-getter-abrupt-get-error.case
@@ -6,6 +6,7 @@ desc: >
     Rest deconstruction doesn't happen if getter return is abrupt
 template: error
 esid: pending
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-getter.case
+++ b/src/dstr-assignment/obj-rest-getter.case
@@ -7,6 +7,7 @@ desc: >
 template: default
 esid: pending
 includes: [propertyHelper.js]
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-nested-obj-nested-rest.case
+++ b/src/dstr-assignment/obj-rest-nested-obj-nested-rest.case
@@ -9,6 +9,7 @@ desc: >
 template: default
 esid: pending
 includes: [propertyHelper.js]
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-nested-obj.case
+++ b/src/dstr-assignment/obj-rest-nested-obj.case
@@ -8,6 +8,7 @@ desc: >
     assignment.
 template: default
 esid: pending
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-not-last-element-invalid.case
+++ b/src/dstr-assignment/obj-rest-not-last-element-invalid.case
@@ -10,6 +10,7 @@ esid: pending
 negative:
   phase: early
   type: SyntaxError
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-number.case
+++ b/src/dstr-assignment/obj-rest-number.case
@@ -6,6 +6,7 @@ desc: >
     RestBindingInitialization creates a new object even if lhs is a Number
 template: default
 esid: pending
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-obj-own-property.case
+++ b/src/dstr-assignment/obj-rest-obj-own-property.case
@@ -6,6 +6,7 @@ desc: >
     Rest object contains just source object's own properties
 template: default
 esid: pending
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-put-const.case
+++ b/src/dstr-assignment/obj-rest-put-const.case
@@ -6,7 +6,7 @@ desc: >
     The object rest deconstruction assignment target should obey `const` semantics.
 template: error
 esid: pending
-features: [const]
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-same-name.case
+++ b/src/dstr-assignment/obj-rest-same-name.case
@@ -6,6 +6,7 @@ desc: >
     Proper setting in the values for rest name equal to a property name.
 template: default
 esid: pending
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-skip-non-enumerable.case
+++ b/src/dstr-assignment/obj-rest-skip-non-enumerable.case
@@ -7,6 +7,7 @@ desc: >
 template: default
 esid: pending
 includes: [propertyHelper.js]
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-str-val.case
+++ b/src/dstr-assignment/obj-rest-str-val.case
@@ -6,6 +6,7 @@ desc: >
     RestBindingInitialization creats an object with indexes as property name
 template: default
 esid: pending
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-symbol-val.case
+++ b/src/dstr-assignment/obj-rest-symbol-val.case
@@ -6,6 +6,7 @@ desc: >
     RestBindingInitialization creates a new object if lhs is a Symbol
 template: default
 esid: pending
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-to-property-with-setter.case
+++ b/src/dstr-assignment/obj-rest-to-property-with-setter.case
@@ -7,6 +7,7 @@ desc: >
     binded as rest object.
 template: default
 esid: pending
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-to-property.case
+++ b/src/dstr-assignment/obj-rest-to-property.case
@@ -8,6 +8,7 @@ desc: >
 template: default
 esid: pending
 includes: [propertyHelper.js]
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-assignment/obj-rest-val-null.case
+++ b/src/dstr-assignment/obj-rest-val-null.case
@@ -7,6 +7,7 @@ desc: >
     used by CopyDataProperties
 template: error
 esid: pending
+features: [object-rest]
 ---*/
 
 //- error

--- a/src/dstr-assignment/obj-rest-val-undefined.case
+++ b/src/dstr-assignment/obj-rest-val-undefined.case
@@ -7,6 +7,7 @@ desc: >
     used by CopyDataProperties
 template: error
 esid: pending
+features: [object-rest]
 ---*/
 
 //- error

--- a/src/dstr-assignment/obj-rest-valid-object.case
+++ b/src/dstr-assignment/obj-rest-valid-object.case
@@ -7,6 +7,7 @@ desc: >
 template: default
 esid: pending
 includes: [propertyHelper.js]
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-binding/obj-ptrn-rest-getter.case
+++ b/src/dstr-binding/obj-ptrn-rest-getter.case
@@ -7,6 +7,7 @@ desc: >
 template: default
 esid: pending
 includes: [propertyHelper.js]
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-binding/obj-ptrn-rest-nested-obj.case
+++ b/src/dstr-binding/obj-ptrn-rest-nested-obj.case
@@ -8,6 +8,7 @@ desc: >
     assignment.
 template: default
 esid: pending
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-binding/obj-ptrn-rest-obj-nested-rest.case
+++ b/src/dstr-binding/obj-ptrn-rest-obj-nested-rest.case
@@ -9,6 +9,7 @@ desc: >
 template: default
 esid: pending
 includes: [propertyHelper.js]
+features: [object-rest]
 ---*/
 
 //- elems

--- a/src/dstr-binding/obj-ptrn-rest-obj-own-property.case
+++ b/src/dstr-binding/obj-ptrn-rest-obj-own-property.case
@@ -7,6 +7,7 @@ desc: >
 template: default
 esid: pending
 includes: [propertyHelper.js]
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-binding/obj-ptrn-rest-skip-non-enumerable.case
+++ b/src/dstr-binding/obj-ptrn-rest-skip-non-enumerable.case
@@ -7,6 +7,7 @@ desc: >
 template: default
 esid: pending
 includes: [propertyHelper.js]
+features: [object-rest]
 ---*/
 
 //- setup

--- a/src/dstr-binding/obj-ptrn-rest-val-obj.case
+++ b/src/dstr-binding/obj-ptrn-rest-val-obj.case
@@ -7,6 +7,7 @@ desc: >
 template: default
 esid: pending
 includes: [propertyHelper.js]
+features: [object-rest]
 ---*/
 
 //- elems

--- a/src/spread/mult-err-obj-getter-throws.case
+++ b/src/spread/mult-err-obj-getter-throws.case
@@ -14,7 +14,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- error

--- a/src/spread/mult-err-obj-unresolvable.case
+++ b/src/spread/mult-err-obj-unresolvable.case
@@ -14,7 +14,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- error

--- a/src/spread/mult-obj-base.case
+++ b/src/spread/mult-obj-base.case
@@ -15,7 +15,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- args

--- a/src/spread/mult-obj-empty.case
+++ b/src/spread/mult-obj-empty.case
@@ -14,7 +14,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- args

--- a/src/spread/mult-obj-ident.case
+++ b/src/spread/mult-obj-ident.case
@@ -15,7 +15,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- setup

--- a/src/spread/mult-obj-null-empty-undefined.case
+++ b/src/spread/mult-obj-null-empty-undefined.case
@@ -15,7 +15,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- args

--- a/src/spread/mult-obj-null.case
+++ b/src/spread/mult-obj-null.case
@@ -14,7 +14,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- args

--- a/src/spread/mult-obj-undefined.case
+++ b/src/spread/mult-obj-undefined.case
@@ -14,7 +14,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- args

--- a/src/spread/obj-getter-descriptor.case
+++ b/src/spread/obj-getter-descriptor.case
@@ -15,7 +15,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- setup

--- a/src/spread/obj-getter-init.case
+++ b/src/spread/obj-getter-init.case
@@ -4,6 +4,7 @@
 desc: Getter in object literal is not evaluated
 template: default
 esid: pending
+features: [object-spread]
 ---*/
 
 //- setup

--- a/src/spread/obj-manipulate-outter-obj-in-getter.case
+++ b/src/spread/obj-manipulate-outter-obj-in-getter.case
@@ -14,7 +14,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- setup

--- a/src/spread/obj-mult-spread-getter.case
+++ b/src/spread/obj-mult-spread-getter.case
@@ -14,7 +14,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- setup

--- a/src/spread/obj-mult-spread.case
+++ b/src/spread/obj-mult-spread.case
@@ -14,7 +14,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- setup

--- a/src/spread/obj-null.case
+++ b/src/spread/obj-null.case
@@ -14,7 +14,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- args

--- a/src/spread/obj-override-immutable.case
+++ b/src/spread/obj-override-immutable.case
@@ -5,6 +5,7 @@ desc: Object Spread overriding immutable properties
 template: default
 esid: pending
 includes: [propertyHelper.js]
+features: [object-spread]
 ---*/
 
 //- setup

--- a/src/spread/obj-overrides-prev-properties.case
+++ b/src/spread/obj-overrides-prev-properties.case
@@ -14,7 +14,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- setup

--- a/src/spread/obj-setter-redef.case
+++ b/src/spread/obj-setter-redef.case
@@ -4,6 +4,7 @@
 desc: Setter are not executed when redefined in Object Spread
 template: default
 esid: pending
+features: [object-spread]
 ---*/
 
 //- setup

--- a/src/spread/obj-skip-non-enumerable.case
+++ b/src/spread/obj-skip-non-enumerable.case
@@ -4,6 +4,7 @@
 desc: Object Spread doesn't copy non-enumerable properties
 template: default
 esid: pending
+features: [object-spread]
 ---*/
 
 //- setup

--- a/src/spread/obj-spread-order.case
+++ b/src/spread/obj-spread-order.case
@@ -15,7 +15,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- setup

--- a/src/spread/obj-symbol-property.case
+++ b/src/spread/obj-symbol-property.case
@@ -14,7 +14,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- setup

--- a/src/spread/obj-undefined.case
+++ b/src/spread/obj-undefined.case
@@ -14,7 +14,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- args

--- a/src/spread/obj-with-overrides.case
+++ b/src/spread/obj-with-overrides.case
@@ -14,7 +14,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- setup

--- a/src/spread/sngl-obj-base.case
+++ b/src/spread/sngl-obj-base.case
@@ -15,7 +15,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- args

--- a/src/spread/sngl-obj-empty.case
+++ b/src/spread/sngl-obj-empty.case
@@ -14,7 +14,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- args

--- a/src/spread/sngl-obj-ident.case
+++ b/src/spread/sngl-obj-ident.case
@@ -15,7 +15,7 @@ info: |
     3. ReturnIfAbrupt(fromValue).
     4. Let excludedNames be a new empty List.
     5. Return CopyDataProperties(object, fromValue, excludedNames).
-
+features: [object-spread]
 ---*/
 
 //- setup

--- a/test/language/expressions/array/spread-err-mult-err-obj-getter-throws.js
+++ b/test/language/expressions/array/spread-err-mult-err-obj-getter-throws.js
@@ -5,6 +5,7 @@
 description: Object Spread operator results in error when there is an getter that throws an exception (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-err-mult-err-obj-unresolvable.js
+++ b/test/language/expressions/array/spread-err-mult-err-obj-unresolvable.js
@@ -5,6 +5,7 @@
 description: Object Spread operator results in error when using an unresolvable reference (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-mult-obj-base.js
+++ b/test/language/expressions/array/spread-mult-obj-base.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/array/spread-mult-obj-empty.js
+++ b/test/language/expressions/array/spread-mult-obj-empty.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with empty object (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-mult-obj-ident.js
+++ b/test/language/expressions/array/spread-mult-obj-ident.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other properties (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/array/spread-mult-obj-null-empty-undefined.js
+++ b/test/language/expressions/array/spread-mult-obj-null-empty-undefined.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with null, undefined and empty object (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 includes: [compareArray.js]
 info: |

--- a/test/language/expressions/array/spread-mult-obj-null.js
+++ b/test/language/expressions/array/spread-mult-obj-null.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with null value (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-mult-obj-undefined.js
+++ b/test/language/expressions/array/spread-mult-obj-undefined.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with undefined (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-obj-getter-descriptor.js
+++ b/test/language/expressions/array/spread-obj-getter-descriptor.js
@@ -5,6 +5,7 @@
 description: Spread operation with getter results in data property descriptor (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/array/spread-obj-getter-init.js
+++ b/test/language/expressions/array/spread-obj-getter-init.js
@@ -5,6 +5,7 @@
 description: Getter in object literal is not evaluated (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-obj-manipulate-outter-obj-in-getter.js
+++ b/test/language/expressions/array/spread-obj-manipulate-outter-obj-in-getter.js
@@ -5,6 +5,7 @@
 description: Getter manipulates outter object before it's spread operation (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-obj-mult-spread-getter.js
+++ b/test/language/expressions/array/spread-obj-mult-spread-getter.js
@@ -5,6 +5,7 @@
 description: Multiple Object Spread usage calls getter multiple times (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-obj-mult-spread.js
+++ b/test/language/expressions/array/spread-obj-mult-spread.js
@@ -5,6 +5,7 @@
 description: Multiple Object Spread operation (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-obj-null.js
+++ b/test/language/expressions/array/spread-obj-null.js
@@ -5,6 +5,7 @@
 description: Null Object Spread is ignored (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-obj-override-immutable.js
+++ b/test/language/expressions/array/spread-obj-override-immutable.js
@@ -5,6 +5,7 @@
 description: Object Spread overriding immutable properties (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/array/spread-obj-overrides-prev-properties.js
+++ b/test/language/expressions/array/spread-obj-overrides-prev-properties.js
@@ -5,6 +5,7 @@
 description: Object Spread properties overrides previous definitions (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-obj-setter-redef.js
+++ b/test/language/expressions/array/spread-obj-setter-redef.js
@@ -5,6 +5,7 @@
 description: Setter are not executed when redefined in Object Spread (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-obj-skip-non-enumerable.js
+++ b/test/language/expressions/array/spread-obj-skip-non-enumerable.js
@@ -5,6 +5,7 @@
 description: Object Spread doesn't copy non-enumerable properties (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-obj-spread-order.js
+++ b/test/language/expressions/array/spread-obj-spread-order.js
@@ -5,6 +5,7 @@
 description: Spread operation follows [[OwnPropertyKeys]] order (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 includes: [compareArray.js]
 info: |

--- a/test/language/expressions/array/spread-obj-symbol-property.js
+++ b/test/language/expressions/array/spread-obj-symbol-property.js
@@ -5,6 +5,7 @@
 description: Spread operation where source object contains Symbol properties (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-obj-undefined.js
+++ b/test/language/expressions/array/spread-obj-undefined.js
@@ -5,6 +5,7 @@
 description: Undefined Object Spread is ignored (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-obj-with-overrides.js
+++ b/test/language/expressions/array/spread-obj-with-overrides.js
@@ -5,6 +5,7 @@
 description: Object Spread properties being overriden (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-sngl-obj-base.js
+++ b/test/language/expressions/array/spread-sngl-obj-base.js
@@ -5,6 +5,7 @@
 description: Object Spread operator without other arguments (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/array/spread-sngl-obj-empty.js
+++ b/test/language/expressions/array/spread-sngl-obj-empty.js
@@ -5,6 +5,7 @@
 description: Object Spread operator on a single empty object (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 info: |
     SpreadElement : ...AssignmentExpression

--- a/test/language/expressions/array/spread-sngl-obj-ident.js
+++ b/test/language/expressions/array/spread-sngl-obj-ident.js
@@ -5,6 +5,7 @@
 description: Object Spread operator without other arguments (Array initializer)
 esid: sec-runtime-semantics-arrayaccumulation
 es6id: 12.2.5.2
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/arrow-function/dstr-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/arrow-function/dstr-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (arrow function expression (default parameter))
 esid: sec-arrow-function-definitions-runtime-semantics-evaluation
 es6id: 14.2.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/arrow-function/dstr-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/arrow-function/dstr-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (arrow function expression (default parameter))
 esid: sec-arrow-function-definitions-runtime-semantics-evaluation
 es6id: 14.2.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     ArrowFunction : ArrowParameters => ConciseBody

--- a/test/language/expressions/arrow-function/dstr-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/arrow-function/dstr-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (arrow function expression (default parameter))
 esid: sec-arrow-function-definitions-runtime-semantics-evaluation
 es6id: 14.2.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/arrow-function/dstr-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/arrow-function/dstr-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (arrow function expression (default parameter))
 esid: sec-arrow-function-definitions-runtime-semantics-evaluation
 es6id: 14.2.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/arrow-function/dstr-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/arrow-function/dstr-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (arrow function expression (default parameter))
 esid: sec-arrow-function-definitions-runtime-semantics-evaluation
 es6id: 14.2.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/arrow-function/dstr-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/arrow-function/dstr-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (arrow function expression (default parameter))
 esid: sec-arrow-function-definitions-runtime-semantics-evaluation
 es6id: 14.2.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/arrow-function/dstr-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/arrow-function/dstr-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (arrow function expression)
 esid: sec-arrow-function-definitions-runtime-semantics-evaluation
 es6id: 14.2.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/arrow-function/dstr-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/arrow-function/dstr-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (arrow function expression)
 esid: sec-arrow-function-definitions-runtime-semantics-evaluation
 es6id: 14.2.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     ArrowFunction : ArrowParameters => ConciseBody

--- a/test/language/expressions/arrow-function/dstr-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/arrow-function/dstr-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (arrow function expression)
 esid: sec-arrow-function-definitions-runtime-semantics-evaluation
 es6id: 14.2.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/arrow-function/dstr-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/arrow-function/dstr-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (arrow function expression)
 esid: sec-arrow-function-definitions-runtime-semantics-evaluation
 es6id: 14.2.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/arrow-function/dstr-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/arrow-function/dstr-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (arrow function expression)
 esid: sec-arrow-function-definitions-runtime-semantics-evaluation
 es6id: 14.2.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/arrow-function/dstr-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/arrow-function/dstr-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (arrow function expression)
 esid: sec-arrow-function-definitions-runtime-semantics-evaluation
 es6id: 14.2.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/assignment/dstr-obj-rest-descriptors.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-descriptors.js
@@ -5,7 +5,7 @@
 description: Object created from rest deconstruction doesn't copy source object property descriptors. (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/assignment/dstr-obj-rest-empty-obj.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-empty-obj.js
@@ -5,7 +5,7 @@
 description: RestBindingInitialization creates a new object even if lhs is an empty object (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     VariableDeclaration : BindingPattern Initializer

--- a/test/language/expressions/assignment/dstr-obj-rest-getter-abrupt-get-error.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-getter-abrupt-get-error.js
@@ -5,7 +5,7 @@
 description: Rest deconstruction doesn't happen if getter return is abrupt (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     VariableDeclaration : BindingPattern Initializer

--- a/test/language/expressions/assignment/dstr-obj-rest-getter.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/assignment/dstr-obj-rest-nested-obj-nested-rest.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-nested-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/assignment/dstr-obj-rest-nested-obj.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     VariableDeclaration : BindingPattern Initializer

--- a/test/language/expressions/assignment/dstr-obj-rest-not-last-element-invalid.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-not-last-element-invalid.js
@@ -5,7 +5,7 @@
 description: Object rest element needs to be the last AssignmenProperty in ObjectAssignmentPattern. (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 negative:
   phase: early

--- a/test/language/expressions/assignment/dstr-obj-rest-number.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-number.js
@@ -5,7 +5,7 @@
 description: RestBindingInitialization creates a new object even if lhs is a Number (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     VariableDeclaration : BindingPattern Initializer

--- a/test/language/expressions/assignment/dstr-obj-rest-obj-own-property.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just source object's own properties (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     VariableDeclaration : BindingPattern Initializer

--- a/test/language/expressions/assignment/dstr-obj-rest-put-const.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-put-const.js
@@ -5,7 +5,7 @@
 description: The object rest deconstruction assignment target should obey `const` semantics. (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [const, destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     VariableDeclaration : BindingPattern Initializer

--- a/test/language/expressions/assignment/dstr-obj-rest-same-name.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-same-name.js
@@ -5,7 +5,7 @@
 description: Proper setting in the values for rest name equal to a property name. (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     VariableDeclaration : BindingPattern Initializer

--- a/test/language/expressions/assignment/dstr-obj-rest-skip-non-enumerable.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/assignment/dstr-obj-rest-str-val.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-str-val.js
@@ -5,7 +5,7 @@
 description: RestBindingInitialization creats an object with indexes as property name (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     VariableDeclaration : BindingPattern Initializer

--- a/test/language/expressions/assignment/dstr-obj-rest-symbol-val.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-symbol-val.js
@@ -5,7 +5,7 @@
 description: RestBindingInitialization creates a new object if lhs is a Symbol (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     VariableDeclaration : BindingPattern Initializer

--- a/test/language/expressions/assignment/dstr-obj-rest-to-property-with-setter.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-to-property-with-setter.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object property setter, its value should be binded as rest object. (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     VariableDeclaration : BindingPattern Initializer

--- a/test/language/expressions/assignment/dstr-obj-rest-to-property.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-to-property.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object property, its value should be binded as rest object. (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/assignment/dstr-obj-rest-val-null.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-val-null.js
@@ -5,7 +5,7 @@
 description: TypeError is thrown when rhs is null because of 7.1.13 ToObject ( argument ) used by CopyDataProperties (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     VariableDeclaration : BindingPattern Initializer

--- a/test/language/expressions/assignment/dstr-obj-rest-val-undefined.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-val-undefined.js
@@ -5,7 +5,7 @@
 description: TypeError is thrown when rhs is ```undefined``` because of 7.1.13 ToObject ( argument ) used by CopyDataProperties (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     VariableDeclaration : BindingPattern Initializer

--- a/test/language/expressions/assignment/dstr-obj-rest-valid-object.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-valid-object.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (AssignmentExpression)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/call/spread-err-mult-err-obj-getter-throws.js
+++ b/test/language/expressions/call/spread-err-mult-err-obj-getter-throws.js
@@ -5,6 +5,7 @@
 description: Object Spread operator results in error when there is an getter that throws an exception (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-err-mult-err-obj-unresolvable.js
+++ b/test/language/expressions/call/spread-err-mult-err-obj-unresolvable.js
@@ -5,6 +5,7 @@
 description: Object Spread operator results in error when using an unresolvable reference (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-mult-obj-base.js
+++ b/test/language/expressions/call/spread-mult-obj-base.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/call/spread-mult-obj-empty.js
+++ b/test/language/expressions/call/spread-mult-obj-empty.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with empty object (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-mult-obj-ident.js
+++ b/test/language/expressions/call/spread-mult-obj-ident.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other properties (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/call/spread-mult-obj-null-empty-undefined.js
+++ b/test/language/expressions/call/spread-mult-obj-null-empty-undefined.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with null, undefined and empty object (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 includes: [compareArray.js]
 info: |

--- a/test/language/expressions/call/spread-mult-obj-null.js
+++ b/test/language/expressions/call/spread-mult-obj-null.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with null value (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-mult-obj-undefined.js
+++ b/test/language/expressions/call/spread-mult-obj-undefined.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with undefined (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-obj-getter-descriptor.js
+++ b/test/language/expressions/call/spread-obj-getter-descriptor.js
@@ -5,6 +5,7 @@
 description: Spread operation with getter results in data property descriptor (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/call/spread-obj-getter-init.js
+++ b/test/language/expressions/call/spread-obj-getter-init.js
@@ -5,6 +5,7 @@
 description: Getter in object literal is not evaluated (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-obj-manipulate-outter-obj-in-getter.js
+++ b/test/language/expressions/call/spread-obj-manipulate-outter-obj-in-getter.js
@@ -5,6 +5,7 @@
 description: Getter manipulates outter object before it's spread operation (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-obj-mult-spread-getter.js
+++ b/test/language/expressions/call/spread-obj-mult-spread-getter.js
@@ -5,6 +5,7 @@
 description: Multiple Object Spread usage calls getter multiple times (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-obj-mult-spread.js
+++ b/test/language/expressions/call/spread-obj-mult-spread.js
@@ -5,6 +5,7 @@
 description: Multiple Object Spread operation (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-obj-null.js
+++ b/test/language/expressions/call/spread-obj-null.js
@@ -5,6 +5,7 @@
 description: Null Object Spread is ignored (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-obj-override-immutable.js
+++ b/test/language/expressions/call/spread-obj-override-immutable.js
@@ -5,6 +5,7 @@
 description: Object Spread overriding immutable properties (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/call/spread-obj-overrides-prev-properties.js
+++ b/test/language/expressions/call/spread-obj-overrides-prev-properties.js
@@ -5,6 +5,7 @@
 description: Object Spread properties overrides previous definitions (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-obj-setter-redef.js
+++ b/test/language/expressions/call/spread-obj-setter-redef.js
@@ -5,6 +5,7 @@
 description: Setter are not executed when redefined in Object Spread (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-obj-skip-non-enumerable.js
+++ b/test/language/expressions/call/spread-obj-skip-non-enumerable.js
@@ -5,6 +5,7 @@
 description: Object Spread doesn't copy non-enumerable properties (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-obj-spread-order.js
+++ b/test/language/expressions/call/spread-obj-spread-order.js
@@ -5,6 +5,7 @@
 description: Spread operation follows [[OwnPropertyKeys]] order (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 includes: [compareArray.js]
 info: |

--- a/test/language/expressions/call/spread-obj-symbol-property.js
+++ b/test/language/expressions/call/spread-obj-symbol-property.js
@@ -5,6 +5,7 @@
 description: Spread operation where source object contains Symbol properties (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-obj-undefined.js
+++ b/test/language/expressions/call/spread-obj-undefined.js
@@ -5,6 +5,7 @@
 description: Undefined Object Spread is ignored (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-obj-with-overrides.js
+++ b/test/language/expressions/call/spread-obj-with-overrides.js
@@ -5,6 +5,7 @@
 description: Object Spread properties being overriden (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-sngl-obj-base.js
+++ b/test/language/expressions/call/spread-sngl-obj-base.js
@@ -5,6 +5,7 @@
 description: Object Spread operator without other arguments (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/call/spread-sngl-obj-empty.js
+++ b/test/language/expressions/call/spread-sngl-obj-empty.js
@@ -5,6 +5,7 @@
 description: Object Spread operator on a single empty object (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 info: |
     CallExpression : MemberExpression Arguments

--- a/test/language/expressions/call/spread-sngl-obj-ident.js
+++ b/test/language/expressions/call/spread-sngl-obj-ident.js
@@ -5,6 +5,7 @@
 description: Object Spread operator without other arguments (CallExpression)
 esid: sec-function-calls-runtime-semantics-evaluation
 es6id: 12.3.4.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/class/dstr-gen-meth-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/class/dstr-gen-meth-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     ClassExpression : class BindingIdentifieropt ClassTail

--- a/test/language/expressions/class/dstr-gen-meth-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/class/dstr-gen-meth-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/class/dstr-gen-meth-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/class/dstr-gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/class/dstr-gen-meth-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/class/dstr-gen-meth-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/class/dstr-gen-meth-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     ClassExpression : class BindingIdentifieropt ClassTail

--- a/test/language/expressions/class/dstr-gen-meth-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/class/dstr-gen-meth-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/class/dstr-gen-meth-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/class/dstr-gen-meth-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/class/dstr-gen-meth-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (static class expression generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (static class expression generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     ClassExpression : class BindingIdentifieropt ClassTail

--- a/test/language/expressions/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (static class expression generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (static class expression generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (static class expression generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (static class expression generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-static-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (static class expression generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-static-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (static class expression generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     ClassExpression : class BindingIdentifieropt ClassTail

--- a/test/language/expressions/class/dstr-gen-meth-static-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (static class expression generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-static-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (static class expression generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-static-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (static class expression generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-gen-meth-static-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/class/dstr-gen-meth-static-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (static class expression generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/class/dstr-meth-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/class/dstr-meth-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     ClassExpression : class BindingIdentifieropt ClassTail

--- a/test/language/expressions/class/dstr-meth-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/class/dstr-meth-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/class/dstr-meth-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/class/dstr-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/class/dstr-meth-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/class/dstr-meth-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/class/dstr-meth-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     ClassExpression : class BindingIdentifieropt ClassTail

--- a/test/language/expressions/class/dstr-meth-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/class/dstr-meth-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/class/dstr-meth-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/class/dstr-meth-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/class/dstr-meth-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-static-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/class/dstr-meth-static-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (static class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-static-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/class/dstr-meth-static-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (static class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     ClassExpression : class BindingIdentifieropt ClassTail

--- a/test/language/expressions/class/dstr-meth-static-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/class/dstr-meth-static-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (static class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-static-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/class/dstr-meth-static-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (static class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-static-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/class/dstr-meth-static-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (static class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-static-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/class/dstr-meth-static-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (static class expression method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-static-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/class/dstr-meth-static-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (static class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-static-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/class/dstr-meth-static-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (static class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     ClassExpression : class BindingIdentifieropt ClassTail

--- a/test/language/expressions/class/dstr-meth-static-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/class/dstr-meth-static-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (static class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-static-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/class/dstr-meth-static-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (static class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-static-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/class/dstr-meth-static-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (static class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/dstr-meth-static-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/class/dstr-meth-static-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (static class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/function/dstr-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/function/dstr-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (function expression (default parameter))
 esid: sec-function-definitions-runtime-semantics-evaluation
 es6id: 14.1.20
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/function/dstr-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/function/dstr-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (function expression (default parameter))
 esid: sec-function-definitions-runtime-semantics-evaluation
 es6id: 14.1.20
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     FunctionExpression : function ( FormalParameters ) { FunctionBody }

--- a/test/language/expressions/function/dstr-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/function/dstr-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (function expression (default parameter))
 esid: sec-function-definitions-runtime-semantics-evaluation
 es6id: 14.1.20
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/function/dstr-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/function/dstr-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (function expression (default parameter))
 esid: sec-function-definitions-runtime-semantics-evaluation
 es6id: 14.1.20
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/function/dstr-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/function/dstr-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (function expression (default parameter))
 esid: sec-function-definitions-runtime-semantics-evaluation
 es6id: 14.1.20
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/function/dstr-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/function/dstr-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (function expression (default parameter))
 esid: sec-function-definitions-runtime-semantics-evaluation
 es6id: 14.1.20
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/function/dstr-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/function/dstr-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (function expression)
 esid: sec-function-definitions-runtime-semantics-evaluation
 es6id: 14.1.20
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/function/dstr-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/function/dstr-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (function expression)
 esid: sec-function-definitions-runtime-semantics-evaluation
 es6id: 14.1.20
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     FunctionExpression : function ( FormalParameters ) { FunctionBody }

--- a/test/language/expressions/function/dstr-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/function/dstr-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (function expression)
 esid: sec-function-definitions-runtime-semantics-evaluation
 es6id: 14.1.20
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/function/dstr-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/function/dstr-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (function expression)
 esid: sec-function-definitions-runtime-semantics-evaluation
 es6id: 14.1.20
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/function/dstr-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/function/dstr-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (function expression)
 esid: sec-function-definitions-runtime-semantics-evaluation
 es6id: 14.1.20
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/function/dstr-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/function/dstr-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (function expression)
 esid: sec-function-definitions-runtime-semantics-evaluation
 es6id: 14.1.20
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/generators/dstr-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/generators/dstr-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (generator function expression (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-evaluation
 es6id: 14.4.14
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/generators/dstr-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/generators/dstr-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (generator function expression (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-evaluation
 es6id: 14.4.14
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     GeneratorExpression : function * ( FormalParameters ) { GeneratorBody }

--- a/test/language/expressions/generators/dstr-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/generators/dstr-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (generator function expression (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-evaluation
 es6id: 14.4.14
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/generators/dstr-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/generators/dstr-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (generator function expression (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-evaluation
 es6id: 14.4.14
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/generators/dstr-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/generators/dstr-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (generator function expression (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-evaluation
 es6id: 14.4.14
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/generators/dstr-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/generators/dstr-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (generator function expression (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-evaluation
 es6id: 14.4.14
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/generators/dstr-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/generators/dstr-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (generator function expression)
 esid: sec-generator-function-definitions-runtime-semantics-evaluation
 es6id: 14.4.14
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/generators/dstr-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/generators/dstr-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (generator function expression)
 esid: sec-generator-function-definitions-runtime-semantics-evaluation
 es6id: 14.4.14
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     GeneratorExpression : function * ( FormalParameters ) { GeneratorBody }

--- a/test/language/expressions/generators/dstr-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/generators/dstr-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (generator function expression)
 esid: sec-generator-function-definitions-runtime-semantics-evaluation
 es6id: 14.4.14
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/generators/dstr-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/generators/dstr-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (generator function expression)
 esid: sec-generator-function-definitions-runtime-semantics-evaluation
 es6id: 14.4.14
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/generators/dstr-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/generators/dstr-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (generator function expression)
 esid: sec-generator-function-definitions-runtime-semantics-evaluation
 es6id: 14.4.14
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/generators/dstr-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/generators/dstr-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (generator function expression)
 esid: sec-generator-function-definitions-runtime-semantics-evaluation
 es6id: 14.4.14
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/new/spread-err-mult-err-obj-getter-throws.js
+++ b/test/language/expressions/new/spread-err-mult-err-obj-getter-throws.js
@@ -5,6 +5,7 @@
 description: Object Spread operator results in error when there is an getter that throws an exception (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-err-mult-err-obj-unresolvable.js
+++ b/test/language/expressions/new/spread-err-mult-err-obj-unresolvable.js
@@ -5,6 +5,7 @@
 description: Object Spread operator results in error when using an unresolvable reference (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-mult-obj-base.js
+++ b/test/language/expressions/new/spread-mult-obj-base.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/new/spread-mult-obj-empty.js
+++ b/test/language/expressions/new/spread-mult-obj-empty.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with empty object (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-mult-obj-ident.js
+++ b/test/language/expressions/new/spread-mult-obj-ident.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other properties (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/new/spread-mult-obj-null-empty-undefined.js
+++ b/test/language/expressions/new/spread-mult-obj-null-empty-undefined.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with null, undefined and empty object (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 includes: [compareArray.js]
 info: |

--- a/test/language/expressions/new/spread-mult-obj-null.js
+++ b/test/language/expressions/new/spread-mult-obj-null.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with null value (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-mult-obj-undefined.js
+++ b/test/language/expressions/new/spread-mult-obj-undefined.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with undefined (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-obj-getter-descriptor.js
+++ b/test/language/expressions/new/spread-obj-getter-descriptor.js
@@ -5,6 +5,7 @@
 description: Spread operation with getter results in data property descriptor (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/new/spread-obj-getter-init.js
+++ b/test/language/expressions/new/spread-obj-getter-init.js
@@ -5,6 +5,7 @@
 description: Getter in object literal is not evaluated (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-obj-manipulate-outter-obj-in-getter.js
+++ b/test/language/expressions/new/spread-obj-manipulate-outter-obj-in-getter.js
@@ -5,6 +5,7 @@
 description: Getter manipulates outter object before it's spread operation (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-obj-mult-spread-getter.js
+++ b/test/language/expressions/new/spread-obj-mult-spread-getter.js
@@ -5,6 +5,7 @@
 description: Multiple Object Spread usage calls getter multiple times (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-obj-mult-spread.js
+++ b/test/language/expressions/new/spread-obj-mult-spread.js
@@ -5,6 +5,7 @@
 description: Multiple Object Spread operation (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-obj-null.js
+++ b/test/language/expressions/new/spread-obj-null.js
@@ -5,6 +5,7 @@
 description: Null Object Spread is ignored (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-obj-override-immutable.js
+++ b/test/language/expressions/new/spread-obj-override-immutable.js
@@ -5,6 +5,7 @@
 description: Object Spread overriding immutable properties (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/new/spread-obj-overrides-prev-properties.js
+++ b/test/language/expressions/new/spread-obj-overrides-prev-properties.js
@@ -5,6 +5,7 @@
 description: Object Spread properties overrides previous definitions (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-obj-setter-redef.js
+++ b/test/language/expressions/new/spread-obj-setter-redef.js
@@ -5,6 +5,7 @@
 description: Setter are not executed when redefined in Object Spread (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-obj-skip-non-enumerable.js
+++ b/test/language/expressions/new/spread-obj-skip-non-enumerable.js
@@ -5,6 +5,7 @@
 description: Object Spread doesn't copy non-enumerable properties (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-obj-spread-order.js
+++ b/test/language/expressions/new/spread-obj-spread-order.js
@@ -5,6 +5,7 @@
 description: Spread operation follows [[OwnPropertyKeys]] order (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 includes: [compareArray.js]
 info: |

--- a/test/language/expressions/new/spread-obj-symbol-property.js
+++ b/test/language/expressions/new/spread-obj-symbol-property.js
@@ -5,6 +5,7 @@
 description: Spread operation where source object contains Symbol properties (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-obj-undefined.js
+++ b/test/language/expressions/new/spread-obj-undefined.js
@@ -5,6 +5,7 @@
 description: Undefined Object Spread is ignored (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-obj-with-overrides.js
+++ b/test/language/expressions/new/spread-obj-with-overrides.js
@@ -5,6 +5,7 @@
 description: Object Spread properties being overriden (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-sngl-obj-base.js
+++ b/test/language/expressions/new/spread-sngl-obj-base.js
@@ -5,6 +5,7 @@
 description: Object Spread operator without other arguments (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/new/spread-sngl-obj-empty.js
+++ b/test/language/expressions/new/spread-sngl-obj-empty.js
@@ -5,6 +5,7 @@
 description: Object Spread operator on a single empty object (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 info: |
     MemberExpression : new MemberExpression Arguments

--- a/test/language/expressions/new/spread-sngl-obj-ident.js
+++ b/test/language/expressions/new/spread-sngl-obj-ident.js
@@ -5,6 +5,7 @@
 description: Object Spread operator without other arguments (`new` operator)
 esid: sec-new-operator-runtime-semantics-evaluation
 es6id: 12.3.3.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-gen-meth-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/object/dstr-gen-meth-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (generator method (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
 es6id: 14.4.13
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-gen-meth-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/object/dstr-gen-meth-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (generator method (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
 es6id: 14.4.13
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     GeneratorMethod :

--- a/test/language/expressions/object/dstr-gen-meth-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/object/dstr-gen-meth-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (generator method (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
 es6id: 14.4.13
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-gen-meth-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/object/dstr-gen-meth-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (generator method (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
 es6id: 14.4.13
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/object/dstr-gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (generator method (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
 es6id: 14.4.13
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-gen-meth-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/object/dstr-gen-meth-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (generator method (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
 es6id: 14.4.13
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-gen-meth-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/object/dstr-gen-meth-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (generator method)
 esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
 es6id: 14.4.13
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-gen-meth-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/object/dstr-gen-meth-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (generator method)
 esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
 es6id: 14.4.13
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     GeneratorMethod :

--- a/test/language/expressions/object/dstr-gen-meth-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/object/dstr-gen-meth-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (generator method)
 esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
 es6id: 14.4.13
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-gen-meth-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/object/dstr-gen-meth-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (generator method)
 esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
 es6id: 14.4.13
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-gen-meth-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/object/dstr-gen-meth-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (generator method)
 esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
 es6id: 14.4.13
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-gen-meth-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/object/dstr-gen-meth-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (generator method)
 esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
 es6id: 14.4.13
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-meth-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/object/dstr-meth-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (method (default parameter))
 esid: sec-runtime-semantics-definemethod
 es6id: 14.3.8
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-meth-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/object/dstr-meth-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (method (default parameter))
 esid: sec-runtime-semantics-definemethod
 es6id: 14.3.8
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }

--- a/test/language/expressions/object/dstr-meth-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/object/dstr-meth-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (method (default parameter))
 esid: sec-runtime-semantics-definemethod
 es6id: 14.3.8
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-meth-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/object/dstr-meth-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (method (default parameter))
 esid: sec-runtime-semantics-definemethod
 es6id: 14.3.8
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/object/dstr-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (method (default parameter))
 esid: sec-runtime-semantics-definemethod
 es6id: 14.3.8
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-meth-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/object/dstr-meth-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (method (default parameter))
 esid: sec-runtime-semantics-definemethod
 es6id: 14.3.8
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-meth-obj-ptrn-rest-getter.js
+++ b/test/language/expressions/object/dstr-meth-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (method)
 esid: sec-runtime-semantics-definemethod
 es6id: 14.3.8
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-meth-obj-ptrn-rest-nested-obj.js
+++ b/test/language/expressions/object/dstr-meth-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (method)
 esid: sec-runtime-semantics-definemethod
 es6id: 14.3.8
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }

--- a/test/language/expressions/object/dstr-meth-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/expressions/object/dstr-meth-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (method)
 esid: sec-runtime-semantics-definemethod
 es6id: 14.3.8
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-meth-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/expressions/object/dstr-meth-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (method)
 esid: sec-runtime-semantics-definemethod
 es6id: 14.3.8
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-meth-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/expressions/object/dstr-meth-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (method)
 esid: sec-runtime-semantics-definemethod
 es6id: 14.3.8
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/object/dstr-meth-obj-ptrn-rest-val-obj.js
+++ b/test/language/expressions/object/dstr-meth-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (method)
 esid: sec-runtime-semantics-definemethod
 es6id: 14.3.8
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/super/call-spread-err-mult-err-obj-getter-throws.js
+++ b/test/language/expressions/super/call-spread-err-mult-err-obj-getter-throws.js
@@ -5,6 +5,7 @@
 description: Object Spread operator results in error when there is an getter that throws an exception (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-err-mult-err-obj-unresolvable.js
+++ b/test/language/expressions/super/call-spread-err-mult-err-obj-unresolvable.js
@@ -5,6 +5,7 @@
 description: Object Spread operator results in error when using an unresolvable reference (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-mult-obj-base.js
+++ b/test/language/expressions/super/call-spread-mult-obj-base.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/super/call-spread-mult-obj-empty.js
+++ b/test/language/expressions/super/call-spread-mult-obj-empty.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with empty object (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-mult-obj-ident.js
+++ b/test/language/expressions/super/call-spread-mult-obj-ident.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other properties (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/super/call-spread-mult-obj-null-empty-undefined.js
+++ b/test/language/expressions/super/call-spread-mult-obj-null-empty-undefined.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with null, undefined and empty object (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 includes: [compareArray.js]
 info: |

--- a/test/language/expressions/super/call-spread-mult-obj-null.js
+++ b/test/language/expressions/super/call-spread-mult-obj-null.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with null value (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-mult-obj-undefined.js
+++ b/test/language/expressions/super/call-spread-mult-obj-undefined.js
@@ -5,6 +5,7 @@
 description: Object Spread operator following other arguments with undefined (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-obj-getter-descriptor.js
+++ b/test/language/expressions/super/call-spread-obj-getter-descriptor.js
@@ -5,6 +5,7 @@
 description: Spread operation with getter results in data property descriptor (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/super/call-spread-obj-getter-init.js
+++ b/test/language/expressions/super/call-spread-obj-getter-init.js
@@ -5,6 +5,7 @@
 description: Getter in object literal is not evaluated (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-obj-manipulate-outter-obj-in-getter.js
+++ b/test/language/expressions/super/call-spread-obj-manipulate-outter-obj-in-getter.js
@@ -5,6 +5,7 @@
 description: Getter manipulates outter object before it's spread operation (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-obj-mult-spread-getter.js
+++ b/test/language/expressions/super/call-spread-obj-mult-spread-getter.js
@@ -5,6 +5,7 @@
 description: Multiple Object Spread usage calls getter multiple times (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-obj-mult-spread.js
+++ b/test/language/expressions/super/call-spread-obj-mult-spread.js
@@ -5,6 +5,7 @@
 description: Multiple Object Spread operation (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-obj-null.js
+++ b/test/language/expressions/super/call-spread-obj-null.js
@@ -5,6 +5,7 @@
 description: Null Object Spread is ignored (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-obj-override-immutable.js
+++ b/test/language/expressions/super/call-spread-obj-override-immutable.js
@@ -5,6 +5,7 @@
 description: Object Spread overriding immutable properties (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/super/call-spread-obj-overrides-prev-properties.js
+++ b/test/language/expressions/super/call-spread-obj-overrides-prev-properties.js
@@ -5,6 +5,7 @@
 description: Object Spread properties overrides previous definitions (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-obj-setter-redef.js
+++ b/test/language/expressions/super/call-spread-obj-setter-redef.js
@@ -5,6 +5,7 @@
 description: Setter are not executed when redefined in Object Spread (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-obj-skip-non-enumerable.js
+++ b/test/language/expressions/super/call-spread-obj-skip-non-enumerable.js
@@ -5,6 +5,7 @@
 description: Object Spread doesn't copy non-enumerable properties (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-obj-spread-order.js
+++ b/test/language/expressions/super/call-spread-obj-spread-order.js
@@ -5,6 +5,7 @@
 description: Spread operation follows [[OwnPropertyKeys]] order (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 includes: [compareArray.js]
 info: |

--- a/test/language/expressions/super/call-spread-obj-symbol-property.js
+++ b/test/language/expressions/super/call-spread-obj-symbol-property.js
@@ -5,6 +5,7 @@
 description: Spread operation where source object contains Symbol properties (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-obj-undefined.js
+++ b/test/language/expressions/super/call-spread-obj-undefined.js
@@ -5,6 +5,7 @@
 description: Undefined Object Spread is ignored (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-obj-with-overrides.js
+++ b/test/language/expressions/super/call-spread-obj-with-overrides.js
@@ -5,6 +5,7 @@
 description: Object Spread properties being overriden (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-sngl-obj-base.js
+++ b/test/language/expressions/super/call-spread-sngl-obj-base.js
@@ -5,6 +5,7 @@
 description: Object Spread operator without other arguments (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/super/call-spread-sngl-obj-empty.js
+++ b/test/language/expressions/super/call-spread-sngl-obj-empty.js
@@ -5,6 +5,7 @@
 description: Object Spread operator on a single empty object (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 info: |
     SuperCall : super Arguments

--- a/test/language/expressions/super/call-spread-sngl-obj-ident.js
+++ b/test/language/expressions/super/call-spread-sngl-obj-ident.js
@@ -5,6 +5,7 @@
 description: Object Spread operator without other arguments (SuperCall)
 esid: sec-super-keyword-runtime-semantics-evaluation
 es6id: 12.3.5.1
+features: [object-spread]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/statements/class/dstr-gen-meth-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (class expression method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/class/dstr-gen-meth-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (class expression method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     ClassDeclaration : class BindingIdentifier ClassTail

--- a/test/language/statements/class/dstr-gen-meth-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/class/dstr-gen-meth-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (class expression method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/class/dstr-gen-meth-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (class expression method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/class/dstr-gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (class expression method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/class/dstr-gen-meth-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (class expression method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-obj-ptrn-rest-getter.js
+++ b/test/language/statements/class/dstr-gen-meth-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/class/dstr-gen-meth-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     ClassDeclaration : class BindingIdentifier ClassTail

--- a/test/language/statements/class/dstr-gen-meth-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/class/dstr-gen-meth-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/class/dstr-gen-meth-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/class/dstr-gen-meth-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/class/dstr-gen-meth-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/statements/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (static class expression generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (static class expression generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     ClassDeclaration : class BindingIdentifier ClassTail

--- a/test/language/statements/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (static class expression generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (static class expression generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (static class expression generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/class/dstr-gen-meth-static-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (static class expression generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-static-obj-ptrn-rest-getter.js
+++ b/test/language/statements/class/dstr-gen-meth-static-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (static class expression generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-static-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/class/dstr-gen-meth-static-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (static class expression generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     ClassDeclaration : class BindingIdentifier ClassTail

--- a/test/language/statements/class/dstr-gen-meth-static-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/class/dstr-gen-meth-static-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (static class expression generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-static-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/class/dstr-gen-meth-static-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (static class expression generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-static-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/class/dstr-gen-meth-static-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (static class expression generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-gen-meth-static-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/class/dstr-gen-meth-static-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (static class expression generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/statements/class/dstr-meth-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (class expression method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/class/dstr-meth-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (class expression method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     ClassDeclaration : class BindingIdentifier ClassTail

--- a/test/language/statements/class/dstr-meth-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/class/dstr-meth-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (class expression method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/class/dstr-meth-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (class expression method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/class/dstr-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (class expression method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/class/dstr-meth-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (class expression method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-obj-ptrn-rest-getter.js
+++ b/test/language/statements/class/dstr-meth-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (class expression method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/class/dstr-meth-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (class expression method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     ClassDeclaration : class BindingIdentifier ClassTail

--- a/test/language/statements/class/dstr-meth-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/class/dstr-meth-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (class expression method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/class/dstr-meth-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (class expression method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/class/dstr-meth-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (class expression method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/class/dstr-meth-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (class expression method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-static-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/statements/class/dstr-meth-static-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (static class expression method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-static-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/class/dstr-meth-static-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (static class expression method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     ClassDeclaration : class BindingIdentifier ClassTail

--- a/test/language/statements/class/dstr-meth-static-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/class/dstr-meth-static-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (static class expression method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-static-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/class/dstr-meth-static-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (static class expression method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-static-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/class/dstr-meth-static-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (static class expression method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-static-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/class/dstr-meth-static-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (static class expression method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-static-obj-ptrn-rest-getter.js
+++ b/test/language/statements/class/dstr-meth-static-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (static class expression method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-static-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/class/dstr-meth-static-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (static class expression method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     ClassDeclaration : class BindingIdentifier ClassTail

--- a/test/language/statements/class/dstr-meth-static-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/class/dstr-meth-static-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (static class expression method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-static-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/class/dstr-meth-static-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (static class expression method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-static-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/class/dstr-meth-static-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (static class expression method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/dstr-meth-static-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/class/dstr-meth-static-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (static class expression method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/const/dstr-obj-ptrn-rest-getter.js
+++ b/test/language/statements/const/dstr-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (`const` statement)
 esid: sec-let-and-const-declarations-runtime-semantics-evaluation
 es6id: 13.3.1.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/const/dstr-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/const/dstr-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (`const` statement)
 esid: sec-let-and-const-declarations-runtime-semantics-evaluation
 es6id: 13.3.1.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     LexicalBinding : BindingPattern Initializer

--- a/test/language/statements/const/dstr-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/const/dstr-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (`const` statement)
 esid: sec-let-and-const-declarations-runtime-semantics-evaluation
 es6id: 13.3.1.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/const/dstr-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/const/dstr-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (`const` statement)
 esid: sec-let-and-const-declarations-runtime-semantics-evaluation
 es6id: 13.3.1.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/const/dstr-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/const/dstr-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (`const` statement)
 esid: sec-let-and-const-declarations-runtime-semantics-evaluation
 es6id: 13.3.1.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/const/dstr-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/const/dstr-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (`const` statement)
 esid: sec-let-and-const-declarations-runtime-semantics-evaluation
 es6id: 13.3.1.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-in/dstr-obj-rest-not-last-element-invalid.js
+++ b/test/language/statements/for-in/dstr-obj-rest-not-last-element-invalid.js
@@ -5,7 +5,7 @@
 description: Object rest element needs to be the last AssignmenProperty in ObjectAssignmentPattern. (For..in statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 negative:
   phase: early

--- a/test/language/statements/for-of/dstr-const-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-of/dstr-const-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-const-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-of/dstr-const-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-const-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-of/dstr-const-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-const-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-of/dstr-const-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-const-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-of/dstr-const-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-const-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-of/dstr-const-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-let-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-of/dstr-let-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-let-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-of/dstr-let-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-let-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-of/dstr-let-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-let-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-of/dstr-let-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-let-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-of/dstr-let-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-let-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-of/dstr-let-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-obj-rest-descriptors.js
+++ b/test/language/statements/for-of/dstr-obj-rest-descriptors.js
@@ -5,7 +5,7 @@
 description: Object created from rest deconstruction doesn't copy source object property descriptors. (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-obj-rest-empty-obj.js
+++ b/test/language/statements/for-of/dstr-obj-rest-empty-obj.js
@@ -5,7 +5,7 @@
 description: RestBindingInitialization creates a new object even if lhs is an empty object (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-obj-rest-getter-abrupt-get-error.js
+++ b/test/language/statements/for-of/dstr-obj-rest-getter-abrupt-get-error.js
@@ -5,7 +5,7 @@
 description: Rest deconstruction doesn't happen if getter return is abrupt (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-obj-rest-getter.js
+++ b/test/language/statements/for-of/dstr-obj-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-obj-rest-nested-obj-nested-rest.js
+++ b/test/language/statements/for-of/dstr-obj-rest-nested-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-obj-rest-nested-obj.js
+++ b/test/language/statements/for-of/dstr-obj-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-obj-rest-not-last-element-invalid.js
+++ b/test/language/statements/for-of/dstr-obj-rest-not-last-element-invalid.js
@@ -5,7 +5,7 @@
 description: Object rest element needs to be the last AssignmenProperty in ObjectAssignmentPattern. (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 negative:
   phase: early

--- a/test/language/statements/for-of/dstr-obj-rest-number.js
+++ b/test/language/statements/for-of/dstr-obj-rest-number.js
@@ -5,7 +5,7 @@
 description: RestBindingInitialization creates a new object even if lhs is a Number (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-obj-rest-obj-own-property.js
+++ b/test/language/statements/for-of/dstr-obj-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just source object's own properties (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-obj-rest-put-const.js
+++ b/test/language/statements/for-of/dstr-obj-rest-put-const.js
@@ -5,7 +5,7 @@
 description: The object rest deconstruction assignment target should obey `const` semantics. (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [const, destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-obj-rest-same-name.js
+++ b/test/language/statements/for-of/dstr-obj-rest-same-name.js
@@ -5,7 +5,7 @@
 description: Proper setting in the values for rest name equal to a property name. (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-obj-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-of/dstr-obj-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-obj-rest-str-val.js
+++ b/test/language/statements/for-of/dstr-obj-rest-str-val.js
@@ -5,7 +5,7 @@
 description: RestBindingInitialization creats an object with indexes as property name (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-obj-rest-symbol-val.js
+++ b/test/language/statements/for-of/dstr-obj-rest-symbol-val.js
@@ -5,7 +5,7 @@
 description: RestBindingInitialization creates a new object if lhs is a Symbol (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-obj-rest-to-property-with-setter.js
+++ b/test/language/statements/for-of/dstr-obj-rest-to-property-with-setter.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object property setter, its value should be binded as rest object. (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-obj-rest-to-property.js
+++ b/test/language/statements/for-of/dstr-obj-rest-to-property.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object property, its value should be binded as rest object. (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-obj-rest-val-null.js
+++ b/test/language/statements/for-of/dstr-obj-rest-val-null.js
@@ -5,7 +5,7 @@
 description: TypeError is thrown when rhs is null because of 7.1.13 ToObject ( argument ) used by CopyDataProperties (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-obj-rest-val-undefined.js
+++ b/test/language/statements/for-of/dstr-obj-rest-val-undefined.js
@@ -5,7 +5,7 @@
 description: TypeError is thrown when rhs is ```undefined``` because of 7.1.13 ToObject ( argument ) used by CopyDataProperties (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-obj-rest-valid-object.js
+++ b/test/language/statements/for-of/dstr-obj-rest-valid-object.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (For..of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-var-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-of/dstr-var-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-var-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-of/dstr-var-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for-of/dstr-var-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-of/dstr-var-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-var-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-of/dstr-var-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-var-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-of/dstr-var-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for-of/dstr-var-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-of/dstr-var-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (for-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 es6id: 13.7.5.11
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-const-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for/dstr-const-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-const-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for/dstr-const-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for/dstr-const-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for/dstr-const-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-const-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for/dstr-const-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-const-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for/dstr-const-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-const-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for/dstr-const-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-let-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for/dstr-let-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-let-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for/dstr-let-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for/dstr-let-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for/dstr-let-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-let-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for/dstr-let-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-let-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for/dstr-let-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-let-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for/dstr-let-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-var-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for/dstr-var-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-var-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for/dstr-var-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     IterationStatement :

--- a/test/language/statements/for/dstr-var-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for/dstr-var-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-var-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for/dstr-var-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-var-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for/dstr-var-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/for/dstr-var-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for/dstr-var-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (for statement)
 esid: sec-for-statement-runtime-semantics-labelledevaluation
 es6id: 13.7.4.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/function/dstr-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/statements/function/dstr-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (function declaration (default parameter))
 esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.1.19
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/function/dstr-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/function/dstr-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (function declaration (default parameter))
 esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.1.19
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     FunctionDeclaration :

--- a/test/language/statements/function/dstr-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/function/dstr-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (function declaration (default parameter))
 esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.1.19
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/function/dstr-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/function/dstr-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (function declaration (default parameter))
 esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.1.19
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/function/dstr-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/function/dstr-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (function declaration (default parameter))
 esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.1.19
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/function/dstr-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/function/dstr-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (function declaration (default parameter))
 esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.1.19
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/function/dstr-obj-ptrn-rest-getter.js
+++ b/test/language/statements/function/dstr-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (function declaration)
 esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.1.19
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/function/dstr-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/function/dstr-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (function declaration)
 esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.1.19
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     FunctionDeclaration :

--- a/test/language/statements/function/dstr-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/function/dstr-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (function declaration)
 esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.1.19
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/function/dstr-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/function/dstr-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (function declaration)
 esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.1.19
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/function/dstr-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/function/dstr-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (function declaration)
 esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.1.19
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/function/dstr-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/function/dstr-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (function declaration)
 esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.1.19
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/generators/dstr-dflt-obj-ptrn-rest-getter.js
+++ b/test/language/statements/generators/dstr-dflt-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (generator function declaration (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.4.12
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/generators/dstr-dflt-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/generators/dstr-dflt-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (generator function declaration (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.4.12
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 info: |
     GeneratorDeclaration : function * ( FormalParameters ) { GeneratorBody }

--- a/test/language/statements/generators/dstr-dflt-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/generators/dstr-dflt-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (generator function declaration (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.4.12
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/generators/dstr-dflt-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/generators/dstr-dflt-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (generator function declaration (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.4.12
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/generators/dstr-dflt-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/generators/dstr-dflt-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (generator function declaration (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.4.12
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/generators/dstr-dflt-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/generators/dstr-dflt-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (generator function declaration (default parameter))
 esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.4.12
-features: [destructuring-binding, default-parameters]
+features: [object-rest, destructuring-binding, default-parameters]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/generators/dstr-obj-ptrn-rest-getter.js
+++ b/test/language/statements/generators/dstr-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (generator function declaration)
 esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.4.12
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/generators/dstr-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/generators/dstr-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (generator function declaration)
 esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.4.12
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     GeneratorDeclaration : function * ( FormalParameters ) { GeneratorBody }

--- a/test/language/statements/generators/dstr-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/generators/dstr-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (generator function declaration)
 esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.4.12
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/generators/dstr-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/generators/dstr-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (generator function declaration)
 esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.4.12
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/generators/dstr-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/generators/dstr-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (generator function declaration)
 esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.4.12
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/generators/dstr-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/generators/dstr-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (generator function declaration)
 esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
 es6id: 14.4.12
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/let/dstr-obj-ptrn-rest-getter.js
+++ b/test/language/statements/let/dstr-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (`let` statement)
 esid: sec-let-and-const-declarations-runtime-semantics-evaluation
 es6id: 13.3.1.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/let/dstr-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/let/dstr-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (`let` statement)
 esid: sec-let-and-const-declarations-runtime-semantics-evaluation
 es6id: 13.3.1.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     LexicalBinding : BindingPattern Initializer

--- a/test/language/statements/let/dstr-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/let/dstr-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (`let` statement)
 esid: sec-let-and-const-declarations-runtime-semantics-evaluation
 es6id: 13.3.1.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/let/dstr-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/let/dstr-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (`let` statement)
 esid: sec-let-and-const-declarations-runtime-semantics-evaluation
 es6id: 13.3.1.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/let/dstr-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/let/dstr-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (`let` statement)
 esid: sec-let-and-const-declarations-runtime-semantics-evaluation
 es6id: 13.3.1.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/let/dstr-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/let/dstr-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (`let` statement)
 esid: sec-let-and-const-declarations-runtime-semantics-evaluation
 es6id: 13.3.1.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/try/dstr-obj-ptrn-rest-getter.js
+++ b/test/language/statements/try/dstr-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (try statement)
 esid: sec-runtime-semantics-catchclauseevaluation
 es6id: 13.15.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/try/dstr-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/try/dstr-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (try statement)
 esid: sec-runtime-semantics-catchclauseevaluation
 es6id: 13.15.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     Catch : catch ( CatchParameter ) Block

--- a/test/language/statements/try/dstr-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/try/dstr-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (try statement)
 esid: sec-runtime-semantics-catchclauseevaluation
 es6id: 13.15.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/try/dstr-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/try/dstr-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (try statement)
 esid: sec-runtime-semantics-catchclauseevaluation
 es6id: 13.15.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/try/dstr-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/try/dstr-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (try statement)
 esid: sec-runtime-semantics-catchclauseevaluation
 es6id: 13.15.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/try/dstr-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/try/dstr-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (try statement)
 esid: sec-runtime-semantics-catchclauseevaluation
 es6id: 13.15.7
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/variable/dstr-obj-ptrn-rest-getter.js
+++ b/test/language/statements/variable/dstr-obj-ptrn-rest-getter.js
@@ -5,7 +5,7 @@
 description: Getter is called when obj is being deconstructed to a rest Object (`var` statement)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/variable/dstr-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/variable/dstr-obj-ptrn-rest-nested-obj.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (`var` statement)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 info: |
     VariableDeclaration : BindingPattern Initializer

--- a/test/language/statements/variable/dstr-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/variable/dstr-obj-ptrn-rest-obj-nested-rest.js
@@ -5,7 +5,7 @@
 description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (`var` statement)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/variable/dstr-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/variable/dstr-obj-ptrn-rest-obj-own-property.js
@@ -5,7 +5,7 @@
 description: Rest object contains just soruce object's own properties (`var` statement)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/variable/dstr-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/variable/dstr-obj-ptrn-rest-skip-non-enumerable.js
@@ -5,7 +5,7 @@
 description: Rest object doesn't contain non-enumerable properties (`var` statement)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/variable/dstr-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/variable/dstr-obj-ptrn-rest-val-obj.js
@@ -5,7 +5,7 @@
 description: Rest object contains just unextracted data (`var` statement)
 esid: sec-variable-statement-runtime-semantics-evaluation
 es6id: 13.3.2.4
-features: [destructuring-binding]
+features: [object-rest, destructuring-binding]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |


### PR DESCRIPTION
cc @caitp 

I'm adding a frontmatter `features` flag for tests w/ Object rest/spread properties.

Next step is updating the async-iterator tests in the same way.