### PR TITLE
Add escape-above-astral.js to cover escaping code units as encoded from extended unicode escape.

### DIFF
--- a/test/annexB/built-ins/escape/escape-above-astral.js
+++ b/test/annexB/built-ins/escape/escape-above-astral.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2017 Microsoft Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-escape-string
+es6id: B.2.1.1
+description: Escaping of code units above 255 from string with extended Unicode escape sequence
+info: |
+    [...]
+    5. Repeat, while k < length,
+       a. Let char be the code unit (represented as a 16-bit unsigned integer)
+          at index k within string.
+       [...]
+       c. Else if char ≥ 256, then
+          i. Let S be a String containing six code units "%uwxyz" where wxyz
+             are the code units of the four uppercase hexadecimal digits
+             encoding the value of char.
+       [...]
+---*/
+
+assert.sameValue(
+  escape('\u{10401}'), '%uD801%uDC01', '\\u{10401} => \\uD801\\uDC01 (surrogate pairs encoded in string)'
+);


### PR DESCRIPTION
This is more of an integration test because the semantics should be that the extended unicode escape is encoded in the string as two UTF-16 code units (surrogate pairs) which are then correctly decoded and escaped.

See also (should I include these in the test file itself in addition to the reference on escape?)

https://tc39.github.io/ecma262/#sec-static-semantics-sv

>The SV of UnicodeEscapeSequence::u{HexDigits} is the UTF16Encoding of the MV of HexDigits.

https://tc39.github.io/ecma262/#sec-utf16encoding