### PR TITLE
Fix offset for detached TypedArray test

### DIFF
--- a/test/built-ins/TypedArrays/buffer-arg-byteoffset-to-number-detachbuffer.js
+++ b/test/built-ins/TypedArrays/buffer-arg-byteoffset-to-number-detachbuffer.js
@@ -15,6 +15,6 @@ includes: [testTypedArray.js, detachArrayBuffer.js]
 testWithTypedArrayConstructors(function(TA) {
   var offset = TA.BYTES_PER_ELEMENT;
   var buffer = new ArrayBuffer(3 * offset);
-  var byteOffset = { valueOf() { $DETACHBUFFER(buffer); return 1; } };
+  var byteOffset = { valueOf() { $DETACHBUFFER(buffer); return offset; } };
   assert.throws(TypeError, () => new TA(buffer, byteOffset));
 });


### PR DESCRIPTION
Bug was reported by @anba at
https://github.com/tc39/ecma262/pull/852#issuecomment-291781031

Without this change, you'd expect a RangeError rather than a TypeError.