### PR TITLE
Add tests for the behavior of |let <newline> await| in normal and async functions

### DIFF
--- a/test/language/statements/async-function/let-newline-await-in-async-function.js
+++ b/test/language/statements/async-function/let-newline-await-in-async-function.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Jeff Walden <jwalden+code@mit.edu>
+esid: sec-let-and-const-declarations
+description: >
+  `await` must not be considered a permissible binding name in
+  LexicalDeclaration as used in async functions.
+info: >
+  LexicalDeclaration is parametrized to indicate whether `async` is permitted as
+  binding name.  In async functions `await` is excluded from LexicalDeclaration
+  as a binding name.  Therefore ASI *can* apply between `let` (where a
+  LexicalDeclaration is permitted) and `await`, so a subsequent `0` forms part
+  of an AwaitExpression and there is no syntax error.
+---*/
+
+async function f() {
+    let
+    await 0;
+}
+
+assert(f instanceof Function);

--- a/test/language/statements/let/syntax/let-newline-await-in-normal-function.js
+++ b/test/language/statements/let/syntax/let-newline-await-in-normal-function.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Jeff Walden <jwalden+code@mit.edu>
+esid: sec-let-and-const-declarations
+description: >
+  `await` must be considered a permissible binding name in LexicalDeclaration as
+  used in non-async functions.
+info: >
+  LexicalDeclaration is parametrized to indicate whether `async` is permitted as
+  binding name.  In non-async functions `await` is a perfectly cromulent binding
+  name.  Therefore ASI can't apply between `let` (where a LexicalDeclaration is
+  permitted) and `await`, so a subsequent `0` where `=` was expected is a syntax
+  error.
+negative:
+  phase: early
+  type: SyntaxError
+---*/
+
+function f() {
+    let
+    await 0;
+}


### PR DESCRIPTION
The behavior of

    let
    await 0;

differs depending whether it's in an async function or not.  In an async function, `LexicalDeclaration`'s binding name production excludes `await` from permissibility, so ASI can trigger to split this into two statements.  In a normal function, `await` isn't excluded, so `let await 0;` is observed and causes a syntax error.

Hat-tip to @anba for originally reporting this in [bug 1353690](https://bugzilla.mozilla.org/show_bug.cgi?id=1353690).