### PR TITLE
Correct test/built-ins/Function/prototype/bind/15.3.4.5-15-5.js

### DIFF
--- a/test/built-ins/Function/prototype/bind/15.3.4.5-15-5.js
+++ b/test/built-ins/Function/prototype/bind/15.3.4.5-15-5.js
@@ -5,7 +5,7 @@
 es5id: 15.3.4.5-15-5
 description: >
     Function.prototype.bind - The [[Configurable]] attribute of length
-    property in F set as false
+    property in F set as true
 ---*/
 
         var canConfigurable = false;
@@ -13,8 +13,8 @@ description: >
         function foo() { }
         var obj = foo.bind({});
         hasProperty = obj.hasOwnProperty("length");
-        delete obj.caller;
+        delete obj.length;
         canConfigurable = !obj.hasOwnProperty("length");
 
 assert(hasProperty, 'hasProperty !== true');
-assert.sameValue(canConfigurable, false, 'canConfigurable');
+assert(canConfigurable, 'canConfigurable !== true');


### PR DESCRIPTION
The `length` property should be [[Configurable]]
https://tc39.github.io/ecma262/#sec-function.prototype.bind

Also the test was testing deleting the wrong property.

Fixes #957.