### PR TITLE
Add Verify Property harness

### DIFF
--- a/test/harness/assert-throws-incorrect-ctor.js
+++ b/test/harness/assert-throws-incorrect-ctor.js
@@ -3,8 +3,8 @@
 
 /*---
 description: >
-    Functions that throw values whose constructor does not match the specified
-    constructor do not satisfy the assertion.
+  Functions that throw values whose constructor does not match the specified
+  constructor do not satisfy the assertion.
 ---*/
 
 var threw = false;

--- a/test/harness/verifyProperty-arguments.js
+++ b/test/harness/verifyProperty-arguments.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2017 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  verifyProperty should receive at least 3 arguments: obj, name, and descriptor
+includes: [propertyHelper.js]
+---*/
+
+// monkeypatch the API
+$ERROR = function $ERROR(message) {
+  throw new Test262Error(message);
+};
+
+assert.throws(Test262Error, () => {
+  verifyProperty();
+}, "0 arguments");
+
+assert.throws(Test262Error, () => {
+  verifyProperty(Object);
+}, "1 argument");
+
+assert.throws(Test262Error, () => {
+  verifyProperty(Object, 'foo');
+}, "2 arguments");

--- a/test/harness/verifyProperty-desc-is-not-object.js
+++ b/test/harness/verifyProperty-desc-is-not-object.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2017 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  The desc argument should be an object or undefined
+includes: [propertyHelper.js]
+---*/
+
+// monkeypatch the API
+$ERROR = function $ERROR(message) {
+  throw new Test262Error(message);
+};
+
+var sample = { foo: 42 };
+
+assert.throws(Test262Error, () => {
+  verifyProperty(sample, "foo", 'configurable');
+}, "string");
+
+assert.throws(Test262Error, () => {
+  verifyProperty(sample, 'foo', true);
+}, "boolean");
+
+assert.throws(Test262Error, () => {
+  verifyProperty(sample, 'foo', 42);
+}, "number");
+
+assert.throws(Test262Error, () => {
+  verifyProperty(sample, 'foo', null);
+}, "null");
+
+assert.throws(Test262Error, () => {
+  verifyProperty(sample, 'foo', Symbol(1));
+}, "symbol");

--- a/test/harness/verifyProperty-noproperty.js
+++ b/test/harness/verifyProperty-noproperty.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  The first argument should have an own property
+includes: [propertyHelper.js]
+---*/
+
+// monkeypatch the API
+$ERROR = function $ERROR(message) {
+  throw new Test262Error(message);
+};
+
+assert.throws(Test262Error, () => {
+  verifyProperty(Object, 'JeanPaulSartre', {});
+}, "inexisting property");
+
+assert.throws(Test262Error, () => {
+  verifyProperty({}, 'hasOwnProperty', {});
+}, "inexisting own property");

--- a/test/harness/verifyProperty-restore-accessor-symbol.js
+++ b/test/harness/verifyProperty-restore-accessor-symbol.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2017 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  verifyProperty allows restoring the original accessor descriptor
+includes: [propertyHelper.js]
+---*/
+
+var obj;
+var prop = Symbol(1);
+var desc = { enumerable: true, configurable: true, get() { return 42; }, set() {} };
+
+obj = {};
+Object.defineProperty(obj, prop, desc);
+
+verifyProperty(obj, prop, desc);
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(obj, prop),
+  false
+);
+
+obj = {};
+Object.defineProperty(obj, prop, desc);
+
+verifyProperty(obj, prop, desc, { restore: true });
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(obj, prop),
+  true
+);
+assert.sameValue(obj[prop], 42);
+assert.sameValue(
+  Object.getOwnPropertyDescriptor(obj, prop).get,
+  desc.get
+);
+
+assert.sameValue(
+  Object.getOwnPropertyDescriptor(obj, prop).set,
+  desc.set
+);

--- a/test/harness/verifyProperty-restore-accessor.js
+++ b/test/harness/verifyProperty-restore-accessor.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2017 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  verifyProperty allows restoring the original accessor descriptor
+includes: [propertyHelper.js]
+---*/
+
+var obj;
+var prop = "prop";
+var desc = { enumerable: true, configurable: true, get() { return 42; }, set() {} };
+
+obj = {};
+Object.defineProperty(obj, prop, desc);
+
+verifyProperty(obj, prop, desc);
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(obj, prop),
+  false
+);
+
+obj = {};
+Object.defineProperty(obj, prop, desc);
+
+verifyProperty(obj, prop, desc, { restore: true });
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(obj, prop),
+  true
+);
+assert.sameValue(obj[prop], 42);
+assert.sameValue(
+  Object.getOwnPropertyDescriptor(obj, prop).get,
+  desc.get
+);
+
+assert.sameValue(
+  Object.getOwnPropertyDescriptor(obj, prop).set,
+  desc.set
+);

--- a/test/harness/verifyProperty-restore-symbol.js
+++ b/test/harness/verifyProperty-restore-symbol.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2017 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  verifyProperty allows restoring the original descriptor
+includes: [propertyHelper.js]
+---*/
+
+var obj;
+var prop = Symbol(1);
+var desc = { enumerable: true, configurable: true, writable: true, value: 42 };
+
+obj = {};
+Object.defineProperty(obj, prop, desc);
+
+verifyProperty(obj, prop, desc);
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(obj, prop),
+  false
+);
+
+obj = {};
+Object.defineProperty(obj, prop, desc);
+
+verifyProperty(obj, prop, desc, { restore: true });
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(obj, prop),
+  true
+);
+assert.sameValue(obj[prop], 42);

--- a/test/harness/verifyProperty-restore.js
+++ b/test/harness/verifyProperty-restore.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2017 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  verifyProperty allows restoring the original descriptor
+includes: [propertyHelper.js]
+---*/
+
+var obj;
+var prop = 'prop';
+var desc = { enumerable: true, configurable: true, writable: true, value: 42 };
+
+obj = {};
+Object.defineProperty(obj, prop, desc);
+
+verifyProperty(obj, prop, desc);
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(obj, prop),
+  false
+);
+
+obj = {};
+Object.defineProperty(obj, prop, desc);
+
+verifyProperty(obj, prop, desc, { restore: true });
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(obj, prop),
+  true
+);
+assert.sameValue(obj[prop], 42);

--- a/test/harness/verifyProperty-string-prop.js
+++ b/test/harness/verifyProperty-string-prop.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2017 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Verify property descriptor
+includes: [propertyHelper.js]
+---*/
+
+var obj;
+var prop = 'prop';
+
+function reset(desc) {
+  obj = {};
+  Object.defineProperty(obj, prop, desc);
+}
+
+function checkDesc(desc) {
+  reset(desc);
+  assert(verifyProperty(obj, prop, desc));
+
+  reset(desc);
+  assert(verifyProperty(obj, prop, { enumerable: desc.enumerable }));
+
+  reset(desc);
+  assert(verifyProperty(obj, prop, { writable: desc.writable }));
+
+  reset(desc);
+  assert(verifyProperty(obj, prop, { configurable: desc.configurable }));
+
+  reset(desc);
+  assert(verifyProperty(obj, prop, { configurable: desc.configurable, enumerable: desc.enumerable }));
+
+  reset(desc);
+  assert(verifyProperty(obj, prop, { configurable: desc.configurable, writable: desc.writable }));
+
+  reset(desc);
+  assert(verifyProperty(obj, prop, { writable: desc.writable, enumerable: desc.enumerable }));
+
+  reset(desc);
+  assert(verifyProperty(obj, prop, { enumerable: desc.enumerable, configurable: desc.configurable }));
+}
+
+checkDesc({ enumerable: true, configurable: true, writable: true });
+checkDesc({ enumerable: false, writable: false, configurable: false });
+checkDesc({ enumerable: true, writable: false, configurable: false });
+checkDesc({ enumerable: false, writable: true, configurable: false });
+checkDesc({ enumerable: false, writable: false, configurable: true });
+checkDesc({ enumerable: true, writable: false, configurable: true });
+checkDesc({ enumerable: true, writable: true, configurable: false });
+checkDesc({ enumerable: false, writable: true, configurable: true });

--- a/test/harness/verifyProperty-symbol-prop.js
+++ b/test/harness/verifyProperty-symbol-prop.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2017 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Verify symbol named property descriptor
+includes: [propertyHelper.js]
+---*/
+
+var obj;
+var prop = Symbol(1);
+
+function reset(desc) {
+  obj = {};
+  Object.defineProperty(obj, prop, desc);
+}
+
+function checkDesc(desc) {
+  reset(desc);
+  assert(verifyProperty(obj, prop, desc));
+
+  reset(desc);
+  assert(verifyProperty(obj, prop, { enumerable: desc.enumerable }));
+
+  reset(desc);
+  assert(verifyProperty(obj, prop, { writable: desc.writable }));
+
+  reset(desc);
+  assert(verifyProperty(obj, prop, { configurable: desc.configurable }));
+
+  reset(desc);
+  assert(verifyProperty(obj, prop, { configurable: desc.configurable, enumerable: desc.enumerable }));
+
+  reset(desc);
+  assert(verifyProperty(obj, prop, { configurable: desc.configurable, writable: desc.writable }));
+
+  reset(desc);
+  assert(verifyProperty(obj, prop, { writable: desc.writable, enumerable: desc.enumerable }));
+
+  reset(desc);
+  assert(verifyProperty(obj, prop, { enumerable: desc.enumerable, configurable: desc.configurable }));
+}
+
+checkDesc({ enumerable: true, configurable: true, writable: true });
+checkDesc({ enumerable: false, writable: false, configurable: false });
+checkDesc({ enumerable: true, writable: false, configurable: false });
+checkDesc({ enumerable: false, writable: true, configurable: false });
+checkDesc({ enumerable: false, writable: false, configurable: true });
+checkDesc({ enumerable: true, writable: false, configurable: true });
+checkDesc({ enumerable: true, writable: true, configurable: false });
+checkDesc({ enumerable: false, writable: true, configurable: true });

--- a/test/harness/verifyProperty-undefined-desc.js
+++ b/test/harness/verifyProperty-undefined-desc.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2017 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Verify an undefined descriptor
+includes: [propertyHelper.js]
+---*/
+
+// monkeypatch the API
+$ERROR = function $ERROR(message) {
+  throw new Test262Error(message);
+};
+
+var sample = {
+  bar: undefined,
+  get baz() {}
+};
+
+assert.sameValue(
+  verifyProperty(sample, "foo", undefined),
+  true,
+  "returns true if desc and property descriptor are both undefined"
+);
+
+assert.throws(Test262Error, () => {
+  verifyProperty(sample, 'bar', undefined);
+}, "dataDescriptor value is undefined");
+
+assert.throws(Test262Error, () => {
+  verifyProperty(sample, 'baz', undefined);
+}, "accessor returns undefined");


### PR DESCRIPTION
signature:

```js
verifyProperty(
  Object obj,
  String|Symbol name,
  Object|undefined {
    Boolean writable,
    Boolean configurable,
    Boolean enumerable
  },
  Object { Boolean restore }
);
```

You can set an expliecit `restore` option if you need to reuse the same property, works well for accessor descriptors too.

I've had to add a monkey patch to `$ERROR` in tests asserting negative effects, it is ugly, but it works.

cc @littledan;


