### PR TITLE
Reference `requirements.txt` file in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-install: pip install pyyaml
+install: pip install --requirement tools/generation/requirements.txt
 script:
   - echo The test generation tool should be working.
   - ./tools/generation/test/run.py


### PR DESCRIPTION
Installing dependencies using this file increases parity between the CI
and development environment. Because the file explicitly specifies a
version of the package to be installed, this approach also produces more
predictable results overall.