### PR TITLE
Optimize decodeURI/encodeURI tests

### DIFF
--- a/harness/decimalToHexString.js
+++ b/harness/decimalToHexString.js
@@ -14,3 +14,8 @@ function decimalToHexString(n) {
   }
   return s;
 }
+
+function decimalToHex2String(n) {
+  var hex = "0123456789ABCDEF";
+  return hex[(n >> 4) & 0xf] + hex[n & 0xf];
+}

--- a/harness/decimalToHexString.js
+++ b/harness/decimalToHexString.js
@@ -2,25 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
+  var hex = "0123456789ABCDEF";
+  n >>>= 0;
+  var s = "";
+  while (n) {
+    s = hex[n & 0xf] + s;
+    n >>>= 4;
   }
-  return h;
+  while (s.length < 4) {
+    s = "0" + s;
+  }
+  return s;
 }

--- a/harness/decimalToHexString.js
+++ b/harness/decimalToHexString.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+function decimalToHexString(n) {
+  n = Number(n);
+  var h = "";
+  for (var i = 3; i >= 0; i--) {
+    if (n >= Math.pow(16, i)) {
+      var t = Math.floor(n / Math.pow(16, i));
+      n -= t * Math.pow(16, i);
+      if ( t >= 10 ) {
+        if ( t == 10 ) { h += "A"; }
+        if ( t == 11 ) { h += "B"; }
+        if ( t == 12 ) { h += "C"; }
+        if ( t == 13 ) { h += "D"; }
+        if ( t == 14 ) { h += "E"; }
+        if ( t == 15 ) { h += "F"; }
+      } else {
+        h += String(t);
+      }
+    } else {
+      h += "0";
+    }
+  }
+  return h;
+}

--- a/harness/decimalToHexString.js
+++ b/harness/decimalToHexString.js
@@ -15,7 +15,7 @@ function decimalToHexString(n) {
   return s;
 }
 
-function decimalToHex2String(n) {
+function decimalToPercentHexString(n) {
   var hex = "0123456789ABCDEF";
-  return hex[(n >> 4) & 0xf] + hex[n & 0xf];
+  return "%" + hex[(n >> 4) & 0xf] + hex[n & 0xf];
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.13_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.13_T1.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.1_A1.13_T1
 description: Complex tests. B = [0xC0 - 0xDF], C = [0x00, 0x7F]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.13_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.13_T1.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xC0; indexB <= 0xDF; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);  
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHexString(indexC);  
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURI("%" + hexB.substring(2) + "%" + hexC.substring(2));
+      decodeURI("%" + hexB + "%" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.13_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.13_T1.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xC0; indexB <= 0xDF; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURI("%" + hexB + "%" + hexC);
+      decodeURI(hexB + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.13_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.13_T2.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.1_A1.13_T2
 description: Complex tests. B = [0xC0 - 0xDF], C = [0xC0, 0xFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.13_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.13_T2.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xC0; indexB <= 0xDF; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);  
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHexString(indexC);  
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURI("%" + hexB.substring(2) + "%" + hexC.substring(2));
+      decodeURI("%" + hexB + "%" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.13_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.13_T2.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xC0; indexB <= 0xDF; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURI("%" + hexB + "%" + hexC);
+      decodeURI(hexB + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.14_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.14_T1.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.1_A1.14_T1
 description: Complex tests. B = [0xE0 - 0xEF], C = [0x00, 0x7F]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.14_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.14_T1.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURI("%" + hexB + "%" + hexC + "%A0");
+      decodeURI(hexB + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.14_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.14_T1.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB); 
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHexString(indexC);  
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURI("%" + hexB.substring(2) + "%" + hexC.substring(2) + "%A0");
+      decodeURI("%" + hexB + "%" + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.14_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.14_T2.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURI("%" + hexB + "%A0" + "%" + hexC);
+      decodeURI(hexB + "%A0" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.14_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.14_T2.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.1_A1.14_T2
 description: Complex tests. B = [0xE0 - 0xEF], C = [0x00, 0x7F]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.14_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.14_T2.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);  
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHexString(indexC);  
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURI("%" + hexB.substring(2) + "%A0" + "%" + hexC.substring(2));
+      decodeURI("%" + hexB + "%A0" + "%" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.14_T3.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.14_T3.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURI("%" + hexB + "%" + hexC + "%A0");
+      decodeURI(hexB + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.14_T3.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.14_T3.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.1_A1.14_T3
 description: Complex tests. B = [0xE0 - 0xEF], C = [0xC0, 0xFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.14_T3.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.14_T3.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB); 
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHexString(indexC);  
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURI("%" + hexB.substring(2) + "%" + hexC.substring(2) + "%A0");
+      decodeURI("%" + hexB + "%" + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.14_T4.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.14_T4.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.1_A1.14_T4
 description: Complex tests. B = [0xE0 - 0xEF], C = [0xC0, 0xFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.14_T4.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.14_T4.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURI("%" + hexB + "%A0" + "%" + hexC);
+      decodeURI(hexB + "%A0" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.14_T4.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.14_T4.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);  
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHexString(indexC);  
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURI("%" + hexB.substring(2) + "%A0" + "%" + hexC.substring(2));
+      decodeURI("%" + hexB + "%A0" + "%" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T1.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.1_A1.15_T1
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0x00, 0x7F]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T1.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB); 
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHexString(indexC);  
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURI("%" + hexB.substring(2) + "%" + hexC.substring(2) + "%A0%A0");
+      decodeURI("%" + hexB + "%" + hexC + "%A0%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T1.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURI("%" + hexB + "%" + hexC + "%A0%A0");
+      decodeURI(hexB + hexC + "%A0%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T2.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB); 
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHexString(indexC);  
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURI("%" + hexB.substring(2) + "%A0" + "%" + hexC.substring(2) + "%A0");
+      decodeURI("%" + hexB + "%A0" + "%" + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T2.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.1_A1.15_T2
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0x00, 0x7F]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T2.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURI("%" + hexB + "%A0" + "%" + hexC + "%A0");
+      decodeURI(hexB + "%A0" + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T3.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T3.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.1_A1.15_T3
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0x00, 0x7F]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T3.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T3.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURI("%" + hexB + "%A0%A0" + "%" + hexC);
+      decodeURI(hexB + "%A0%A0" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T3.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T3.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB); 
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHexString(indexC);  
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURI("%" + hexB.substring(2) + "%A0%A0" + "%" + hexC.substring(2));
+      decodeURI("%" + hexB + "%A0%A0" + "%" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T4.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T4.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB); 
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHexString(indexC);  
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURI("%" + hexB.substring(2) + "%" + hexC.substring(2) + "%A0%A0");
+      decodeURI("%" + hexB + "%" + hexC + "%A0%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T4.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T4.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.1_A1.15_T4
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0xC0, 0xFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T4.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T4.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURI("%" + hexB + "%" + hexC + "%A0%A0");
+      decodeURI(hexB + hexC + "%A0%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T5.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T5.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.1_A1.15_T5
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0xC0, 0xFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T5.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T5.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB); 
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHexString(indexC);  
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURI("%" + hexB.substring(2) + "%A0" + "%" + hexC.substring(2) + "%A0");
+      decodeURI("%" + hexB + "%A0" + "%" + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T5.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T5.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURI("%" + hexB + "%A0" + "%" + hexC + "%A0");
+      decodeURI(hexB + "%A0" + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T6.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T6.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURI("%" + hexB + "%A0%A0" + "%" + hexC);
+      decodeURI(hexB + "%A0%A0" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T6.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T6.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB); 
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHexString(indexC);  
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURI("%" + hexB.substring(2) + "%A0%A0" + "%" + hexC.substring(2));
+      decodeURI("%" + hexB + "%A0%A0" + "%" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.15_T6.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.15_T6.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.1_A1.15_T6
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0xC0, 0xFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.3_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.3_T1.js
@@ -15,9 +15,9 @@ var indexO = 0;
 
 for (var index = 0x80; index <= 0xBF; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURI("%" + hex);
+    decodeURI(hex);
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.3_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.3_T1.js
@@ -5,6 +5,7 @@
 info: If B = 10xxxxxx or B = 11111xxx, throw URIError
 es5id: 15.1.3.1_A1.3_T1
 description: Complex tests. B = 10xxxxxx -> B in [0x80 - 0xBF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -50,28 +51,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.3_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.3_T1.js
@@ -15,9 +15,9 @@ var indexO = 0;
 
 for (var index = 0x80; index <= 0xBF; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURI("%" + hex.substring(2));
+    decodeURI("%" + hex);
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.3_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.3_T2.js
@@ -15,9 +15,9 @@ var indexO = 0;
 
 for (var index = 0xF8; index <= 0xFF; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURI("%" + hex.substring(2));
+    decodeURI("%" + hex);
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.3_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.3_T2.js
@@ -5,6 +5,7 @@
 info: If B = 10xxxxxx or B = 11111xxx, throw URIError
 es5id: 15.1.3.1_A1.3_T2
 description: Complex tests. B = 11111xxx -> B in [0xF8 - 0xFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -50,28 +51,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.3_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.3_T2.js
@@ -15,9 +15,9 @@ var indexO = 0;
 
 for (var index = 0xF8; index <= 0xFF; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURI("%" + hex);
+    decodeURI(hex);
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.4_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.4_T1.js
@@ -18,9 +18,9 @@ for (var index = 0xC0; index <= 0xDF; index++) {
   var str = "";
   var result = true;
   for (var len = 0; len < 3; len++) {
-    var hex = decimalToHex2String(index);
+    var hex = decimalToPercentHexString(index);
     try {
-      decodeURI("%" + hex + str);
+      decodeURI(hex + str);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.4_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.4_T1.js
@@ -18,9 +18,9 @@ for (var index = 0xC0; index <= 0xDF; index++) {
   var str = "";
   var result = true;
   for (var len = 0; len < 3; len++) {
-    var hex = decimalToHexString(index);
+    var hex = decimalToHex2String(index);
     try {
-      decodeURI("%" + hex.substring(2) + str);      
+      decodeURI("%" + hex + str);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.4_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.4_T1.js
@@ -5,6 +5,7 @@
 info: If B = 110xxxxx (n = 2) and (k + 2) + 3 >= length, throw URIError
 es5id: 15.1.3.1_A1.4_T1
 description: Complex tests. B = [0xC0 - 0xDF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -58,28 +59,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.5_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.5_T1.js
@@ -5,6 +5,7 @@
 info: If B = 1110xxxx (n = 3) and (k + 2) + 6 >= length, throw URIError
 es5id: 15.1.3.1_A1.5_T1
 description: Complex tests. B = [0xE0 - 0xEF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -58,28 +59,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.5_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.5_T1.js
@@ -18,9 +18,9 @@ for (var index = 0xE0; index <= 0xEF; index++) {
   var str = "";
   var result = true;
   for (var len = 0; len < 6; len++) {
-    var hex = decimalToHexString(index);
+    var hex = decimalToHex2String(index);
     try {
-      decodeURI("%" + hex.substring(2) + str);      
+      decodeURI("%" + hex + str);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.5_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.5_T1.js
@@ -18,9 +18,9 @@ for (var index = 0xE0; index <= 0xEF; index++) {
   var str = "";
   var result = true;
   for (var len = 0; len < 6; len++) {
-    var hex = decimalToHex2String(index);
+    var hex = decimalToPercentHexString(index);
     try {
-      decodeURI("%" + hex + str);
+      decodeURI(hex + str);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.6_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.6_T1.js
@@ -18,9 +18,9 @@ for (var index = 0xF0; index <= 0xF7; index++) {
   var str = "";
   var result = true;
   for (var len = 0; len < 9; len++) {
-    var hex = decimalToHex2String(index);
+    var hex = decimalToPercentHexString(index);
     try {
-      decodeURI("%" + hex + str);
+      decodeURI(hex + str);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.6_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.6_T1.js
@@ -18,9 +18,9 @@ for (var index = 0xF0; index <= 0xF7; index++) {
   var str = "";
   var result = true;
   for (var len = 0; len < 9; len++) {
-    var hex = decimalToHexString(index);
+    var hex = decimalToHex2String(index);
     try {
-      decodeURI("%" + hex.substring(2) + str);      
+      decodeURI("%" + hex + str);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.6_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.6_T1.js
@@ -5,6 +5,7 @@
 info: If B = 11110xxx (n = 4) and (k + 2) + 9 >= length, throw URIError
 es5id: 15.1.3.1_A1.6_T1
 description: Complex tests. B = [0xF0 - 0xF7]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -58,28 +59,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.7_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.7_T1.js
@@ -7,6 +7,7 @@ info: >
     URIError
 es5id: 15.1.3.1_A1.7_T1
 description: Complex tests. B = [0xC0 - 0xDF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -52,28 +53,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.7_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.7_T1.js
@@ -17,9 +17,9 @@ var indexO = 0;
 
 for (var index = 0xC0; index <= 0xDF; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURI("%" + hex.substring(2) + "111");
+    decodeURI("%" + hex + "111");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.7_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.7_T1.js
@@ -17,9 +17,9 @@ var indexO = 0;
 
 for (var index = 0xC0; index <= 0xDF; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURI("%" + hex + "111");
+    decodeURI(hex + "111");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.8_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.8_T1.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xE0; index <= 0xEF; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURI("%" + hex + "111%A0");
+    decodeURI(hex + "111%A0");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.8_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.8_T1.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xE0; index <= 0xEF; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURI("%" + hex.substring(2) + "111%A0");
+    decodeURI("%" + hex + "111%A0");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.8_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.8_T1.js
@@ -7,8 +7,8 @@ info: >
     string.charAt(k + 6) not equal "%", throw URIError
 es5id: 15.1.3.1_A1.8_T1
 description: >
-    Complex tests. B = [0xE0 - 0xEF],  string.charAt(k + 3) not equal
-    "%"
+    Complex tests. B = [0xE0 - 0xEF],  string.charAt(k + 3) not equal "%"
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -54,28 +54,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.8_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.8_T2.js
@@ -7,8 +7,8 @@ info: >
     string.charAt(k + 6) not equal "%", throw URIError
 es5id: 15.1.3.1_A1.8_T2
 description: >
-    Complex tests. B = [0xE0 - 0xEF],  string.charAt(k + 6) not equal
-    "%"
+    Complex tests. B = [0xE0 - 0xEF],  string.charAt(k + 6) not equal "%"
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -54,28 +54,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.8_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.8_T2.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xE0; index <= 0xEF; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURI("%" + hex + "%A0111");
+    decodeURI(hex + "%A0111");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.8_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.8_T2.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xE0; index <= 0xEF; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURI("%" + hex.substring(2) + "%A0111");
+    decodeURI("%" + hex + "%A0111");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.9_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.9_T1.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURI("%" + hex.substring(2) + "111%A0%A0");
+    decodeURI("%" + hex + "111%A0%A0");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.9_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.9_T1.js
@@ -7,8 +7,8 @@ info: >
     string.charAt(k + 6), string.charAt(k + 9) not equal "%", throw URIError
 es5id: 15.1.3.1_A1.9_T1
 description: >
-    Complex tests. B = [0xF0 - 0x0F7],  string.charAt(k + 3) not equal
-    "%"
+    Complex tests. B = [0xF0 - 0x0F7],  string.charAt(k + 3) not equal "%"
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -54,28 +54,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.9_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.9_T1.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURI("%" + hex + "111%A0%A0");
+    decodeURI(hex + "111%A0%A0");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.9_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.9_T2.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURI("%" + hex.substring(2) + "%A0111%A0");
+    decodeURI("%" + hex + "%A0111%A0");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.9_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.9_T2.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURI("%" + hex + "%A0111%A0");
+    decodeURI(hex + "%A0111%A0");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.9_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.9_T2.js
@@ -7,8 +7,8 @@ info: >
     string.charAt(k + 6), string.charAt(k + 9) not equal "%", throw URIError
 es5id: 15.1.3.1_A1.9_T2
 description: >
-    Complex tests. B = [0xF0 - 0x0F7],  string.charAt(k + 6) not equal
-    "%"
+    Complex tests. B = [0xF0 - 0x0F7],  string.charAt(k + 6) not equal "%"
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -54,28 +54,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.9_T3.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.9_T3.js
@@ -7,8 +7,8 @@ info: >
     string.charAt(k + 6), string.charAt(k + 9) not equal "%", throw URIError
 es5id: 15.1.3.1_A1.9_T3
 description: >
-    Complex tests. B = [0xF0 - 0x0F7],  string.charAt(k + 9) not equal
-    "%"
+    Complex tests. B = [0xF0 - 0x0F7],  string.charAt(k + 9) not equal "%"
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -54,28 +54,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.9_T3.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.9_T3.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURI("%" + hex + "%A0%A0111");
+    decodeURI(hex + "%A0%A0111");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.9_T3.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.9_T3.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURI("%" + hex.substring(2) + "%A0%A0111");
+    decodeURI("%" + hex + "%A0%A0111");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.1_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.1_T1.js
@@ -5,6 +5,7 @@
 info: If string.charAt(k) not equal "%", return this char
 es5id: 15.1.3.1_A2.1_T1
 description: Complex tests
+includes: [decimalToHexString.js]
 ---*/
 
 //CHECK
@@ -29,28 +30,4 @@ for (var indexI = 0; indexI <= 65535; indexI++) {
 
 if (errorCount > 0) {    
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count);
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.2_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.2_T1.js
@@ -18,15 +18,13 @@ for (var indexB1 = 0x00; indexB1 <= 0x7F; indexB1++) {
   count++;
   var hexB1 = decimalToPercentHexString(indexB1);
   var index = indexB1;  
-  try {
-    var hex = String.fromCharCode(index);
-    for (var indexC = 0; indexC < uriReserved.length; indexC++) {
-      if (hex === uriReserved[indexC]) continue l;        
-    } 
-    if (hex === "#") continue l;
-    if (decodeURI(hexB1) === hex) continue;
-  } catch (e) {
-  }   
+  var hex = String.fromCharCode(index);
+  for (var indexC = 0; indexC < uriReserved.length; indexC++) {
+    if (hex === uriReserved[indexC]) continue l;
+  }
+  if (hex === "#") continue;
+  if (decodeURI(hexB1) === hex) continue;
+
   if (indexO === 0) { 
     indexO = index;
   } else {

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.2_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.2_T1.js
@@ -16,7 +16,7 @@ var uriReserved = [";", "/", "?", ":", "@", "&", "=", "+", "$", ","];
 l:
 for (var indexB1 = 0x00; indexB1 <= 0x7F; indexB1++) {       
   count++;
-  var hexB1 = decimalToHex2String(indexB1);
+  var hexB1 = decimalToPercentHexString(indexB1);
   var index = indexB1;  
   try {
     var hex = String.fromCharCode(index);
@@ -24,7 +24,7 @@ for (var indexB1 = 0x00; indexB1 <= 0x7F; indexB1++) {
       if (hex === uriReserved[indexC]) continue l;        
     } 
     if (hex === "#") continue l;
-    if (decodeURI("%" + hexB1) === hex) continue;
+    if (decodeURI(hexB1) === hex) continue;
   } catch (e) {
     if (e instanceof Test262Error) throw e;
   }   

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.2_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.2_T1.js
@@ -26,7 +26,6 @@ for (var indexB1 = 0x00; indexB1 <= 0x7F; indexB1++) {
     if (hex === "#") continue l;
     if (decodeURI(hexB1) === hex) continue;
   } catch (e) {
-    if (e instanceof Test262Error) throw e;
   }   
   if (indexO === 0) { 
     indexO = index;

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.2_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.2_T1.js
@@ -5,6 +5,7 @@
 info: If B1 = 0xxxxxxxx ([0x00 - 0x7F]), without [uriReserved, #], return B1
 es5id: 15.1.3.1_A2.2_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -57,28 +58,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.2_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.2_T1.js
@@ -16,7 +16,7 @@ var uriReserved = [";", "/", "?", ":", "@", "&", "=", "+", "$", ","];
 l:
 for (var indexB1 = 0x00; indexB1 <= 0x7F; indexB1++) {       
   count++;
-  var hexB1 = decimalToHexString(indexB1);  
+  var hexB1 = decimalToHex2String(indexB1);
   var index = indexB1;  
   try {
     var hex = String.fromCharCode(index);
@@ -24,7 +24,7 @@ for (var indexB1 = 0x00; indexB1 <= 0x7F; indexB1++) {
       if (hex === uriReserved[indexC]) continue l;        
     } 
     if (hex === "#") continue l;
-    if (decodeURI("%" + hexB1.substring(2)) === hex) continue;
+    if (decodeURI("%" + hexB1) === hex) continue;
   } catch (e) {
     if (e instanceof Test262Error) throw e;
   }   

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.3_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.3_T1.js
@@ -16,13 +16,13 @@ var indexP;
 var indexO = 0;
 
 for (var indexB1 = 0xC2; indexB1 <= 0xDF; indexB1++) {     
-  var hexB1 = decimalToHex2String(indexB1);
+  var hexB1 = decimalToPercentHexString(indexB1);
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     count++;
-    var hexB2 = decimalToHex2String(indexB2);
+    var hexB2 = decimalToPercentHexString(indexB2);
     var index = (indexB1 & 0x1F) * 0x40 + (indexB2 & 0x3F);  
     try {
-      if (decodeURI("%" + hexB1 + "%" + hexB2) === String.fromCharCode(index)) continue;
+      if (decodeURI(hexB1 + hexB2) === String.fromCharCode(index)) continue;
   } catch (e) {
       if (e instanceof Test262Error) throw e;
     }   

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.3_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.3_T1.js
@@ -23,8 +23,7 @@ for (var indexB1 = 0xC2; indexB1 <= 0xDF; indexB1++) {
     var index = (indexB1 & 0x1F) * 0x40 + (indexB2 & 0x3F);  
     try {
       if (decodeURI(hexB1_B2) === String.fromCharCode(index)) continue;
-  } catch (e) {
-      if (e instanceof Test262Error) throw e;
+    } catch (e) {
     }   
     if (indexO === 0) { 
       indexO = index;

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.3_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.3_T1.js
@@ -21,10 +21,8 @@ for (var indexB1 = 0xC2; indexB1 <= 0xDF; indexB1++) {
     count++;
     var hexB1_B2 = hexB1 + decimalToPercentHexString(indexB2);
     var index = (indexB1 & 0x1F) * 0x40 + (indexB2 & 0x3F);  
-    try {
-      if (decodeURI(hexB1_B2) === String.fromCharCode(index)) continue;
-    } catch (e) {
-    }   
+    if (decodeURI(hexB1_B2) === String.fromCharCode(index)) continue;
+
     if (indexO === 0) { 
       indexO = index;
     } else {

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.3_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.3_T1.js
@@ -16,13 +16,13 @@ var indexP;
 var indexO = 0;
 
 for (var indexB1 = 0xC2; indexB1 <= 0xDF; indexB1++) {     
-  var hexB1 = decimalToHexString(indexB1);
+  var hexB1 = decimalToHex2String(indexB1);
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     count++;
-    var hexB2 = decimalToHexString(indexB2);
+    var hexB2 = decimalToHex2String(indexB2);
     var index = (indexB1 & 0x1F) * 0x40 + (indexB2 & 0x3F);  
     try {
-      if (decodeURI("%" + hexB1.substring(2) + "%" + hexB2.substring(2)) === String.fromCharCode(index)) continue;
+      if (decodeURI("%" + hexB1 + "%" + hexB2) === String.fromCharCode(index)) continue;
   } catch (e) {
       if (e instanceof Test262Error) throw e;
     }   

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.3_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.3_T1.js
@@ -19,10 +19,10 @@ for (var indexB1 = 0xC2; indexB1 <= 0xDF; indexB1++) {
   var hexB1 = decimalToPercentHexString(indexB1);
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     count++;
-    var hexB2 = decimalToPercentHexString(indexB2);
+    var hexB1_B2 = hexB1 + decimalToPercentHexString(indexB2);
     var index = (indexB1 & 0x1F) * 0x40 + (indexB2 & 0x3F);  
     try {
-      if (decodeURI(hexB1 + hexB2) === String.fromCharCode(index)) continue;
+      if (decodeURI(hexB1_B2) === String.fromCharCode(index)) continue;
   } catch (e) {
       if (e instanceof Test262Error) throw e;
     }   

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.3_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.3_T1.js
@@ -7,6 +7,7 @@ info: >
     B1 = [0xC0, 0xC1], return UTF8(B1, B2)
 es5id: 15.1.3.1_A2.3_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -56,28 +57,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
@@ -17,17 +17,17 @@ var indexP;
 var indexO = 0;
 
 for (var indexB1 = 0xE0; indexB1 <= 0xEF; indexB1++) {     
-  var hexB1 = decimalToHex2String(indexB1);
+  var hexB1 = decimalToPercentHexString(indexB1);
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     if ((indexB1 === 0xE0) && (indexB2 <= 0x9F)) continue;
     if ((indexB1 === 0xED) && (0xA0 <= indexB2)) continue;         
-    var hexB2 = decimalToHex2String(indexB2);
+    var hexB2 = decimalToPercentHexString(indexB2);
     for (var indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
       count++;
-      var hexB3 = decimalToHex2String(indexB3);
+      var hexB3 = decimalToPercentHexString(indexB3);
       var index = (indexB1 & 0x0F) * 0x1000 + (indexB2 & 0x3F) * 0x40 + (indexB3 & 0x3F);  
       try {
-        if (decodeURI("%" + hexB1 + "%" + hexB2 + "%" + hexB3) === String.fromCharCode(index)) continue;
+        if (decodeURI(hexB1 + hexB2 + hexB3) === String.fromCharCode(index)) continue;
       } catch (e) {
         if (e instanceof Test262Error) throw e;
       }   

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
@@ -17,17 +17,17 @@ var indexP;
 var indexO = 0;
 
 for (var indexB1 = 0xE0; indexB1 <= 0xEF; indexB1++) {     
-  var hexB1 = decimalToHexString(indexB1);
+  var hexB1 = decimalToHex2String(indexB1);
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     if ((indexB1 === 0xE0) && (indexB2 <= 0x9F)) continue;
     if ((indexB1 === 0xED) && (0xA0 <= indexB2)) continue;         
-    var hexB2 = decimalToHexString(indexB2);
+    var hexB2 = decimalToHex2String(indexB2);
     for (var indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
       count++;
-      var hexB3 = decimalToHexString(indexB3);
+      var hexB3 = decimalToHex2String(indexB3);
       var index = (indexB1 & 0x0F) * 0x1000 + (indexB2 & 0x3F) * 0x40 + (indexB3 & 0x3F);  
       try {
-        if (decodeURI("%" + hexB1.substring(2) + "%" + hexB2.substring(2) + "%" + hexB3.substring(2)) === String.fromCharCode(index)) continue;
+        if (decodeURI("%" + hexB1 + "%" + hexB2 + "%" + hexB3) === String.fromCharCode(index)) continue;
       } catch (e) {
         if (e instanceof Test262Error) throw e;
       }   

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
@@ -29,7 +29,6 @@ for (var indexB1 = 0xE0; indexB1 <= 0xEF; indexB1++) {
       try {
         if (decodeURI(hexB1_B2_B3) === String.fromCharCode(index)) continue;
       } catch (e) {
-        if (e instanceof Test262Error) throw e;
       }   
       if (indexO === 0) { 
         indexO = index;

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
@@ -21,13 +21,13 @@ for (var indexB1 = 0xE0; indexB1 <= 0xEF; indexB1++) {
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     if ((indexB1 === 0xE0) && (indexB2 <= 0x9F)) continue;
     if ((indexB1 === 0xED) && (0xA0 <= indexB2)) continue;         
-    var hexB2 = decimalToPercentHexString(indexB2);
+    var hexB1_B2 = hexB1 + decimalToPercentHexString(indexB2);
     for (var indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
       count++;
-      var hexB3 = decimalToPercentHexString(indexB3);
+      var hexB1_B2_B3 = hexB1_B2 + decimalToPercentHexString(indexB3);
       var index = (indexB1 & 0x0F) * 0x1000 + (indexB2 & 0x3F) * 0x40 + (indexB3 & 0x3F);  
       try {
-        if (decodeURI(hexB1 + hexB2 + hexB3) === String.fromCharCode(index)) continue;
+        if (decodeURI(hexB1_B2_B3) === String.fromCharCode(index)) continue;
       } catch (e) {
         if (e instanceof Test262Error) throw e;
       }   

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
@@ -26,10 +26,8 @@ for (var indexB1 = 0xE0; indexB1 <= 0xEF; indexB1++) {
       count++;
       var hexB1_B2_B3 = hexB1_B2 + decimalToPercentHexString(indexB3);
       var index = (indexB1 & 0x0F) * 0x1000 + (indexB2 & 0x3F) * 0x40 + (indexB3 & 0x3F);  
-      try {
-        if (decodeURI(hexB1_B2_B3) === String.fromCharCode(index)) continue;
-      } catch (e) {
-      }   
+      if (decodeURI(hexB1_B2_B3) === String.fromCharCode(index)) continue;
+
       if (indexO === 0) { 
         indexO = index;
       } else {

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
@@ -8,6 +8,7 @@ info: >
     0xDFFF), return UTF8(B1, B2, B3)
 es5id: 15.1.3.1_A2.4_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -62,28 +63,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
@@ -17,21 +17,21 @@ var indexP;
 var indexO = 0;
 
 for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {     
-  var hexB1 = decimalToHex2String(indexB1);
+  var hexB1 = decimalToPercentHexString(indexB1);
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     if ((indexB1 === 0xF0) && (indexB2 <= 0x9F)) continue;            
     if ((indexB1 === 0xF4) && (indexB2 >= 0x90)) continue;
-    var hexB2 = decimalToHex2String(indexB2);
+    var hexB2 = decimalToPercentHexString(indexB2);
     for (var indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
-      var hexB3 = decimalToHex2String(indexB3);
+      var hexB3 = decimalToPercentHexString(indexB3);
       for (var indexB4 = 0x80; indexB4 <= 0xBF; indexB4++) {
-        var hexB4 = decimalToHex2String(indexB4);
+        var hexB4 = decimalToPercentHexString(indexB4);
         count++;
         var index = (indexB1 & 0x07) * 0x40000 + (indexB2 & 0x3F) * 0x1000 + (indexB3 & 0x3F) * 0x40 + (indexB4 & 0x3F);
         var L = ((index - 0x10000) & 0x03FF) + 0xDC00;
         var H = (((index - 0x10000) >> 10) & 0x03FF) + 0xD800;  
         try {
-          if (decodeURI("%" + hexB1 + "%" + hexB2 + "%" + hexB3 + "%" + hexB4) === String.fromCharCode(H) + String.fromCharCode(L)) continue;
+          if (decodeURI(hexB1 + hexB2 + hexB3 + hexB4) === String.fromCharCode(H) + String.fromCharCode(L)) continue;
         } catch (e) {
           if (e instanceof Test262Error) throw e;
         }   

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
@@ -33,7 +33,6 @@ for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
         try {
           if (decodeURI(hexB1_B2_B3_B4) === String.fromCharCode(H, L)) continue;
         } catch (e) {
-          if (e instanceof Test262Error) throw e;
         }   
         if (indexO === 0) { 
           indexO = index;

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
@@ -21,17 +21,17 @@ for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     if ((indexB1 === 0xF0) && (indexB2 <= 0x9F)) continue;            
     if ((indexB1 === 0xF4) && (indexB2 >= 0x90)) continue;
-    var hexB2 = decimalToPercentHexString(indexB2);
+    var hexB1_B2 = hexB1 + decimalToPercentHexString(indexB2);
     for (var indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
-      var hexB3 = decimalToPercentHexString(indexB3);
+      var hexB1_B2_B3 = hexB1_B2 + decimalToPercentHexString(indexB3);
       for (var indexB4 = 0x80; indexB4 <= 0xBF; indexB4++) {
-        var hexB4 = decimalToPercentHexString(indexB4);
+        var hexB1_B2_B3_B4 = hexB1_B2_B3 + decimalToPercentHexString(indexB4);
         count++;
         var index = (indexB1 & 0x07) * 0x40000 + (indexB2 & 0x3F) * 0x1000 + (indexB3 & 0x3F) * 0x40 + (indexB4 & 0x3F);
         var L = ((index - 0x10000) & 0x03FF) + 0xDC00;
         var H = (((index - 0x10000) >> 10) & 0x03FF) + 0xD800;  
         try {
-          if (decodeURI(hexB1 + hexB2 + hexB3 + hexB4) === String.fromCharCode(H, L)) continue;
+          if (decodeURI(hexB1_B2_B3_B4) === String.fromCharCode(H, L)) continue;
         } catch (e) {
           if (e instanceof Test262Error) throw e;
         }   

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
@@ -31,7 +31,7 @@ for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
         var L = ((index - 0x10000) & 0x03FF) + 0xDC00;
         var H = (((index - 0x10000) >> 10) & 0x03FF) + 0xD800;  
         try {
-          if (decodeURI(hexB1 + hexB2 + hexB3 + hexB4) === String.fromCharCode(H) + String.fromCharCode(L)) continue;
+          if (decodeURI(hexB1 + hexB2 + hexB3 + hexB4) === String.fromCharCode(H, L)) continue;
         } catch (e) {
           if (e instanceof Test262Error) throw e;
         }   

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
@@ -30,10 +30,8 @@ for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
         var index = (indexB1 & 0x07) * 0x40000 + (indexB2 & 0x3F) * 0x1000 + (indexB3 & 0x3F) * 0x40 + (indexB4 & 0x3F);
         var L = ((index - 0x10000) & 0x03FF) + 0xDC00;
         var H = (((index - 0x10000) >> 10) & 0x03FF) + 0xD800;  
-        try {
-          if (decodeURI(hexB1_B2_B3_B4) === String.fromCharCode(H, L)) continue;
-        } catch (e) {
-        }   
+        if (decodeURI(hexB1_B2_B3_B4) === String.fromCharCode(H, L)) continue;
+
         if (indexO === 0) { 
           indexO = index;
         } else {

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
@@ -8,6 +8,7 @@ info: >
     return UTF8(B1, B2, B3, B4)
 es5id: 15.1.3.1_A2.5_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -30,7 +31,7 @@ for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
         var L = ((index - 0x10000) & 0x03FF) + 0xDC00;
         var H = (((index - 0x10000) >> 10) & 0x03FF) + 0xD800;  
         try {
-          if (decodeURI("%" + hexB1.substring(3) + "%" + hexB2.substring(3) + "%" + hexB3.substring(3) + "%" + hexB4.substring(3)) === String.fromCharCode(H) + String.fromCharCode(L)) continue;
+          if (decodeURI("%" + hexB1.substring(2) + "%" + hexB2.substring(2) + "%" + hexB3.substring(2) + "%" + hexB4.substring(2)) === String.fromCharCode(H) + String.fromCharCode(L)) continue;
         } catch (e) {
           if (e instanceof Test262Error) throw e;
         }   
@@ -67,28 +68,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 4; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
@@ -17,21 +17,21 @@ var indexP;
 var indexO = 0;
 
 for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {     
-  var hexB1 = decimalToHexString(indexB1);
+  var hexB1 = decimalToHex2String(indexB1);
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     if ((indexB1 === 0xF0) && (indexB2 <= 0x9F)) continue;            
     if ((indexB1 === 0xF4) && (indexB2 >= 0x90)) continue;
-    var hexB2 = decimalToHexString(indexB2);
+    var hexB2 = decimalToHex2String(indexB2);
     for (var indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
-      var hexB3 = decimalToHexString(indexB3);
+      var hexB3 = decimalToHex2String(indexB3);
       for (var indexB4 = 0x80; indexB4 <= 0xBF; indexB4++) {
-        var hexB4 = decimalToHexString(indexB4);
+        var hexB4 = decimalToHex2String(indexB4);
         count++;
         var index = (indexB1 & 0x07) * 0x40000 + (indexB2 & 0x3F) * 0x1000 + (indexB3 & 0x3F) * 0x40 + (indexB4 & 0x3F);
         var L = ((index - 0x10000) & 0x03FF) + 0xDC00;
         var H = (((index - 0x10000) >> 10) & 0x03FF) + 0xD800;  
         try {
-          if (decodeURI("%" + hexB1.substring(2) + "%" + hexB2.substring(2) + "%" + hexB3.substring(2) + "%" + hexB4.substring(2)) === String.fromCharCode(H) + String.fromCharCode(L)) continue;
+          if (decodeURI("%" + hexB1 + "%" + hexB2 + "%" + hexB3 + "%" + hexB4) === String.fromCharCode(H) + String.fromCharCode(L)) continue;
         } catch (e) {
           if (e instanceof Test262Error) throw e;
         }   

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T1.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xC0; indexB <= 0xDF; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHexString(indexC);
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURIComponent("%" + hexB.substring(2) + "%" + hexC.substring(2));
+      decodeURIComponent("%" + hexB + "%" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T1.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xC0; indexB <= 0xDF; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURIComponent("%" + hexB + "%" + hexC);
+      decodeURIComponent(hexB + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T1.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.2_A1.13_T1
 description: Complex tests. B = [0xC0 - 0xDF], C = [0x00, 0x7F]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T2.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xC0; indexB <= 0xDF; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHexString(indexC);
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURIComponent("%" + hexB.substring(2) + "%" + hexC.substring(2));
+      decodeURIComponent("%" + hexB + "%" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T2.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xC0; indexB <= 0xDF; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURIComponent("%" + hexB + "%" + hexC);
+      decodeURIComponent(hexB + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.13_T2.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.2_A1.13_T2
 description: Complex tests. B = [0xC0 - 0xDF], C = [0xC0, 0xFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T1.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.2_A1.14_T1
 description: Complex tests. B = [0xE0 - 0xEF], C = [0x00, 0x7F]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T1.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURIComponent("%" + hexB + "%" + hexC + "%A0");
+      decodeURIComponent(hexB + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T1.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHexString(indexC);
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURIComponent("%" + hexB.substring(2) + "%" + hexC.substring(2) + "%A0");
+      decodeURIComponent("%" + hexB + "%" + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T2.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURIComponent("%" + hexB + "%A0" + "%" + hexC);
+      decodeURIComponent(hexB + "%A0" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T2.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHexString(indexC);
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURIComponent("%" + hexB.substring(2) + "%A0" + "%" + hexC.substring(2));
+      decodeURIComponent("%" + hexB + "%A0" + "%" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T2.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.2_A1.14_T2
 description: Complex tests. B = [0xE0 - 0xEF], C = [0x00, 0x7F]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T3.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURIComponent("%" + hexB + "%" + hexC + "%A0");
+      decodeURIComponent(hexB + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T3.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHexString(indexC);
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURIComponent("%" + hexB.substring(2) + "%" + hexC.substring(2) + "%A0");
+      decodeURIComponent("%" + hexB + "%" + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T3.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.2_A1.14_T3
 description: Complex tests. B = [0xE0 - 0xEF], C = [0xC0, 0xFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T4.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T4.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.2_A1.14_T4
 description: Complex tests. B = [0xE0 - 0xEF], C = [0xC0, 0xFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T4.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T4.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURIComponent("%" + hexB + "%A0" + "%" + hexC);
+      decodeURIComponent(hexB + "%A0" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T4.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.14_T4.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xE0; indexB <= 0xEF; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHexString(indexC);
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURIComponent("%" + hexB.substring(2) + "%A0" + "%" + hexC.substring(2));
+      decodeURIComponent("%" + hexB + "%A0" + "%" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T1.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHexString(indexC);
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURIComponent("%" + hexB.substring(2) + "%" + hexC.substring(2) + "%A0%A0");
+      decodeURIComponent("%" + hexB + "%" + hexC + "%A0%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T1.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.2_A1.15_T1
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0x00, 0x7F]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T1.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURIComponent("%" + hexB + "%" + hexC + "%A0%A0");
+      decodeURIComponent(hexB + hexC + "%A0%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T2.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.2_A1.15_T2
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0x00, 0x7F]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T2.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHexString(indexC);
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURIComponent("%" + hexB.substring(2) + "%A0" + "%" + hexC.substring(2) + "%A0");
+      decodeURIComponent("%" + hexB + "%A0" + "%" + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T2.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURIComponent("%" + hexB + "%A0" + "%" + hexC + "%A0");
+      decodeURIComponent(hexB + "%A0" + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T3.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURIComponent("%" + hexB + "%A0%A0" + "%" + hexC);
+      decodeURIComponent(hexB + "%A0%A0" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T3.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.2_A1.15_T3
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0x00, 0x7F]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T3.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0x00; indexC <= 0x7F; indexC++) {
-    var hexC = decimalToHexString(indexC);
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURIComponent("%" + hexB.substring(2) + "%A0%A0" + "%" + hexC.substring(2));
+      decodeURIComponent("%" + hexB + "%A0%A0" + "%" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T4.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T4.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURIComponent("%" + hexB + "%" + hexC + "%A0%A0");
+      decodeURIComponent(hexB + hexC + "%A0%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T4.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T4.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.2_A1.15_T4
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0xC0, 0xFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T4.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T4.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHexString(indexC);
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURIComponent("%" + hexB.substring(2) + "%" + hexC.substring(2) + "%A0%A0");
+      decodeURIComponent("%" + hexB + "%" + hexC + "%A0%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T5.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T5.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURIComponent("%" + hexB + "%A0" + "%" + hexC + "%A0");
+      decodeURIComponent(hexB + "%A0" + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T5.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T5.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.2_A1.15_T5
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0xC0, 0xFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T5.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T5.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHexString(indexC);
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURIComponent("%" + hexB.substring(2) + "%A0" + "%" + hexC.substring(2) + "%A0");
+      decodeURIComponent("%" + hexB + "%A0" + "%" + hexC + "%A0");
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T6.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T6.js
@@ -7,6 +7,7 @@ info: >
     throw URIError
 es5id: 15.1.3.2_A1.15_T6
 description: Complex tests. B = [0xF0 - 0x0F7], C = [0xC0, 0xFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -59,28 +60,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T6.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T6.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHex2String(indexB);
+  var hexB = decimalToPercentHexString(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHex2String(indexC);
+    var hexC = decimalToPercentHexString(indexC);
     try {
-      decodeURIComponent("%" + hexB + "%A0%A0" + "%" + hexC);
+      decodeURIComponent(hexB + "%A0%A0" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T6.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.15_T6.js
@@ -17,12 +17,12 @@ var indexO = 0;
 
 for (var indexB = 0xF0; indexB <= 0xF7; indexB++) {
   count++; 
-  var hexB = decimalToHexString(indexB);
+  var hexB = decimalToHex2String(indexB);
   var result = true;
   for (var indexC = 0xC0; indexC <= 0xFF; indexC++) {
-    var hexC = decimalToHexString(indexC);
+    var hexC = decimalToHex2String(indexC);
     try {
-      decodeURIComponent("%" + hexB.substring(2) + "%A0%A0" + "%" + hexC.substring(2));
+      decodeURIComponent("%" + hexB + "%A0%A0" + "%" + hexC);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T1.js
@@ -5,6 +5,7 @@
 info: If B = 10xxxxxx or B = 11111xxx, throw URIError
 es5id: 15.1.3.2_A1.3_T1
 description: Complex tests. B = 10xxxxxx -> B in [0x80 - 0xBF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -50,28 +51,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T1.js
@@ -15,9 +15,9 @@ var indexO = 0;
 
 for (var index = 0x80; index <= 0xBF; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURIComponent("%" + hex.substring(2));
+    decodeURIComponent("%" + hex);
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T1.js
@@ -15,9 +15,9 @@ var indexO = 0;
 
 for (var index = 0x80; index <= 0xBF; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURIComponent("%" + hex);
+    decodeURIComponent(hex);
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T2.js
@@ -15,9 +15,9 @@ var indexO = 0;
 
 for (var index = 0xF8; index <= 0xFF; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURIComponent("%" + hex.substring(2));
+    decodeURIComponent("%" + hex);
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T2.js
@@ -5,6 +5,7 @@
 info: If B = 10xxxxxx or B = 11111xxx, throw URIError
 es5id: 15.1.3.2_A1.3_T2
 description: Complex tests. B = 11111xxx -> B in [0xF8 - 0xFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -50,28 +51,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.3_T2.js
@@ -15,9 +15,9 @@ var indexO = 0;
 
 for (var index = 0xF8; index <= 0xFF; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURIComponent("%" + hex);
+    decodeURIComponent(hex);
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.4_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.4_T1.js
@@ -5,6 +5,7 @@
 info: If B = 110xxxxx (n = 2) and (k + 2) + 3 >= length, throw URIError
 es5id: 15.1.3.2_A1.4_T1
 description: Complex tests. B = [0xC0 - 0xDF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -58,28 +59,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.4_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.4_T1.js
@@ -18,9 +18,9 @@ for (var index = 0xC0; index <= 0xDF; index++) {
   var str = "";
   var result = true;
   for (var len = 0; len < 3; len++) {
-    var hex = decimalToHexString(index);
+    var hex = decimalToHex2String(index);
     try {
-      decodeURIComponent("%" + hex.substring(2) + str);      
+      decodeURIComponent("%" + hex + str);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.4_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.4_T1.js
@@ -18,9 +18,9 @@ for (var index = 0xC0; index <= 0xDF; index++) {
   var str = "";
   var result = true;
   for (var len = 0; len < 3; len++) {
-    var hex = decimalToHex2String(index);
+    var hex = decimalToPercentHexString(index);
     try {
-      decodeURIComponent("%" + hex + str);
+      decodeURIComponent(hex + str);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.5_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.5_T1.js
@@ -5,6 +5,7 @@
 info: If B = 1110xxxx (n = 3) and (k + 2) + 6 >= length, throw URIError
 es5id: 15.1.3.2_A1.5_T1
 description: Complex tests. B = [0xE0 - 0xEF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -58,28 +59,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.5_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.5_T1.js
@@ -18,9 +18,9 @@ for (var index = 0xE0; index <= 0xEF; index++) {
   var str = "";
   var result = true;
   for (var len = 0; len < 6; len++) {
-    var hex = decimalToHexString(index);
+    var hex = decimalToHex2String(index);
     try {
-      decodeURIComponent("%" + hex.substring(2) + str);      
+      decodeURIComponent("%" + hex + str);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.5_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.5_T1.js
@@ -18,9 +18,9 @@ for (var index = 0xE0; index <= 0xEF; index++) {
   var str = "";
   var result = true;
   for (var len = 0; len < 6; len++) {
-    var hex = decimalToHex2String(index);
+    var hex = decimalToPercentHexString(index);
     try {
-      decodeURIComponent("%" + hex + str);
+      decodeURIComponent(hex + str);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.6_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.6_T1.js
@@ -18,9 +18,9 @@ for (var index = 0xF0; index <= 0xF7; index++) {
   var str = "";
   var result = true;
   for (var len = 0; len < 9; len++) {
-    var hex = decimalToHexString(index);
+    var hex = decimalToHex2String(index);
     try {
-      decodeURIComponent("%" + hex.substring(2) + str);      
+      decodeURIComponent("%" + hex + str);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.6_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.6_T1.js
@@ -18,9 +18,9 @@ for (var index = 0xF0; index <= 0xF7; index++) {
   var str = "";
   var result = true;
   for (var len = 0; len < 9; len++) {
-    var hex = decimalToHex2String(index);
+    var hex = decimalToPercentHexString(index);
     try {
-      decodeURIComponent("%" + hex + str);
+      decodeURIComponent(hex + str);
     } catch (e) { 
       if ((e instanceof URIError) === true) continue;                
     }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.6_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.6_T1.js
@@ -5,6 +5,7 @@
 info: If B = 11110xxx (n = 4) and (k + 2) + 9 >= length, throw URIError
 es5id: 15.1.3.2_A1.6_T1
 description: Complex tests. B = [0xF0 - 0xF7]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -58,28 +59,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.7_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.7_T1.js
@@ -17,9 +17,9 @@ var indexO = 0;
 
 for (var index = 0xC0; index <= 0xDF; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURIComponent("%" + hex + "111");
+    decodeURIComponent(hex + "111");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.7_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.7_T1.js
@@ -7,6 +7,7 @@ info: >
     URIError
 es5id: 15.1.3.2_A1.7_T1
 description: Complex tests. B = [0xC0 - 0xDF]
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -52,28 +53,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.7_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.7_T1.js
@@ -17,9 +17,9 @@ var indexO = 0;
 
 for (var index = 0xC0; index <= 0xDF; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURIComponent("%" + hex.substring(2) + "111");
+    decodeURIComponent("%" + hex + "111");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T1.js
@@ -7,8 +7,8 @@ info: >
     string.charAt(k + 6) not equal "%", throw URIError
 es5id: 15.1.3.2_A1.8_T1
 description: >
-    Complex tests. B = [0xE0 - 0xEF],  string.charAt(k + 3) not equal
-    "%"
+    Complex tests. B = [0xE0 - 0xEF],  string.charAt(k + 3) not equal "%"
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -54,28 +54,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T1.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xE0; index <= 0xEF; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURIComponent("%" + hex + "111%A0");
+    decodeURIComponent(hex + "111%A0");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T1.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xE0; index <= 0xEF; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURIComponent("%" + hex.substring(2) + "111%A0");
+    decodeURIComponent("%" + hex + "111%A0");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T2.js
@@ -7,8 +7,8 @@ info: >
     string.charAt(k + 6) not equal "%", throw URIError
 es5id: 15.1.3.2_A1.8_T2
 description: >
-    Complex tests. B = [0xE0 - 0xEF],  string.charAt(k + 6) not equal
-    "%"
+    Complex tests. B = [0xE0 - 0xEF],  string.charAt(k + 6) not equal "%"
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -54,28 +54,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T2.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xE0; index <= 0xEF; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURIComponent("%" + hex + "%A0111");
+    decodeURIComponent(hex + "%A0111");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.8_T2.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xE0; index <= 0xEF; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURIComponent("%" + hex.substring(2) + "%A0111");
+    decodeURIComponent("%" + hex + "%A0111");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T1.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURIComponent("%" + hex + "111%A0%A0");
+    decodeURIComponent(hex + "111%A0%A0");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T1.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURIComponent("%" + hex.substring(2) + "111%A0%A0");
+    decodeURIComponent("%" + hex + "111%A0%A0");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T1.js
@@ -7,8 +7,8 @@ info: >
     string.charAt(k + 6), string.charAt(k + 9) not equal "%", throw URIError
 es5id: 15.1.3.2_A1.9_T1
 description: >
-    Complex tests. B = [0xF0 - 0x0F7],  string.charAt(k + 3) not equal
-    "%"
+    Complex tests. B = [0xF0 - 0x0F7],  string.charAt(k + 3) not equal "%"
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -54,28 +54,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T2.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURIComponent("%" + hex + "%A0111%A0");
+    decodeURIComponent(hex + "%A0111%A0");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T2.js
@@ -7,8 +7,8 @@ info: >
     string.charAt(k + 6), string.charAt(k + 9) not equal "%", throw URIError
 es5id: 15.1.3.2_A1.9_T2
 description: >
-    Complex tests. B = [0xF0 - 0x0F7],  string.charAt(k + 6) not equal
-    "%"
+    Complex tests. B = [0xF0 - 0x0F7],  string.charAt(k + 6) not equal "%"
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -54,28 +54,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T2.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURIComponent("%" + hex.substring(2) + "%A0111%A0");
+    decodeURIComponent("%" + hex + "%A0111%A0");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T3.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  var hex = decimalToHex2String(index);
+  var hex = decimalToPercentHexString(index);
   try {
-    decodeURIComponent("%" + hex + "%A0%A0111");
+    decodeURIComponent(hex + "%A0%A0111");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T3.js
@@ -18,9 +18,9 @@ var indexO = 0;
 
 for (var index = 0xF0; index <= 0xF7; index++) {
   count++; 
-  var hex = decimalToHexString(index);
+  var hex = decimalToHex2String(index);
   try {
-    decodeURIComponent("%" + hex.substring(2) + "%A0%A0111");
+    decodeURIComponent("%" + hex + "%A0%A0111");
   } catch (e) { 
     if ((e instanceof URIError) === true) continue;                
   }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.9_T3.js
@@ -7,8 +7,8 @@ info: >
     string.charAt(k + 6), string.charAt(k + 9) not equal "%", throw URIError
 es5id: 15.1.3.2_A1.9_T3
 description: >
-    Complex tests. B = [0xF0 - 0x0F7],  string.charAt(k + 9) not equal
-    "%"
+    Complex tests. B = [0xF0 - 0x0F7],  string.charAt(k + 9) not equal "%"
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -54,28 +54,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.1_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.1_T1.js
@@ -5,6 +5,7 @@
 info: If string.charAt(k) not equal "%", return this char
 es5id: 15.1.3.2_A2.1_T1
 description: Complex tests
+includes: [decimalToHexString.js]
 ---*/
 
 //CHECK
@@ -29,28 +30,4 @@ for (var indexI = 0; indexI <= 65535; indexI++) {
 
 if (errorCount > 0) {    
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count);
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.2_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.2_T1.js
@@ -14,11 +14,11 @@ var indexP;
 var indexO = 0;
 for (var indexB1 = 0x00; indexB1 <= 0x7F; indexB1++) {
   count++;
-  var hexB1 = decimalToHex2String(indexB1);
+  var hexB1 = decimalToPercentHexString(indexB1);
   var index = indexB1;  
   try {
     var hex = String.fromCharCode(index);
-    if (decodeURIComponent("%" + hexB1) === hex) continue;
+    if (decodeURIComponent(hexB1) === hex) continue;
   } catch (e) {
     if (e instanceof Test262Error) throw e;
   }   

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.2_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.2_T1.js
@@ -14,11 +14,11 @@ var indexP;
 var indexO = 0;
 for (var indexB1 = 0x00; indexB1 <= 0x7F; indexB1++) {
   count++;
-  var hexB1 = decimalToHexString(indexB1);  
+  var hexB1 = decimalToHex2String(indexB1);
   var index = indexB1;  
   try {
     var hex = String.fromCharCode(index);
-    if (decodeURIComponent("%" + hexB1.substring(2)) === hex) continue;
+    if (decodeURIComponent("%" + hexB1) === hex) continue;
   } catch (e) {
     if (e instanceof Test262Error) throw e;
   }   

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.2_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.2_T1.js
@@ -5,6 +5,7 @@
 info: If B1 = 0xxxxxxxx ([0x00 - 0x7F]), return B1
 es5id: 15.1.3.2_A2.2_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -51,28 +52,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.2_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.2_T1.js
@@ -16,11 +16,9 @@ for (var indexB1 = 0x00; indexB1 <= 0x7F; indexB1++) {
   count++;
   var hexB1 = decimalToPercentHexString(indexB1);
   var index = indexB1;  
-  try {
-    var hex = String.fromCharCode(index);
-    if (decodeURIComponent(hexB1) === hex) continue;
-  } catch (e) {
-  }   
+  var hex = String.fromCharCode(index);
+  if (decodeURIComponent(hexB1) === hex) continue;
+
   if (indexO === 0) { 
     indexO = index;
   } else {

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.2_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.2_T1.js
@@ -20,7 +20,6 @@ for (var indexB1 = 0x00; indexB1 <= 0x7F; indexB1++) {
     var hex = String.fromCharCode(index);
     if (decodeURIComponent(hexB1) === hex) continue;
   } catch (e) {
-    if (e instanceof Test262Error) throw e;
   }   
   if (indexO === 0) { 
     indexO = index;

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
@@ -21,10 +21,8 @@ for (var indexB1 = 0xC2; indexB1 <= 0xDF; indexB1++) {
     count++;
     var hexB1_B2 = hexB1 + decimalToPercentHexString(indexB2);
     var index = (indexB1 & 0x1F) * 0x40 + (indexB2 & 0x3F);  
-    try {
-      if (decodeURIComponent(hexB1_B2) === String.fromCharCode(index)) continue;
-    } catch (e) {
-    }   
+    if (decodeURIComponent(hexB1_B2) === String.fromCharCode(index)) continue;
+
     if (indexO === 0) { 
       indexO = index;
     } else {

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
@@ -7,6 +7,7 @@ info: >
     B1 = [0xC0, 0xC1], return UTF8(B1, B2)
 es5id: 15.1.3.2_A2.3_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -56,28 +57,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
@@ -16,13 +16,13 @@ var indexP;
 var indexO = 0;
 
 for (var indexB1 = 0xC2; indexB1 <= 0xDF; indexB1++) {
-  var hexB1 = decimalToHex2String(indexB1);
+  var hexB1 = decimalToPercentHexString(indexB1);
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     count++;
-    var hexB2 = decimalToHex2String(indexB2);
+    var hexB2 = decimalToPercentHexString(indexB2);
     var index = (indexB1 & 0x1F) * 0x40 + (indexB2 & 0x3F);  
     try {
-      if (decodeURIComponent("%" + hexB1 + "%" + hexB2) === String.fromCharCode(index)) continue;
+      if (decodeURIComponent(hexB1 + hexB2) === String.fromCharCode(index)) continue;
     } catch (e) {
       if (e instanceof Test262Error) throw e;
     }   

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
@@ -16,13 +16,13 @@ var indexP;
 var indexO = 0;
 
 for (var indexB1 = 0xC2; indexB1 <= 0xDF; indexB1++) {
-  var hexB1 = decimalToHexString(indexB1);
+  var hexB1 = decimalToHex2String(indexB1);
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     count++;
-    var hexB2 = decimalToHexString(indexB2);
+    var hexB2 = decimalToHex2String(indexB2);
     var index = (indexB1 & 0x1F) * 0x40 + (indexB2 & 0x3F);  
     try {
-      if (decodeURIComponent("%" + hexB1.substring(2) + "%" + hexB2.substring(2)) === String.fromCharCode(index)) continue;
+      if (decodeURIComponent("%" + hexB1 + "%" + hexB2) === String.fromCharCode(index)) continue;
     } catch (e) {
       if (e instanceof Test262Error) throw e;
     }   

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
@@ -24,7 +24,6 @@ for (var indexB1 = 0xC2; indexB1 <= 0xDF; indexB1++) {
     try {
       if (decodeURIComponent(hexB1_B2) === String.fromCharCode(index)) continue;
     } catch (e) {
-      if (e instanceof Test262Error) throw e;
     }   
     if (indexO === 0) { 
       indexO = index;

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.3_T1.js
@@ -19,10 +19,10 @@ for (var indexB1 = 0xC2; indexB1 <= 0xDF; indexB1++) {
   var hexB1 = decimalToPercentHexString(indexB1);
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     count++;
-    var hexB2 = decimalToPercentHexString(indexB2);
+    var hexB1_B2 = hexB1 + decimalToPercentHexString(indexB2);
     var index = (indexB1 & 0x1F) * 0x40 + (indexB2 & 0x3F);  
     try {
-      if (decodeURIComponent(hexB1 + hexB2) === String.fromCharCode(index)) continue;
+      if (decodeURIComponent(hexB1_B2) === String.fromCharCode(index)) continue;
     } catch (e) {
       if (e instanceof Test262Error) throw e;
     }   

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
@@ -17,17 +17,17 @@ var indexP;
 var indexO = 0;
 
 for (var indexB1 = 0xE0; indexB1 <= 0xEF; indexB1++) {
-  var hexB1 = decimalToHexString(indexB1);
+  var hexB1 = decimalToHex2String(indexB1);
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     if ((indexB1 === 0xE0) && (indexB2 <= 0x9F)) continue;
     if ((indexB1 === 0xED) && (0xA0 <= indexB2)) continue;         
-    var hexB2 = decimalToHexString(indexB2);
+    var hexB2 = decimalToHex2String(indexB2);
     for (var indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
       count++;
-      var hexB3 = decimalToHexString(indexB3);
+      var hexB3 = decimalToHex2String(indexB3);
       var index = (indexB1 & 0x0F) * 0x1000 + (indexB2 & 0x3F) * 0x40 + (indexB3 & 0x3F);  
       try {
-        if (decodeURIComponent("%" + hexB1.substring(2) + "%" + hexB2.substring(2) + "%" + hexB3.substring(2)) === String.fromCharCode(index)) continue;
+        if (decodeURIComponent("%" + hexB1 + "%" + hexB2 + "%" + hexB3) === String.fromCharCode(index)) continue;
       } catch (e) {
         if (e instanceof Test262Error) throw e;
       }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
@@ -29,7 +29,6 @@ for (var indexB1 = 0xE0; indexB1 <= 0xEF; indexB1++) {
       try {
         if (decodeURIComponent(hexB1_B2_B3) === String.fromCharCode(index)) continue;
       } catch (e) {
-        if (e instanceof Test262Error) throw e;
       }
       if (indexO === 0) { 
         indexO = index;

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
@@ -17,17 +17,17 @@ var indexP;
 var indexO = 0;
 
 for (var indexB1 = 0xE0; indexB1 <= 0xEF; indexB1++) {
-  var hexB1 = decimalToHex2String(indexB1);
+  var hexB1 = decimalToPercentHexString(indexB1);
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     if ((indexB1 === 0xE0) && (indexB2 <= 0x9F)) continue;
     if ((indexB1 === 0xED) && (0xA0 <= indexB2)) continue;         
-    var hexB2 = decimalToHex2String(indexB2);
+    var hexB2 = decimalToPercentHexString(indexB2);
     for (var indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
       count++;
-      var hexB3 = decimalToHex2String(indexB3);
+      var hexB3 = decimalToPercentHexString(indexB3);
       var index = (indexB1 & 0x0F) * 0x1000 + (indexB2 & 0x3F) * 0x40 + (indexB3 & 0x3F);  
       try {
-        if (decodeURIComponent("%" + hexB1 + "%" + hexB2 + "%" + hexB3) === String.fromCharCode(index)) continue;
+        if (decodeURIComponent(hexB1 + hexB2 + hexB3) === String.fromCharCode(index)) continue;
       } catch (e) {
         if (e instanceof Test262Error) throw e;
       }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
@@ -26,10 +26,8 @@ for (var indexB1 = 0xE0; indexB1 <= 0xEF; indexB1++) {
       count++;
       var hexB1_B2_B3 = hexB1_B2 + decimalToPercentHexString(indexB3);
       var index = (indexB1 & 0x0F) * 0x1000 + (indexB2 & 0x3F) * 0x40 + (indexB3 & 0x3F);  
-      try {
-        if (decodeURIComponent(hexB1_B2_B3) === String.fromCharCode(index)) continue;
-      } catch (e) {
-      }
+      if (decodeURIComponent(hexB1_B2_B3) === String.fromCharCode(index)) continue;
+
       if (indexO === 0) { 
         indexO = index;
       } else {

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
@@ -21,13 +21,13 @@ for (var indexB1 = 0xE0; indexB1 <= 0xEF; indexB1++) {
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     if ((indexB1 === 0xE0) && (indexB2 <= 0x9F)) continue;
     if ((indexB1 === 0xED) && (0xA0 <= indexB2)) continue;         
-    var hexB2 = decimalToPercentHexString(indexB2);
+    var hexB1_B2 = hexB1 + decimalToPercentHexString(indexB2);
     for (var indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
       count++;
-      var hexB3 = decimalToPercentHexString(indexB3);
+      var hexB1_B2_B3 = hexB1_B2 + decimalToPercentHexString(indexB3);
       var index = (indexB1 & 0x0F) * 0x1000 + (indexB2 & 0x3F) * 0x40 + (indexB3 & 0x3F);  
       try {
-        if (decodeURIComponent(hexB1 + hexB2 + hexB3) === String.fromCharCode(index)) continue;
+        if (decodeURIComponent(hexB1_B2_B3) === String.fromCharCode(index)) continue;
       } catch (e) {
         if (e instanceof Test262Error) throw e;
       }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
@@ -8,6 +8,7 @@ info: >
     0xDFFF), return UTF8(B1, B2, B3)
 es5id: 15.1.3.2_A2.4_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -62,28 +63,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
@@ -21,17 +21,17 @@ for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     if ((indexB1 === 0xF0) && (indexB2 <= 0x9F)) continue;            
     if ((indexB1 === 0xF4) && (indexB2 >= 0x90)) continue;
-    var hexB2 = decimalToPercentHexString(indexB2);
+    var hexB1_B2 = hexB1 + decimalToPercentHexString(indexB2);
     for (var indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
-      var hexB3 = decimalToPercentHexString(indexB3);
+      var hexB1_B2_B3 = hexB1_B2 + decimalToPercentHexString(indexB3);
       for (var indexB4 = 0x80; indexB4 <= 0xBF; indexB4++) {
-        var hexB4 = decimalToPercentHexString(indexB4);
+        var hexB1_B2_B3_B4 = hexB1_B2_B3 + decimalToPercentHexString(indexB4);
         count++;
         var index = (indexB1 & 0x07) * 0x40000 + (indexB2 & 0x3F) * 0x1000 + (indexB3 & 0x3F) * 0x40 + (indexB4 & 0x3F);
         var L = ((index - 0x10000) & 0x03FF) + 0xDC00;
         var H = (((index - 0x10000) >> 10) & 0x03FF) + 0xD800;  
         try {
-          if (decodeURIComponent(hexB1 + hexB2 + hexB3 + hexB4) === String.fromCharCode(H, L)) continue;
+          if (decodeURIComponent(hexB1_B2_B3_B4) === String.fromCharCode(H, L)) continue;
         } catch (e) {
           if (e instanceof Test262Error) throw e;
         }   

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
@@ -17,21 +17,21 @@ var indexP;
 var indexO = 0;
 
 for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
-  var hexB1 = decimalToHexString(indexB1);
+  var hexB1 = decimalToHex2String(indexB1);
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     if ((indexB1 === 0xF0) && (indexB2 <= 0x9F)) continue;            
     if ((indexB1 === 0xF4) && (indexB2 >= 0x90)) continue;
-    var hexB2 = decimalToHexString(indexB2);
+    var hexB2 = decimalToHex2String(indexB2);
     for (var indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
-      var hexB3 = decimalToHexString(indexB3);
+      var hexB3 = decimalToHex2String(indexB3);
       for (var indexB4 = 0x80; indexB4 <= 0xBF; indexB4++) {
-        var hexB4 = decimalToHexString(indexB4);
+        var hexB4 = decimalToHex2String(indexB4);
         count++;
         var index = (indexB1 & 0x07) * 0x40000 + (indexB2 & 0x3F) * 0x1000 + (indexB3 & 0x3F) * 0x40 + (indexB4 & 0x3F);
         var L = ((index - 0x10000) & 0x03FF) + 0xDC00;
         var H = (((index - 0x10000) >> 10) & 0x03FF) + 0xD800;  
         try {
-          if (decodeURIComponent("%" + hexB1.substring(2) + "%" + hexB2.substring(2) + "%" + hexB3.substring(2) + "%" + hexB4.substring(2)) === String.fromCharCode(H) + String.fromCharCode(L)) continue;
+          if (decodeURIComponent("%" + hexB1 + "%" + hexB2 + "%" + hexB3 + "%" + hexB4) === String.fromCharCode(H) + String.fromCharCode(L)) continue;
         } catch (e) {
           if (e instanceof Test262Error) throw e;
         }   

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
@@ -33,7 +33,6 @@ for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
         try {
           if (decodeURIComponent(hexB1_B2_B3_B4) === String.fromCharCode(H, L)) continue;
         } catch (e) {
-          if (e instanceof Test262Error) throw e;
         }   
         if (indexO === 0) { 
           indexO = index;

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
@@ -30,10 +30,8 @@ for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
         var index = (indexB1 & 0x07) * 0x40000 + (indexB2 & 0x3F) * 0x1000 + (indexB3 & 0x3F) * 0x40 + (indexB4 & 0x3F);
         var L = ((index - 0x10000) & 0x03FF) + 0xDC00;
         var H = (((index - 0x10000) >> 10) & 0x03FF) + 0xD800;  
-        try {
-          if (decodeURIComponent(hexB1_B2_B3_B4) === String.fromCharCode(H, L)) continue;
-        } catch (e) {
-        }   
+        if (decodeURIComponent(hexB1_B2_B3_B4) === String.fromCharCode(H, L)) continue;
+
         if (indexO === 0) { 
           indexO = index;
         } else {

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
@@ -17,21 +17,21 @@ var indexP;
 var indexO = 0;
 
 for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
-  var hexB1 = decimalToHex2String(indexB1);
+  var hexB1 = decimalToPercentHexString(indexB1);
   for (var indexB2 = 0x80; indexB2 <= 0xBF; indexB2++) {
     if ((indexB1 === 0xF0) && (indexB2 <= 0x9F)) continue;            
     if ((indexB1 === 0xF4) && (indexB2 >= 0x90)) continue;
-    var hexB2 = decimalToHex2String(indexB2);
+    var hexB2 = decimalToPercentHexString(indexB2);
     for (var indexB3 = 0x80; indexB3 <= 0xBF; indexB3++) {
-      var hexB3 = decimalToHex2String(indexB3);
+      var hexB3 = decimalToPercentHexString(indexB3);
       for (var indexB4 = 0x80; indexB4 <= 0xBF; indexB4++) {
-        var hexB4 = decimalToHex2String(indexB4);
+        var hexB4 = decimalToPercentHexString(indexB4);
         count++;
         var index = (indexB1 & 0x07) * 0x40000 + (indexB2 & 0x3F) * 0x1000 + (indexB3 & 0x3F) * 0x40 + (indexB4 & 0x3F);
         var L = ((index - 0x10000) & 0x03FF) + 0xDC00;
         var H = (((index - 0x10000) >> 10) & 0x03FF) + 0xD800;  
         try {
-          if (decodeURIComponent("%" + hexB1 + "%" + hexB2 + "%" + hexB3 + "%" + hexB4) === String.fromCharCode(H) + String.fromCharCode(L)) continue;
+          if (decodeURIComponent(hexB1 + hexB2 + hexB3 + hexB4) === String.fromCharCode(H) + String.fromCharCode(L)) continue;
         } catch (e) {
           if (e instanceof Test262Error) throw e;
         }   

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
@@ -8,6 +8,7 @@ info: >
     return UTF8(B1, B2, B3, B4)
 es5id: 15.1.3.2_A2.5_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -30,7 +31,7 @@ for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
         var L = ((index - 0x10000) & 0x03FF) + 0xDC00;
         var H = (((index - 0x10000) >> 10) & 0x03FF) + 0xD800;  
         try {
-          if (decodeURIComponent("%" + hexB1.substring(3) + "%" + hexB2.substring(3) + "%" + hexB3.substring(3) + "%" + hexB4.substring(3)) === String.fromCharCode(H) + String.fromCharCode(L)) continue;
+          if (decodeURIComponent("%" + hexB1.substring(2) + "%" + hexB2.substring(2) + "%" + hexB3.substring(2) + "%" + hexB4.substring(2)) === String.fromCharCode(H) + String.fromCharCode(L)) continue;
         } catch (e) {
           if (e instanceof Test262Error) throw e;
         }   
@@ -67,28 +68,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 4; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
@@ -31,7 +31,7 @@ for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
         var L = ((index - 0x10000) & 0x03FF) + 0xDC00;
         var H = (((index - 0x10000) >> 10) & 0x03FF) + 0xD800;  
         try {
-          if (decodeURIComponent(hexB1 + hexB2 + hexB3 + hexB4) === String.fromCharCode(H) + String.fromCharCode(L)) continue;
+          if (decodeURIComponent(hexB1 + hexB2 + hexB3 + hexB4) === String.fromCharCode(H, L)) continue;
         } catch (e) {
           if (e instanceof Test262Error) throw e;
         }   

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.1_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.1_T1.js
@@ -5,6 +5,7 @@
 info: If string.charAt(k) in [0xDC00 - 0xDFFF], throw URIError
 es5id: 15.1.3.3_A1.1_T1
 description: Complex tests
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -50,28 +51,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.1_T2.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.1_T2.js
@@ -5,6 +5,7 @@
 info: If string.charAt(k) in [0xDC00 - 0xDFFF], throw URIError
 es5id: 15.1.3.3_A1.1_T2
 description: Complex tests
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -50,28 +51,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.2_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.2_T1.js
@@ -7,6 +7,7 @@ info: >
     URIError
 es5id: 15.1.3.3_A1.2_T1
 description: Complex tests
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -52,28 +53,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.2_T2.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.2_T2.js
@@ -7,6 +7,7 @@ info: >
     URIError
 es5id: 15.1.3.3_A1.2_T2
 description: Complex tests
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -52,28 +53,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.3_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.3_T1.js
@@ -9,6 +9,7 @@ es5id: 15.1.3.3_A1.3_T1
 description: >
     Complex tests, string.charAt(k+1) in [0x0000, 0xD7FF, 0xD800,
     0xDBFE, 0xDBFF, 0xE000, 0xFFFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var chars = [0x0000, 0xD7FF, 0xD800, 0xDBFE, 0xDBFF, 0xE000, 0xFFFF];
@@ -61,28 +62,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.1_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.1_T1.js
@@ -28,9 +28,8 @@ for (var index = 0x0000; index <= 0x007F; index++) {
     if (uriUnescaped[indexC] === str) continue l;
   }    
   if ("#" === str) continue l; 
-  try {
-    if (encodeURI(str).toUpperCase() === decimalToPercentHexString(index)) continue l;
-  } catch(e) {}     
+  if (encodeURI(str).toUpperCase() === decimalToPercentHexString(index)) continue l;
+
   if (indexO === 0) { 
     indexO = index;
   } else {

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.1_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.1_T1.js
@@ -29,7 +29,7 @@ for (var index = 0x0000; index <= 0x007F; index++) {
   }    
   if ("#" === str) continue l; 
   try {
-    if (encodeURI(str).toUpperCase() === "%" + decimalToHexString(index).substring(2)) continue l; 
+    if (encodeURI(str).toUpperCase() === "%" + decimalToHex2String(index)) continue l;
   } catch(e) {}     
   if (indexO === 0) { 
     indexO = index;

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.1_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.1_T1.js
@@ -7,6 +7,7 @@ info: >
     return 1 octet (00000000 0zzzzzzz -> 0zzzzzzz)
 es5id: 15.1.3.3_A2.1_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var uriReserved = [";", "/", "?", ":", "@", "&", "=", "+", "$", ","];
@@ -60,28 +61,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.1_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.1_T1.js
@@ -29,7 +29,7 @@ for (var index = 0x0000; index <= 0x007F; index++) {
   }    
   if ("#" === str) continue l; 
   try {
-    if (encodeURI(str).toUpperCase() === "%" + decimalToHex2String(index)) continue l;
+    if (encodeURI(str).toUpperCase() === decimalToPercentHexString(index)) continue l;
   } catch(e) {}     
   if (indexO === 0) { 
     indexO = index;

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.2_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.2_T1.js
@@ -7,6 +7,7 @@ info: >
     yyzzzzzz -> 110yyyyy 10zzzzzz)
 es5id: 15.1.3.3_A2.2_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -52,28 +53,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.2_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.2_T1.js
@@ -20,9 +20,8 @@ for (var index = 0x0080; index <= 0x07FF; index++) {
   var hex1 = decimalToPercentHexString(0x0080 + (index & 0x003F));
   var hex2 = decimalToPercentHexString(0x00C0 + (index & 0x07C0) / 0x0040);
   var str = String.fromCharCode(index);
-  try {
-    if (encodeURI(str).toUpperCase() === hex2 + hex1) continue;
-  } catch(e) {}  
+  if (encodeURI(str).toUpperCase() === hex2 + hex1) continue;
+
   if (indexO === 0) { 
     indexO = index;
   } else {

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.2_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.2_T1.js
@@ -17,11 +17,11 @@ var indexO = 0;
 l:
 for (var index = 0x0080; index <= 0x07FF; index++) {
   count++;  
-  var hex1 = decimalToHex2String(0x0080 + (index & 0x003F));
-  var hex2 = decimalToHex2String(0x00C0 + (index & 0x07C0) / 0x0040);
+  var hex1 = decimalToPercentHexString(0x0080 + (index & 0x003F));
+  var hex2 = decimalToPercentHexString(0x00C0 + (index & 0x07C0) / 0x0040);
   var str = String.fromCharCode(index);
   try {
-    if (encodeURI(str).toUpperCase() === "%" + hex2 + "%" + hex1) continue;
+    if (encodeURI(str).toUpperCase() === hex2 + hex1) continue;
   } catch(e) {}  
   if (indexO === 0) { 
     indexO = index;

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.2_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.2_T1.js
@@ -17,8 +17,8 @@ var indexO = 0;
 l:
 for (var index = 0x0080; index <= 0x07FF; index++) {
   count++;  
-  var hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
-  var hex2 = decimalToHexString(0x00C0 + (index & 0x07C0) / 0x0040).substring(2);
+  var hex1 = decimalToHex2String(0x0080 + (index & 0x003F));
+  var hex2 = decimalToHex2String(0x00C0 + (index & 0x07C0) / 0x0040);
   var str = String.fromCharCode(index);
   try {
     if (encodeURI(str).toUpperCase() === "%" + hex2 + "%" + hex1) continue;

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.3_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.3_T1.js
@@ -7,6 +7,7 @@ info: >
     yyzzzzzz -> 1110xxxx 10yyyyyy 10zzzzzz)
 es5id: 15.1.3.3_A2.3_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -52,28 +53,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.3_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.3_T1.js
@@ -16,9 +16,9 @@ var indexP;
 var indexO = 0; 
 for (var index = 0x0800; index <= 0xD7FF; index++) {
   count++; 
-  var hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
-  var hex2 = decimalToHexString(0x0080 + (index & 0x0FC0) / 0x0040).substring(2);
-  var hex3 = decimalToHexString(0x00E0 + (index & 0xF000) / 0x1000).substring(2);
+  var hex1 = decimalToHex2String(0x0080 + (index & 0x003F));
+  var hex2 = decimalToHex2String(0x0080 + (index & 0x0FC0) / 0x0040);
+  var hex3 = decimalToHex2String(0x00E0 + (index & 0xF000) / 0x1000);
   var str = String.fromCharCode(index);
   try {
     if (encodeURI(str).toUpperCase() === "%" + hex3 + "%" + hex2 + "%" + hex1) continue;

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.3_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.3_T1.js
@@ -20,9 +20,8 @@ for (var index = 0x0800; index <= 0xD7FF; index++) {
   var hex2 = decimalToPercentHexString(0x0080 + (index & 0x0FC0) / 0x0040);
   var hex3 = decimalToPercentHexString(0x00E0 + (index & 0xF000) / 0x1000);
   var str = String.fromCharCode(index);
-  try {
-    if (encodeURI(str).toUpperCase() === hex3 + hex2 + hex1) continue;
-  } catch(e) {}      
+  if (encodeURI(str).toUpperCase() === hex3 + hex2 + hex1) continue;
+
   if (indexO === 0) { 
     indexO = index;
   } else {

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.3_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.3_T1.js
@@ -16,12 +16,12 @@ var indexP;
 var indexO = 0; 
 for (var index = 0x0800; index <= 0xD7FF; index++) {
   count++; 
-  var hex1 = decimalToHex2String(0x0080 + (index & 0x003F));
-  var hex2 = decimalToHex2String(0x0080 + (index & 0x0FC0) / 0x0040);
-  var hex3 = decimalToHex2String(0x00E0 + (index & 0xF000) / 0x1000);
+  var hex1 = decimalToPercentHexString(0x0080 + (index & 0x003F));
+  var hex2 = decimalToPercentHexString(0x0080 + (index & 0x0FC0) / 0x0040);
+  var hex3 = decimalToPercentHexString(0x00E0 + (index & 0xF000) / 0x1000);
   var str = String.fromCharCode(index);
   try {
-    if (encodeURI(str).toUpperCase() === "%" + hex3 + "%" + hex2 + "%" + hex1) continue;
+    if (encodeURI(str).toUpperCase() === hex3 + hex2 + hex1) continue;
   } catch(e) {}      
   if (indexO === 0) { 
     indexO = index;

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.4_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.4_T1.js
@@ -27,11 +27,9 @@ for (var index = 0xD800; index <= 0xDBFF; index++) {
     var hex3 = decimalToPercentHexString(0x0080 + (index1 & 0x3F000) / 0x1000);
     var hex4 = decimalToPercentHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000);
     var str = String.fromCharCode(index, chars[indexC]);
-    try {
-      if (encodeURI(str).toUpperCase() !== hex4 + hex3 + hex2 + hex1) {
-        res = false;
-      }
-    } catch(e) {res = false}    
+    if (encodeURI(str).toUpperCase() === hex4 + hex3 + hex2 + hex1) continue;
+
+    res = false;
   }
   if (res !== true) {  
     if (indexO === 0) { 

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.4_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.4_T1.js
@@ -22,10 +22,10 @@ for (var index = 0xD800; index <= 0xDBFF; index++) {
   var res = true;
   for (var indexC = 0; indexC < chars.length; indexC++) {
     var index1 = (index - 0xD800) * 0x400 + (chars[indexC] - 0xDC00) + 0x10000;
-    var hex1 = decimalToHexString(0x0080 + (index1 & 0x003F)).substring(2);
-    var hex2 = decimalToHexString(0x0080 + (index1 & 0x0FC0) / 0x0040).substring(2);
-    var hex3 = decimalToHexString(0x0080 + (index1 & 0x3F000) / 0x1000).substring(2);
-    var hex4 = decimalToHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000).substring(2);
+    var hex1 = decimalToHex2String(0x0080 + (index1 & 0x003F));
+    var hex2 = decimalToHex2String(0x0080 + (index1 & 0x0FC0) / 0x0040);
+    var hex3 = decimalToHex2String(0x0080 + (index1 & 0x3F000) / 0x1000);
+    var hex4 = decimalToHex2String(0x00F0 + (index1 & 0x1C0000) / 0x40000);
     var str = String.fromCharCode(index, chars[indexC]);
     try {
       if (encodeURI(str).toUpperCase() !== "%" + hex4 + "%" + hex3 + "%" + hex2 + "%" + hex1) {

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.4_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.4_T1.js
@@ -22,13 +22,13 @@ for (var index = 0xD800; index <= 0xDBFF; index++) {
   var res = true;
   for (var indexC = 0; indexC < chars.length; indexC++) {
     var index1 = (index - 0xD800) * 0x400 + (chars[indexC] - 0xDC00) + 0x10000;
-    var hex1 = decimalToHex2String(0x0080 + (index1 & 0x003F));
-    var hex2 = decimalToHex2String(0x0080 + (index1 & 0x0FC0) / 0x0040);
-    var hex3 = decimalToHex2String(0x0080 + (index1 & 0x3F000) / 0x1000);
-    var hex4 = decimalToHex2String(0x00F0 + (index1 & 0x1C0000) / 0x40000);
+    var hex1 = decimalToPercentHexString(0x0080 + (index1 & 0x003F));
+    var hex2 = decimalToPercentHexString(0x0080 + (index1 & 0x0FC0) / 0x0040);
+    var hex3 = decimalToPercentHexString(0x0080 + (index1 & 0x3F000) / 0x1000);
+    var hex4 = decimalToPercentHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000);
     var str = String.fromCharCode(index, chars[indexC]);
     try {
-      if (encodeURI(str).toUpperCase() !== "%" + hex4 + "%" + hex3 + "%" + hex2 + "%" + hex1) {
+      if (encodeURI(str).toUpperCase() !== hex4 + hex3 + hex2 + hex1) {
         res = false;
       }
     } catch(e) {res = false}    

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.4_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.4_T1.js
@@ -10,6 +10,7 @@ es5id: 15.1.3.3_A2.4_T1
 description: >
     Complex tests, use RFC 3629, string.charAt(k+1) in [0xDC00,
     0xDDFF, 0xDFFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var chars = [0xDC00, 0xDDFF, 0xDFFF];
@@ -65,28 +66,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.4_T2.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.4_T2.js
@@ -10,6 +10,7 @@ es5id: 15.1.3.3_A2.4_T2
 description: >
     Complex tests, use RFC 3629, string.charAt(k) in [0xD800, 0xDBFF,
     0xD9FF]
+includes: [decimalToHexString.js]
 ---*/
 
 var chars = [0xD800, 0xDBFF, 0xD9FF];
@@ -65,28 +66,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.4_T2.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.4_T2.js
@@ -22,13 +22,13 @@ for (var index = 0xDC00; index <= 0xDFFF; index++) {
   var res = true;
   for (var indexC = 0; indexC < chars.length; indexC++) {
     var index1 = (chars[indexC] - 0xD800) * 0x400 + (index - 0xDC00) + 0x10000;
-    var hex1 = decimalToHex2String(0x0080 + (index1 & 0x003F));
-    var hex2 = decimalToHex2String(0x0080 + (index1 & 0x0FC0) / 0x0040);
-    var hex3 = decimalToHex2String(0x0080 + (index1 & 0x3F000) / 0x1000);
-    var hex4 = decimalToHex2String(0x00F0 + (index1 & 0x1C0000) / 0x40000);
+    var hex1 = decimalToPercentHexString(0x0080 + (index1 & 0x003F));
+    var hex2 = decimalToPercentHexString(0x0080 + (index1 & 0x0FC0) / 0x0040);
+    var hex3 = decimalToPercentHexString(0x0080 + (index1 & 0x3F000) / 0x1000);
+    var hex4 = decimalToPercentHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000);
     var str = String.fromCharCode(chars[indexC], index);
     try {
-      if (encodeURI(str).toUpperCase() !== "%" + hex4 + "%" + hex3 + "%" + hex2 + "%" + hex1) {
+      if (encodeURI(str).toUpperCase() !== hex4 + hex3 + hex2 + hex1) {
         res = false;
       }
     } catch(e) {res = false}    

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.4_T2.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.4_T2.js
@@ -27,11 +27,9 @@ for (var index = 0xDC00; index <= 0xDFFF; index++) {
     var hex3 = decimalToPercentHexString(0x0080 + (index1 & 0x3F000) / 0x1000);
     var hex4 = decimalToPercentHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000);
     var str = String.fromCharCode(chars[indexC], index);
-    try {
-      if (encodeURI(str).toUpperCase() !== hex4 + hex3 + hex2 + hex1) {
-        res = false;
-      }
-    } catch(e) {res = false}    
+    if (encodeURI(str).toUpperCase() === hex4 + hex3 + hex2 + hex1) continue;
+
+    res = false;
   }
   if (res !== true) {  
     if (indexO === 0) { 

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.4_T2.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.4_T2.js
@@ -22,10 +22,10 @@ for (var index = 0xDC00; index <= 0xDFFF; index++) {
   var res = true;
   for (var indexC = 0; indexC < chars.length; indexC++) {
     var index1 = (chars[indexC] - 0xD800) * 0x400 + (index - 0xDC00) + 0x10000;
-    var hex1 = decimalToHexString(0x0080 + (index1 & 0x003F)).substring(2);
-    var hex2 = decimalToHexString(0x0080 + (index1 & 0x0FC0) / 0x0040).substring(2);
-    var hex3 = decimalToHexString(0x0080 + (index1 & 0x3F000) / 0x1000).substring(2);
-    var hex4 = decimalToHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000).substring(2);
+    var hex1 = decimalToHex2String(0x0080 + (index1 & 0x003F));
+    var hex2 = decimalToHex2String(0x0080 + (index1 & 0x0FC0) / 0x0040);
+    var hex3 = decimalToHex2String(0x0080 + (index1 & 0x3F000) / 0x1000);
+    var hex4 = decimalToHex2String(0x00F0 + (index1 & 0x1C0000) / 0x40000);
     var str = String.fromCharCode(chars[indexC], index);
     try {
       if (encodeURI(str).toUpperCase() !== "%" + hex4 + "%" + hex3 + "%" + hex2 + "%" + hex1) {

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.5_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.5_T1.js
@@ -16,12 +16,12 @@ var indexP;
 var indexO = 0; 
 for (var index = 0xE000; index <= 0xFFFF; index++) {
   count++;  
-  var hex1 = decimalToHex2String(0x0080 + (index & 0x003F));
-  var hex2 = decimalToHex2String(0x0080 + (index & 0x0FC0) / 0x0040);
-  var hex3 = decimalToHex2String(0x00E0 + (index & 0xF000) / 0x1000);
+  var hex1 = decimalToPercentHexString(0x0080 + (index & 0x003F));
+  var hex2 = decimalToPercentHexString(0x0080 + (index & 0x0FC0) / 0x0040);
+  var hex3 = decimalToPercentHexString(0x00E0 + (index & 0xF000) / 0x1000);
   var str = String.fromCharCode(index);
   try {
-    if (encodeURI(str).toUpperCase() === "%" + hex3 + "%" + hex2 + "%" + hex1) continue;
+    if (encodeURI(str).toUpperCase() === hex3 + hex2 + hex1) continue;
   } catch(e) {}      
   if (indexO === 0) { 
     indexO = index;

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.5_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.5_T1.js
@@ -7,6 +7,7 @@ info: >
     yyzzzzzz -> 1110xxxx 10yyyyyy 10zzzzzz)
 es5id: 15.1.3.3_A2.5_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -52,28 +53,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.5_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.5_T1.js
@@ -20,9 +20,8 @@ for (var index = 0xE000; index <= 0xFFFF; index++) {
   var hex2 = decimalToPercentHexString(0x0080 + (index & 0x0FC0) / 0x0040);
   var hex3 = decimalToPercentHexString(0x00E0 + (index & 0xF000) / 0x1000);
   var str = String.fromCharCode(index);
-  try {
-    if (encodeURI(str).toUpperCase() === hex3 + hex2 + hex1) continue;
-  } catch(e) {}      
+  if (encodeURI(str).toUpperCase() === hex3 + hex2 + hex1) continue;
+
   if (indexO === 0) { 
     indexO = index;
   } else {

--- a/test/built-ins/encodeURI/S15.1.3.3_A2.5_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A2.5_T1.js
@@ -16,9 +16,9 @@ var indexP;
 var indexO = 0; 
 for (var index = 0xE000; index <= 0xFFFF; index++) {
   count++;  
-  var hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
-  var hex2 = decimalToHexString(0x0080 + (index & 0x0FC0) / 0x0040).substring(2);
-  var hex3 = decimalToHexString(0x00E0 + (index & 0xF000) / 0x1000).substring(2);
+  var hex1 = decimalToHex2String(0x0080 + (index & 0x003F));
+  var hex2 = decimalToHex2String(0x0080 + (index & 0x0FC0) / 0x0040);
+  var hex3 = decimalToHex2String(0x00E0 + (index & 0xF000) / 0x1000);
   var str = String.fromCharCode(index);
   try {
     if (encodeURI(str).toUpperCase() === "%" + hex3 + "%" + hex2 + "%" + hex1) continue;

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.1_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.1_T1.js
@@ -5,6 +5,7 @@
 info: If string.charAt(k) in [0xDC00 - 0xDFFF], throw URIError
 es5id: 15.1.3.4_A1.1_T1
 description: Complex tests
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -50,28 +51,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.1_T2.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.1_T2.js
@@ -5,6 +5,7 @@
 info: If string.charAt(k) in [0xDC00 - 0xDFFF], throw URIError
 es5id: 15.1.3.4_A1.1_T2
 description: Complex tests
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -50,28 +51,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.2_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.2_T1.js
@@ -7,6 +7,7 @@ info: >
     URIError
 es5id: 15.1.3.4_A1.2_T1
 description: Complex tests
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -52,28 +53,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.2_T2.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.2_T2.js
@@ -7,6 +7,7 @@ info: >
     URIError
 es5id: 15.1.3.4_A1.2_T2
 description: Complex tests
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -52,28 +53,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.3_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.3_T1.js
@@ -9,6 +9,7 @@ es5id: 15.1.3.4_A1.3_T1
 description: >
     Complex tests, string.charAt(k+1) in [0x0000, 0xD7FF, 0xD800,
     0xDBFE, 0xDBFF, 0xE000, 0xFFFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var chars = [0x0000, 0xD7FF, 0xD800, 0xDBFE, 0xDBFF, 0xE000, 0xFFFF];
@@ -61,28 +62,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.1_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.1_T1.js
@@ -7,6 +7,7 @@ info: >
     (00000000 0zzzzzzz -> 0zzzzzzz)
 es5id: 15.1.3.4_A2.1_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var uriUnescaped = ["-", "_", ".", "!", "~", "*", "'", "(", ")", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
@@ -55,28 +56,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.1_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.1_T1.js
@@ -23,9 +23,8 @@ for (var index = 0x0000; index <= 0x007F; index++) {
     for (var indexC = 0; indexC < uriUnescaped.length; indexC++) {
     if (uriUnescaped[indexC] === str) continue l;
   }    
-  try {
-    if (encodeURIComponent(str).toUpperCase() === decimalToPercentHexString(index)) continue l;
-  } catch(e) {}     
+  if (encodeURIComponent(str).toUpperCase() === decimalToPercentHexString(index)) continue l;
+
   if (indexO === 0) { 
     indexO = index;
   } else {

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.1_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.1_T1.js
@@ -24,7 +24,7 @@ for (var index = 0x0000; index <= 0x007F; index++) {
     if (uriUnescaped[indexC] === str) continue l;
   }    
   try {
-    if (encodeURIComponent(str).toUpperCase() === "%" + decimalToHexString(index).substring(2)) continue l; 
+    if (encodeURIComponent(str).toUpperCase() === "%" + decimalToHex2String(index)) continue l;
   } catch(e) {}     
   if (indexO === 0) { 
     indexO = index;

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.1_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.1_T1.js
@@ -24,7 +24,7 @@ for (var index = 0x0000; index <= 0x007F; index++) {
     if (uriUnescaped[indexC] === str) continue l;
   }    
   try {
-    if (encodeURIComponent(str).toUpperCase() === "%" + decimalToHex2String(index)) continue l;
+    if (encodeURIComponent(str).toUpperCase() === decimalToPercentHexString(index)) continue l;
   } catch(e) {}     
   if (indexO === 0) { 
     indexO = index;

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.2_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.2_T1.js
@@ -7,6 +7,7 @@ info: >
     yyzzzzzz -> 110yyyyy 10zzzzzz)
 es5id: 15.1.3.4_A2.2_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -52,28 +53,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.2_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.2_T1.js
@@ -17,11 +17,11 @@ var indexO = 0;
 l:
 for (var index = 0x0080; index <= 0x07FF; index++) {
   count++;  
-  var hex1 = decimalToHex2String(0x0080 + (index & 0x003F));
-  var hex2 = decimalToHex2String(0x00C0 + (index & 0x07C0) / 0x0040);
+  var hex1 = decimalToPercentHexString(0x0080 + (index & 0x003F));
+  var hex2 = decimalToPercentHexString(0x00C0 + (index & 0x07C0) / 0x0040);
   var str = String.fromCharCode(index);
   try {
-    if (encodeURIComponent(str).toUpperCase() === "%" + hex2 + "%" + hex1) continue;
+    if (encodeURIComponent(str).toUpperCase() === hex2 + hex1) continue;
   } catch(e) {}  
   if (indexO === 0) { 
     indexO = index;

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.2_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.2_T1.js
@@ -20,9 +20,8 @@ for (var index = 0x0080; index <= 0x07FF; index++) {
   var hex1 = decimalToPercentHexString(0x0080 + (index & 0x003F));
   var hex2 = decimalToPercentHexString(0x00C0 + (index & 0x07C0) / 0x0040);
   var str = String.fromCharCode(index);
-  try {
-    if (encodeURIComponent(str).toUpperCase() === hex2 + hex1) continue;
-  } catch(e) {}  
+  if (encodeURIComponent(str).toUpperCase() === hex2 + hex1) continue;
+
   if (indexO === 0) { 
     indexO = index;
   } else {

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.2_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.2_T1.js
@@ -17,8 +17,8 @@ var indexO = 0;
 l:
 for (var index = 0x0080; index <= 0x07FF; index++) {
   count++;  
-  var hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
-  var hex2 = decimalToHexString(0x00C0 + (index & 0x07C0) / 0x0040).substring(2);
+  var hex1 = decimalToHex2String(0x0080 + (index & 0x003F));
+  var hex2 = decimalToHex2String(0x00C0 + (index & 0x07C0) / 0x0040);
   var str = String.fromCharCode(index);
   try {
     if (encodeURIComponent(str).toUpperCase() === "%" + hex2 + "%" + hex1) continue;

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.3_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.3_T1.js
@@ -20,9 +20,8 @@ for (var index = 0x0800; index <= 0xD7FF; index++) {
   var hex2 = decimalToPercentHexString(0x0080 + (index & 0x0FC0) / 0x0040);
   var hex3 = decimalToPercentHexString(0x00E0 + (index & 0xF000) / 0x1000);
   var str = String.fromCharCode(index);
-  try {
-    if (encodeURIComponent(str).toUpperCase() === hex3 + hex2 + hex1) continue;
-  } catch(e) {}      
+  if (encodeURIComponent(str).toUpperCase() === hex3 + hex2 + hex1) continue;
+
   if (indexO === 0) { 
     indexO = index;
   } else {

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.3_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.3_T1.js
@@ -7,6 +7,7 @@ info: >
     yyzzzzzz -> 1110xxxx 10yyyyyy 10zzzzzz)
 es5id: 15.1.3.4_A2.3_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -52,28 +53,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.3_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.3_T1.js
@@ -16,12 +16,12 @@ var indexP;
 var indexO = 0; 
 for (var index = 0x0800; index <= 0xD7FF; index++) {
   count++; 
-  var hex1 = decimalToHex2String(0x0080 + (index & 0x003F));
-  var hex2 = decimalToHex2String(0x0080 + (index & 0x0FC0) / 0x0040);
-  var hex3 = decimalToHex2String(0x00E0 + (index & 0xF000) / 0x1000);
+  var hex1 = decimalToPercentHexString(0x0080 + (index & 0x003F));
+  var hex2 = decimalToPercentHexString(0x0080 + (index & 0x0FC0) / 0x0040);
+  var hex3 = decimalToPercentHexString(0x00E0 + (index & 0xF000) / 0x1000);
   var str = String.fromCharCode(index);
   try {
-    if (encodeURIComponent(str).toUpperCase() === "%" + hex3 + "%" + hex2 + "%" + hex1) continue;
+    if (encodeURIComponent(str).toUpperCase() === hex3 + hex2 + hex1) continue;
   } catch(e) {}      
   if (indexO === 0) { 
     indexO = index;

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.3_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.3_T1.js
@@ -16,9 +16,9 @@ var indexP;
 var indexO = 0; 
 for (var index = 0x0800; index <= 0xD7FF; index++) {
   count++; 
-  var hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
-  var hex2 = decimalToHexString(0x0080 + (index & 0x0FC0) / 0x0040).substring(2);
-  var hex3 = decimalToHexString(0x00E0 + (index & 0xF000) / 0x1000).substring(2);
+  var hex1 = decimalToHex2String(0x0080 + (index & 0x003F));
+  var hex2 = decimalToHex2String(0x0080 + (index & 0x0FC0) / 0x0040);
+  var hex3 = decimalToHex2String(0x00E0 + (index & 0xF000) / 0x1000);
   var str = String.fromCharCode(index);
   try {
     if (encodeURIComponent(str).toUpperCase() === "%" + hex3 + "%" + hex2 + "%" + hex1) continue;

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T1.js
@@ -10,6 +10,7 @@ es5id: 15.1.3.4_A2.4_T1
 description: >
     Complex tests, use RFC 3629, string.charAt(k+1) in [0xDC00,
     0xDDFF, 0xDFFF]
+includes: [decimalToHexString.js]
 ---*/
 
 var chars = [0xDC00, 0xDDFF, 0xDFFF];
@@ -65,28 +66,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T1.js
@@ -22,13 +22,13 @@ for (var index = 0xD800; index <= 0xDBFF; index++) {
   var res = true;
   for (var indexC = 0; indexC < chars.length; indexC++) {
     var index1 = (index - 0xD800) * 0x400 + (chars[indexC] - 0xDC00) + 0x10000;
-    var hex1 = decimalToHex2String(0x0080 + (index1 & 0x003F));
-    var hex2 = decimalToHex2String(0x0080 + (index1 & 0x0FC0) / 0x0040);
-    var hex3 = decimalToHex2String(0x0080 + (index1 & 0x3F000) / 0x1000);
-    var hex4 = decimalToHex2String(0x00F0 + (index1 & 0x1C0000) / 0x40000);
+    var hex1 = decimalToPercentHexString(0x0080 + (index1 & 0x003F));
+    var hex2 = decimalToPercentHexString(0x0080 + (index1 & 0x0FC0) / 0x0040);
+    var hex3 = decimalToPercentHexString(0x0080 + (index1 & 0x3F000) / 0x1000);
+    var hex4 = decimalToPercentHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000);
     var str = String.fromCharCode(index, chars[indexC]);
     try {
-      if (encodeURIComponent(str).toUpperCase() !== "%" + hex4 + "%" + hex3 + "%" + hex2 + "%" + hex1) {
+      if (encodeURIComponent(str).toUpperCase() !== hex4 + hex3 + hex2 + hex1) {
         res = false;
       }
     } catch(e) {res = false}    

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T1.js
@@ -27,11 +27,9 @@ for (var index = 0xD800; index <= 0xDBFF; index++) {
     var hex3 = decimalToPercentHexString(0x0080 + (index1 & 0x3F000) / 0x1000);
     var hex4 = decimalToPercentHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000);
     var str = String.fromCharCode(index, chars[indexC]);
-    try {
-      if (encodeURIComponent(str).toUpperCase() !== hex4 + hex3 + hex2 + hex1) {
-        res = false;
-      }
-    } catch(e) {res = false}    
+    if (encodeURIComponent(str).toUpperCase() === hex4 + hex3 + hex2 + hex1) continue;
+
+    res = false;
   }
   if (res !== true) {  
     if (indexO === 0) { 

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T1.js
@@ -22,10 +22,10 @@ for (var index = 0xD800; index <= 0xDBFF; index++) {
   var res = true;
   for (var indexC = 0; indexC < chars.length; indexC++) {
     var index1 = (index - 0xD800) * 0x400 + (chars[indexC] - 0xDC00) + 0x10000;
-    var hex1 = decimalToHexString(0x0080 + (index1 & 0x003F)).substring(2);
-    var hex2 = decimalToHexString(0x0080 + (index1 & 0x0FC0) / 0x0040).substring(2);
-    var hex3 = decimalToHexString(0x0080 + (index1 & 0x3F000) / 0x1000).substring(2);
-    var hex4 = decimalToHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000).substring(2);
+    var hex1 = decimalToHex2String(0x0080 + (index1 & 0x003F));
+    var hex2 = decimalToHex2String(0x0080 + (index1 & 0x0FC0) / 0x0040);
+    var hex3 = decimalToHex2String(0x0080 + (index1 & 0x3F000) / 0x1000);
+    var hex4 = decimalToHex2String(0x00F0 + (index1 & 0x1C0000) / 0x40000);
     var str = String.fromCharCode(index, chars[indexC]);
     try {
       if (encodeURIComponent(str).toUpperCase() !== "%" + hex4 + "%" + hex3 + "%" + hex2 + "%" + hex1) {

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T2.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T2.js
@@ -10,6 +10,7 @@ es5id: 15.1.3.4_A2.4_T2
 description: >
     Complex tests, use RFC 3629, string.charAt(k) in [0xD800, 0xDBFF,
     0xD9FF]
+includes: [decimalToHexString.js]
 ---*/
 
 var chars = [0xD800, 0xDBFF, 0xD9FF];
@@ -65,28 +66,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T2.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T2.js
@@ -27,11 +27,9 @@ for (var index = 0xDC00; index <= 0xDFFF; index++) {
     var hex3 = decimalToPercentHexString(0x0080 + (index1 & 0x3F000) / 0x1000);
     var hex4 = decimalToPercentHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000);
     var str = String.fromCharCode(chars[indexC], index);
-    try {
-      if (encodeURIComponent(str).toUpperCase() !== hex4 + hex3 + hex2 + hex1) {
-        res = false;
-      }
-    } catch(e) {res = false}    
+    if (encodeURIComponent(str).toUpperCase() === hex4 + hex3 + hex2 + hex1) continue;
+
+    res = false;
   }
   if (res !== true) {  
     if (indexO === 0) { 

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T2.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T2.js
@@ -22,10 +22,10 @@ for (var index = 0xDC00; index <= 0xDFFF; index++) {
   var res = true;
   for (var indexC = 0; indexC < chars.length; indexC++) {
     var index1 = (chars[indexC] - 0xD800) * 0x400 + (index - 0xDC00) + 0x10000;
-    var hex1 = decimalToHexString(0x0080 + (index1 & 0x003F)).substring(2);
-    var hex2 = decimalToHexString(0x0080 + (index1 & 0x0FC0) / 0x0040).substring(2);
-    var hex3 = decimalToHexString(0x0080 + (index1 & 0x3F000) / 0x1000).substring(2);
-    var hex4 = decimalToHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000).substring(2);
+    var hex1 = decimalToHex2String(0x0080 + (index1 & 0x003F));
+    var hex2 = decimalToHex2String(0x0080 + (index1 & 0x0FC0) / 0x0040);
+    var hex3 = decimalToHex2String(0x0080 + (index1 & 0x3F000) / 0x1000);
+    var hex4 = decimalToHex2String(0x00F0 + (index1 & 0x1C0000) / 0x40000);
     var str = String.fromCharCode(chars[indexC], index);
     try {
       if (encodeURIComponent(str).toUpperCase() !== "%" + hex4 + "%" + hex3 + "%" + hex2 + "%" + hex1) {

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T2.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.4_T2.js
@@ -22,13 +22,13 @@ for (var index = 0xDC00; index <= 0xDFFF; index++) {
   var res = true;
   for (var indexC = 0; indexC < chars.length; indexC++) {
     var index1 = (chars[indexC] - 0xD800) * 0x400 + (index - 0xDC00) + 0x10000;
-    var hex1 = decimalToHex2String(0x0080 + (index1 & 0x003F));
-    var hex2 = decimalToHex2String(0x0080 + (index1 & 0x0FC0) / 0x0040);
-    var hex3 = decimalToHex2String(0x0080 + (index1 & 0x3F000) / 0x1000);
-    var hex4 = decimalToHex2String(0x00F0 + (index1 & 0x1C0000) / 0x40000);
+    var hex1 = decimalToPercentHexString(0x0080 + (index1 & 0x003F));
+    var hex2 = decimalToPercentHexString(0x0080 + (index1 & 0x0FC0) / 0x0040);
+    var hex3 = decimalToPercentHexString(0x0080 + (index1 & 0x3F000) / 0x1000);
+    var hex4 = decimalToPercentHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000);
     var str = String.fromCharCode(chars[indexC], index);
     try {
-      if (encodeURIComponent(str).toUpperCase() !== "%" + hex4 + "%" + hex3 + "%" + hex2 + "%" + hex1) {
+      if (encodeURIComponent(str).toUpperCase() !== hex4 + hex3 + hex2 + hex1) {
         res = false;
       }
     } catch(e) {res = false}    

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.5_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.5_T1.js
@@ -20,9 +20,8 @@ for (var index = 0xE000; index <= 0xFFFF; index++) {
   var hex2 = decimalToPercentHexString(0x0080 + (index & 0x0FC0) / 0x0040);
   var hex3 = decimalToPercentHexString(0x00E0 + (index & 0xF000) / 0x1000);
   var str = String.fromCharCode(index);
-  try {
-    if (encodeURIComponent(str).toUpperCase() === hex3 + hex2 + hex1) continue;
-  } catch(e) {}      
+  if (encodeURIComponent(str).toUpperCase() === hex3 + hex2 + hex1) continue;
+
   if (indexO === 0) { 
     indexO = index;
   } else {

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.5_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.5_T1.js
@@ -7,6 +7,7 @@ info: >
     yyzzzzzz -> 1110xxxx 10yyyyyy 10zzzzzz)
 es5id: 15.1.3.4_A2.5_T1
 description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
 ---*/
 
 var errorCount = 0;
@@ -52,28 +53,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.5_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.5_T1.js
@@ -16,9 +16,9 @@ var indexP;
 var indexO = 0; 
 for (var index = 0xE000; index <= 0xFFFF; index++) {
   count++;  
-  var hex1 = decimalToHexString(0x0080 + (index & 0x003F)).substring(2);
-  var hex2 = decimalToHexString(0x0080 + (index & 0x0FC0) / 0x0040).substring(2);
-  var hex3 = decimalToHexString(0x00E0 + (index & 0xF000) / 0x1000).substring(2);
+  var hex1 = decimalToHex2String(0x0080 + (index & 0x003F));
+  var hex2 = decimalToHex2String(0x0080 + (index & 0x0FC0) / 0x0040);
+  var hex3 = decimalToHex2String(0x00E0 + (index & 0xF000) / 0x1000);
   var str = String.fromCharCode(index);
   try {
     if (encodeURIComponent(str).toUpperCase() === "%" + hex3 + "%" + hex2 + "%" + hex1) continue;

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A2.5_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A2.5_T1.js
@@ -16,12 +16,12 @@ var indexP;
 var indexO = 0; 
 for (var index = 0xE000; index <= 0xFFFF; index++) {
   count++;  
-  var hex1 = decimalToHex2String(0x0080 + (index & 0x003F));
-  var hex2 = decimalToHex2String(0x0080 + (index & 0x0FC0) / 0x0040);
-  var hex3 = decimalToHex2String(0x00E0 + (index & 0xF000) / 0x1000);
+  var hex1 = decimalToPercentHexString(0x0080 + (index & 0x003F));
+  var hex2 = decimalToPercentHexString(0x0080 + (index & 0x0FC0) / 0x0040);
+  var hex3 = decimalToPercentHexString(0x00E0 + (index & 0xF000) / 0x1000);
   var str = String.fromCharCode(index);
   try {
-    if (encodeURIComponent(str).toUpperCase() === "%" + hex3 + "%" + hex2 + "%" + hex1) continue;
+    if (encodeURIComponent(str).toUpperCase() === hex3 + hex2 + hex1) continue;
   } catch(e) {}      
   if (indexO === 0) { 
     indexO = index;

--- a/test/built-ins/parseFloat/S15.1.2.3_A6.js
+++ b/test/built-ins/parseFloat/S15.1.2.3_A6.js
@@ -9,6 +9,7 @@ info: >
     characters were ignored.
 es5id: 15.1.2.3_A6
 description: Complex test without eval
+includes: [decimalToHexString.js]
 ---*/
 
 //CHECK
@@ -53,28 +54,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }

--- a/test/built-ins/parseInt/S15.1.2.2_A8.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A8.js
@@ -9,6 +9,7 @@ info: >
     characters were ignored.
 es5id: 15.1.2.2_A8
 description: Complex test without eval
+includes: [decimalToHexString.js]
 ---*/
 
 //CHECK
@@ -55,28 +56,4 @@ if (errorCount > 0) {
     $ERROR('#' + hexP + ' ');
   }     
   $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }


### PR DESCRIPTION
These tests take a long time to complete in non-release builds, is almost like they were written to be slow. 😛 

I've prepared eight commits to clean-up and optimize the tests:
- 9e1cf7b: Only moves the decimalToHexString function into a new harness file to avoid duplicating it in multiple files
- 9efab94: Optimizes decimalToHexString and adds support to format numbers greater than 0xffff (needed for the next part)
- bcfad84: Removes the remaining, slightly different decimalToHexString functions from test files
- 09c0393: decimalToHexString was often called to format numbers in [0, 0xff], but as decimalToHexString always returns a zero-padded string, substring() was used to adjust the return value. Add decimalToHex2String to avoid these substring() calls.
- af1bf56: We can further improve 09c0393, because the two-digit hex-string is always needed as a percent string, so let's move the percent-sign concatenation into the helper function.

Further polishing:
- 29977e7: Replace two calls to String.fromCharCode with a single call
- a1dd4ff: Hoist string concatenations outside of loop bodies
- 1baa38b: It doesn't even make sense to handle Test262Error in the catch-handlers.

We could definitely perform more clean-up for these tests, e.g. remove the error collection code (which doesn't actually work because the first call to $ERROR will throw a Test262Error), but these changes should help implementers to run the test in non-release builds. 