### PR TITLE
Add early error cases for `async async` in property definitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,8 @@ $DONE(arg) | see Writing Asynchronous Tests, below
 assert(value, message) | throw a new Test262Error instance if the specified value is not strictly equal to the JavaScript `true` value; accepts an optional string message for use in creating the error
 assert.sameValue(actual, expected, message) | throw a new Test262Error instance if the first two arguments are not [the same value](https://tc39.github.io/ecma262/#sec-samevalue); accepts an optional string message for use in creating the error
 assert.notSameValue(actual, unexpected, message) | throw a new Test262Error instance if the first two arguments are [the same value](https://tc39.github.io/ecma262/#sec-samevalue); accepts an optional string message for use in creating the error
-assert.throws(expectedErrorConstructor, fn) | throw a new Test262Error instance if the provided function does not throw an error, or if the constructor of the value thrown does not match the provided constructor
+assert.throws(expectedErrorConstructor, fn, message) | throw a new Test262Error instance if the provided function does not throw an error, or if the constructor of the value thrown does not match the provided constructor
+assert.throws.early(expectedErrorConstructor, fn) | throw a new Test262Error instance if the provided function does not throw an early error, or if the constructor of the value thrown does not match the provided constructor. This assertion catches only errors that will be parsed through `Function(code)`.
 
 ```
 /// error class

--- a/harness/assert.js
+++ b/harness/assert.js
@@ -79,3 +79,10 @@ assert.throws = function (expectedErrorConstructor, func, message) {
   message += 'Expected a ' + expectedErrorConstructor.name + ' to be thrown but no exception was thrown at all';
   $ERROR(message);
 };
+
+assert.throws.early = function(err, code) {
+  let wrappedCode = `function wrapperFn() { ${code} }`;
+  let ieval = eval;
+
+  assert.throws(err, () => { Function(wrappedCode); }, `Function: ${code}`);
+};

--- a/test/harness/assert-throws-early-incorrect-ctor.js
+++ b/test/harness/assert-throws-early-incorrect-ctor.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Functions that throw values whose constructor does not match the specified
+  constructor do not satisfy the assertion.
+---*/
+
+// monkeypatch the API
+$ERROR = function $ERROR(message) {
+  throw new Test262Error(message);
+};
+
+assert.throws(Test262Error, () => {
+  assert.throws.early(SyntaxError, "1 = 1;");
+}, "'1=1' is a ReferenceError");
+assert.throws(Test262Error, () => {
+  assert.throws.early(ReferenceError, "var;");
+}, "'var;' is a SyntaxError");

--- a/test/harness/assert-throws-early-not-early.js
+++ b/test/harness/assert-throws-early-not-early.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The assertion fails when the code does not parse with an early error
+---*/
+
+// monkeypatch the API
+$ERROR = function $ERROR(message) {
+  throw new Test262Error(message);
+};
+
+assert.throws(Test262Error, () => {
+  assert.throws.early(ReferenceError, 'x = 1');
+});

--- a/test/harness/assert-throws-early-referenceerror.js
+++ b/test/harness/assert-throws-early-referenceerror.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The assertion pass when the code parses with an early ReferenceError
+---*/
+
+assert.throws.early(ReferenceError, '1 = 1;');

--- a/test/harness/assert-throws-early-syntaxerror.js
+++ b/test/harness/assert-throws-early-syntaxerror.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    The assertion pass when the code parses with an early SyntaxError
+---*/
+
+assert.throws.early(SyntaxError, 'let let');

--- a/test/language/expressions/object/prop-def-invalid-async-prefix.js
+++ b/test/language/expressions/object/prop-def-invalid-async-prefix.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  async is not a valid prefix of an identifier reference
+esid: sec-object-initializer
+info: |
+    PropertyDefinition:
+      IdentifierReference
+      CoverInitializedName
+      PropertyName : AssignmentExpression
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ( UniqueFormalParameters ) { FunctionBody }
+      AsyncMethod
+
+    AsyncMethod:
+      async [no LineTerminator here] PropertyName ( UniqueFormalParameters ) { AsyncFunctionBody }
+      VariableDeclaration : BindingPattern Initializer
+
+      1. Let rhs be the result of evaluating Initializer.
+      2. Let rval be GetValue(rhs).
+      3. ReturnIfAbrupt(rval).
+      4. Return the result of performing BindingInitialization for
+         BindingPattern passing rval and undefined as arguments.
+negative:
+  phase: early
+  type: SyntaxError
+---*/
+
+({async async});


### PR DESCRIPTION
I've been working over [an original patch](https://bugzilla.mozilla.org/show_bug.cgi?id=1358246) from @anba to the SpiderMonkey tests suite, while I was trying to find a good way to port them here.

This approach is simple, fast, and allows a quick porting. 

The alternative is migrating each case to an individual file with the negative flag.

There are some trade offs for each option. The negative flag allows the purest form to verify an early error, nothing can beat it being the minimal unit part to assert.

In the meanwhile, this assert.throws.early api allows not only a quick port, but verifying the code being parsed internally as in `Function()`, `eval()`, and an indirect eval call.

I'm not silver into any of these forms, my preference is whatever communicates better with those contributing and consuming the tests from test262. For that, I'm requesting feedback.