### PR TITLE
Update RegExp tests for named-capturing and dotAll

### DIFF
--- a/test/annexB/built-ins/RegExp/prototype/flags/order-after-compile.js
+++ b/test/annexB/built-ins/RegExp/prototype/flags/order-after-compile.js
@@ -4,8 +4,16 @@
 /*---
 esid: sec-get-regexp.prototype.flags
 description: >
-  RegExp.prototype.flags come in a single order, independent of source order
-info: >
+  The flags come in the same order in a new instance produced by RegExp.prototype.compile
+info: |
+  B.2.5.1 RegExp.prototype.compile ( pattern, flags )
+
+  ...
+  5. Return ? RegExpInitialize(O, P, F).
+
+  21.2.5.3 get RegExp.prototype.flags
+
+  ...
   4. Let global be ToBoolean(? Get(R, "global")).
   5. If global is true, append "g" as the last code unit of result.
   6. Let ignoreCase be ToBoolean(? Get(R, "ignoreCase")).
@@ -18,8 +26,10 @@ info: >
   13. If unicode is true, append "u" as the last code unit of result.
   14. Let sticky be ToBoolean(? Get(R, "sticky")).
   15. If sticky is true, append "y" as the last code unit of result.
+  14. Return result.
 features: [regexp-dotall]
 ---*/
 
-assert.sameValue(new RegExp("", "gimsuy").flags, "gimsuy", "gimsuy => gimsuy");
-assert.sameValue(new RegExp("", "yusmig").flags, "gimsuy", "yusmig => gimsuy");
+let re = /(?:)/;
+re.compile("(?:)", "imsuyg");
+assert.sameValue(re.flags, "gimsuy");

--- a/test/built-ins/RegExp/named-groups/lookbehind.js
+++ b/test/built-ins/RegExp/named-groups/lookbehind.js
@@ -3,7 +3,7 @@
 
 /*---
 description: Named groups can be used in conjunction with lookbehind
-esid: pending
+esid: prod-GroupSpecifier
 features: [regexp-named-groups, regexp-lookbehind]
 includes: [compareArray.js]
 ---*/

--- a/test/built-ins/RegExp/named-groups/non-unicode-malformed.js
+++ b/test/built-ins/RegExp/named-groups/non-unicode-malformed.js
@@ -5,7 +5,7 @@
 description: >
   Named groups in Unicode RegExps have some syntax errors and some
   compatibility escape fallback behavior.
-esid: pending
+esid: prod-GroupSpecifier
 features: [regexp-named-groups, regexp-lookbehind]
 includes: [compareArray.js]
 ---*/

--- a/test/built-ins/RegExp/named-groups/non-unicode-match.js
+++ b/test/built-ins/RegExp/named-groups/non-unicode-match.js
@@ -3,7 +3,7 @@
 
 /*---
 description: Basic matching cases with non-Unicode groups
-esid: pending
+esid: prod-GroupSpecifier
 features: [regexp-named-groups]
 includes: [compareArray.js]
 ---*/

--- a/test/built-ins/RegExp/named-groups/non-unicode-property-names.js
+++ b/test/built-ins/RegExp/named-groups/non-unicode-property-names.js
@@ -3,7 +3,7 @@
 
 /*---
 description: Exotic named group names in non-Unicode RegExps
-esid: pending
+esid: prod-GroupSpecifier
 features: [regexp-named-groups]
 includes: [compareArray.js]
 ---*/
@@ -13,7 +13,7 @@ assert.throws(SyntaxError, () => eval('/(?<\\u{03C0}>a)/'), "\\u{} escapes allow
 assert.sameValue("a", /(?<π>a)/.exec("bab").groups.\u03C0);
 assert.sameValue("a", /(?<$>a)/.exec("bab").groups.$);
 assert.sameValue("a", /(?<_>a)/.exec("bab").groups._);
-assert.throws(SyntaxError, () => eval('/(?<$𐒤>a)/'), "Individual surrogates not in ID_Continue);
+assert.throws(SyntaxError, () => eval('/(?<$𐒤>a)/'), "Individual surrogates not in ID_Continue");
 assert.sameValue("a", /(?<_\u200C>a)/.exec("bab").groups._\u200C);
 assert.sameValue("a", /(?<_\u200D>a)/.exec("bab").groups._\u200D);
 assert.sameValue("a", /(?<ಠ_ಠ>a)/.exec("bab").groups.ಠ_ಠ);

--- a/test/built-ins/RegExp/named-groups/non-unicode-property-names.js
+++ b/test/built-ins/RegExp/named-groups/non-unicode-property-names.js
@@ -30,7 +30,6 @@ assert.throws(SyntaxError, () => eval("/(?<a\\u{10FFFF}>.)/"));
 assert.throws(SyntaxError, () => eval("/(?<a\uD801>.)/"), "Lea");
 assert.throws(SyntaxError, () => eval("/(?<a\uDCA4>.)/"), "Trai");
 assert(RegExp("(?<\u{0041}>.)").test("a"), "Non-surrogate");
-assert(RegExp("(?<a\u{104A4}>.)").test("a"), "Surrogate, ID_Continue");
 
 // Bracketed escapes are not allowed;
 // 4-char escapes must be the proper ID_Start/ID_Continue

--- a/test/built-ins/RegExp/named-groups/non-unicode-references.js
+++ b/test/built-ins/RegExp/named-groups/non-unicode-references.js
@@ -3,7 +3,7 @@
 
 /*---
 description: Named backreferences in non-Unicode RegExps
-esid: pending
+esid: prod-GroupSpecifier
 features: [regexp-named-groups]
 includes: [compareArray.js]
 ---*/

--- a/test/built-ins/RegExp/named-groups/string-replace-nocaptures.js
+++ b/test/built-ins/RegExp/named-groups/string-replace-nocaptures.js
@@ -18,7 +18,7 @@ info: >
 // @@replace with a string replacement argument (no named captures).
 
 let source = "(.)(.)|(x)";
-for (let flags of ["", "u", "g", "gu"]) {
+for (let flags of ["", "u"]) {
   let re = new RegExp(source, flags);
   assert.sameValue("$<snd>$<fst>cd", "abcd".replace(re, "$<snd>$<fst>"));
   assert.sameValue("bacd", "abcd".replace(re, "$2$1"));

--- a/test/built-ins/RegExp/named-groups/unicode-malformed.js
+++ b/test/built-ins/RegExp/named-groups/unicode-malformed.js
@@ -3,7 +3,7 @@
 
 /*---
 description: Various syntax errors for Unicode RegExps containing named groups
-esid: pending
+esid: prod-GroupSpecifier
 features: [regexp-named-groups]
 ---*/
 

--- a/test/built-ins/RegExp/named-groups/unicode-match.js
+++ b/test/built-ins/RegExp/named-groups/unicode-match.js
@@ -3,7 +3,7 @@
 
 /*---
 description: Basic matching cases with Unicode groups
-esid: pending
+esid: prod-GroupSpecifier
 features: [regexp-named-groups]
 includes: [compareArray.js]
 ---*/

--- a/test/built-ins/RegExp/named-groups/unicode-property-names.js
+++ b/test/built-ins/RegExp/named-groups/unicode-property-names.js
@@ -3,7 +3,7 @@
 
 /*---
 description: Exotic named group names in Unicode RegExps
-esid: pending
+esid: prod-GroupSpecifier
 features: [regexp-named-groups]
 ---*/
 


### PR DESCRIPTION
Ref #1008 

It does not address the `\k` parts as it's still being discussed there.