### PR TITLE
Add tests for completion value of function / class declaration statements

### DIFF
--- a/test/language/statements/async-function/cptn-decl.js
+++ b/test/language/statements/async-function/cptn-decl.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2017 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-async-function-definitions-runtime-semantics-evaluation
+description: Async function declaration completion value is empty.
+info: >
+    AsyncFunctionDeclaration : async [no LineTerminator here] function BindingIdentifier ( FormalParameters ) { AsyncFunctionBody }
+
+    1. Return NormalCompletion(empty).
+---*/
+
+assert.sameValue(eval('async function f() {}'), undefined);
+assert.sameValue(eval('1; async function f() {}'), 1);

--- a/test/language/statements/class/cptn-decl.js
+++ b/test/language/statements/class/cptn-decl.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2017 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-class-definitions-runtime-semantics-evaluation
+description: Class declaration completion value is empty.
+info: >
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Perform ? BindingClassDeclarationEvaluation of this ClassDeclaration.
+    2. Return NormalCompletion(empty).
+---*/
+
+assert.sameValue(eval('class C {}'), undefined);
+assert.sameValue(eval('1; class C {}'), 1);

--- a/test/language/statements/function/cptn-decl.js
+++ b/test/language/statements/function/cptn-decl.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2017 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-function-definitions-runtime-semantics-evaluation
+description: Function declaration completion value is empty.
+info: >
+    FunctionDeclaration : function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    1. Return NormalCompletion(empty).
+---*/
+
+assert.sameValue(eval('function f() {}'), undefined);
+assert.sameValue(eval('1; function f() {}'), 1);

--- a/test/language/statements/generators/cptn-decl.js
+++ b/test/language/statements/generators/cptn-decl.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2017 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-statement-semantics-runtime-semantics-evaluation
+description: Generator declaration completion value is empty.
+info: >
+    GeneratorDeclaration[Yield, Await, Default]:
+
+        function * BindingIdentifier[?Yield, ?Await] ( FormalParameters[+Yield, ~Await] ) { GeneratorBody }
+
+    HoistableDeclaration : GeneratorDeclaration
+
+    1. Return NormalCompletion(empty).
+---*/
+
+assert.sameValue(eval('function* f() {}'), undefined);
+assert.sameValue(eval('1; function* f() {}'), 1);


### PR DESCRIPTION
Check completion value of more declarations are empty:

```js
eval(`1; function f(){}`) === 1
eval(`1; function* f(){}`) === 1
eval(`1; async function f(){}`) === 1
eval(`1; class C {}`) === 1
```

Browsers:
* Firefox passes all
* Chrome fails for `class` - [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=716715)
* WebKit fails for `class` - [bug](https://bugs.webkit.org/show_bug.cgi?id=171265)
* Edge fails for `class` - [bug](https://github.com/Microsoft/ChakraCore/issues/2890)
