### PR TITLE
for-await-of: dstr-binding, async func & async gen templates (update steps)

### DIFF
--- a/src/dstr-binding/default/for-await-of-async-func-const.template
+++ b/src/dstr-binding/default/for-await-of-async-func-const.template
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/src/dstr-binding/default/for-await-of-async-func-let.template
+++ b/src/dstr-binding/default/for-await-of-async-func-let.template
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/src/dstr-binding/default/for-await-of-async-func-var.template
+++ b/src/dstr-binding/default/for-await-of-async-func-var.template
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/src/dstr-binding/default/for-await-of-async-gen-const.template
+++ b/src/dstr-binding/default/for-await-of-async-gen-const.template
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/src/dstr-binding/default/for-await-of-async-gen-let.template
+++ b/src/dstr-binding/default/for-await-of-async-gen-let.template
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/src/dstr-binding/default/for-await-of-async-gen-var.template
+++ b/src/dstr-binding/default/for-await-of-async-gen-var.template
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-init-iter-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-init-iter-close.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-init-iter-no-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-init-iter-no-close.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-name-iter-val.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-name-iter-val.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-elem-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-elem-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-elem-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-elem-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-elision-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-elision-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-elision-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-elision-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-empty-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-empty-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-empty-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-empty-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-rest-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-rest-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-rest-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-rest-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-arrow.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-class.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-cover.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-fn.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-gen.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-hole.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-hole.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-undef.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-undef.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-iter-complete.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-iter-complete.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-iter-done.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-iter-done.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-iter-val.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-iter-val.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-obj-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-obj-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-obj-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-obj-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-obj-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-obj-prop-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-obj-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elision-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elision-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-ary-elem.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-ary-elem.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-ary-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-ary-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-ary-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-ary-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-ary-rest.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-ary-rest.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-id-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-id-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-id-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-id-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-ary.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-id.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-obj.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-not-final-ary.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-not-final-id.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-not-final-obj.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-obj-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-obj-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-obj-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-arrow.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-class.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-cover.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-fn.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-gen.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-ary-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-ary-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-ary-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-ary-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-ary.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-id-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-obj-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-obj-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-obj.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-rest-getter.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-rest-nested-obj.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-rest-obj-nested-rest.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-rest-obj-own-property.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-rest-skip-non-enumerable.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-rest-val-obj.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-init-iter-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-init-iter-close.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-init-iter-no-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-init-iter-no-close.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-name-iter-val.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-name-iter-val.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-elem-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-elem-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-elem-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-elem-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-elision-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-elision-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-elision-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-elision-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-empty-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-empty-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-empty-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-empty-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-rest-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-rest-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-rest-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-rest-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-arrow.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-class.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-cover.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-fn.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-gen.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-hole.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-hole.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-undef.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-undef.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-iter-complete.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-iter-complete.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-iter-done.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-iter-done.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-iter-val.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-iter-val.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-obj-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-obj-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-obj-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-obj-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-obj-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-obj-prop-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-obj-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elision-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elision-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-ary-elem.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-ary-elem.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-ary-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-ary-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-ary-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-ary-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-ary-rest.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-ary-rest.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-id-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-id-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-id-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-id-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-ary.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-id.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-obj.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-not-final-ary.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-not-final-id.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-not-final-obj.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-obj-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-obj-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-obj-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-arrow.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-class.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-cover.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-fn.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-gen.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-ary-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-ary-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-ary-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-ary-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-ary.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-id-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-obj-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-obj-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-obj.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-rest-getter.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-rest-nested-obj.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-rest-obj-nested-rest.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-rest-obj-own-property.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-rest-skip-non-enumerable.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-rest-val-obj.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-init-iter-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-init-iter-close.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-init-iter-no-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-init-iter-no-close.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-name-iter-val.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-name-iter-val.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-elem-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-elem-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-elem-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-elem-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-elision-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-elision-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-elision-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-elision-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-empty-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-empty-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-empty-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-empty-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-rest-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-rest-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-rest-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-rest-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-arrow.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-class.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-cover.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-fn.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-gen.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-hole.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-hole.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-undef.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-undef.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-iter-complete.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-iter-complete.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-iter-done.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-iter-done.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-iter-val.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-iter-val.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-obj-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-obj-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-obj-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-obj-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-obj-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-obj-prop-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-obj-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elision-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elision-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-ary-elem.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-ary-elem.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-ary-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-ary-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-ary-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-ary-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-ary-rest.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-ary-rest.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-id-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-id-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-id-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-id-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-ary.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-id.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-obj.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-not-final-ary.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-not-final-id.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-not-final-obj.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-obj-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-obj-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-obj-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-arrow.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-class.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-cover.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-fn.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-gen.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-ary-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-ary-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-ary-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-ary-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-ary.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-id-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-obj-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-obj-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-obj.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-rest-getter.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-rest-nested-obj.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-rest-obj-nested-rest.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-rest-obj-own-property.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-rest-skip-non-enumerable.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-rest-val-obj.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-init-iter-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-init-iter-close.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-init-iter-no-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-init-iter-no-close.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-name-iter-val.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-name-iter-val.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-elem-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-elem-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-elem-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-elem-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-elision-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-elision-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-elision-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-elision-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-empty-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-empty-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-empty-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-empty-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-rest-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-rest-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-rest-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-rest-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-arrow.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-class.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-cover.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-fn.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-gen.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-hole.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-hole.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-undef.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-undef.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-iter-complete.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-iter-complete.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-iter-done.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-iter-done.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-iter-val.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-iter-val.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-obj-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-obj-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-obj-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-obj-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-obj-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-obj-prop-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-obj-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elision-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elision-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-ary-elem.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-ary-elem.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-ary-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-ary-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-ary-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-ary-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-ary-rest.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-ary-rest.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-id-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-id-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-id-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-id-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-ary.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-id.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-obj.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-not-final-ary.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-not-final-id.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-not-final-obj.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-obj-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-obj-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-obj-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-arrow.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-class.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-cover.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-fn.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-gen.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-ary-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-ary-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-ary-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-ary-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-ary.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-id-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-obj-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-obj-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-obj.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-getter.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-nested-obj.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-obj-nested-rest.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-obj-own-property.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-skip-non-enumerable.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-val-obj.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-init-iter-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-init-iter-close.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-init-iter-no-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-init-iter-no-close.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-name-iter-val.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-name-iter-val.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-elem-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-elem-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-elem-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-elem-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-elision-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-elision-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-elision-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-elision-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-empty-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-empty-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-empty-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-empty-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-rest-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-rest-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-rest-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-rest-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-arrow.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-class.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-cover.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-fn.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-gen.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-hole.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-hole.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-undef.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-undef.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-iter-complete.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-iter-complete.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-iter-done.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-iter-done.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-iter-val.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-iter-val.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-obj-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-obj-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-obj-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-obj-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-obj-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-obj-prop-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-obj-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elision-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elision-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-ary-elem.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-ary-elem.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-ary-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-ary-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-ary-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-ary-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-ary-rest.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-ary-rest.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-id-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-id-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-id-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-id-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-ary.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-id.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-obj.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-not-final-ary.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-not-final-id.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-not-final-obj.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-obj-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-obj-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-obj-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-arrow.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-class.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-cover.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-fn.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-gen.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-ary-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-ary-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-ary-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-ary-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-ary.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-id-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-obj-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-obj-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-obj.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-getter.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-nested-obj.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-obj-nested-rest.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-obj-own-property.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-skip-non-enumerable.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-val-obj.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-init-iter-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-init-iter-close.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-init-iter-no-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-init-iter-no-close.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-name-iter-val.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-name-iter-val.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-elem-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-elem-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-elem-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-elem-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-elision-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-elision-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-elision-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-elision-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-empty-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-empty-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-empty-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-empty-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-rest-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-rest-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-rest-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-rest-iter.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-arrow.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-class.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-cover.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-fn.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-gen.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-hole.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-hole.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-undef.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-undef.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-iter-complete.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-iter-complete.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-iter-done.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-iter-done.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-iter-val.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-iter-val.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-obj-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-obj-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-obj-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-obj-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-obj-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-obj-prop-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-obj-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elision-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elision-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-ary-elem.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-ary-elem.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-ary-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-ary-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-ary-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-ary-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-ary-rest.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-ary-rest.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-id-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-id-elision.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-id-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-id-exhausted.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-ary.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-id.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-obj.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-not-final-ary.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-not-final-id.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-not-final-obj.js
@@ -20,13 +20,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-obj-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-obj-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-obj-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-empty.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-arrow.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-class.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-cover.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-fn.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-gen.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-ary-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-ary-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-ary-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-ary-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-ary.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-id-init-skipped.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-id-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-id-trailing-comma.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-id.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-obj-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-obj-init.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-prop-obj.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-rest-getter.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-rest-nested-obj.js
@@ -17,13 +17,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-rest-obj-nested-rest.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-rest-obj-own-property.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-rest-skip-non-enumerable.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then

--- a/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-rest-val-obj.js
@@ -18,13 +18,13 @@ info: |
     13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
 
     [...]
-    3. Let destructuring be IsDestructuring of lhs.
+    4. Let destructuring be IsDestructuring of lhs.
     [...]
-    5. Repeat
+    6. Repeat
        [...]
-       h. If destructuring is false, then
+       j. If destructuring is false, then
           [...]
-       i. Else
+       k. Else
           i. If lhsKind is assignment, then
              [...]
           ii. Else if lhsKind is varBinding, then


### PR DESCRIPTION
~~Hold for generated tests~~

This is purely an update to the runtime semantics steps in the test frontmatter. **There are no changes to the actual tests themselves.**