### PR TITLE
Switch to assert-lib in intl402

### DIFF
--- a/test/intl402/6.2.2_b.js
+++ b/test/intl402/6.2.2_b.js
@@ -25,18 +25,10 @@ var invalidLanguageTags = [
 
 testWithIntlConstructors(function (Constructor) {
     invalidLanguageTags.forEach(function (tag) {
-        var error;
-        try {
-            // this must throw an exception for an invalid language tag
+        // this must throw an exception for an invalid language tag
+        assert.throws(RangeError, function() {
             var obj = new Constructor([tag]);
-        } catch (e) {
-            error = e;
-        }
-        if (error === undefined) {
-            $ERROR("Invalid language tag " + tag + " was not rejected.");
-        } else if (error.name !== "RangeError") {
-            $ERROR("Invalid language tag " + tag + " was rejected with wrong error " + error.name + ".");
-        }
+        }, "Invalid language tag " + tag + " was not rejected.");
     });
     return true;
 });

--- a/test/intl402/6.2.2_c.js
+++ b/test/intl402/6.2.2_c.js
@@ -31,18 +31,10 @@ var invalidLanguageTags = [
 
 testWithIntlConstructors(function (Constructor) {
     invalidLanguageTags.forEach(function (tag) {
-        var error;
-        try {
-            // this must throw an exception for an invalid language tag
+        // this must throw an exception for an invalid language tag
+        assert.throws(RangeError, function() {
             var obj = new Constructor([tag]);
-        } catch (e) {
-            error = e;
-        }
-        if (error === undefined) {
-            $ERROR("Invalid language tag " + tag + " was not rejected.");
-        } else if (error.name !== "RangeError") {
-            $ERROR("Invalid language tag " + tag + " was rejected with wrong error " + error.name + ".");
-        }
+        }, "Invalid language tag " + tag + " was not rejected.");
     });
     return true;
 });

--- a/test/intl402/6.2.3.js
+++ b/test/intl402/6.2.3.js
@@ -35,9 +35,7 @@ var canonicalizedTags = {
 // make sure the data above is correct
 Object.getOwnPropertyNames(canonicalizedTags).forEach(function (tag) {
     canonicalizedTags[tag].forEach(function (canonicalTag) {
-        if (!isCanonicalizedStructurallyValidLanguageTag(canonicalTag)) {
-            $ERROR("Test data \"" + canonicalTag + "\" is not canonicalized and structurally valid language tag.");
-        }
+        assert(isCanonicalizedStructurallyValidLanguageTag(canonicalTag), "Test data \"" + canonicalTag + "\" is not canonicalized and structurally valid language tag.");
     });
 });
 
@@ -51,17 +49,11 @@ testWithIntlConstructors(function (Constructor) {
         // In this variant, shortened forms or the default locale may be returned
         var object = new Constructor([tag], {localeMatcher: "lookup"});
         var locale = object.resolvedOptions().locale;
-        if (canonicalizedTags[tag].indexOf(locale) === -1 && locale !== defaultLocale) {
-            $ERROR("For " + tag + " got " + locale + "; expected one of " +
-                canonicalizedTags[tag].join(", ") + ".");
-        }
+        assert(canonicalizedTags[tag].indexOf(locale) !== -1 || locale === defaultLocale, "For " + tag + " got " + locale + "; expected one of " + canonicalizedTags[tag].join(", ") + ".");
         
         // Variant 2: get the supported locales. If the tag is supported, it should be returned canonicalized but unshortened
         var supported = Constructor.supportedLocalesOf([tag]);
-        if (supported.length > 0 && supported[0] !== canonicalizedTags[tag][0]) {
-            $ERROR("For " + tag + " got " + supported[0] + "; expected " +
-                canonicalizedTags[tag][0] + ".");
-        }            
+        assert(supported.length === 0 || supported[0] === canonicalizedTags[tag][0], "For " + tag + " got " + supported[0] + "; expected " + canonicalizedTags[tag][0] + ".");
     });
     return true;
 });

--- a/test/intl402/6.2.4.js
+++ b/test/intl402/6.2.4.js
@@ -12,8 +12,6 @@ includes: [testIntl.js]
 
 testWithIntlConstructors(function (Constructor) {
     var defaultLocale = new Constructor().resolvedOptions().locale;
-    if (!isCanonicalizedStructurallyValidLanguageTag(defaultLocale)) {
-        $ERROR("Default locale \"" + defaultLocale + "\" is not canonicalized and structurally valid language tag.");
-    }
+    assert(isCanonicalizedStructurallyValidLanguageTag(defaultLocale), "Default locale \"" + defaultLocale + "\" is not canonicalized and structurally valid language tag.");
     return true;
 });

--- a/test/intl402/9.1_a.js
+++ b/test/intl402/9.1_a.js
@@ -11,7 +11,5 @@ includes: [testIntl.js]
 testWithIntlConstructors(function (Constructor) {
     var defaultLocale = new Constructor().resolvedOptions().locale;
     var supportedLocales = Constructor.supportedLocalesOf([defaultLocale]);
-    if (supportedLocales.indexOf(defaultLocale) === -1) {
-        $ERROR("Default locale is not reported as available.");
-    }
+    assert.notSameValue(supportedLocales.indexOf(defaultLocale), -1, "Default locale is not reported as available.");
 });

--- a/test/intl402/9.1_b.js
+++ b/test/intl402/9.1_b.js
@@ -17,16 +17,12 @@ testWithIntlConstructors(function (Constructor) {
         var pos = locale.lastIndexOf("-");
         if (pos !== -1) {
             fallback = locale.substring(0, pos);
-            if (info.supported.indexOf(fallback) === -1) {
-                $ERROR("Locale " + locale + " is supported, but fallback " + fallback + " isn't.");
-            }
+            assert.notSameValue(info.supported.indexOf(fallback), -1, "Locale " + locale + " is supported, but fallback " + fallback + " isn't.");
         }
         var match = /([a-z]{2,3})(-[A-Z][a-z]{3})(-[A-Z]{2})/.exec(locale);
         if (match !== null) {
             fallback = match[1] + match[3];
-            if (info.supported.indexOf(fallback) === -1) {
-                $ERROR("Locale " + locale + " is supported, but fallback " + fallback + " isn't.");
-            }
+            assert.notSameValue(info.supported.indexOf(fallback), -1, "Locale " + locale + " is supported, but fallback " + fallback + " isn't.");
         }
     });
 });

--- a/test/intl402/9.2.1_1.js
+++ b/test/intl402/9.2.1_1.js
@@ -13,12 +13,8 @@ includes: [testIntl.js]
 testWithIntlConstructors(function (Constructor) {
     var supportedForUndefined = Constructor.supportedLocalesOf(undefined);
     var supportedForEmptyList = Constructor.supportedLocalesOf([]);
-    if (supportedForUndefined.length !== supportedForEmptyList.length) {
-        $ERROR("Supported locales differ between undefined and empty list input.");
-    }
+    assert.sameValue(supportedForUndefined.length, supportedForEmptyList.length, "Supported locales differ between undefined and empty list input.");
     // we don't compare the elements because length should be 0 - let's just verify that
-    if (supportedForUndefined.length !== 0) {
-        $ERROR("Internal test error: Assumption about length being 0 is invalid.");
-    }
+    assert.sameValue(supportedForUndefined.length, 0, "Internal test error: Assumption about length being 0 is invalid.");
     return true;
 });

--- a/test/intl402/9.2.1_2.js
+++ b/test/intl402/9.2.1_2.js
@@ -15,7 +15,5 @@ taintArray();
 testWithIntlConstructors(function (Constructor) {
     var defaultLocale = new Constructor().resolvedOptions().locale;
     var canonicalized = Constructor.supportedLocalesOf([defaultLocale, defaultLocale]);
-    if (canonicalized.length > 1) {
-        $ERROR("Canonicalization didn't remove duplicate language tags from locale list.");
-    }
+    assert.sameValue(canonicalized.length > 1, false, "Canonicalization didn't remove duplicate language tags from locale list.");
 });

--- a/test/intl402/9.2.1_3.js
+++ b/test/intl402/9.2.1_3.js
@@ -61,24 +61,11 @@ testWithIntlConstructors(function (Constructor) {
             error2 = e;
         }
 
-        if ((error1 === undefined) !== (error2 === undefined)) {
-            if (error1 === undefined) {
-                $ERROR("Single locale string " + locale +
-                    " was accepted, but locale list containing that string wasn't.");
-            } else {
-                $ERROR("Single locale string " + locale +
-                    " was rejected, but locale list containing that string wasn't.");
-            }
-        } else if (error1 === undefined) {
-             if (locale1 !== locale2) {
-                $ERROR("Single locale string " + locale + " results in " + locale1 +
-                    ", but locale list [" + locale + "] results in " + locale2 + ".");
-             }
+        assert.sameValue((error1 === undefined), (error2 === undefined), "Single locale string " + locale + " was " + (error1 === undefined ? "accepted" : "rejected") + ", but locale list containing that string wasn't.");
+        if (error1 === undefined) {
+            assert.sameValue(locale1, locale2, "Single locale string " + locale + " results in " + locale1 + ", but locale list [" + locale + "] results in " + locale2 + ".");
         } else {
-            if (error1.name !== error2.name) {
-                $ERROR("Single locale string " + locale + " results in error " + error1.name +
-                    ", but locale list [" + locale + "] results in error " + error2.name + ".");
-             }
+            assert.sameValue(error1.name, error2.name, "Single locale string " + locale + " results in error " + error1.name + ", but locale list [" + locale + "] results in error " + error2.name + ".");
         }
     });
     

--- a/test/intl402/9.2.1_4.js
+++ b/test/intl402/9.2.1_4.js
@@ -14,34 +14,20 @@ testWithIntlConstructors(function (Constructor) {
     // undefined is handled separately
     
     // null should result in a TypeError
-    var error;
-    try {
+    assert.throws(TypeError, function() {
         var supportedForNull = Constructor.supportedLocalesOf(null);
-    } catch (e) {
-        error = e;
-    }
-    if (error === undefined) {
-        $ERROR("Null as locale list was not rejected.");
-    } else if (error.name !== "TypeError") {
-        $ERROR("Null as locale list was rejected with wrong error " + error.name + ".");
-    }    
+    }, "Null as locale list was not rejected.");
     
     // let's use an empty list for comparison
     var supportedForEmptyList = Constructor.supportedLocalesOf([]);
     // we don't compare the elements because length should be 0 - let's just verify that
-    if (supportedForEmptyList.length !== 0) {
-        $ERROR("Internal test error: Assumption about length being 0 is invalid.");
-    }
+    assert.sameValue(supportedForEmptyList.length, 0, "Internal test error: Assumption about length being 0 is invalid.");
 
     // most non-objects will be interpreted as empty lists because a missing length property is interpreted as 0
     var supportedForNumber = Constructor.supportedLocalesOf(5);
-    if (supportedForNumber.length !== supportedForEmptyList.length) {
-        $ERROR("Supported locales differ between numeric and empty list input.");
-    }
+    assert.sameValue(supportedForNumber.length, supportedForEmptyList.length, "Supported locales differ between numeric and empty list input.");
     var supportedForBoolean = Constructor.supportedLocalesOf(true);
-    if (supportedForBoolean.length !== supportedForEmptyList.length) {
-        $ERROR("Supported locales differ between boolean and empty list input.");
-    }
+    assert.sameValue(supportedForBoolean.length, supportedForEmptyList.length, "Supported locales differ between boolean and empty list input.");
     
     return true;
 });

--- a/test/intl402/9.2.1_8_c_ii.js
+++ b/test/intl402/9.2.1_8_c_ii.js
@@ -12,17 +12,9 @@ var notStringOrObject = [undefined, null, true, false, 0, 5, -5, NaN];
 
 testWithIntlConstructors(function (Constructor) {
     notStringOrObject.forEach(function (value) {
-        var error;
-        try {
+        assert.throws(TypeError, function() {
             var supported = Constructor.supportedLocalesOf([value]);
-        } catch (e) {
-            error = e;
-        }
-        if (error === undefined) {
-            $ERROR("" + value + " as locale was not rejected.");
-        } else if (error.name !== "TypeError") {
-            $ERROR("" + value + " as locale was rejected with wrong error " + error.name + ".");
-        }
+        }, "" + value + " as locale was not rejected.");
     });
     
     return true;

--- a/test/intl402/9.2.1_8_c_vi.js
+++ b/test/intl402/9.2.1_8_c_vi.js
@@ -13,7 +13,5 @@ includes: [testIntl.js]
 testWithIntlConstructors(function (Constructor) {
     var defaultLocale = new Constructor().resolvedOptions().locale;
     var canonicalized = Constructor.supportedLocalesOf([defaultLocale, defaultLocale]);
-    if (canonicalized.length > 1) {
-        $ERROR("Canonicalization didn't remove duplicate language tags from locale list.");
-    }
+    assert.sameValue(canonicalized.length > 1, false, "Canonicalization didn't remove duplicate language tags from locale list.");
 });

--- a/test/intl402/9.2.2.js
+++ b/test/intl402/9.2.2.js
@@ -23,23 +23,15 @@ testWithIntlConstructors(function (Constructor) {
         while (i < limit && supportedByConstructor[i] === supported[i]) {
             i++;
         }
-        if (i < supportedByConstructor.length) {
-            $ERROR("Locale " + supportedByConstructor[i] +
-                " is returned by resolvedOptions but not by supportedLocalesOf.");
-        } else if (i < supported.length) {
-            $ERROR("Locale " + supported[i] +
-                " is returned by supportedLocalesOf but not by resolvedOptions.");
-        }
+        assert.sameValue(i < supportedByConstructor.length, false, "Locale " + supportedByConstructor[i] + " is returned by resolvedOptions but not by supportedLocalesOf.");
+        assert.sameValue(i < supported.length, false, "Locale " + supported[i] + " is returned by supportedLocalesOf but not by resolvedOptions.");
     });
     
     // this test is only valid for lookup - best fit may find additional locales supported
     var unsupportedByConstructor = info.unsupported;
     var supported = Constructor.supportedLocalesOf(unsupportedByConstructor,
             {localeMatcher: "lookup"});
-    if (supported.length > 0) {
-        $ERROR("Locale " + supported[0] +
-            " is returned by supportedLocalesOf but not by resolvedOptions.");
-    }
+    assert.sameValue(supported.length > 0, false, "Locale " + supported[0] + " is returned by supportedLocalesOf but not by resolvedOptions.");
 
     return true;
 });

--- a/test/intl402/9.2.3_5.js
+++ b/test/intl402/9.2.3_5.js
@@ -14,9 +14,7 @@ taintProperties(["locale", "extension", "extensionIndex"]);
 
 testWithIntlConstructors(function (Constructor) {
     var locale = new Constructor(undefined, {localeMatcher: "lookup"}).resolvedOptions().locale;
-    if (!isCanonicalizedStructurallyValidLanguageTag(locale)) {
-        $ERROR("Constructor returns invalid locale " + locale + ".");
-    }
+    assert(isCanonicalizedStructurallyValidLanguageTag(locale), "Constructor returns invalid locale " + locale + ".");
 
     return true;
 });

--- a/test/intl402/9.2.5_6.js
+++ b/test/intl402/9.2.5_6.js
@@ -14,9 +14,7 @@ taintProperties(["dataLocale", "nu", "ca", "co", "locale"]);
 
 testWithIntlConstructors(function (Constructor) {
     var locale = new Constructor(undefined, {localeMatcher: "lookup"}).resolvedOptions().locale;
-    if (!isCanonicalizedStructurallyValidLanguageTag(locale)) {
-        $ERROR("Constructor returns invalid locale " + locale + ".");
-    }
+    assert(isCanonicalizedStructurallyValidLanguageTag(locale), "Constructor returns invalid locale " + locale + ".");
 
     return true;
 });

--- a/test/intl402/9.2.6_2.js
+++ b/test/intl402/9.2.6_2.js
@@ -18,9 +18,7 @@ testWithIntlConstructors(function (Constructor) {
         var defaultLocale = new Constructor().resolvedOptions().locale;
         var canonicalized = Constructor.supportedLocalesOf([defaultLocale, defaultLocale],
             {localeMatcher: matcher});
-        if (canonicalized.length > 1) {
-            $ERROR("Canonicalization with matcher " + matcher + " didn't remove duplicate language tags from locale list.");
-        }
+        assert.sameValue(canonicalized.length > 1, false, "Canonicalization with matcher " + matcher + " didn't remove duplicate language tags from locale list.");
     });
 
     return true;

--- a/test/intl402/9.2.6_4.js
+++ b/test/intl402/9.2.6_4.js
@@ -14,9 +14,7 @@ testWithIntlConstructors(function (Constructor) {
     // this test should work equally for both matching algorithms
     ["lookup", "best fit"].forEach(function (matcher) {
         var supported = Constructor.supportedLocalesOf([], {localeMatcher: matcher});
-        if (supported.length !== 0) {
-            $ERROR("SupportedLocales with matcher " + matcher + " returned a non-empty list for an empty list.");
-        }
+        assert.sameValue(supported.length, 0, "SupportedLocales with matcher " + matcher + " returned a non-empty list for an empty list.");
     });
 
     return true;

--- a/test/intl402/9.2.6_4_b.js
+++ b/test/intl402/9.2.6_4_b.js
@@ -25,19 +25,13 @@ testWithIntlConstructors(function (Constructor) {
             var supported3 = Constructor.supportedLocalesOf([locale + invalidExtension],
                 {localeMatcher: matcher});
             if (supported1.length === 1) {
-                if (supported2.length !== 1 || supported3.length !== 1) {
-                    $ERROR("Presence of Unicode locale extension sequence affects whether locale " +
-                        locale + " is considered supported with matcher " + matcher + ".");
-                }
-                if (supported2[0] !== locale + validExtension || supported3[0] !== locale + invalidExtension) {
-                    $ERROR("Unicode locale extension sequence is not correctly returned for locale " +
-                        locale + " with matcher " + matcher + ".");
-                }
+                assert.sameValue(supported2.length, 1, "#1.1: Presence of Unicode locale extension sequence affects whether locale " + locale + " is considered supported with matcher " + matcher + ".");
+                assert.sameValue(supported3.length, 1, "#1.2: Presence of Unicode locale extension sequence affects whether locale " + locale + " is considered supported with matcher " + matcher + ".");
+                assert.sameValue(supported2[0], locale + validExtension, "#2.1: Unicode locale extension sequence is not correctly returned for locale " + locale + " with matcher " + matcher + ".");
+                assert.sameValue(supported3[0], locale + invalidExtension, "#2.2: Unicode locale extension sequence is not correctly returned for locale " + locale + " with matcher " + matcher + ".");
             } else {
-                if (supported2.length !== 0 || supported3.length !== 0) {
-                    $ERROR("Presence of Unicode locale extension sequence affects whether locale " +
-                        locale + " is considered supported with matcher " + matcher + ".");
-                }
+                assert.sameValue(supported2.length, 0, "#3.1: Presence of Unicode locale extension sequence affects whether locale " + locale + " is considered supported with matcher " + matcher + ".");
+                assert.sameValue(supported3.length, 0, "#3.2: Presence of Unicode locale extension sequence affects whether locale " + locale + " is considered supported with matcher " + matcher + ".");
             }
         });
     });

--- a/test/intl402/9.2.6_4_c.js
+++ b/test/intl402/9.2.6_4_c.js
@@ -17,15 +17,9 @@ testWithIntlConstructors(function (Constructor) {
         var noLinguisticContent = "zxx";
         var supported = Constructor.supportedLocalesOf([defaultLocale, noLinguisticContent],
             {localeMatcher: matcher});
-        if (supported.indexOf(defaultLocale) === -1) {
-            $ERROR("SupportedLocales didn't return default locale with matcher " + matcher + ".");
-        }
-        if (supported.indexOf(noLinguisticContent) !== -1) {
-            $ERROR("SupportedLocales returned the \"no linguistic content\" locale with matcher " + matcher + ".");
-        }
-        if (supported.length > 1) {
-            $ERROR("SupportedLocales returned stray locales: " + supported.join(", ") + " with matcher " + matcher + ".");
-        }
+        assert.notSameValue(supported.indexOf(defaultLocale), -1, "SupportedLocales didn't return default locale with matcher " + matcher + ".");
+        assert.sameValue(supported.indexOf(noLinguisticContent), -1, "SupportedLocales returned the \"no linguistic content\" locale with matcher " + matcher + ".");
+        assert.sameValue(supported.length > 1, false, "SupportedLocales returned stray locales: " + supported.join(", ") + " with matcher " + matcher + ".");
     });
 
     return true;

--- a/test/intl402/9.2.8_1_c.js
+++ b/test/intl402/9.2.8_1_c.js
@@ -18,17 +18,9 @@ testWithIntlConstructors(function (Constructor) {
     
     var invalidValues = [null, 0, 5, NaN, true, false, "invalid"];
     invalidValues.forEach(function (value) {
-        var error;
-        try {
+        assert.throws(RangeError, function() {
             var supported = Constructor.supportedLocalesOf([defaultLocale], {localeMatcher: value});
-        } catch (e) {
-            error = e;
-        }
-        if (error === undefined) {
-            $ERROR("Invalid localeMatcher value " + value + " was not rejected.");
-        } else if (error.name !== "RangeError") {
-            $ERROR("Invalid localeMatcher value " + value + " was rejected with wrong error " + error.name + ".");
-        }
+        }, "Invalid localeMatcher value " + value + " was not rejected.");
     });
     
     return true;

--- a/test/intl402/9.2.8_4.js
+++ b/test/intl402/9.2.8_4.js
@@ -12,20 +12,14 @@ includes: [testIntl.js]
 
 function testFrozenProperty(obj, property) {
     var desc = Object.getOwnPropertyDescriptor(obj, property);
-    if (desc.writable) {
-        $ERROR("Property " + property + " of object returned by SupportedLocales is writable.");
-    }
-    if (desc.configurable) {
-        $ERROR("Property " + property + " of object returned by SupportedLocales is configurable.");
-    }
+    assert.sameValue(desc.writable, false, "Property " + property + " of object returned by SupportedLocales is writable.");
+    assert.sameValue(desc.configurable, false, "Property " + property + " of object returned by SupportedLocales is configurable.");
 }
 
 testWithIntlConstructors(function (Constructor) {
     var defaultLocale = new Constructor().resolvedOptions().locale;
     var supported = Constructor.supportedLocalesOf([defaultLocale]);
-    if (!Object.isExtensible(supported)) {
-        $ERROR("Object returned by SupportedLocales is not extensible.");
-    }
+    assert(Object.isExtensible(supported), "Object returned by SupportedLocales is not extensible.");
     for (var i = 0; i < supported.length; i++) {
         testFrozenProperty(supported, i);
     }

--- a/test/intl402/Collator/10.1.1_1.js
+++ b/test/intl402/Collator/10.1.1_1.js
@@ -14,16 +14,12 @@ testWithIntlConstructors(function (Constructor) {
     // variant 1: use constructor in a "new" expression
     obj = new Constructor();
     newObj = Intl.Collator.call(obj);
-    if (obj === newObj) {
-      $ERROR("Collator object created with \"new\" was not ignored as this-value.");
-    }
+    assert.notSameValue(obj, newObj, "Collator object created with \"new\" was not ignored as this-value.");
 
     // variant 2: use constructor as a function
     obj = Constructor();
     newObj = Intl.Collator.call(obj);
-    if (obj === newObj) {
-      $ERROR("Collator object created with constructor as function was not ignored as this-value.");
-    }
+    assert.notSameValue(obj, newObj, "Collator object created with constructor as function was not ignored as this-value.");
 
     return true;
 });

--- a/test/intl402/Collator/10.1.1_10.js
+++ b/test/intl402/Collator/10.1.1_10.js
@@ -13,6 +13,4 @@ includes: [testIntl.js]
 taintProperties(["localeMatcher", "kn", "kf"]);
 
 var locale = new Intl.Collator(undefined, {localeMatcher: "lookup"}).resolvedOptions().locale;
-if (!isCanonicalizedStructurallyValidLanguageTag(locale)) {
-    $ERROR("Collator returns invalid locale " + locale + ".");
-}
+assert(isCanonicalizedStructurallyValidLanguageTag(locale), "Collator returns invalid locale " + locale + ".");

--- a/test/intl402/Collator/10.1.1_19_b.js
+++ b/test/intl402/Collator/10.1.1_19_b.js
@@ -13,16 +13,10 @@ function checkCollation(extensionCoValue, usageValue, expectedCollations, expect
     var collator = new Intl.Collator([requestLocale], options);
 
     var collation = collator.resolvedOptions().collation;
-    if (expectedCollations.indexOf(collation) === -1) {
-        $ERROR((extensionCoValue === undefined ? "Default collation" : "Collation for \"" + extensionCoValue) +
-            "\" should be " + expectedCollations.join(" or ") + ", but is " + collation + ".");
-    }
+    assert.notSameValue(expectedCollations.indexOf(collation), -1, (extensionCoValue === undefined ? "Default collation" : "Collation for \"" + extensionCoValue) + "\" should be " + expectedCollations.join(" or ") + ", but is " + collation + ".");
 
     var usage = collator.resolvedOptions().usage;
-    if (expectedUsage !== usage) {
-        $ERROR((usageValue === undefined ? "Default usage" : "Usage") +
-            " should be " + expectedUsage + ", but is " + usage + ".");
-    }
+    assert.sameValue(usage, expectedUsage, (usageValue === undefined ? "Default usage" : "Usage") + " mismatch.");
 }
 
 checkCollation(undefined, undefined, ["default"], "sort");

--- a/test/intl402/Collator/10.1.1_19_c.js
+++ b/test/intl402/Collator/10.1.1_19_c.js
@@ -35,10 +35,7 @@ options.forEach(function (option) {
     supportedValues.forEach(function (value) {
         collator = new Intl.Collator([defaultLocale + "-u-" + option.key + "-" + value]);
         result = collator.resolvedOptions()[option.property];
-        if (result !== value) {
-            $ERROR("Property " + option.property + " couldn't be set through locale extension key " +
-                option.key + "; requested value: " + value + "; actual value: " + result + ".");
-        }
+        assert.sameValue(result, value, "Property " + option.property + " couldn't be set through locale extension key " + option.key + ".");
     });
     
     // verify that the options setting overrides the locale setting
@@ -54,10 +51,7 @@ options.forEach(function (option) {
             opt[option.property] = value;
             collator = new Intl.Collator([defaultLocale + "-u-" + option.key + "-" + otherValue], opt);
             result = collator.resolvedOptions()[option.property];
-            if (result !== value) {
-                $ERROR("Options value for property " + option.property + " doesn't override locale extension key " +
-                    option.key + "; requested value: " + value + "; actual value: " + result + ".");
-            }
+            assert.sameValue(result, value, "Options value for property " + option.property + " doesn't override locale extension key " + option.key + ".");
         }
     });
 });

--- a/test/intl402/Collator/10.1.3.js
+++ b/test/intl402/Collator/10.1.3.js
@@ -12,10 +12,6 @@ author: Norbert Lindenberg
 var obj = new Intl.Collator();
 
 var actualPrototype = Object.getPrototypeOf(obj);
-if (actualPrototype !== Intl.Collator.prototype) {
-    $ERROR("Prototype of object constructed by Intl.Collator isn't Intl.Collator.prototype; got " + actualPrototype);
-}
+assert.sameValue(actualPrototype, Intl.Collator.prototype, "Prototype of object constructed by Intl.Collator isn't Intl.Collator.prototype.");
 
-if (!Object.isExtensible(obj)) {
-    $ERROR("Object constructed by Intl.Collator must be extensible.");
-}
+assert(Object.isExtensible(obj), "Object constructed by Intl.Collator must be extensible.");

--- a/test/intl402/Collator/10.2.3_b.js
+++ b/test/intl402/Collator/10.2.3_b.js
@@ -39,14 +39,8 @@ Object.getOwnPropertyNames(keyValues).forEach(function (key) {
     keyValues[key].forEach(function (value) {
         var collator = new Intl.Collator([defaultLocale + "-u-" + key + "-" + value]);
         var options = collator.resolvedOptions();
-        if (options.locale !== defaultLocale) {
-            $ERROR("Locale " + options.locale + " is affected by key " +
-                key + "; value " + value + ".");
-        }
-        if (JSON.stringify(options) !== defaultOptionsJSON) {
-            $ERROR("Resolved options " + JSON.stringify(options) + " are affected by key " +
-                key + "; value " + value + ".");
-        }
+        assert.sameValue(options.locale, defaultLocale, "Locale " + options.locale + " is affected by key " + key + "; value " + value + ".");
+        assert.sameValue(JSON.stringify(options), defaultOptionsJSON, "Resolved options " + JSON.stringify(options) + " are affected by key " + key + "; value " + value + ".");
         testArraysAreSame(defaultSortedArray, testArray.sort(collator.compare));
     });
 });

--- a/test/intl402/Collator/10.4_a.js
+++ b/test/intl402/Collator/10.4_a.js
@@ -10,6 +10,4 @@ author: Norbert Lindenberg
 var obj = new Intl.Collator();
 
 var toStringValue = Object.prototype.toString.call(obj);
-if (toStringValue !== "[object Object]") {
-    $ERROR("Intl.Collator instance produces wrong [[Class]] - toString returns " + toStringValue + ".");
-}
+assert.sameValue(toStringValue, "[object Object]", "Intl.Collator instance produces wrong [[Class]] - toString returns " + toStringValue + ".");

--- a/test/intl402/Collator/9.2.5_11_g_ii_2.js
+++ b/test/intl402/Collator/9.2.5_11_g_ii_2.js
@@ -17,11 +17,7 @@ extensions.forEach(function (extension) {
     var locale = collator.resolvedOptions().locale;
     var numeric = collator.resolvedOptions().numeric;
     if (numeric !== undefined) {
-        if (numeric !== true) {
-            $ERROR("Default value for \"kn\" should be true, but is " + numeric + ".");
-        }
-        if (locale.indexOf("-kn") !== -1) {
-            $ERROR("\"kn\" is returned in locale, but shouldn't be.");
-        }
+        assert.sameValue(numeric, true, "Default value for \"kn\" should be true, but is " + numeric + ".");
+        assert.sameValue(locale.indexOf("-kn"), -1, "\"kn\" is returned in locale, but shouldn't be.");
     }
 });

--- a/test/intl402/Collator/prototype/10.2.1.js
+++ b/test/intl402/Collator/prototype/10.2.1.js
@@ -8,15 +8,7 @@ author: Norbert Lindenberg
 ---*/
 
 var desc = Object.getOwnPropertyDescriptor(Intl.Collator, "prototype");
-if (desc === undefined) {
-    $ERROR("Intl.Collator.prototype is not defined.");
-}
-if (desc.writable) {
-    $ERROR("Intl.Collator.prototype must not be writable.");
-}
-if (desc.enumerable) {
-    $ERROR("Intl.Collator.prototype must not be enumerable.");
-}
-if (desc.configurable) {
-    $ERROR("Intl.Collator.prototype must not be configurable.");
-}
+assert.notSameValue(desc, undefined, "Intl.Collator.prototype is not defined.");
+assert.sameValue(desc.writable, false, "Intl.Collator.prototype must not be writable.");
+assert.sameValue(desc.enumerable, false, "Intl.Collator.prototype must not be enumerable.");
+assert.sameValue(desc.configurable, false, "Intl.Collator.prototype must not be configurable.");

--- a/test/intl402/Collator/prototype/10.3_a.js
+++ b/test/intl402/Collator/prototype/10.3_a.js
@@ -10,7 +10,4 @@ description: >
 
 // test by calling a function that would fail if "this" were not an object
 // initialized as an Intl.Collator
-if (Intl.Collator.prototype.compare("aаあ아", "aаあ아") !== 0) {
-    $ERROR("Intl.Collator.prototype is not an object that has been " +
-        "initialized as an Intl.Collator.");
-}
+assert.sameValue(Intl.Collator.prototype.compare("aаあ아", "aаあ아"), 0, "Intl.Collator.prototype is not an object that has been initialized as an Intl.Collator.");

--- a/test/intl402/Collator/prototype/10.3_b.js
+++ b/test/intl402/Collator/prototype/10.3_b.js
@@ -19,16 +19,8 @@ var invalidTargets = [undefined, null, true, 0, "Collator", [], {}];
 Object.getOwnPropertyNames(functions).forEach(function (functionName) {
     var f = functions[functionName];
     invalidTargets.forEach(function (target) {
-        var error;
-        try {
+        assert.throws(TypeError, function() {
             f.call(target);
-        } catch (e) {
-            error = e;
-        }
-        if (error === undefined) {
-            $ERROR("Calling " + functionName + " on " + target + " was not rejected.");
-        } else if (error.name !== "TypeError") {
-            $ERROR("Calling " + functionName + " on " + target + " was rejected with wrong error " + error.name + ".");
-        }
+        }, "Calling " + functionName + " on " + target + " was not rejected.");
     });
 });

--- a/test/intl402/Collator/prototype/compare/10.3.2_CS_a.js
+++ b/test/intl402/Collator/prototype/compare/10.3.2_CS_a.js
@@ -52,10 +52,7 @@ var pairs = [
 var i;
 for (i = 0; i < pairs.length; i++) {
     var pair = pairs[i];
-    if (collator.compare(pair[0], pair[1]) !== 0) {
-        $ERROR("Collator.compare considers " + pair[0] + " (" + toU(pair[0]) +
-            ") ≠ " + pair[1] + " (" + toU(pair[1]) + ").");
-    }
+    assert.sameValue(collator.compare(pair[0], pair[1]), 0, "Collator.compare considers " + pair[0] + " (" + toU(pair[0]) + ") ≠ " + pair[1] + " (" + toU(pair[1]) + ").");
 }
 
 function toU(s) {

--- a/test/intl402/Collator/prototype/constructor/10.3.1.js
+++ b/test/intl402/Collator/prototype/constructor/10.3.1.js
@@ -8,7 +8,4 @@ description: >
     Intl.Collator.
 ---*/
 
-if (Intl.Collator.prototype.constructor !== Intl.Collator) {
-    $ERROR("Intl.Collator.prototype.constructor is not the same as " +
-           "Intl.Collator");
-}
+assert.sameValue(Intl.Collator.prototype.constructor, Intl.Collator, "Intl.Collator.prototype.constructor is not the same as Intl.Collator");

--- a/test/intl402/Collator/prototype/resolvedOptions/10.3.3.js
+++ b/test/intl402/Collator/prototype/resolvedOptions/10.3.3.js
@@ -13,9 +13,7 @@ includes: [testIntl.js]
 var actual = new Intl.Collator().resolvedOptions();
 
 var actual2 = new Intl.Collator().resolvedOptions();
-if (actual2 === actual) {
-    $ERROR("resolvedOptions returned the same object twice.");
-}
+assert.notSameValue(actual2, actual, "resolvedOptions returned the same object twice.");
 
 // source: CLDR file common/bcp47/collation.xml; version CLDR 21.
 var collations = [

--- a/test/intl402/Collator/supportedLocalesOf/10.2.2_a.js
+++ b/test/intl402/Collator/supportedLocalesOf/10.2.2_a.js
@@ -14,15 +14,9 @@ var requestedLocales = [defaultLocale, notSupported];
 
 var supportedLocales;
 
-if (!Intl.Collator.hasOwnProperty('supportedLocalesOf')) {
-    $ERROR("Intl.Collator doesn't have a supportedLocalesOf property.");
-}
+assert(Intl.Collator.hasOwnProperty('supportedLocalesOf'), "Intl.Collator doesn't have a supportedLocalesOf property.");
 
 supportedLocales = Intl.Collator.supportedLocalesOf(requestedLocales);
-if (supportedLocales.length !== 1) {
-    $ERROR('The length of supported locales list is not 1.');
-}
+assert.sameValue(supportedLocales.length, 1, 'The length of supported locales list is not 1.');
 
-if (supportedLocales[0] !== defaultLocale) {
-    $ERROR('The default locale is not returned in the supported list.');
-}
+assert.sameValue(supportedLocales[0], defaultLocale, 'The default locale is not returned in the supported list.');

--- a/test/intl402/Date/prototype/13.3.0_1.js
+++ b/test/intl402/Date/prototype/13.3.0_1.js
@@ -19,16 +19,8 @@ var invalidValues = [undefined, null, 5, "5", false, {valueOf: function () { ret
 Object.getOwnPropertyNames(functions).forEach(function (p) {
     var f = functions[p];
     invalidValues.forEach(function (value) {
-        var error;
-        try {
+        assert.throws(TypeError, function() {
             var result = f.call(value);
-        } catch (e) {
-            error = e;
-        }
-        if (error === undefined) {
-            $ERROR("Date.prototype." + p + " did not reject this = " + value + ".");
-        } else if (error.name !== "TypeError") {
-            $ERROR("Date.prototype." + p + " rejected this = " + value + " with wrong error " + error.name + ".");
-        }
+        }, "Date.prototype." + p + " did not reject this = " + value + ".");
     });
 });

--- a/test/intl402/Date/prototype/13.3.0_2.js
+++ b/test/intl402/Date/prototype/13.3.0_2.js
@@ -20,9 +20,6 @@ Object.getOwnPropertyNames(functions).forEach(function (p) {
     var f = functions[p];
     invalidValues.forEach(function (value) {
         var result = f.call(new Date(value));
-        if (result !== "Invalid Date") {
-            $ERROR("Date.prototype." + p + " did not return \"Invalid Date\" for " +
-                value + " – got " + result + " instead.");
-        }
+        assert.sameValue(result, "Invalid Date", "Date.prototype." + p + " did not return \"Invalid Date\" for " + value);
     });
 });

--- a/test/intl402/Date/prototype/13.3.0_6_1.js
+++ b/test/intl402/Date/prototype/13.3.0_6_1.js
@@ -31,21 +31,11 @@ Object.getOwnPropertyNames(functions).forEach(function (p) {
         } catch (e) {
             referenceError = e;
         }
-        if (referenceError === undefined) {
-            $ERROR("Internal error: Expected exception was not thrown by Intl.DateTimeFormat for locales " + locales + ".");
-        }
-        
-        try {
+        assert.notSameValue(referenceError, undefined, "Internal error: Expected exception was not thrown by Intl.DateTimeFormat for locales " + locales + ".");
+
+        assert.throws(referenceError.constructor, function() {
             var result = f.call(new Date(), locales);
-        } catch (e) {
-            error = e;
-        }
-        if (error === undefined) {
-            $ERROR("Date.prototype." + p + " didn't throw exception for locales " + locales + ".");
-        } else if (error.name !== referenceError.name) {
-            $ERROR("Date.prototype." + p + " threw exception " + error.name +
-                " for locales " + locales + "; expected " + referenceError.name + ".");
-        }
+        }, "Date.prototype." + p + " didn't throw exception for locales " + locales + ".");
     });
     
     options.forEach(function (options) {
@@ -55,22 +45,10 @@ Object.getOwnPropertyNames(functions).forEach(function (p) {
         } catch (e) {
             referenceError = e;
         }
-        if (referenceError === undefined) {
-            $ERROR("Internal error: Expected exception was not thrown by Intl.DateTimeFormat for options " +
-                JSON.stringify(options) + ".");
-        }
-        
-        try {
+        assert.notSameValue(referenceError, undefined, "Internal error: Expected exception was not thrown by Intl.DateTimeFormat for options " + JSON.stringify(options) + ".");
+
+        assert.throws(referenceError.constructor, function() {
             var result = f.call(new Date(), [], options);
-        } catch (e) {
-            error = e;
-        }
-        if (error === undefined) {
-            $ERROR("Date.prototype." + p + " didn't throw exception for options " +
-                JSON.stringify(options) + ".");
-        } else if (error.name !== referenceError.name) {
-            $ERROR("Date.prototype." + p + " threw exception " + error.name +
-                " for options " + JSON.stringify(options) + "; expected " + referenceError.name + ".");
-        }
+        }, "Date.prototype." + p + " didn't throw exception for options " + JSON.stringify(options) + ".");
     });
 });

--- a/test/intl402/DateTimeFormat/12.1.1_1.js
+++ b/test/intl402/DateTimeFormat/12.1.1_1.js
@@ -19,16 +19,12 @@ testWithIntlConstructors(function (Constructor) {
     // variant 1: use constructor in a "new" expression
     obj = new Constructor();
     newObj = Intl.DateTimeFormat.call(obj);
-    if (obj === newObj) {
-      $ERROR("DateTimeFormat object created with \"new\" was not ignored as this-value.");
-    }
+    assert.notSameValue(obj, newObj, "DateTimeFormat object created with \"new\" was not ignored as this-value.");
 
     // variant 2: use constructor as a function
     obj = Constructor();
     newObj = Intl.DateTimeFormat.call(obj);
-    if (obj === newObj) {
-      $ERROR("DateTimeFormat object created with constructor as function was not ignored as this-value.");
-    }
+    assert.notSameValue(obj, newObj, "DateTimeFormat object created with constructor as function was not ignored as this-value.");
 
     return true;
 });

--- a/test/intl402/DateTimeFormat/12.1.1_22.js
+++ b/test/intl402/DateTimeFormat/12.1.1_22.js
@@ -13,6 +13,4 @@ includes: [testIntl.js]
 taintProperties(["weekday", "era", "year", "month", "day", "hour", "minute", "second", "timeZone"]);
 
 var locale = new Intl.DateTimeFormat(undefined, {localeMatcher: "lookup"}).resolvedOptions().locale;
-if (!isCanonicalizedStructurallyValidLanguageTag(locale)) {
-    $ERROR("DateTimeFormat returns invalid locale " + locale + ".");
-}
+assert(isCanonicalizedStructurallyValidLanguageTag(locale), "DateTimeFormat returns invalid locale " + locale + ".");

--- a/test/intl402/DateTimeFormat/12.1.1_5.js
+++ b/test/intl402/DateTimeFormat/12.1.1_5.js
@@ -13,6 +13,4 @@ includes: [testIntl.js]
 taintProperties(["localeMatcher"]);
 
 var locale = new Intl.DateTimeFormat(undefined, {localeMatcher: "lookup"}).resolvedOptions().locale;
-if (!isCanonicalizedStructurallyValidLanguageTag(locale)) {
-    $ERROR("DateTimeFormat returns invalid locale " + locale + ".");
-}
+assert(isCanonicalizedStructurallyValidLanguageTag(locale), "DateTimeFormat returns invalid locale " + locale + ".");

--- a/test/intl402/DateTimeFormat/12.1.1_TDTO.js
+++ b/test/intl402/DateTimeFormat/12.1.1_TDTO.js
@@ -19,19 +19,17 @@ function testWithDateTimeFormat(options, expected) {
         var resolvedOptions = format.resolvedOptions();
         getDateTimeComponents().forEach(function (component) {
             if (resolvedOptions.hasOwnProperty(component)) {
-                if (!expected.hasOwnProperty(component)) {
-                    $ERROR("Unrequested component " + component +
+                assert(expected.hasOwnProperty(component),
+                        "Unrequested component " + component +
                         " added to expected subset " + JSON.stringify(expected) +
                         "; locales " + locales + ", options " +
                         (options ? JSON.stringify(options) : options) + ".");
-                }
             } else {
-                if (expected.hasOwnProperty(component)) {
-                    $ERROR("Missing component " + component +
+                assert.sameValue(expected.hasOwnProperty(component), false,
+                        "Missing component " + component +
                         " from expected subset " + JSON.stringify(expected) +
                         "; locales " + locales + ", options " +
                         (options ? JSON.stringify(options) : options) + ".");
-                }
             }
         });
     });
@@ -50,13 +48,12 @@ function testWithToLocale(f, options, expected) {
                 var referenceFormat = new Intl.DateTimeFormat(locales, expected);
                 expectedStrings.push(referenceFormat.format(date));
             });
-            if (expectedStrings.indexOf(formatted) === -1) {
-                $ERROR("Function " + f + " did not return expected string for locales " +
+            assert.notSameValue(expectedStrings.indexOf(formatted), -1,
+                    "Function " + f + " did not return expected string for locales " +
                     locales + ", options " + (options? JSON.stringify(options) : options) +
                     "; expected " +
                     (expectedStrings.length === 1 ? expectedStrings[0] : "one of " + expectedStrings) +
                     ", got " + formatted + ".");
-            }
         });
     });
 }   

--- a/test/intl402/DateTimeFormat/12.1.3.js
+++ b/test/intl402/DateTimeFormat/12.1.3.js
@@ -12,10 +12,6 @@ author: Norbert Lindenberg
 var obj = new Intl.DateTimeFormat();
 
 var actualPrototype = Object.getPrototypeOf(obj);
-if (actualPrototype !== Intl.DateTimeFormat.prototype) {
-    $ERROR("Prototype of object constructed by Intl.DateTimeFormat isn't Intl.DateTimeFormat.prototype; got " + actualPrototype);
-}
+assert.sameValue(actualPrototype, Intl.DateTimeFormat.prototype, "Prototype of object constructed by Intl.DateTimeFormat isn't Intl.DateTimeFormat.prototype.");
 
-if (!Object.isExtensible(obj)) {
-    $ERROR("Object constructed by Intl.DateTimeFormat must be extensible.");
-}
+assert(Object.isExtensible(obj), "Object constructed by Intl.DateTimeFormat must be extensible.");

--- a/test/intl402/DateTimeFormat/12.2.3_b.js
+++ b/test/intl402/DateTimeFormat/12.2.3_b.js
@@ -30,18 +30,9 @@ locales.forEach(function (locale) {
         keyValues[key].forEach(function (value) {
             var dateTimeFormat = new Intl.DateTimeFormat([locale + "-u-" + key + "-" + value]);
             var options = dateTimeFormat.resolvedOptions();
-            if (options.locale !== defaultLocale) {
-                $ERROR("Locale " + options.locale + " is affected by key " +
-                key + "; value " + value + ".");
-            }
-            if (JSON.stringify(options) !== defaultOptionsJSON) {
-                $ERROR("Resolved options " + JSON.stringify(options) + " are affected by key " +
-                key + "; value " + value + ".");
-            }
-            if (defaultFormatted !== dateTimeFormat.format(input)) {
-                $ERROR("Formatted value " + dateTimeFormat.format(input) + " is affected by key " +
-                key + "; value " + value + ".");
-            }
+            assert.sameValue(options.locale, defaultLocale, "Locale " + options.locale + " is affected by key " + key + "; value " + value + ".");
+            assert.sameValue(JSON.stringify(options), defaultOptionsJSON, "Resolved options " + JSON.stringify(options) + " are affected by key " + key + "; value " + value + ".");
+            assert.sameValue(dateTimeFormat.format(input), defaultFormatted, "Formatted value " + dateTimeFormat.format(input) + " is affected by key " + key + "; value " + value + ".");
         });
     });
 });

--- a/test/intl402/DateTimeFormat/12.2.3_c.js
+++ b/test/intl402/DateTimeFormat/12.2.3_c.js
@@ -28,11 +28,10 @@ locales.forEach(function (locale) {
         var actual = format.resolvedOptions();
         getDateTimeComponents().forEach(function (component) {
             if (actual.hasOwnProperty(component)) {
-                if (!subset.hasOwnProperty(component)) {
-                    $ERROR("Unrequested component " + component +
+                assert(subset.hasOwnProperty(component),
+                        "Unrequested component " + component +
                         " added to requested subset " + JSON.stringify(subset) +
                         "; locale " + locale + ".");
-                }
                 try {
                     testValidDateTimeComponentValue(component, actual[component]);
                 } catch (e) {
@@ -41,11 +40,10 @@ locales.forEach(function (locale) {
                     throw e;
                 }
             } else {
-                if (subset.hasOwnProperty(component)) {
-                    $ERROR("Missing component " + component +
+                assert.sameValue(subset.hasOwnProperty(component), false,
+                        "Missing component " + component +
                         " from requested subset " + JSON.stringify(subset) +
                         "; locale " + locale + ".");
-                }
             }
         });
     });

--- a/test/intl402/DateTimeFormat/12.4_a.js
+++ b/test/intl402/DateTimeFormat/12.4_a.js
@@ -12,6 +12,4 @@ author: Norbert Lindenberg
 var obj = new Intl.DateTimeFormat();
 
 var toStringValue = Object.prototype.toString.call(obj);
-if (toStringValue !== "[object Object]") {
-    $ERROR("Intl.DateTimeFormat instance produces wrong [[Class]] - toString returns " + toStringValue + ".");
-}
+assert.sameValue(toStringValue, "[object Object]", "Intl.DateTimeFormat instance produces wrong [[Class]] - toString returns " + toStringValue + ".");

--- a/test/intl402/DateTimeFormat/6.4_a.js
+++ b/test/intl402/DateTimeFormat/6.4_a.js
@@ -15,8 +15,5 @@ var validTimeZoneNames = [
 validTimeZoneNames.forEach(function (name) {
     // this must not throw an exception for a valid time zone name
     var format = new Intl.DateTimeFormat(["de-de"], {timeZone: name});
-    if (format.resolvedOptions().timeZone !== name.toUpperCase()) {
-        $ERROR("Time zone name " + name + " was not correctly accepted; turned into " +
-            format.resolvedOptions().timeZone + ".");
-    }
+    assert.sameValue(format.resolvedOptions().timeZone, name.toUpperCase(), "Time zone name " + name + " was not correctly accepted.");
 });

--- a/test/intl402/DateTimeFormat/6.4_b.js
+++ b/test/intl402/DateTimeFormat/6.4_b.js
@@ -19,16 +19,8 @@ var invalidTimeZoneNames = [
 ];
 
 invalidTimeZoneNames.forEach(function (name) {
-    var error;
-    try {
-        // this must throw an exception for an invalid time zone name
+    // this must throw an exception for an invalid time zone name
+    assert.throws(RangeError, function() {
         var format = new Intl.DateTimeFormat(["de-de"], {timeZone: name});
-    } catch (e) {
-        error = e;
-    }
-    if (error === undefined) {
-        $ERROR("Invalid time zone name " + name + " was not rejected.");
-    } else if (error.name !== "RangeError") {
-        $ERROR("Invalid time zone name " + name + " was rejected with wrong error " + error.name + ".");
-    }
+    }, "Invalid time zone name " + name + " was not rejected.");
 });

--- a/test/intl402/DateTimeFormat/6.4_c.js
+++ b/test/intl402/DateTimeFormat/6.4_c.js
@@ -28,11 +28,8 @@ Object.getOwnPropertyNames(additionalTimeZoneNames).forEach(function (name) {
     if (error === undefined) {
         var actual = format.resolvedOptions().timeZone;
         var expected = additionalTimeZoneNames[name];
-        if (actual !== expected) {
-            $ERROR("Time zone name " + name + " was accepted, but incorrectly canonicalized to " +
-                actual + "; expected " + expected + ".");
-        }
-    } else if (error.name !== "RangeError") {
-        $ERROR("Time zone name " + name + " was rejected with wrong error " + error.name + ".");
+        assert.sameValue(actual, expected, "Time zone name " + name + " was accepted, but incorrectly canonicalized.");
+    } else {
+        assert(error instanceof RangeError, "Time zone name " + name + " was rejected with wrong error " + error.name + ".");
     }
 });

--- a/test/intl402/DateTimeFormat/prototype/12.2.1.js
+++ b/test/intl402/DateTimeFormat/prototype/12.2.1.js
@@ -10,15 +10,7 @@ author: Norbert Lindenberg
 ---*/
 
 var desc = Object.getOwnPropertyDescriptor(Intl.DateTimeFormat, "prototype");
-if (desc === undefined) {
-    $ERROR("Intl.DateTimeFormat.prototype is not defined.");
-}
-if (desc.writable) {
-    $ERROR("Intl.DateTimeFormat.prototype must not be writable.");
-}
-if (desc.enumerable) {
-    $ERROR("Intl.DateTimeFormat.prototype must not be enumerable.");
-}
-if (desc.configurable) {
-    $ERROR("Intl.DateTimeFormat.prototype must not be configurable.");
-}
+assert.notSameValue(desc, undefined, "Intl.DateTimeFormat.prototype is not defined.");
+assert.sameValue(desc.writable, false, "Intl.DateTimeFormat.prototype must not be writable.");
+assert.sameValue(desc.enumerable, false, "Intl.DateTimeFormat.prototype must not be enumerable.");
+assert.sameValue(desc.configurable, false, "Intl.DateTimeFormat.prototype must not be configurable.");

--- a/test/intl402/DateTimeFormat/prototype/12.3_a.js
+++ b/test/intl402/DateTimeFormat/prototype/12.3_a.js
@@ -11,7 +11,4 @@ author: Roozbeh Pournader
 
 // test by calling a function that would fail if "this" were not an object
 // initialized as an Intl.DateTimeFormat
-if (typeof Intl.DateTimeFormat.prototype.format(0) !== "string") {
-    $ERROR("Intl.DateTimeFormat's prototype is not an object that has been " +
-        "initialized as an Intl.DateTimeFormat");
-}
+assert.sameValue(typeof Intl.DateTimeFormat.prototype.format(0), "string", "Intl.DateTimeFormat's prototype is not an object that has been initialized as an Intl.DateTimeFormat");

--- a/test/intl402/DateTimeFormat/prototype/12.3_b.js
+++ b/test/intl402/DateTimeFormat/prototype/12.3_b.js
@@ -19,16 +19,8 @@ var invalidTargets = [undefined, null, true, 0, "DateTimeFormat", [], {}];
 Object.getOwnPropertyNames(functions).forEach(function (functionName) {
     var f = functions[functionName];
     invalidTargets.forEach(function (target) {
-        var error;
-        try {
+        assert.throws(TypeError, function() {
             f.call(target);
-        } catch (e) {
-            error = e;
-        }
-        if (error === undefined) {
-            $ERROR("Calling " + functionName + " on " + target + " was not rejected.");
-        } else if (error.name !== "TypeError") {
-            $ERROR("Calling " + functionName + " on " + target + " was rejected with wrong error " + error.name + ".");
-        }
+        }, "Calling " + functionName + " on " + target + " was not rejected.");
     });
 });

--- a/test/intl402/DateTimeFormat/prototype/constructor/12.3.1.js
+++ b/test/intl402/DateTimeFormat/prototype/constructor/12.3.1.js
@@ -9,7 +9,4 @@ description: >
 author: Roozbeh Pournader
 ---*/
 
-if (Intl.DateTimeFormat.prototype.constructor !== Intl.DateTimeFormat) {
-    $ERROR("Intl.DateTimeFormat.prototype.constructor is not the same as " +
-          "Intl.DateTimeFormat");
-}
+assert.sameValue(Intl.DateTimeFormat.prototype.constructor, Intl.DateTimeFormat, "Intl.DateTimeFormat.prototype.constructor is not the same as Intl.DateTimeFormat");

--- a/test/intl402/DateTimeFormat/prototype/format/12.3.2_1_c.js
+++ b/test/intl402/DateTimeFormat/prototype/format/12.3.2_1_c.js
@@ -23,11 +23,7 @@ locales.forEach(function (locales) {
         dates.forEach(function (date) {
             var referenceFormatted = formatObj.format(date);
             var formatted = formatFunc(date);
-            if (referenceFormatted !== formatted) {
-                $ERROR("format function produces different result than format method for locales " +
-                    locales + "; options: " + (options ? JSON.stringify(options) : options) +
-                    " : " + formatted + " vs. " + referenceFormatted + ".");
-            }
+            assert.sameValue(referenceFormatted, formatted, "format function produces different result than format method for locales " + locales + "; options: " + (options ? JSON.stringify(options) : options) + ".");
         });
     });
 });

--- a/test/intl402/DateTimeFormat/prototype/format/12.3.2_FDT_1.js
+++ b/test/intl402/DateTimeFormat/prototype/format/12.3.2_FDT_1.js
@@ -12,15 +12,7 @@ var invalidValues = [NaN, Infinity, -Infinity];
 var format = new Intl.DateTimeFormat();
 
 invalidValues.forEach(function (value) {
-    var error;
-    try {
+    assert.throws(RangeError, function() {
         var result = format.format(value);
-    } catch (e) {
-        error = e;
-    }
-    if (error === undefined) {
-        $ERROR("Invalid value " + value + " was not rejected.");
-    } else if (error.name !== "RangeError") {
-        $ERROR("Invalid value " + value + " was rejected with wrong error " + error.name + ".");
-    }
+    }, "Invalid value " + value + " was not rejected.");
 });

--- a/test/intl402/DateTimeFormat/prototype/format/12.3.2_FDT_7_a_iv.js
+++ b/test/intl402/DateTimeFormat/prototype/format/12.3.2_FDT_7_a_iv.js
@@ -18,17 +18,12 @@ var dates = [
 var format = new Intl.DateTimeFormat(["en-US"], {year: "numeric", month: "long", timeZone: "UTC"});
 
 // this test requires a Gregorian calendar, which we usually find in the US
-if (format.resolvedOptions().calendar !== "gregory") {
-    $ERROR("Internal error: Didn't find Gregorian calendar");
-}
+assert.sameValue(format.resolvedOptions().calendar, "gregory", "Internal error: Didn't find Gregorian calendar");
 
 dates.forEach(function (date) {
     var year = new Date(date).getUTCFullYear();
     var expectedYear = year <= 0 ? 1 - year : year;
     var expectedYearString = expectedYear.toLocaleString(["en-US"], {useGrouping: false});
     var dateString = format.format(date);
-    if (dateString.indexOf(expectedYearString) === -1) {
-        $ERROR("Formatted year doesn't contain expected year – expected " +
-            expectedYearString + ", got " + dateString + ".");
-    }
+    assert.notSameValue(dateString.indexOf(expectedYearString), -1, "Formatted year doesn't contain expected year – expected " + expectedYearString + ", got " + dateString + ".");
 });

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/12.3.3.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/12.3.3.js
@@ -14,9 +14,7 @@ includes: [testIntl.js]
 var actual = new Intl.DateTimeFormat().resolvedOptions();
 
 var actual2 = new Intl.DateTimeFormat().resolvedOptions();
-if (actual2 === actual) {
-    $ERROR("resolvedOptions returned the same object twice.");
-}
+assert.notSameValue(actual2, actual, "resolvedOptions returned the same object twice.");
 
 // source: CLDR file common/bcp47/calendar.xml; version CLDR 21.
 var calendars = [

--- a/test/intl402/DateTimeFormat/supportedLocalesOf/12.2.2_a.js
+++ b/test/intl402/DateTimeFormat/supportedLocalesOf/12.2.2_a.js
@@ -15,15 +15,9 @@ var requestedLocales = [defaultLocale, notSupported];
     
 var supportedLocales;
 
-if (!Intl.DateTimeFormat.hasOwnProperty('supportedLocalesOf')) {
-    $ERROR("Intl.DateTimeFormat doesn't have a supportedLocalesOf property.");
-}
+assert(Intl.DateTimeFormat.hasOwnProperty('supportedLocalesOf'), "Intl.DateTimeFormat doesn't have a supportedLocalesOf property.");
     
 supportedLocales = Intl.DateTimeFormat.supportedLocalesOf(requestedLocales);
-if (supportedLocales.length !== 1) {
-    $ERROR('The length of supported locales list is not 1.');
-}
+assert.sameValue(supportedLocales.length, 1, 'The length of supported locales list is not 1.');
     
-if (supportedLocales[0] !== defaultLocale) {
-    $ERROR('The default locale is not returned in the supported list.');
-}
+assert.sameValue(supportedLocales[0], defaultLocale, 'The default locale is not returned in the supported list.');

--- a/test/intl402/Intl/8.0.js
+++ b/test/intl402/Intl/8.0.js
@@ -7,6 +7,4 @@ description: Tests that Intl has Object.prototype as its prototype.
 author: Norbert Lindenberg
 ---*/
 
-if (Object.getPrototypeOf(Intl) !== Object.prototype) {
-    $ERROR("Intl doesn't have Object.prototype as its prototype.");
-}
+assert.sameValue(Object.getPrototypeOf(Intl), Object.prototype, "Intl doesn't have Object.prototype as its prototype.");

--- a/test/intl402/Number/prototype/toLocaleString/13.2.1_1.js
+++ b/test/intl402/Number/prototype/toLocaleString/13.2.1_1.js
@@ -11,17 +11,9 @@ var invalidValues = [undefined, null, "5", false, {valueOf: function () { return
 var validValues = [5, NaN, -1234567.89, -Infinity];
 
 invalidValues.forEach(function (value) {
-    var error;
-    try {
+    assert.throws(TypeError, function() {
         var result = Number.prototype.toLocaleString.call(value);
-    } catch (e) {
-        error = e;
-    }
-    if (error === undefined) {
-        $ERROR("Number.prototype.toLocaleString did not reject this = " + value + ".");
-    } else if (error.name !== "TypeError") {
-        $ERROR("Number.prototype.toLocaleString rejected this = " + value + " with wrong error " + error.name + ".");
-    }
+    }, "Number.prototype.toLocaleString did not reject this = " + value + ".");
 });
 
 // for valid values, just check that a Number value and the corresponding
@@ -30,8 +22,5 @@ validValues.forEach(function (value) {
     var Constructor = Number; // to keep jshint happy
     var valueResult = Number.prototype.toLocaleString.call(value);
     var objectResult = Number.prototype.toLocaleString.call(new Constructor(value));
-    if (valueResult !== objectResult) {
-        $ERROR("Number.prototype.toLocaleString produces different results for Number value " +
-            value + " and corresponding Number object: " + valueResult + " vs. " + objectResult + ".");
-    }
+    assert.sameValue(valueResult, objectResult, "Number.prototype.toLocaleString produces different results for Number value " + value + " and corresponding Number object.");
 });

--- a/test/intl402/Number/prototype/toLocaleString/13.2.1_4_1.js
+++ b/test/intl402/Number/prototype/toLocaleString/13.2.1_4_1.js
@@ -25,21 +25,11 @@ locales.forEach(function (locales) {
     } catch (e) {
         referenceError = e;
     }
-    if (referenceError === undefined) {
-        $ERROR("Internal error: Expected exception was not thrown by Intl.NumberFormat for locales " + locales + ".");
-    }
-    
-    try {
+    assert.notSameValue(referenceError, undefined, "Internal error: Expected exception was not thrown by Intl.NumberFormat for locales " + locales + ".");
+
+    assert.throws(referenceError.constructor, function() {
         var result = (0).toLocaleString(locales);
-    } catch (e) {
-        error = e;
-    }
-    if (error === undefined) {
-        $ERROR("Number.prototype.toLocaleString didn't throw exception for locales " + locales + ".");
-    } else if (error.name !== referenceError.name) {
-        $ERROR("Number.prototype.toLocaleString threw exception " + error.name +
-            " for locales " + locales + "; expected " + referenceError.name + ".");
-    }
+    }, "Number.prototype.toLocaleString didn't throw exception for locales " + locales + ".");
 });
 
 options.forEach(function (options) {
@@ -49,21 +39,9 @@ options.forEach(function (options) {
     } catch (e) {
         referenceError = e;
     }
-    if (referenceError === undefined) {
-        $ERROR("Internal error: Expected exception was not thrown by Intl.NumberFormat for options " +
-            JSON.stringify(options) + ".");
-    }
-    
-    try {
+    assert.notSameValue(referenceError, undefined, "Internal error: Expected exception was not thrown by Intl.NumberFormat for options " + JSON.stringify(options) + ".");
+
+    assert.throws(referenceError.constructor, function() {
         var result = (0).toLocaleString([], options);
-    } catch (e) {
-        error = e;
-    }
-    if (error === undefined) {
-        $ERROR("Number.prototype.toLocaleString didn't throw exception for options " +
-            JSON.stringify(options) + ".");
-    } else if (error.name !== referenceError.name) {
-        $ERROR("Number.prototype.toLocaleString threw exception " + error.name +
-            " for options " + JSON.stringify(options) + "; expected " + referenceError.name + ".");
-    }
+    }, "Number.prototype.toLocaleString didn't throw exception for options " + JSON.stringify(options) + ".");
 });

--- a/test/intl402/NumberFormat/11.1.1_1.js
+++ b/test/intl402/NumberFormat/11.1.1_1.js
@@ -19,16 +19,12 @@ testWithIntlConstructors(function (Constructor) {
     // variant 1: use constructor in a "new" expression
     obj = new Constructor();
     newObj = Intl.NumberFormat.call(obj);
-    if (obj === newObj) {
-      $ERROR("NumberFormat object created with \"new\" was not ignored as this-value.");
-    }
+    assert.notSameValue(obj, newObj, "NumberFormat object created with \"new\" was not ignored as this-value.");
 
     // variant 2: use constructor as a function
     obj = Constructor();
     newObj = Intl.NumberFormat.call(obj);
-    if (obj === newObj) {
-      $ERROR("NumberFormat object created with constructor as function was not ignored as this-value.");
-    }
+    assert.notSameValue(obj, newObj, "NumberFormat object created with constructor as function was not ignored as this-value.");
 
     return true;
 });

--- a/test/intl402/NumberFormat/11.1.1_17.js
+++ b/test/intl402/NumberFormat/11.1.1_17.js
@@ -19,63 +19,37 @@ validValues.forEach(function (value) {
     format = new Intl.NumberFormat([defaultLocale], {style: "currency", currency: value});
     actual = format.resolvedOptions().currency;
     expected = value.toString().toUpperCase();
-    if (actual !== expected) {
-        $ERROR("Incorrect resolved currency with currency style - expected " +
-            expected + "; got " + actual + ".");
-    }
+    assert.sameValue(actual, expected, "Incorrect resolved currency with currency style.");
     
     // without currency style, we shouldn't get any currency back
     format = new Intl.NumberFormat([defaultLocale], {currency: value});
     actual = format.resolvedOptions().currency;
     expected = undefined;
-    if (actual !== expected) {
-        $ERROR("Incorrect resolved currency with non-currency style - expected " +
-            expected + "; got " + actual + ".");
-    }
+    assert.sameValue(actual, expected, "Incorrect resolved currency with non-currency style.");
     
     // currencies specified through the locale must be ignored
     format = new Intl.NumberFormat([defaultLocale + "-u-cu-krw"], {style: "currency", currency: value});
     actual = format.resolvedOptions().currency;
     expected = value.toString().toUpperCase();
-    if (actual !== expected) {
-        $ERROR("Incorrect resolved currency with -u-cu- and currency style - expected " +
-            expected + "; got " + actual + ".");
-    }
+    assert.sameValue(actual, expected, "Incorrect resolved currency with -u-cu- and currency style.");
     
     format = new Intl.NumberFormat([defaultLocale + "-u-cu-krw"], {currency: value});
     actual = format.resolvedOptions().currency;
     expected = undefined;
-    if (actual !== expected) {
-        $ERROR("Incorrect resolved currency with -u-cu- and non-currency style - expected " +
-            expected + "; got " + actual + ".");
-    }
+    assert.sameValue(actual, expected, "Incorrect resolved currency with -u-cu- and non-currency style.");
 });
 
 invalidValues.forEach(function (value) {
-    function expectError(f) {
-        var error;
-        try {
-            f();
-        } catch (e) {
-            error = e;
-        }
-        if (error === undefined) {
-            $ERROR("Invalid currency value " + value + " was not rejected.");
-        } else if (error.name !== "RangeError") {
-            $ERROR("Invalid currency value " + value + " was rejected with wrong error " + error.name + ".");
-        }
-    }
-
-    expectError(function () {
+    assert.throws(RangeError, function () {
             return new Intl.NumberFormat([defaultLocale], {style: "currency", currency: value});
-    });
-    expectError(function () {
+    }, "Invalid currency value " + value + " was not rejected.");
+    assert.throws(RangeError, function () {
             return new Intl.NumberFormat([defaultLocale], {currency: value});
-    });
-    expectError(function () {
+    }, "Invalid currency value " + value + " was not rejected.");
+    assert.throws(RangeError, function () {
             return new Intl.NumberFormat([defaultLocale + "-u-cu-krw"], {style: "currency", currency: value});
-    });
-    expectError(function () {
+    }, "Invalid currency value " + value + " was not rejected.");
+    assert.throws(RangeError, function () {
             return new Intl.NumberFormat([defaultLocale + "-u-cu-krw"], {currency: value});
-    });
+    }, "Invalid currency value " + value + " was not rejected.");
 });

--- a/test/intl402/NumberFormat/11.1.1_19.js
+++ b/test/intl402/NumberFormat/11.1.1_19.js
@@ -11,23 +11,10 @@ author: Norbert Lindenberg
 
 var defaultLocale = new Intl.NumberFormat().resolvedOptions().locale;
 
-function expectError(f) {
-    var error;
-    try {
-        f();
-    } catch (e) {
-        error = e;
-    }
-    if (error === undefined) {
-        $ERROR("Invalid currency value " + value + " was not rejected.");
-    } else if (error.name !== "TypeError") {
-        $ERROR("Invalid currency value " + value + " was rejected with wrong error " + error.name + ".");
-    }
-}
-
-expectError(function () {
+assert.throws(TypeError, function () {
         return new Intl.NumberFormat([defaultLocale], {style: "currency"});
-});
-expectError(function () {
+}, "Throws TypeError when currency code is not specified.");
+
+assert.throws(TypeError, function () {
         return new Intl.NumberFormat([defaultLocale + "-u-cu-krw"], {style: "currency"});
-});
+}, "Throws TypeError when currency code is not specified; Currenty code from Unicode locale extension sequence is ignored.");

--- a/test/intl402/NumberFormat/11.1.1_20_c.js
+++ b/test/intl402/NumberFormat/11.1.1_20_c.js
@@ -183,12 +183,6 @@ Object.getOwnPropertyNames(currencyDigits).forEach(function (currency) {
     var format = Intl.NumberFormat([], {style: "currency", currency: currency});
     var min = format.resolvedOptions().minimumFractionDigits;
     var max = format.resolvedOptions().maximumFractionDigits;
-    if (min !== digits) {
-        $ERROR("Didn't get correct minimumFractionDigits for currency " +
-            currency + "; expected " + digits + ", got " + min + ".");
-    }
-    if (max !== digits) {
-        $ERROR("Didn't get correct maximumFractionDigits for currency " +
-            currency + "; expected " + digits + ", got " + max + ".");
-    }
+    assert.sameValue(min, digits, "Didn't get correct minimumFractionDigits for currency " + currency + ".");
+    assert.sameValue(max, digits, "Didn't get correct maximumFractionDigits for currency " + currency + ".");
 });

--- a/test/intl402/NumberFormat/11.1.1_6.js
+++ b/test/intl402/NumberFormat/11.1.1_6.js
@@ -13,6 +13,4 @@ includes: [testIntl.js]
 taintProperties(["localeMatcher"]);
 
 var locale = new Intl.NumberFormat(undefined, {localeMatcher: "lookup"}).resolvedOptions().locale;
-if (!isCanonicalizedStructurallyValidLanguageTag(locale)) {
-    $ERROR("NumberFormat returns invalid locale " + locale + ".");
-}
+assert(isCanonicalizedStructurallyValidLanguageTag(locale), "NumberFormat returns invalid locale " + locale + ".");

--- a/test/intl402/NumberFormat/11.1.3.js
+++ b/test/intl402/NumberFormat/11.1.3.js
@@ -12,10 +12,6 @@ author: Norbert Lindenberg
 var obj = new Intl.NumberFormat();
 
 var actualPrototype = Object.getPrototypeOf(obj);
-if (actualPrototype !== Intl.NumberFormat.prototype) {
-    $ERROR("Prototype of object constructed by Intl.NumberFormat isn't Intl.NumberFormat.prototype; got " + actualPrototype);
-}
+assert.sameValue(actualPrototype, Intl.NumberFormat.prototype, "Prototype of object constructed by Intl.NumberFormat isn't Intl.NumberFormat.prototype.");
 
-if (!Object.isExtensible(obj)) {
-    $ERROR("Object constructed by Intl.NumberFormat must be extensible.");
-}
+assert(Object.isExtensible(obj), "Object constructed by Intl.NumberFormat must be extensible.");

--- a/test/intl402/NumberFormat/11.2.3_b.js
+++ b/test/intl402/NumberFormat/11.2.3_b.js
@@ -29,18 +29,9 @@ locales.forEach(function (locale) {
         keyValues[key].forEach(function (value) {
             var numberFormat = new Intl.NumberFormat([locale + "-u-" + key + "-" + value]);
             var options = numberFormat.resolvedOptions();
-            if (options.locale !== defaultLocale) {
-                $ERROR("Locale " + options.locale + " is affected by key " +
-                key + "; value " + value + ".");
-            }
-            if (JSON.stringify(options) !== defaultOptionsJSON) {
-                $ERROR("Resolved options " + JSON.stringify(options) + " are affected by key " +
-                key + "; value " + value + ".");
-            }
-            if (defaultFormatted !== numberFormat.format(input)) {
-                $ERROR("Formatted value " + numberFormat.format(input) + " is affected by key " +
-                key + "; value " + value + ".");
-            }
+            assert.sameValue(options.locale, defaultLocale, "Locale " + options.locale + " is affected by key " + key + "; value " + value + ".");
+            assert.sameValue(JSON.stringify(options), defaultOptionsJSON, "Resolved options " + JSON.stringify(options) + " are affected by key " + key + "; value " + value + ".");
+            assert.sameValue(numberFormat.format(input), defaultFormatted, "Formatted value " + numberFormat.format(input) + " is affected by key " + key + "; value " + value + ".");
         });
     });
 });

--- a/test/intl402/NumberFormat/11.4_a.js
+++ b/test/intl402/NumberFormat/11.4_a.js
@@ -12,6 +12,4 @@ author: Norbert Lindenberg
 var obj = new Intl.NumberFormat();
 
 var toStringValue = Object.prototype.toString.call(obj);
-if (toStringValue !== "[object Object]") {
-    $ERROR("Intl.NumberFormat instance produces wrong [[Class]] - toString returns " + toStringValue + ".");
-}
+assert.sameValue(toStringValue, "[object Object]", "Intl.NumberFormat instance produces wrong [[Class]] - toString returns " + toStringValue + ".");

--- a/test/intl402/NumberFormat/6.3.1_a.js
+++ b/test/intl402/NumberFormat/6.3.1_a.js
@@ -18,8 +18,5 @@ var wellFormedCurrencyCodes = [
 wellFormedCurrencyCodes.forEach(function (code) {
     // this must not throw an exception for a valid currency code
     var format = new Intl.NumberFormat(["de-de"], {style: "currency", currency: code});
-    if (format.resolvedOptions().currency !== code.toUpperCase()) {
-        $ERROR("Currency " + code + " was not correctly accepted; turned into " +
-            format.resolvedOptions().currency + ".");
-    }
+    assert.sameValue(format.resolvedOptions().currency, code.toUpperCase(), "Currency " + code + " was not correctly accepted.");
 });

--- a/test/intl402/NumberFormat/6.3.1_b.js
+++ b/test/intl402/NumberFormat/6.3.1_b.js
@@ -20,16 +20,8 @@ var invalidCurrencyCodes = [
 ];
 
 invalidCurrencyCodes.forEach(function (code) {
-    var error;
-    try {
-        // this must throw an exception for an invalid currency code
+    // this must throw an exception for an invalid currency code
+    assert.throws(RangeError, function() {
         var format = new Intl.NumberFormat(["de-de"], {style: "currency", currency: code});
-    } catch (e) {
-        error = e;
-    }
-    if (error === undefined) {
-        $ERROR("Invalid currency code '" + code + "' was not rejected.");
-    } else if (error.name !== "RangeError") {
-        $ERROR("Invalid currency code '" + code + "' was rejected with wrong error " + error.name + ".");
-    }
+    }, "Invalid currency code '" + code + "' was not rejected.");
 });

--- a/test/intl402/NumberFormat/prototype/11.2.1.js
+++ b/test/intl402/NumberFormat/prototype/11.2.1.js
@@ -8,15 +8,7 @@ author: Norbert Lindenberg
 ---*/
 
 var desc = Object.getOwnPropertyDescriptor(Intl.NumberFormat, "prototype");
-if (desc === undefined) {
-    $ERROR("Intl.NumberFormat.prototype is not defined.");
-}
-if (desc.writable) {
-    $ERROR("Intl.NumberFormat.prototype must not be writable.");
-}
-if (desc.enumerable) {
-    $ERROR("Intl.NumberFormat.prototype must not be enumerable.");
-}
-if (desc.configurable) {
-    $ERROR("Intl.NumberFormat.prototype must not be configurable.");
-}
+assert.notSameValue(desc, undefined, "Intl.NumberFormat.prototype is not defined.");
+assert.sameValue(desc.writable, false, "Intl.NumberFormat.prototype must not be writable.");
+assert.sameValue(desc.enumerable, false, "Intl.NumberFormat.prototype must not be enumerable.");
+assert.sameValue(desc.configurable, false, "Intl.NumberFormat.prototype must not be configurable.");

--- a/test/intl402/NumberFormat/prototype/11.3_a.js
+++ b/test/intl402/NumberFormat/prototype/11.3_a.js
@@ -11,7 +11,4 @@ author: Roozbeh Pournader
 
 // test by calling a function that would fail if "this" were not an object
 // initialized as an Intl.NumberFormat
-if (typeof Intl.NumberFormat.prototype.format(0) !== "string") {
-    $ERROR("Intl.NumberFormat's prototype is not an object that has been " +
-        "initialized as an Intl.NumberFormat");
-}
+assert.sameValue(typeof Intl.NumberFormat.prototype.format(0), "string", "Intl.NumberFormat's prototype is not an object that has been initialized as an Intl.NumberFormat");

--- a/test/intl402/NumberFormat/prototype/11.3_b.js
+++ b/test/intl402/NumberFormat/prototype/11.3_b.js
@@ -19,16 +19,8 @@ var invalidTargets = [undefined, null, true, 0, "NumberFormat", [], {}];
 Object.getOwnPropertyNames(functions).forEach(function (functionName) {
     var f = functions[functionName];
     invalidTargets.forEach(function (target) {
-        var error;
-        try {
+        assert.throws(TypeError, function() {
             f.call(target);
-        } catch (e) {
-            error = e;
-        }
-        if (error === undefined) {
-            $ERROR("Calling " + functionName + " on " + target + " was not rejected.");
-        } else if (error.name !== "TypeError") {
-            $ERROR("Calling " + functionName + " on " + target + " was rejected with wrong error " + error.name + ".");
-        }
+        }, "Calling " + functionName + " on " + target + " was not rejected.");
     });
 });

--- a/test/intl402/NumberFormat/prototype/constructor/11.3.1.js
+++ b/test/intl402/NumberFormat/prototype/constructor/11.3.1.js
@@ -9,7 +9,4 @@ description: >
 author: Roozbeh Pournader
 ---*/
 
-if (Intl.NumberFormat.prototype.constructor !== Intl.NumberFormat) {
-    $ERROR("Intl.NumberFormat.prototype.constructor is not the same as " +
-          "Intl.NumberFormat");
-}
+assert.sameValue(Intl.NumberFormat.prototype.constructor, Intl.NumberFormat, "Intl.NumberFormat.prototype.constructor is not the same as Intl.NumberFormat");

--- a/test/intl402/NumberFormat/prototype/format/11.3.2_1_a_ii.js
+++ b/test/intl402/NumberFormat/prototype/format/11.3.2_1_a_ii.js
@@ -20,9 +20,5 @@ for (i in testData) {
     correctResult = formatter.format(number);
     
     result = formatter.format(input);
-    if (result !== correctResult) {
-        $ERROR('Intl.NumberFormat does not convert other ' +
-            'types to numbers. Input: "'+input+'" Output: "'+result+'" '+
-            'Expected output: "'+correctResult+'"');
-    }
+    assert.sameValue(result, correctResult, 'Intl.NumberFormat does not convert other types to numbers. Input: "' + input + '".');
 }

--- a/test/intl402/NumberFormat/prototype/format/11.3.2_1_c.js
+++ b/test/intl402/NumberFormat/prototype/format/11.3.2_1_c.js
@@ -30,11 +30,7 @@ locales.forEach(function (locales) {
         numbers.forEach(function (number) {
             var referenceFormatted = formatObj.format(number);
             var formatted = formatFunc(number);
-            if (referenceFormatted !== formatted) {
-                $ERROR("format function produces different result than format method for locales " +
-                    locales + "; options: " + (options ? JSON.stringify(options) : options) +
-                    " : " + formatted + " vs. " + referenceFormatted + ".");
-            }
+            assert.sameValue(referenceFormatted, formatted, "format function produces different result than format method for locales " + locales + "; options: " + (options ? JSON.stringify(options) : options) + ".");
         });
     });
 });

--- a/test/intl402/NumberFormat/prototype/format/11.3.2_FN_1.js
+++ b/test/intl402/NumberFormat/prototype/format/11.3.2_FN_1.js
@@ -11,10 +11,6 @@ author: Roozbeh Pournader
 
 var formatter = new Intl.NumberFormat();
   
-if (formatter.format(1) === formatter.format(-1)) {
-    $ERROR('Intl.NumberFormat is formatting 1 and -1 the same way.');
-}
+assert.notSameValue(formatter.format(1), formatter.format(-1), 'Intl.NumberFormat is formatting 1 and -1 the same way.');
 
-if (formatter.format(-0) !== formatter.format(0)) {
-    $ERROR('Intl.NumberFormat is formatting signed zeros differently.');
-}
+assert.sameValue(formatter.format(-0), formatter.format(0), 'Intl.NumberFormat is formatting signed zeros differently.');

--- a/test/intl402/NumberFormat/prototype/format/11.3.2_FN_2.js
+++ b/test/intl402/NumberFormat/prototype/format/11.3.2_FN_2.js
@@ -30,31 +30,14 @@ var formattedNaN = formatter.format(NaN);
 var formattedInfinity = formatter.format(Infinity);
 var formattedNegativeInfinity = formatter.format(-Infinity);
 
-if (formattedNaN === formattedInfinity) {
-    $ERROR('Intl.NumberFormat formats NaN and Infinity the ' +
-        'same way.');
-}
+assert.notSameValue(formattedNaN, formattedInfinity, 'Intl.NumberFormat formats NaN and Infinity the same way.');
 
-if (formattedNaN === formattedNegativeInfinity) {
-    $ERROR('Intl.NumberFormat formats NaN and negative ' +
-        'Infinity the same way.');
-}
+assert.notSameValue(formattedNaN, formattedNegativeInfinity, 'Intl.NumberFormat formats NaN and negative Infinity the same way.');
 
-if (formattedInfinity === formattedNegativeInfinity) {
-    $ERROR('Intl.NumberFormat formats Infinity and ' +
-        'negative Infinity the same way.');
-}
+assert.notSameValue(formattedInfinity, formattedNegativeInfinity, 'Intl.NumberFormat formats Infinity and negative Infinity the same way.');
 
-if (hasUnicodeDigits.test(formattedNaN)) {
-    $ERROR('Intl.NumberFormat formats NaN using a digit.');
-}
+assert.sameValue(hasUnicodeDigits.test(formattedNaN), false, 'Intl.NumberFormat formats NaN using a digit.');
 
-if (hasUnicodeDigits.test(formattedInfinity)) {
-    $ERROR('Intl.NumberFormat formats Infinity using a ' +
-        'digit.');
-}
+assert.sameValue(hasUnicodeDigits.test(formattedInfinity), false, 'Intl.NumberFormat formats Infinity using a digit.');
 
-if (hasUnicodeDigits.test(formattedNegativeInfinity)) {
-    $ERROR('Intl.NumberFormat formats negative Infinity ' + 
-        'using a digit.');
-}
+assert.sameValue(hasUnicodeDigits.test(formattedNegativeInfinity), false, 'Intl.NumberFormat formats negative Infinity using a digit.');

--- a/test/intl402/NumberFormat/prototype/format/11.3.2_FN_3_b.js
+++ b/test/intl402/NumberFormat/prototype/format/11.3.2_FN_3_b.js
@@ -17,12 +17,7 @@ var formattedTwentyPercent = percentFormatter.format(0.20);
 
 // FIXME: May not work for some theoretical locales where percents and
 // normal numbers are formatted using different numbering systems.
-if (formattedTwentyPercent.indexOf(formattedTwenty) === -1) {
-    $ERROR("Intl.NumberFormat's formatting of 20% does not include a " +
-        "formatting of 20 as a substring.");
-}
+assert.notSameValue(formattedTwentyPercent.indexOf(formattedTwenty), -1, "Intl.NumberFormat's formatting of 20% does not include a formatting of 20 as a substring.");
 
 // FIXME: Move this to somewhere appropriate
-if (percentFormatter.format(0.011) === percentFormatter.format(0.02)) {
-    $ERROR('Intl.NumberFormat is formatting 1.1% and 2% the same way.');
-}
+assert.notSameValue(percentFormatter.format(0.011), percentFormatter.format(0.02), 'Intl.NumberFormat is formatting 1.1% and 2% the same way.');

--- a/test/intl402/NumberFormat/prototype/resolvedOptions/11.3.3.js
+++ b/test/intl402/NumberFormat/prototype/resolvedOptions/11.3.3.js
@@ -14,9 +14,7 @@ includes: [testIntl.js]
 var actual = new Intl.NumberFormat().resolvedOptions();
 
 var actual2 = new Intl.NumberFormat().resolvedOptions();
-if (actual2 === actual) {
-    $ERROR("resolvedOptions returned the same object twice.");
-}
+assert.notSameValue(actual2, actual, "resolvedOptions returned the same object twice.");
 
 // this assumes the default values where the specification provides them
 mustHaveProperty(actual, "locale", isCanonicalizedStructurallyValidLanguageTag);

--- a/test/intl402/NumberFormat/supportedLocalesOf/11.2.2_a.js
+++ b/test/intl402/NumberFormat/supportedLocalesOf/11.2.2_a.js
@@ -15,15 +15,9 @@ var requestedLocales = [defaultLocale, notSupported];
     
 var supportedLocales;
 
-if (!Intl.NumberFormat.hasOwnProperty('supportedLocalesOf')) {
-    $ERROR("Intl.NumberFormat doesn't have a supportedLocalesOf property.");
-}
+assert(Intl.NumberFormat.hasOwnProperty('supportedLocalesOf'), "Intl.NumberFormat doesn't have a supportedLocalesOf property.");
     
 supportedLocales = Intl.NumberFormat.supportedLocalesOf(requestedLocales);
-if (supportedLocales.length !== 1) {
-    $ERROR('The length of supported locales list is not 1.');
-}
+assert.sameValue(supportedLocales.length, 1, 'The length of supported locales list is not 1.');
     
-if (supportedLocales[0] !== defaultLocale) {
-    $ERROR('The default locale is not returned in the supported list.');
-}
+assert.sameValue(supportedLocales[0], defaultLocale, 'The default locale is not returned in the supported list.');

--- a/test/intl402/PluralRules/internals.js
+++ b/test/intl402/PluralRules/internals.js
@@ -12,10 +12,6 @@ author: Zibi Braniecki
 var obj = new Intl.PluralRules();
 
 var actualPrototype = Object.getPrototypeOf(obj);
-if (actualPrototype !== Intl.PluralRules.prototype) {
-    $ERROR("Prototype of object constructed by Intl.PluralRules isn't Intl.PluralRules.prototype; got " + actualPrototype);
-}
+assert.sameValue(actualPrototype, Intl.PluralRules.prototype, "Prototype of object constructed by Intl.PluralRules isn't Intl.PluralRules.prototype; got " + actualPrototype);
 
-if (!Object.isExtensible(obj)) {
-    $ERROR("Object constructed by Intl.PluralRules must be extensible.");
-}
+assert(Object.isExtensible(obj), "Object constructed by Intl.PluralRules must be extensible.");

--- a/test/intl402/PluralRules/prototype/bind.js
+++ b/test/intl402/PluralRules/prototype/bind.js
@@ -19,16 +19,8 @@ var invalidTargets = [undefined, null, true, 0, "PluralRules", [], {}];
 Object.getOwnPropertyNames(functions).forEach(function (functionName) {
     var f = functions[functionName];
     invalidTargets.forEach(function (target) {
-        var error;
-        try {
+        assert.throws(TypeError, function () {
             f.call(target);
-        } catch (e) {
-            error = e;
-        }
-        if (error === undefined) {
-            $ERROR("Calling " + functionName + " on " + target + " was not rejected.");
-        } else if (error.name !== "TypeError") {
-            $ERROR("Calling " + functionName + " on " + target + " was rejected with wrong error " + error.name + ".");
-        }
+        }, "Calling " + functionName + " on " + target + " was not rejected.");
     });
 });

--- a/test/intl402/PluralRules/prototype/constructor/main.js
+++ b/test/intl402/PluralRules/prototype/constructor/main.js
@@ -9,7 +9,4 @@ description: >
 author: Zibi Braniecki
 ---*/
 
-if (Intl.PluralRules.prototype.constructor !== Intl.PluralRules) {
-    $ERROR("Intl.PluralRules.prototype.constructor is not the same as " +
-          "Intl.PluralRules");
-}
+assert.sameValue(Intl.PluralRules.prototype.constructor, Intl.PluralRules, "Intl.PluralRules.prototype.constructor is not the same as Intl.PluralRules");

--- a/test/intl402/PluralRules/prototype/properties.js
+++ b/test/intl402/PluralRules/prototype/properties.js
@@ -8,15 +8,7 @@ author: Zibi Braniecki
 ---*/
 
 var desc = Object.getOwnPropertyDescriptor(Intl.PluralRules, "prototype");
-if (desc === undefined) {
-    $ERROR("Intl.PluralRules.prototype is not defined.");
-}
-if (desc.writable) {
-    $ERROR("Intl.PluralRules.prototype must not be writable.");
-}
-if (desc.enumerable) {
-    $ERROR("Intl.PluralRules.prototype must not be enumerable.");
-}
-if (desc.configurable) {
-    $ERROR("Intl.PluralRules.prototype must not be configurable.");
-}
+assert.notSameValue(desc, undefined, "Intl.PluralRules.prototype is not defined.");
+assert.sameValue(desc.writable, false, "Intl.PluralRules.prototype must not be writable.");
+assert.sameValue(desc.enumerable, false, "Intl.PluralRules.prototype must not be enumerable.");
+assert.sameValue(desc.configurable, false, "Intl.PluralRules.prototype must not be configurable.");

--- a/test/intl402/PluralRules/prototype/resolvedOptions/properties.js
+++ b/test/intl402/PluralRules/prototype/resolvedOptions/properties.js
@@ -14,9 +14,7 @@ includes: [testIntl.js]
 var actual = new Intl.PluralRules().resolvedOptions();
 
 var actual2 = new Intl.PluralRules().resolvedOptions();
-if (actual2 === actual) {
-    $ERROR("resolvedOptions returned the same object twice.");
-}
+assert.notSameValue(actual2, actual, "resolvedOptions returned the same object twice.");
 
 // this assumes the default values where the specification provides them
 mustHaveProperty(actual, "locale", isCanonicalizedStructurallyValidLanguageTag);

--- a/test/intl402/PluralRules/supportedLocalesOf/main.js
+++ b/test/intl402/PluralRules/supportedLocalesOf/main.js
@@ -15,15 +15,9 @@ var requestedLocales = [defaultLocale, notSupported];
     
 var supportedLocales;
 
-if (!Intl.PluralRules.hasOwnProperty('supportedLocalesOf')) {
-    $ERROR("Intl.PluralRules doesn't have a supportedLocalesOf property.");
-}
+assert(Intl.PluralRules.hasOwnProperty('supportedLocalesOf'), "Intl.PluralRules doesn't have a supportedLocalesOf property.");
     
 supportedLocales = Intl.PluralRules.supportedLocalesOf(requestedLocales);
-if (supportedLocales.length !== 1) {
-    $ERROR('The length of supported locales list is not 1.');
-}
-    
-if (supportedLocales[0] !== defaultLocale) {
-    $ERROR('The default locale is not returned in the supported list.');
-}
+assert.sameValue(supportedLocales.length, 1, 'The length of supported locales list is not 1.');
+
+assert.sameValue(supportedLocales[0], defaultLocale, 'The default locale is not returned in the supported list.');

--- a/test/intl402/String/prototype/localeCompare/13.1.1_1.js
+++ b/test/intl402/String/prototype/localeCompare/13.1.1_1.js
@@ -12,15 +12,7 @@ author: Norbert Lindenberg
 var invalidValues = [undefined, null];
  
 invalidValues.forEach(function (value) {
-    var error;
-    try {
+    assert.throws(TypeError, function() {
         var result = String.prototype.localeCompare.call(value, "");
-    } catch (e) {
-        error = e;
-    }
-    if (error === undefined) {
-        $ERROR("String.prototype.localeCompare did not reject this = " + value + ".");
-    } else if (error.name !== "TypeError") {
-        $ERROR("String.prototype.localeCompare rejected this = " + value + " with wrong error " + error.name + ".");
-    }
+    }, "String.prototype.localeCompare did not reject this = " + value + ".");
 });

--- a/test/intl402/String/prototype/localeCompare/13.1.1_2.js
+++ b/test/intl402/String/prototype/localeCompare/13.1.1_2.js
@@ -15,12 +15,6 @@ for (i = 0; i < thisValues.length; i++) {
     var j;
     for (j = 0; j < thatValues.length; j++) {
         var result = String.prototype.localeCompare.call(thisValues[i], thatValues[j]);
-        if ((result === 0) !== (i === j)) {
-            if (result === 0) {
-                $ERROR("localeCompare treats " + thisValues[i] + " and " + thatValues[j] + " as equal.");
-            } else {
-                $ERROR("localeCompare treats " + thisValues[i] + " and " + thatValues[j] + " as different.");
-            }
-        }
+        assert.sameValue((result === 0), (i === j), "localeCompare treats " + thisValues[i] + " and " + thatValues[j] + " as " + (result === 0 ? "equal" : "different") + ".");
     }
 }

--- a/test/intl402/String/prototype/localeCompare/13.1.1_3_1.js
+++ b/test/intl402/String/prototype/localeCompare/13.1.1_3_1.js
@@ -15,12 +15,6 @@ for (i = 0; i < thisValues.length; i++) {
     var j;
     for (j = 0; j < thatValues.length; j++) {
         var result = String.prototype.localeCompare.call(thisValues[i], thatValues[j]);
-        if ((result === 0) !== (i === j)) {
-            if (result === 0) {
-                $ERROR("localeCompare treats " + thisValues[i] + " and " + thatValues[j] + " as equal.");
-            } else {
-                $ERROR("localeCompare treats " + thisValues[i] + " and " + thatValues[j] + " as different.");
-            }
-        }
+        assert.sameValue((result === 0), (i === j), "localeCompare treats " + thisValues[i] + " and " + thatValues[j] + " as " + (result === 0 ? "equal" : "different") + ".");
     }
 }

--- a/test/intl402/String/prototype/localeCompare/13.1.1_3_2.js
+++ b/test/intl402/String/prototype/localeCompare/13.1.1_3_2.js
@@ -14,10 +14,6 @@ var thisValues = ["a", "t", "u", "undefined", "UNDEFINED", "nicht definiert", "x
 var i;
 for (i = 0; i < thisValues.length; i++) {
     var thisValue = thisValues[i];
-    if (thisValue.localeCompare() !== thisValue.localeCompare(undefined)) {
-        $ERROR("String.prototype.localeCompare does not treat missing 'that' argument as undefined.");
-    }
-    if (thisValue.localeCompare(undefined) !== thisValue.localeCompare("undefined")) {
-        $ERROR("String.prototype.localeCompare does not treat undefined 'that' argument as \"undefined\".");
-    }
+    assert.sameValue(thisValue.localeCompare(), thisValue.localeCompare(undefined), "String.prototype.localeCompare does not treat missing 'that' argument as undefined.");
+    assert.sameValue(thisValue.localeCompare(undefined), thisValue.localeCompare("undefined"), "String.prototype.localeCompare does not treat undefined 'that' argument as \"undefined\".");
 }

--- a/test/intl402/String/prototype/localeCompare/13.1.1_6_1.js
+++ b/test/intl402/String/prototype/localeCompare/13.1.1_6_1.js
@@ -23,21 +23,11 @@ locales.forEach(function (locales) {
     } catch (e) {
         referenceError = e;
     }
-    if (referenceError === undefined) {
-        $ERROR("Internal error: Expected exception was not thrown by Intl.Collator for locales " + locales + ".");
-    }
-    
-    try {
+    assert.notSameValue(referenceError, undefined, "Internal error: Expected exception was not thrown by Intl.Collator for locales " + locales + ".");
+
+    assert.throws(referenceError.constructor, function() {
         var result = "".localeCompare("", locales);
-    } catch (e) {
-        error = e;
-    }
-    if (error === undefined) {
-        $ERROR("String.prototype.localeCompare didn't throw exception for locales " + locales + ".");
-    } else if (error.name !== referenceError.name) {
-        $ERROR("String.prototype.localeCompare threw exception " + error.name +
-            " for locales " + locales + "; expected " + referenceError.name + ".");
-    }
+    }, "String.prototype.localeCompare didn't throw exception for locales " + locales + ".");
 });
 
 options.forEach(function (options) {
@@ -47,21 +37,9 @@ options.forEach(function (options) {
     } catch (e) {
         referenceError = e;
     }
-    if (referenceError === undefined) {
-        $ERROR("Internal error: Expected exception was not thrown by Intl.Collator for options " +
-            JSON.stringify(options) + ".");
-    }
-    
-    try {
+    assert.notSameValue(referenceError, undefined, "Internal error: Expected exception was not thrown by Intl.Collator for options " + JSON.stringify(options) + ".");
+
+    assert.throws(referenceError.constructor, function() {
         var result = "".localeCompare("", [], options);
-    } catch (e) {
-        error = e;
-    }
-    if (error === undefined) {
-        $ERROR("String.prototype.localeCompare didn't throw exception for options " +
-            JSON.stringify(options) + ".");
-    } else if (error.name !== referenceError.name) {
-        $ERROR("String.prototype.localeCompare threw exception " + error.name +
-            " for options " + JSON.stringify(options) + "; expected " + referenceError.name + ".");
-    }
+    }, "String.prototype.localeCompare didn't throw exception for options " + JSON.stringify(options) + ".");
 });


### PR DESCRIPTION
This is a (for the most part) automatic conversion to use the assert-lib for the intl402 tests. There's is definitely room for improvement, e.g. some lines are too long, some error messages could be improved, there are also tests which should probably be rewritten from scratch. But the goal for this PR is only the conversion from `$ERROR` to `assert` - any other improvements should be done in a separate PR. 😄 