### PR TITLE
Fix test for ES5 & add new test for ES6

### DIFF
--- a/test/built-ins/Function/prototype/call/S15.3.4.4_A9.js
+++ b/test/built-ins/Function/prototype/call/S15.3.4.4_A9.js
@@ -17,11 +17,11 @@ if (!(Function.prototype.call.hasOwnProperty('length'))) {
 }
 
 //CHECK#1
-if (!delete Function.prototype.call.length) {
-  $ERROR('#1: The Function.prototype.call.length property does not have the attributes DontDelete');
+if (delete Function.prototype.call.length) {
+  $ERROR('#1: The Function.prototype.call.length property does have the attributes DontDelete');
 }
 
 //CHECK#2
-if (Function.prototype.call.hasOwnProperty('length')) {
-  $ERROR('#2: The Function.prototype.call.length property does not have the attributes DontDelete');
+if (!(Function.prototype.call.hasOwnProperty('length'))) {
+  $ERROR('#2: The Function.prototype.call has length property');
 }

--- a/test/built-ins/Function/prototype/call/length.js
+++ b/test/built-ins/Function/prototype/call/length.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 Tomas Mysik. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: >
+    The Function.prototype.call.length property is configurable
+es6id: 19.2.3.3
+description: >
+    Checking if deleting the Function.prototype.call.length property
+    fails
+---*/
+
+//CHECK#0
+if (!(Function.prototype.call.hasOwnProperty('length'))) {
+  $ERROR('#0: the Function.prototype.call has length property');
+}
+
+//CHECK#1
+if (!delete Function.prototype.call.length) {
+  $ERROR('#1: The Function.prototype.call.length property is not configurable');
+}
+
+//CHECK#2
+if (Function.prototype.call.hasOwnProperty('length')) {
+  $ERROR('#2: The Function.prototype.call.length property is not configurable');
+}


### PR DESCRIPTION
The original test used `es5id` but verified `ES6` behavior. Added new test which verifies behavior on `ES6`.

There are more similar tests like this one that could be fixed this way but since I am not sure whether my understanding of `es5id` etc. is correct, creating PR for just one test for now :)

Thank you.
