### PR TITLE
Add tests for Promises rejection queue

### DIFF
--- a/test/built-ins/Promise/reject-via-abrupt-queue.js
+++ b/test/built-ins/Promise/reject-via-abrupt-queue.js
@@ -36,7 +36,7 @@ info: |
 flags: [async]
 ---*/
 
-var thenable = new Promise(function() {});
+var thenable = Promise.resolve();
 var p = new Promise(function() {
   throw thenable;
 });

--- a/test/built-ins/Promise/reject-via-abrupt-queue.js
+++ b/test/built-ins/Promise/reject-via-abrupt-queue.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Rejecting through an abrupt completion - captured in a queued job
+esid: sec-promise-executor
+info: |
+  25.4.3.1 Promise ( executor )
+
+  ...
+  9. Let completion be Call(executor, undefined, « resolvingFunctions.[[Resolve]],
+    resolvingFunctions.[[Reject]] »).
+  10. If completion is an abrupt completion, then
+    a. Perform ? Call(resolvingFunctions.[[Reject]], undefined, « completion.[[Value]] »).
+  11. Return promise.
+
+  25.4.1.3.1 Promise Reject Functions
+
+  ...
+  6. Return RejectPromise(promise, reason).
+
+  25.4.5.3.1 PerformPromiseThen ( promise, onFulfilled, onRejected, resultCapability )
+
+  ...
+  4. If IsCallable(onRejected) is false, then
+    a. Set onRejected to undefined.
+  ...
+  6. Let rejectReaction be the PromiseReaction { [[Capability]]: resultCapability,
+    [[Type]]: "Reject", [[Handler]]: onRejected }.
+  ...
+  9. Else,
+    a. Assert: The value of promise.[[PromiseState]] is "rejected".
+    ...
+    d. Perform EnqueueJob("PromiseJobs", PromiseReactionJob, « rejectReaction, reason »).
+flags: [async]
+---*/
+
+var thenable = new Promise(function() {});
+var p = new Promise(function() {
+  throw thenable;
+});
+
+p.then(function() {
+    $DONE('The promise should not be fulfilled.');
+  }).then(function() {
+    $DONE('The promise should not be fulfilled.');
+  }, function(x) {
+    if (x !== thenable) {
+      $DONE('The promise should be rejected with the resolution value.');
+      return;
+    }
+    $DONE();
+  });

--- a/test/built-ins/Promise/reject-via-fn-deferred-queue.js
+++ b/test/built-ins/Promise/reject-via-fn-deferred-queue.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Rejecting through deferred invocation of the provided resolving function,
+  captured in a queued job.
+esid: sec-promise-executor
+info: |
+  25.4.3.1 Promise ( executor )
+
+  ...
+  9. Let completion be Call(executor, undefined, « resolvingFunctions.[[Resolve]],
+    resolvingFunctions.[[Reject]] »).
+  10. If completion is an abrupt completion, then
+    a. Perform ? Call(resolvingFunctions.[[Reject]], undefined, « completion.[[Value]] »).
+  11. Return promise.
+
+  25.4.1.3.1 Promise Reject Functions
+
+  ...
+  6. Return RejectPromise(promise, reason).
+
+  25.4.5.3.1 PerformPromiseThen ( promise, onFulfilled, onRejected, resultCapability )
+
+  ...
+  4. If IsCallable(onRejected) is false, then
+    a. Set onRejected to undefined.
+  ...
+  6. Let rejectReaction be the PromiseReaction { [[Capability]]: resultCapability,
+    [[Type]]: "Reject", [[Handler]]: onRejected }.
+  7. If promise.[[PromiseState]] is "pending", then
+    ...
+    b. Append rejectReaction as the last element of the List that is
+      promise.[[PromiseRejectReactions]].
+  ...
+flags: [async]
+---*/
+
+var thenable = new Promise(function() {});
+var returnValue = null;
+var reject;
+var p = new Promise(function(_, _reject) {
+  reject = _reject;
+});
+
+p.then(function() {
+    $DONE('The promise should not be fulfilled.');
+  }).then(function() {
+    $DONE('The promise should not be fulfilled.');
+  }, function(x) {
+    if (x !== thenable) {
+      $DONE('The promise should be rejected with the resolution value.');
+      return;
+    }
+
+    $DONE();
+  });
+
+returnValue = reject(thenable);
+
+assert.sameValue(returnValue, undefined, '"reject" function return value');

--- a/test/built-ins/Promise/reject-via-fn-deferred-queue.js
+++ b/test/built-ins/Promise/reject-via-fn-deferred-queue.js
@@ -37,7 +37,7 @@ info: |
 flags: [async]
 ---*/
 
-var thenable = new Promise(function() {});
+var thenable = Promise.resolve();
 var returnValue = null;
 var reject;
 var p = new Promise(function(_, _reject) {

--- a/test/built-ins/Promise/reject-via-fn-immed-queue.js
+++ b/test/built-ins/Promise/reject-via-fn-immed-queue.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Rejecting through immediate invocation of the provided resolving function,
+  captured in a queued job.
+esid: sec-promise-executor
+info: |
+  25.4.3.1 Promise ( executor )
+
+  ...
+  9. Let completion be Call(executor, undefined, « resolvingFunctions.[[Resolve]],
+    resolvingFunctions.[[Reject]] »).
+  10. If completion is an abrupt completion, then
+    a. Perform ? Call(resolvingFunctions.[[Reject]], undefined, « completion.[[Value]] »).
+  11. Return promise.
+
+  25.4.1.3.1 Promise Reject Functions
+
+  ...
+  6. Return RejectPromise(promise, reason).
+
+  25.4.5.3.1 PerformPromiseThen ( promise, onFulfilled, onRejected, resultCapability )
+
+  ...
+  4. If IsCallable(onRejected) is false, then
+    a. Set onRejected to undefined.
+  ...
+  6. Let rejectReaction be the PromiseReaction { [[Capability]]: resultCapability,
+    [[Type]]: "Reject", [[Handler]]: onRejected }.
+  ...
+  9. Else,
+    a. Assert: The value of promise.[[PromiseState]] is "rejected".
+    ...
+    d. Perform EnqueueJob("PromiseJobs", PromiseReactionJob, « rejectReaction, reason »).
+flags: [async]
+---*/
+
+var thenable = new Promise(function() {});
+var returnValue = null;
+var p = new Promise(function(_, reject) {
+  returnValue = reject(thenable);
+});
+
+assert.sameValue(returnValue, undefined, '"reject" function return value');
+
+p.then(function() {
+    $DONE('The promise should not be fulfilled.');
+  }).then(function() {
+    $DONE('The promise should not be fulfilled.');
+  }, function(x) {
+    if (x !== thenable) {
+      $DONE('The promise should be rejected with the resolution value.');
+      return;
+    }
+
+    $DONE();
+  });

--- a/test/built-ins/Promise/reject-via-fn-immed-queue.js
+++ b/test/built-ins/Promise/reject-via-fn-immed-queue.js
@@ -37,7 +37,7 @@ info: |
 flags: [async]
 ---*/
 
-var thenable = new Promise(function() {});
+var thenable = Promise.resolve();
 var returnValue = null;
 var p = new Promise(function(_, reject) {
   returnValue = reject(thenable);


### PR DESCRIPTION
These basic tests assert the rejection is captured but a later queued job
from a chain of then calls.