### PR TITLE
Assert iterators are consumed - and closed - in dstr patterns

### DIFF
--- a/src/dstr-binding/ary-ptrn-elision-iter-close.case
+++ b/src/dstr-binding/ary-ptrn-elision-iter-close.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: iter-close
+desc: >
+  The iterator is properly consumed by the destructuring pattern
+---*/
+
+//- setup
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+//- elems
+[,]
+//- iter
+iter
+//- assertions
+assert.sameValue(iter.next().done, true, 'iteration occurred as expected');

--- a/src/dstr-binding/ary-ptrn-rest-id-iter-close.case
+++ b/src/dstr-binding/ary-ptrn-rest-id-iter-close.case
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: iter-close
+desc: >
+  The iterator is properly consumed by the destructuring pattern
+---*/
+
+//- setup
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+//- elems
+[...x]
+//- iter
+iter
+//- assertions
+assert.sameValue(iter.next().done, true, 'iteration occurred as expected');

--- a/src/dstr-binding/iter-close/for-await-of-async-func-const.template
+++ b/src/dstr-binding/iter-close/for-await-of-async-func-const.template
@@ -1,0 +1,50 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/for-await-of/async-func-dstr-const-
+name: for-await-of statement in an async function
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+async function fn() {
+  for await (const /*{ elems }*/ of [/*{ iter }*/]) {
+    return;
+  }
+}
+
+fn()
+  .then(() => {
+    /*{ assertions }*/
+  })
+  .then($DONE, $DONE);

--- a/src/dstr-binding/iter-close/for-await-of-async-func-let.template
+++ b/src/dstr-binding/iter-close/for-await-of-async-func-let.template
@@ -1,0 +1,50 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for-await-of/async-func-dstr-let-
+name: for-await-of statement
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+async function fn() {
+  for await (let /*{ elems }*/ of [/*{ iter }*/]) {
+    return;
+  }
+}
+
+fn()
+  .then(() => {
+    /*{ assertions }*/
+  })
+  .then($DONE, $DONE);
+

--- a/src/dstr-binding/iter-close/for-await-of-async-func-var.template
+++ b/src/dstr-binding/iter-close/for-await-of-async-func-var.template
@@ -1,0 +1,46 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for-await-of/async-func-dstr-var-
+name: for-await-of statement
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [async]
+info: |
+    IterationStatement :
+        for await ( var ForBinding of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForBinding, Statement, keyResult,
+        varBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              1. Assert: lhs is a ForBinding.
+              2. Let status be the result of performing BindingInitialization
+                 for lhs passing nextValue and undefined as the arguments.
+          [...]
+---*/
+
+async function fn() {
+  for await (var /*{ elems }*/ of [/*{ iter }*/]) {
+    return;
+  }
+}
+
+fn()
+  .then(() => {
+    /*{ assertions }*/
+  })
+  .then($DONE, $DONE);

--- a/src/dstr-binding/iter-close/for-await-of-async-gen-const.template
+++ b/src/dstr-binding/iter-close/for-await-of-async-gen-const.template
@@ -1,0 +1,50 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for-await-of/async-gen-dstr-const-
+name: for-await-of statement
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+async function* fn() {
+  for await (const /*{ elems }*/ of [/*{ iter }*/]) {
+    return;
+  }
+}
+
+fn()
+  .next()
+  .then(() => {
+    /*{ assertions }*/
+  })
+  .then($DONE, $DONE);

--- a/src/dstr-binding/iter-close/for-await-of-async-gen-let.template
+++ b/src/dstr-binding/iter-close/for-await-of-async-gen-let.template
@@ -1,0 +1,50 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for-await-of/async-gen-dstr-let-
+name: for-await-of statement
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+async function* fn() {
+  for await (let /*{ elems }*/ of [/*{ iter }*/]) {
+    return;
+  }
+}
+
+fn()
+  .next()
+  .then(() => {
+    /*{ assertions }*/
+  })
+  .then($DONE, $DONE);

--- a/src/dstr-binding/iter-close/for-await-of-async-gen-var.template
+++ b/src/dstr-binding/iter-close/for-await-of-async-gen-var.template
@@ -1,0 +1,47 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for-await-of/async-gen-dstr-var-
+name: for-await-of statement
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [async]
+info: |
+    IterationStatement :
+        for await ( var ForBinding of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForBinding, Statement, keyResult,
+        varBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              1. Assert: lhs is a ForBinding.
+              2. Let status be the result of performing BindingInitialization
+                 for lhs passing nextValue and undefined as the arguments.
+          [...]
+---*/
+
+async function* fn() {
+  for await (var /*{ elems }*/ of [/*{ iter }*/]) {
+    return;
+  }
+}
+
+fn()
+  .next()
+  .then(() => {
+    /*{ assertions }*/
+  })
+  .then($DONE, $DONE);

--- a/src/dstr-binding/iter-close/for-const.template
+++ b/src/dstr-binding/iter-close/for-const.template
@@ -1,0 +1,47 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for/dstr-const-
+name: for statement
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+es6id: 13.7.4.7
+features: [destructuring-binding]
+info: |
+    IterationStatement :
+        for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    [...]
+    7. Let forDcl be the result of evaluating LexicalDeclaration.
+    [...]
+
+    LexicalDeclaration : LetOrConst BindingList ;
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return NormalCompletion(empty).
+
+    BindingList : BindingList , LexicalBinding
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating LexicalBinding.
+
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context’s LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+---*/
+
+function fn() {
+  for (const /*{ elems }*/ = /*{ iter }*/; ; ) {
+    return;
+  }
+}
+
+fn();
+
+/*{ assertions }*/

--- a/src/dstr-binding/iter-close/for-let.template
+++ b/src/dstr-binding/iter-close/for-let.template
@@ -1,0 +1,47 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for/dstr-let-
+name: for statement
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+es6id: 13.7.4.7
+features: [destructuring-binding]
+info: |
+    IterationStatement :
+        for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    [...]
+    7. Let forDcl be the result of evaluating LexicalDeclaration.
+    [...]
+
+    LexicalDeclaration : LetOrConst BindingList ;
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return NormalCompletion(empty).
+
+    BindingList : BindingList , LexicalBinding
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating LexicalBinding.
+
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context’s LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+---*/
+
+function fn() {
+  for (let /*{ elems }*/ = /*{ iter }*/; ; ) {
+    return;
+  }
+}
+
+fn();
+
+/*{ assertions }*/

--- a/src/dstr-binding/iter-close/for-of-const.template
+++ b/src/dstr-binding/iter-close/for-of-const.template
@@ -1,0 +1,47 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for-of/dstr-const-
+name: for-of statement
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+es6id: 13.7.5.11
+features: [destructuring-binding]
+info: |
+    IterationStatement :
+        for ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+function fn() {
+  for (const /*{ elems }*/ of [/*{ iter }*/]) {
+    return;
+  }
+}
+
+fn();
+
+/*{ assertions }*/

--- a/src/dstr-binding/iter-close/for-of-let.template
+++ b/src/dstr-binding/iter-close/for-of-let.template
@@ -1,0 +1,48 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for-of/dstr-let-
+name: for-of statement
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+es6id: 13.7.5.11
+features: [destructuring-binding]
+info: |
+    IterationStatement :
+        for ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+function fn() {
+  for (let /*{ elems }*/ of [/*{ iter }*/]) {
+    return;
+  }
+}
+
+fn();
+
+/*{ assertions }*/
+

--- a/src/dstr-binding/iter-close/for-of-var.template
+++ b/src/dstr-binding/iter-close/for-of-var.template
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for-of/dstr-var-
+name: for-of statement
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+es6id: 13.7.5.11
+features: [destructuring-binding]
+info: |
+    IterationStatement :
+        for ( var ForBinding of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForBinding, Statement, keyResult,
+       varBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              1. Assert: lhs is a ForBinding.
+              2. Let status be the result of performing BindingInitialization
+                 for lhs passing nextValue and undefined as the arguments.
+          [...]
+---*/
+
+function fn() {
+  for (var /*{ elems }*/ of [/*{ iter }*/]) {
+    return;
+  }
+}
+
+fn();
+
+/*{ assertions }*/
+

--- a/src/dstr-binding/iter-close/for-var.template
+++ b/src/dstr-binding/iter-close/for-var.template
@@ -1,0 +1,41 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for/dstr-var-
+name: for statement
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+es6id: 13.7.4.7
+features: [destructuring-binding]
+info: |
+    IterationStatement :
+        for ( var VariableDeclarationList ; Expressionopt ; Expressionopt ) Statement
+
+    1. Let varDcl be the result of evaluating VariableDeclarationList.
+    [...]
+
+    13.3.2.4 Runtime Semantics: Evaluation
+
+    VariableDeclarationList : VariableDeclarationList , VariableDeclaration
+
+    1. Let next be the result of evaluating VariableDeclarationList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating VariableDeclaration.
+
+    VariableDeclaration : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let rval be GetValue(rhs).
+    3. ReturnIfAbrupt(rval).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing rval and undefined as arguments.
+---*/
+
+function fn() {
+  for (var /*{ elems }*/ = /*{ iter }*/; ; ) {
+    return;
+  }
+}
+
+fn();
+
+/*{ assertions }*/

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elision-iter-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elision-iter-close.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-iter-close.case
+// - src/dstr-binding/iter-close/for-await-of-async-func-const.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-await-of statement in an async function)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+
+async function fn() {
+  for await (const [,] of [iter]) {
+    return;
+  }
+}
+
+fn()
+  .then(() => {
+    assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+  })
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-id-iter-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-id-iter-close.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-iter-close.case
+// - src/dstr-binding/iter-close/for-await-of-async-func-const.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-await-of statement in an async function)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+
+async function fn() {
+  for await (const [...x] of [iter]) {
+    return;
+  }
+}
+
+fn()
+  .then(() => {
+    assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+  })
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elision-iter-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elision-iter-close.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-iter-close.case
+// - src/dstr-binding/iter-close/for-await-of-async-func-let.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+async function fn() {
+  for await (let [,] of [iter]) {
+    return;
+  }
+}
+
+fn()
+  .then(() => {
+    assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+  })
+  .then($DONE, $DONE);
+

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-id-iter-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-id-iter-close.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-iter-close.case
+// - src/dstr-binding/iter-close/for-await-of-async-func-let.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+async function fn() {
+  for await (let [...x] of [iter]) {
+    return;
+  }
+}
+
+fn()
+  .then(() => {
+    assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+  })
+  .then($DONE, $DONE);
+

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elision-iter-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elision-iter-close.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-iter-close.case
+// - src/dstr-binding/iter-close/for-await-of-async-func-var.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( var ForBinding of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForBinding, Statement, keyResult,
+        varBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              1. Assert: lhs is a ForBinding.
+              2. Let status be the result of performing BindingInitialization
+                 for lhs passing nextValue and undefined as the arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+async function fn() {
+  for await (var [,] of [iter]) {
+    return;
+  }
+}
+
+fn()
+  .then(() => {
+    assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+  })
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-id-iter-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-id-iter-close.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-iter-close.case
+// - src/dstr-binding/iter-close/for-await-of-async-func-var.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( var ForBinding of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForBinding, Statement, keyResult,
+        varBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              1. Assert: lhs is a ForBinding.
+              2. Let status be the result of performing BindingInitialization
+                 for lhs passing nextValue and undefined as the arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+async function fn() {
+  for await (var [...x] of [iter]) {
+    return;
+  }
+}
+
+fn()
+  .then(() => {
+    assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+  })
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elision-iter-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elision-iter-close.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-iter-close.case
+// - src/dstr-binding/iter-close/for-await-of-async-gen-const.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+async function* fn() {
+  for await (const [,] of [iter]) {
+    return;
+  }
+}
+
+fn()
+  .next()
+  .then(() => {
+    assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+  })
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-id-iter-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-id-iter-close.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-iter-close.case
+// - src/dstr-binding/iter-close/for-await-of-async-gen-const.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+async function* fn() {
+  for await (const [...x] of [iter]) {
+    return;
+  }
+}
+
+fn()
+  .next()
+  .then(() => {
+    assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+  })
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elision-iter-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elision-iter-close.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-iter-close.case
+// - src/dstr-binding/iter-close/for-await-of-async-gen-let.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+async function* fn() {
+  for await (let [,] of [iter]) {
+    return;
+  }
+}
+
+fn()
+  .next()
+  .then(() => {
+    assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+  })
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-id-iter-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-id-iter-close.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-iter-close.case
+// - src/dstr-binding/iter-close/for-await-of-async-gen-let.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+async function* fn() {
+  for await (let [...x] of [iter]) {
+    return;
+  }
+}
+
+fn()
+  .next()
+  .then(() => {
+    assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+  })
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elision-iter-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elision-iter-close.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-iter-close.case
+// - src/dstr-binding/iter-close/for-await-of-async-gen-var.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( var ForBinding of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForBinding, Statement, keyResult,
+        varBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              1. Assert: lhs is a ForBinding.
+              2. Let status be the result of performing BindingInitialization
+                 for lhs passing nextValue and undefined as the arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+async function* fn() {
+  for await (var [,] of [iter]) {
+    return;
+  }
+}
+
+fn()
+  .next()
+  .then(() => {
+    assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+  })
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-id-iter-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-id-iter-close.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-iter-close.case
+// - src/dstr-binding/iter-close/for-await-of-async-gen-var.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( var ForBinding of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForBinding, Statement, keyResult,
+        varBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              1. Assert: lhs is a ForBinding.
+              2. Let status be the result of performing BindingInitialization
+                 for lhs passing nextValue and undefined as the arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+async function* fn() {
+  for await (var [...x] of [iter]) {
+    return;
+  }
+}
+
+fn()
+  .next()
+  .then(() => {
+    assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+  })
+  .then($DONE, $DONE);

--- a/test/language/statements/for-of/dstr-const-ary-ptrn-elision-iter-close.js
+++ b/test/language/statements/for-of/dstr-const-ary-ptrn-elision-iter-close.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-iter-close.case
+// - src/dstr-binding/iter-close/for-of-const.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+es6id: 13.7.5.11
+features: [destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+function fn() {
+  for (const [,] of [iter]) {
+    return;
+  }
+}
+
+fn();
+
+assert.sameValue(iter.next().done, true, 'iteration occurred as expected');

--- a/test/language/statements/for-of/dstr-const-ary-ptrn-rest-id-iter-close.js
+++ b/test/language/statements/for-of/dstr-const-ary-ptrn-rest-id-iter-close.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-iter-close.case
+// - src/dstr-binding/iter-close/for-of-const.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+es6id: 13.7.5.11
+features: [destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+function fn() {
+  for (const [...x] of [iter]) {
+    return;
+  }
+}
+
+fn();
+
+assert.sameValue(iter.next().done, true, 'iteration occurred as expected');

--- a/test/language/statements/for-of/dstr-let-ary-ptrn-elision-iter-close.js
+++ b/test/language/statements/for-of/dstr-let-ary-ptrn-elision-iter-close.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-iter-close.case
+// - src/dstr-binding/iter-close/for-of-let.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+es6id: 13.7.5.11
+features: [destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+function fn() {
+  for (let [,] of [iter]) {
+    return;
+  }
+}
+
+fn();
+
+assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+

--- a/test/language/statements/for-of/dstr-let-ary-ptrn-rest-id-iter-close.js
+++ b/test/language/statements/for-of/dstr-let-ary-ptrn-rest-id-iter-close.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-iter-close.case
+// - src/dstr-binding/iter-close/for-of-let.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+es6id: 13.7.5.11
+features: [destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+function fn() {
+  for (let [...x] of [iter]) {
+    return;
+  }
+}
+
+fn();
+
+assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+

--- a/test/language/statements/for-of/dstr-var-ary-ptrn-elision-iter-close.js
+++ b/test/language/statements/for-of/dstr-var-ary-ptrn-elision-iter-close.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-iter-close.case
+// - src/dstr-binding/iter-close/for-of-var.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+es6id: 13.7.5.11
+features: [destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( var ForBinding of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForBinding, Statement, keyResult,
+       varBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              1. Assert: lhs is a ForBinding.
+              2. Let status be the result of performing BindingInitialization
+                 for lhs passing nextValue and undefined as the arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+function fn() {
+  for (var [,] of [iter]) {
+    return;
+  }
+}
+
+fn();
+
+assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+

--- a/test/language/statements/for-of/dstr-var-ary-ptrn-rest-id-iter-close.js
+++ b/test/language/statements/for-of/dstr-var-ary-ptrn-rest-id-iter-close.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-iter-close.case
+// - src/dstr-binding/iter-close/for-of-var.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+es6id: 13.7.5.11
+features: [destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( var ForBinding of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForBinding, Statement, keyResult,
+       varBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              1. Assert: lhs is a ForBinding.
+              2. Let status be the result of performing BindingInitialization
+                 for lhs passing nextValue and undefined as the arguments.
+          [...]
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+function fn() {
+  for (var [...x] of [iter]) {
+    return;
+  }
+}
+
+fn();
+
+assert.sameValue(iter.next().done, true, 'iteration occurred as expected');
+

--- a/test/language/statements/for/dstr-const-ary-ptrn-elision-iter-close.js
+++ b/test/language/statements/for/dstr-const-ary-ptrn-elision-iter-close.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-iter-close.case
+// - src/dstr-binding/iter-close/for-const.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+es6id: 13.7.4.7
+features: [destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    [...]
+    7. Let forDcl be the result of evaluating LexicalDeclaration.
+    [...]
+
+    LexicalDeclaration : LetOrConst BindingList ;
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return NormalCompletion(empty).
+
+    BindingList : BindingList , LexicalBinding
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating LexicalBinding.
+
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context’s LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+function fn() {
+  for (const [,] = iter; ; ) {
+    return;
+  }
+}
+
+fn();
+
+assert.sameValue(iter.next().done, true, 'iteration occurred as expected');

--- a/test/language/statements/for/dstr-const-ary-ptrn-rest-id-iter-close.js
+++ b/test/language/statements/for/dstr-const-ary-ptrn-rest-id-iter-close.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-iter-close.case
+// - src/dstr-binding/iter-close/for-const.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+es6id: 13.7.4.7
+features: [destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    [...]
+    7. Let forDcl be the result of evaluating LexicalDeclaration.
+    [...]
+
+    LexicalDeclaration : LetOrConst BindingList ;
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return NormalCompletion(empty).
+
+    BindingList : BindingList , LexicalBinding
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating LexicalBinding.
+
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context’s LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+function fn() {
+  for (const [...x] = iter; ; ) {
+    return;
+  }
+}
+
+fn();
+
+assert.sameValue(iter.next().done, true, 'iteration occurred as expected');

--- a/test/language/statements/for/dstr-let-ary-ptrn-elision-iter-close.js
+++ b/test/language/statements/for/dstr-let-ary-ptrn-elision-iter-close.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-iter-close.case
+// - src/dstr-binding/iter-close/for-let.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+es6id: 13.7.4.7
+features: [destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    [...]
+    7. Let forDcl be the result of evaluating LexicalDeclaration.
+    [...]
+
+    LexicalDeclaration : LetOrConst BindingList ;
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return NormalCompletion(empty).
+
+    BindingList : BindingList , LexicalBinding
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating LexicalBinding.
+
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context’s LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+function fn() {
+  for (let [,] = iter; ; ) {
+    return;
+  }
+}
+
+fn();
+
+assert.sameValue(iter.next().done, true, 'iteration occurred as expected');

--- a/test/language/statements/for/dstr-let-ary-ptrn-rest-id-iter-close.js
+++ b/test/language/statements/for/dstr-let-ary-ptrn-rest-id-iter-close.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-iter-close.case
+// - src/dstr-binding/iter-close/for-let.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+es6id: 13.7.4.7
+features: [destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    [...]
+    7. Let forDcl be the result of evaluating LexicalDeclaration.
+    [...]
+
+    LexicalDeclaration : LetOrConst BindingList ;
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return NormalCompletion(empty).
+
+    BindingList : BindingList , LexicalBinding
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating LexicalBinding.
+
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context’s LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+function fn() {
+  for (let [...x] = iter; ; ) {
+    return;
+  }
+}
+
+fn();
+
+assert.sameValue(iter.next().done, true, 'iteration occurred as expected');

--- a/test/language/statements/for/dstr-var-ary-ptrn-elision-iter-close.js
+++ b/test/language/statements/for/dstr-var-ary-ptrn-elision-iter-close.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-iter-close.case
+// - src/dstr-binding/iter-close/for-var.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+es6id: 13.7.4.7
+features: [destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( var VariableDeclarationList ; Expressionopt ; Expressionopt ) Statement
+
+    1. Let varDcl be the result of evaluating VariableDeclarationList.
+    [...]
+
+    13.3.2.4 Runtime Semantics: Evaluation
+
+    VariableDeclarationList : VariableDeclarationList , VariableDeclaration
+
+    1. Let next be the result of evaluating VariableDeclarationList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating VariableDeclaration.
+
+    VariableDeclaration : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let rval be GetValue(rhs).
+    3. ReturnIfAbrupt(rval).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing rval and undefined as arguments.
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+function fn() {
+  for (var [,] = iter; ; ) {
+    return;
+  }
+}
+
+fn();
+
+assert.sameValue(iter.next().done, true, 'iteration occurred as expected');

--- a/test/language/statements/for/dstr-var-ary-ptrn-rest-id-iter-close.js
+++ b/test/language/statements/for/dstr-var-ary-ptrn-rest-id-iter-close.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-iter-close.case
+// - src/dstr-binding/iter-close/for-var.template
+/*---
+description: The iterator is properly consumed by the destructuring pattern (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+es6id: 13.7.4.7
+features: [destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( var VariableDeclarationList ; Expressionopt ; Expressionopt ) Statement
+
+    1. Let varDcl be the result of evaluating VariableDeclarationList.
+    [...]
+
+    13.3.2.4 Runtime Semantics: Evaluation
+
+    VariableDeclarationList : VariableDeclarationList , VariableDeclaration
+
+    1. Let next be the result of evaluating VariableDeclarationList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating VariableDeclaration.
+
+    VariableDeclaration : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let rval be GetValue(rhs).
+    3. ReturnIfAbrupt(rval).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing rval and undefined as arguments.
+---*/
+const iter = (function* () {
+  yield;
+  yield;
+})();
+
+
+function fn() {
+  for (var [...x] = iter; ; ) {
+    return;
+  }
+}
+
+fn();
+
+assert.sameValue(iter.next().done, true, 'iteration occurred as expected');


### PR DESCRIPTION
These tests just confirm the iterator allow loops to properly close iterators after an immediate return with normal completions.

Other cases previously written by @rwaldron are already testing abrupt completions, so they are not 
covered in this PR.

Ref https://bugzilla.mozilla.org/show_bug.cgi?id=1364608