### PR TITLE
Add templates for dstr-binding w/ for-await-of looping over async iterators

### DIFF
--- a/src/dstr-binding/default/for-await-of-async-func-const-async.template
+++ b/src/dstr-binding/default/for-await-of-async-func-const-async.template
@@ -1,0 +1,54 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for-await-of/async-func-dstr-const-async-
+name: for-await-of statement
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [/*{ vals }*/];
+})();
+
+async function fn() {
+  for await (const /*{ elems }*/ of asyncIter) {
+    /*{ body }*/
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/src/dstr-binding/default/for-await-of-async-func-let-async.template
+++ b/src/dstr-binding/default/for-await-of-async-func-let-async.template
@@ -1,0 +1,54 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for-await-of/async-func-dstr-let-async-
+name: for-await-of statement
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [/*{ vals }*/];
+})();
+
+async function fn() {
+  for await (let /*{ elems }*/ of asyncIter) {
+    /*{ body }*/
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/src/dstr-binding/default/for-await-of-async-func-var-async.template
+++ b/src/dstr-binding/default/for-await-of-async-func-var-async.template
@@ -1,0 +1,54 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for-await-of/async-func-dstr-var-async-
+name: for-await-of statement
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [/*{ vals }*/];
+})();
+
+async function fn() {
+  for await (var /*{ elems }*/ of asyncIter) {
+    /*{ body }*/
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/src/dstr-binding/default/for-await-of-async-gen-const-async.template
+++ b/src/dstr-binding/default/for-await-of-async-gen-const-async.template
@@ -1,0 +1,54 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for-await-of/async-gen-dstr-const-async-
+name: for-await-of statement
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [/*{ vals }*/];
+})();
+
+async function *fn() {
+  for await (const /*{ elems }*/ of asyncIter) {
+    /*{ body }*/
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/src/dstr-binding/default/for-await-of-async-gen-let-async.template
+++ b/src/dstr-binding/default/for-await-of-async-gen-let-async.template
@@ -1,0 +1,54 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for-await-of/async-gen-dstr-let-async-
+name: for-await-of statement
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [/*{ vals }*/];
+})();
+
+async function *fn() {
+  for await (let /*{ elems }*/ of asyncIter) {
+    /*{ body }*/
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/src/dstr-binding/default/for-await-of-async-gen-var-async.template
+++ b/src/dstr-binding/default/for-await-of-async-gen-var-async.template
@@ -1,0 +1,54 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/for-await-of/async-gen-dstr-var-async-
+name: for-await-of statement
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [/*{ vals }*/];
+})();
+
+async function *fn() {
+  for await (var /*{ elems }*/ of asyncIter) {
+    /*{ body }*/
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-init-iter-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-init-iter-close.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-close.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Iterator is closed when not exhausted by pattern evaluation (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.5 Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, return ? IteratorClose(iterator,
+       result).
+    [...]
+
+---*/
+var doneCallCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { value: null, done: false };
+    },
+    return: function() {
+      doneCallCount += 1;
+      return {};
+    }
+  };
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (const [x] of asyncIter) {
+    assert.sameValue(doneCallCount, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-init-iter-no-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-init-iter-no-close.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-no-close.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Iterator is not closed when exhausted by pattern evaluation (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.5 Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, return ? IteratorClose(iterator,
+       result).
+    [...]
+
+---*/
+var doneCallCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { value: null, done: true };
+    },
+    return: function() {
+      doneCallCount += 1;
+      return {};
+    }
+  };
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (const [x] of asyncIter) {
+    assert.sameValue(doneCallCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-name-iter-val.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-name-iter-val.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-name-iter-val.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: SingleNameBinding with normal value iteration (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (const [x, y, z] of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-elem-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-elem-init.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elem-init.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [[x, y, z] = [4, 5, 6]] of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-elem-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-elem-iter.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elem-iter.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[7, 8, 9]]];
+})();
+
+async function fn() {
+  for await (const [[x, y, z] = [4, 5, 6]] of asyncIter) {
+    assert.sameValue(x, 7);
+    assert.sameValue(y, 8);
+    assert.sameValue(z, 9);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-elision-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-elision-init.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elision-init.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [[,] = g()] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-elision-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-elision-iter.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elision-iter.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+
+---*/
+var callCount = 0;
+function* g() {
+  callCount += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[]]];
+})();
+
+async function fn() {
+  for await (const [[,] = g()] of asyncIter) {
+    assert.sameValue(callCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-empty-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-empty-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-empty-init.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var initCount = 0;
+var iterCount = 0;
+var iter = function*() { iterCount += 1; }();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [[] = function() { initCount += 1; return iter; }()] of asyncIter) {
+    assert.sameValue(initCount, 1);
+    assert.sameValue(iterCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-empty-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-empty-iter.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-empty-iter.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var initCount = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[23]]];
+})();
+
+async function fn() {
+  for await (const [[] = function() { initCount += 1; }()] of asyncIter) {
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-rest-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-rest-init.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-rest-init.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var values = [2, 1, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [[...x] = values] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x[0], 2);
+    assert.sameValue(x[1], 1);
+    assert.sameValue(x[2], 3);
+    assert.sameValue(x.length, 3);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-rest-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-ary-rest-iter.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-rest-iter.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var values = [2, 1, 3];
+var initCount = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[values]];
+})();
+
+async function fn() {
+  for await (const [[...x] = function() { initCount += 1; }()] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x[0], 2);
+    assert.sameValue(x[1], 1);
+    assert.sameValue(x[2], 3);
+    assert.sameValue(x.length, 3);
+    assert.notSameValue(x, values);
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-exhausted.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Destructuring initializer with an exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-arrow.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-arrow.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: SingleNameBinding does assign name to arrow functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [arrow = () => {}] of asyncIter) {
+    assert.sameValue(arrow.name, 'arrow');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-class.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-class.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" classes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] of asyncIter) {
+    assert.sameValue(cls.name, 'cls');
+    assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-cover.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-cover.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: SingleNameBinding does assign name to "anonymous" functions "through" cover grammar (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [cover = (function () {}), xCover = (0, function() {})] of asyncIter) {
+    assert.sameValue(cover.name, 'cover');
+    assert.notSameValue(xCover.name, 'xCover');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-fn.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-fn.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [fn = function () {}, xFn = function x() {}] of asyncIter) {
+    assert.sameValue(fn.name, 'fn');
+    assert.notSameValue(xFn.name, 'xFn');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-gen.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-gen.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" generator functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [gen = function* () {}, xGen = function* x() {}] of asyncIter) {
+    assert.sameValue(gen.name, 'gen');
+    assert.notSameValue(xGen.name, 'xGen');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-hole.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-hole.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-hole.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Destructuring initializer with a "hole" (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    SingleNameBinding : BindingIdentifier Initializeropt
+    [...] 6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v). 8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[,]];
+})();
+
+async function fn() {
+  for await (const [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+    // another statement
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-skipped.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[null, 0, false, '']];
+})();
+
+async function fn() {
+  for await (const [w = counter(), x = counter(), y = counter(), z = counter()] of asyncIter) {
+    assert.sameValue(w, null);
+    assert.sameValue(x, 0);
+    assert.sameValue(y, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-undef.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-undef.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-undef.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Destructuring initializer with an undefined value (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[undefined]];
+})();
+
+async function fn() {
+  for await (const [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-iter-complete.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-iter-complete.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-complete.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: SingleNameBinding when value iteration completes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [x] of asyncIter) {
+    assert.sameValue(x, undefined);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-iter-done.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-iter-done.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-done.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: SingleNameBinding when value iteration was completed previously (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [_, x] of asyncIter) {
+    assert.sameValue(x, undefined);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-iter-val.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-iter-val.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: SingleNameBinding when value iteration was completed previously (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (const [x, y, z] of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-obj-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-obj-id-init.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-id-init.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [{ x, y, z } = { x: 44, y: 55, z: 66 }] of asyncIter) {
+    assert.sameValue(x, 44);
+    assert.sameValue(y, 55);
+    assert.sameValue(z, 66);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-obj-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-obj-id.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-id.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[{ x: 11, y: 22, z: 33 }]];
+})();
+
+async function fn() {
+  for await (const [{ x, y, z } = { x: 44, y: 55, z: 66 }] of asyncIter) {
+    assert.sameValue(x, 11);
+    assert.sameValue(y, 22);
+    assert.sameValue(z, 33);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-obj-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-obj-prop-id-init.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-prop-id-init.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [{ u: v, w: x, y: z } = { u: 444, w: 555, y: 666 }] of asyncIter) {
+    assert.sameValue(v, 444);
+    assert.sameValue(x, 555);
+    assert.sameValue(z, 666);
+
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-obj-prop-id.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[{ u: 777, w: 888, y: 999 }]];
+})();
+
+async function fn() {
+  for await (const [{ u: v, w: x, y: z } = { u: 444, w: 555, y: 666 }] of asyncIter) {
+    assert.sameValue(v, 777);
+    assert.sameValue(x, 888);
+    assert.sameValue(z, 999);
+
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elision-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elision-exhausted.js
@@ -1,0 +1,73 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Elision accepts exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       [...]
+    2. Return NormalCompletion(empty).
+
+---*/
+var iter = function*() {}();
+iter.next();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (const [,] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elision.js
@@ -1,0 +1,82 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Elision advances iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+    2. Return NormalCompletion(empty).
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [g()];
+})();
+
+async function fn() {
+  for await (const [,] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-empty.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-empty.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: No iteration occurs for an "empty" array binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ ]
+
+    1. Return NormalCompletion(empty).
+
+---*/
+var iterations = 0;
+var iter = function*() {
+  iterations += 1;
+}();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (const [] of asyncIter) {
+    assert.sameValue(iterations, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-ary-elem.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-ary-elem.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-elem.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Rest element containing an array BindingElementList pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[3, 4, 5]];
+})();
+
+async function fn() {
+  for await (const [...[x, y, z]] of asyncIter) {
+    assert.sameValue(x, 3);
+    assert.sameValue(y, 4);
+    assert.sameValue(z, 5);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-ary-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-ary-elision.js
@@ -1,0 +1,95 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-elision.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Rest element containing an elision (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+    2. Return NormalCompletion(empty).
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [g()];
+})();
+
+async function fn() {
+  for await (const [...[,]] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-ary-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-ary-empty.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-empty.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Rest element containing an "empty" array pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ ]
+
+    1. Return NormalCompletion(empty).
+
+---*/
+var iterations = 0;
+var iter = function*() {
+  iterations += 1;
+}();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (const [...[]] of asyncIter) {
+    assert.sameValue(iterations, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-ary-rest.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-ary-rest.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-rest.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Rest element containing a rest element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+var values = [1, 2, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function fn() {
+  for await (const [...[...x]] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 1);
+    assert.sameValue(x[1], 2);
+    assert.sameValue(x[2], 3);
+    assert.notSameValue(x, values);
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-id-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-id-elision.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-elision.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Rest element following elision elements (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    ArrayBindingPattern : [ Elisionopt BindingRestElement ]
+    1. If Elision is present, then
+       a. Let status be the result of performing
+          IteratorDestructuringAssignmentEvaluation of Elision with
+          iteratorRecord as the argument.
+       b. ReturnIfAbrupt(status).
+    2. Return the result of performing IteratorBindingInitialization for
+       BindingRestElement with iteratorRecord and environment as arguments.
+---*/
+var values = [1, 2, 3, 4, 5];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function fn() {
+  for await (const [ , , ...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 3);
+    assert.sameValue(x[1], 4);
+    assert.sameValue(x[2], 5);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-id-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-id-exhausted.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: RestElement applied to an exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    BindingRestElement : ... BindingIdentifier
+    1. Let lhs be ResolveBinding(StringValue of BindingIdentifier,
+       environment).
+    2. ReturnIfAbrupt(lhs). 3. Let A be ArrayCreate(0). 4. Let n=0. 5. Repeat,
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. If environment is undefined, return PutValue(lhs, A).
+          ii. Return InitializeReferencedBinding(lhs, A).
+
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2]];
+})();
+
+async function fn() {
+  for await (const [, , ...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-id.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Lone rest element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    BindingRestElement : ... BindingIdentifier
+    [...] 3. Let A be ArrayCreate(0). [...] 5. Repeat
+       [...]
+       f. Let status be CreateDataProperty(A, ToString (n), nextValue).
+       [...]
+---*/
+var values = [1, 2, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function fn() {
+  for await (const [...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 1);
+    assert.sameValue(x[1], 2);
+    assert.sameValue(x[2], 3);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-ary.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-ary.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Reset element (nested array pattern) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [...[ x ] = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-id.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-id.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Reset element (identifier) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [...x = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-obj.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Reset element (nested object pattern) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (const [...{ x } = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-ary.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-ary.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (const [...[x], y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-id.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-id.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Rest element (identifier) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (const [...x, y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-obj.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (const [...{ x }, y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-obj-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-obj-id.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-obj-id.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Rest element containing an object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (const [...{ length }] of asyncIter) {
+    assert.sameValue(length, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-obj-prop-id.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-obj-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Rest element containing an object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+let length = "outer";
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[7, 8, 9]];
+})();
+
+async function fn() {
+  for await (const [...{ 0: v, 1: w, 2: x, 3: y, length: z }] of asyncIter) {
+    assert.sameValue(v, 7);
+    assert.sameValue(w, 8);
+    assert.sameValue(x, 9);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 3);
+
+    assert.sameValue(length, "outer", "the length prop is not set as a binding name");
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-empty.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-empty.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: No property access occurs for an "empty" object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    Runtime Semantics: BindingInitialization
+
+    ObjectBindingPattern : { }
+
+    1. Return NormalCompletion(empty).
+---*/
+var accessCount = 0;
+var obj = Object.defineProperty({}, 'attr', {
+  get: function() {
+    accessCount += 1;
+  }
+});
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [obj];
+})();
+
+async function fn() {
+  for await (const {} of asyncIter) {
+    assert.sameValue(accessCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-arrow.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-arrow.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: SingleNameBinding assigns `name` to arrow functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (const { arrow = () => {} } of asyncIter) {
+    assert.sameValue(arrow.name, 'arrow');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-class.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-class.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" classes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (const { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } of asyncIter) {
+    assert.sameValue(cls.name, 'cls');
+    assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-cover.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-cover.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" functions "through" cover grammar (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (const { cover = (function () {}), xCover = (0, function() {})  } of asyncIter) {
+    assert.sameValue(cover.name, 'cover');
+    assert.notSameValue(xCover.name, 'xCover');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-fn.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-fn.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (const { fn = function () {}, xFn = function x() {} } of asyncIter) {
+    assert.sameValue(fn.name, 'fn');
+    assert.notSameValue(xFn.name, 'xFn');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-gen.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-gen.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" generator functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (const { gen = function* () {}, xGen = function* x() {} } of asyncIter) {
+    assert.sameValue(gen.name, 'gen');
+    assert.notSameValue(xGen.name, 'xGen');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-skipped.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+    [...]
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: null, x: 0, y: false, z: '' }];
+})();
+
+async function fn() {
+  for await (const { w = counter(), x = counter(), y = counter(), z = counter() } of asyncIter) {
+    assert.sameValue(w, null);
+    assert.sameValue(x, 0);
+    assert.sameValue(y, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-trailing-comma.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function fn() {
+  for await (const { x, } of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-ary-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-ary-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary-init.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Object binding pattern with "nested" array binding pattern using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (const { w: [x, y, z] = [4, 5, 6] } of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-ary-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-ary-trailing-comma.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: [45] }];
+})();
+
+async function fn() {
+  for await (const { x: [y], } of asyncIter) {
+    assert.sameValue(y,45);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-ary.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Object binding pattern with "nested" array binding pattern not using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       [...]
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: [7, undefined, ] }];
+})();
+
+async function fn() {
+  for await (const { w: [x, y, z] = [4, 5, 6] } of asyncIter) {
+    assert.sameValue(x, 7);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, undefined);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-id-init-skipped.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    BindingElement : BindingPattern Initializeropt
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+    [...]
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ s: null, u: 0, w: false, y: '' }];
+})();
+
+async function fn() {
+  for await (const { s: t = counter(), u: v = counter(), w: x = counter(), y: z = counter() } of asyncIter) {
+    assert.sameValue(t, null);
+    assert.sameValue(v, 0);
+    assert.sameValue(x, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    assert.throws(ReferenceError, function() {
+      s;
+    });
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-id-init.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-init.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Binding as specified via property name, identifier, and initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ }];
+})();
+
+async function fn() {
+  for await (const { x: y = 33 } of asyncIter) {
+    assert.sameValue(y, 33);
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-id-trailing-comma.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function fn() {
+  for await (const { x: y, } of asyncIter) {
+    assert.sameValue(y, 23);
+
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-id.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Binding as specified via property name and identifier (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function fn() {
+  for await (const { x: y } of asyncIter) {
+    assert.sameValue(y, 23);
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-obj-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-obj-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-obj-init.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Object binding pattern with "nested" object binding pattern using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: undefined }];
+})();
+
+async function fn() {
+  for await (const { w: { x, y, z } = { x: 4, y: 5, z: 6 } } of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-prop-obj.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Object binding pattern with "nested" object binding pattern not using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       [...]
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: { x: undefined, z: 7 } }];
+})();
+
+async function fn() {
+  for await (const { w: { x, y, z } = { x: 4, y: 5, z: 6 } } of asyncIter) {
+    assert.sameValue(x, undefined);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 7);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-getter.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-getter.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Getter is called when obj is being deconstructed to a rest Object (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var count = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ get v() { count++; return 2; } }];
+})();
+
+async function fn() {
+  for await (const {...x} of asyncIter) {
+    assert.sameValue(x.v, 2);
+    assert.sameValue(count, 1);
+
+    verifyEnumerable(x, "v");
+    verifyWritable(x, "v");
+    verifyConfigurable(x, "v");
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-nested-obj.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-nested-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var obj = {a: 3, b: 4};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{a: 1, b: 2, c: 3, d: 4, e: 5}];
+})();
+
+async function fn() {
+  for await (const {a, b, ...{c, e}} of asyncIter) {
+    assert.sameValue(a, 1);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 3);
+    assert.sameValue(e, 5);
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-obj-nested-rest.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-obj-nested-rest.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{a: 1, b: 2, c: 3, d: 4, e: 5}];
+})();
+
+async function fn() {
+  for await (const {a, b, ...{c, ...rest}} of asyncIter) {
+    assert.sameValue(a, 1);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 3);
+
+    assert.sameValue(rest.d, 4);
+    assert.sameValue(rest.e, 5);
+
+    verifyEnumerable(rest, "d");
+    verifyWritable(rest, "d");
+    verifyConfigurable(rest, "d");
+
+    verifyEnumerable(rest, "e");
+    verifyWritable(rest, "e");
+    verifyConfigurable(rest, "e");
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-obj-own-property.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-obj-own-property.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Rest object contains just soruce object's own properties (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var o = Object.create({ x: 1, y: 2 });
+o.z = 3;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [o];
+})();
+
+async function fn() {
+  for await (const { x, ...{y , z} } of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 3);
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-skip-non-enumerable.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-skip-non-enumerable.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Rest object doesn't contain non-enumerable properties (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var o = {a: 3, b: 4};
+Object.defineProperty(o, "x", { value: 4, enumerable: false });
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [o];
+})();
+
+async function fn() {
+  for await (const {...rest} of asyncIter) {
+    assert.sameValue(rest.a, 3);
+    assert.sameValue(rest.b, 4);
+    assert.sameValue(rest.x, undefined);
+
+    verifyEnumerable(rest, "a");
+    verifyWritable(rest, "a");
+    verifyConfigurable(rest, "a");
+
+    verifyEnumerable(rest, "b");
+    verifyWritable(rest, "b");
+    verifyConfigurable(rest, "b");
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-val-obj.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-val-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-const-async.template
+/*---
+description: Rest object contains just unextracted data (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{x: 1, y: 2, a: 5, b: 3}];
+})();
+
+async function fn() {
+  for await (const {a, b, ...rest} of asyncIter) {
+    assert.sameValue(rest.x, 1);
+    assert.sameValue(rest.y, 2);
+    assert.sameValue(rest.a, undefined);
+    assert.sameValue(rest.b, undefined);
+
+    verifyEnumerable(rest, "x");
+    verifyWritable(rest, "x");
+    verifyConfigurable(rest, "x");
+
+    verifyEnumerable(rest, "y");
+    verifyWritable(rest, "y");
+    verifyConfigurable(rest, "y");
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-init-iter-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-init-iter-close.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-close.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Iterator is closed when not exhausted by pattern evaluation (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.5 Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, return ? IteratorClose(iterator,
+       result).
+    [...]
+
+---*/
+var doneCallCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { value: null, done: false };
+    },
+    return: function() {
+      doneCallCount += 1;
+      return {};
+    }
+  };
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (let [x] of asyncIter) {
+    assert.sameValue(doneCallCount, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-init-iter-no-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-init-iter-no-close.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-no-close.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Iterator is not closed when exhausted by pattern evaluation (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.5 Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, return ? IteratorClose(iterator,
+       result).
+    [...]
+
+---*/
+var doneCallCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { value: null, done: true };
+    },
+    return: function() {
+      doneCallCount += 1;
+      return {};
+    }
+  };
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (let [x] of asyncIter) {
+    assert.sameValue(doneCallCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-name-iter-val.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-name-iter-val.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-name-iter-val.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: SingleNameBinding with normal value iteration (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (let [x, y, z] of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-elem-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-elem-init.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elem-init.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [[x, y, z] = [4, 5, 6]] of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-elem-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-elem-iter.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elem-iter.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[7, 8, 9]]];
+})();
+
+async function fn() {
+  for await (let [[x, y, z] = [4, 5, 6]] of asyncIter) {
+    assert.sameValue(x, 7);
+    assert.sameValue(y, 8);
+    assert.sameValue(z, 9);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-elision-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-elision-init.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elision-init.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [[,] = g()] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-elision-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-elision-iter.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elision-iter.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+
+---*/
+var callCount = 0;
+function* g() {
+  callCount += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[]]];
+})();
+
+async function fn() {
+  for await (let [[,] = g()] of asyncIter) {
+    assert.sameValue(callCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-empty-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-empty-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-empty-init.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var initCount = 0;
+var iterCount = 0;
+var iter = function*() { iterCount += 1; }();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [[] = function() { initCount += 1; return iter; }()] of asyncIter) {
+    assert.sameValue(initCount, 1);
+    assert.sameValue(iterCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-empty-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-empty-iter.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-empty-iter.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var initCount = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[23]]];
+})();
+
+async function fn() {
+  for await (let [[] = function() { initCount += 1; }()] of asyncIter) {
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-rest-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-rest-init.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-rest-init.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var values = [2, 1, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [[...x] = values] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x[0], 2);
+    assert.sameValue(x[1], 1);
+    assert.sameValue(x[2], 3);
+    assert.sameValue(x.length, 3);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-rest-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-rest-iter.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-rest-iter.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var values = [2, 1, 3];
+var initCount = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[values]];
+})();
+
+async function fn() {
+  for await (let [[...x] = function() { initCount += 1; }()] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x[0], 2);
+    assert.sameValue(x[1], 1);
+    assert.sameValue(x[2], 3);
+    assert.sameValue(x.length, 3);
+    assert.notSameValue(x, values);
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-exhausted.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Destructuring initializer with an exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-arrow.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-arrow.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: SingleNameBinding does assign name to arrow functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [arrow = () => {}] of asyncIter) {
+    assert.sameValue(arrow.name, 'arrow');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-class.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-class.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" classes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] of asyncIter) {
+    assert.sameValue(cls.name, 'cls');
+    assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-cover.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-cover.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: SingleNameBinding does assign name to "anonymous" functions "through" cover grammar (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [cover = (function () {}), xCover = (0, function() {})] of asyncIter) {
+    assert.sameValue(cover.name, 'cover');
+    assert.notSameValue(xCover.name, 'xCover');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-fn.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-fn.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [fn = function () {}, xFn = function x() {}] of asyncIter) {
+    assert.sameValue(fn.name, 'fn');
+    assert.notSameValue(xFn.name, 'xFn');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-gen.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-gen.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" generator functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [gen = function* () {}, xGen = function* x() {}] of asyncIter) {
+    assert.sameValue(gen.name, 'gen');
+    assert.notSameValue(xGen.name, 'xGen');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-hole.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-hole.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-hole.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Destructuring initializer with a "hole" (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    SingleNameBinding : BindingIdentifier Initializeropt
+    [...] 6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v). 8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[,]];
+})();
+
+async function fn() {
+  for await (let [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+    // another statement
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-skipped.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[null, 0, false, '']];
+})();
+
+async function fn() {
+  for await (let [w = counter(), x = counter(), y = counter(), z = counter()] of asyncIter) {
+    assert.sameValue(w, null);
+    assert.sameValue(x, 0);
+    assert.sameValue(y, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-undef.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-undef.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-undef.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Destructuring initializer with an undefined value (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[undefined]];
+})();
+
+async function fn() {
+  for await (let [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-iter-complete.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-iter-complete.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-complete.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: SingleNameBinding when value iteration completes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [x] of asyncIter) {
+    assert.sameValue(x, undefined);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-iter-done.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-iter-done.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-done.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: SingleNameBinding when value iteration was completed previously (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [_, x] of asyncIter) {
+    assert.sameValue(x, undefined);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-iter-val.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-iter-val.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: SingleNameBinding when value iteration was completed previously (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (let [x, y, z] of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-obj-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-obj-id-init.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-id-init.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [{ x, y, z } = { x: 44, y: 55, z: 66 }] of asyncIter) {
+    assert.sameValue(x, 44);
+    assert.sameValue(y, 55);
+    assert.sameValue(z, 66);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-obj-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-obj-id.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-id.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[{ x: 11, y: 22, z: 33 }]];
+})();
+
+async function fn() {
+  for await (let [{ x, y, z } = { x: 44, y: 55, z: 66 }] of asyncIter) {
+    assert.sameValue(x, 11);
+    assert.sameValue(y, 22);
+    assert.sameValue(z, 33);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-obj-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-obj-prop-id-init.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-prop-id-init.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [{ u: v, w: x, y: z } = { u: 444, w: 555, y: 666 }] of asyncIter) {
+    assert.sameValue(v, 444);
+    assert.sameValue(x, 555);
+    assert.sameValue(z, 666);
+
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-obj-prop-id.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[{ u: 777, w: 888, y: 999 }]];
+})();
+
+async function fn() {
+  for await (let [{ u: v, w: x, y: z } = { u: 444, w: 555, y: 666 }] of asyncIter) {
+    assert.sameValue(v, 777);
+    assert.sameValue(x, 888);
+    assert.sameValue(z, 999);
+
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elision-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elision-exhausted.js
@@ -1,0 +1,73 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Elision accepts exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       [...]
+    2. Return NormalCompletion(empty).
+
+---*/
+var iter = function*() {}();
+iter.next();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (let [,] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elision.js
@@ -1,0 +1,82 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Elision advances iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+    2. Return NormalCompletion(empty).
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [g()];
+})();
+
+async function fn() {
+  for await (let [,] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-empty.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-empty.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: No iteration occurs for an "empty" array binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ ]
+
+    1. Return NormalCompletion(empty).
+
+---*/
+var iterations = 0;
+var iter = function*() {
+  iterations += 1;
+}();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (let [] of asyncIter) {
+    assert.sameValue(iterations, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-ary-elem.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-ary-elem.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-elem.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Rest element containing an array BindingElementList pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[3, 4, 5]];
+})();
+
+async function fn() {
+  for await (let [...[x, y, z]] of asyncIter) {
+    assert.sameValue(x, 3);
+    assert.sameValue(y, 4);
+    assert.sameValue(z, 5);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-ary-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-ary-elision.js
@@ -1,0 +1,95 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-elision.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Rest element containing an elision (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+    2. Return NormalCompletion(empty).
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [g()];
+})();
+
+async function fn() {
+  for await (let [...[,]] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-ary-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-ary-empty.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-empty.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Rest element containing an "empty" array pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ ]
+
+    1. Return NormalCompletion(empty).
+
+---*/
+var iterations = 0;
+var iter = function*() {
+  iterations += 1;
+}();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (let [...[]] of asyncIter) {
+    assert.sameValue(iterations, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-ary-rest.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-ary-rest.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-rest.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Rest element containing a rest element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+var values = [1, 2, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function fn() {
+  for await (let [...[...x]] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 1);
+    assert.sameValue(x[1], 2);
+    assert.sameValue(x[2], 3);
+    assert.notSameValue(x, values);
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-id-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-id-elision.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-elision.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Rest element following elision elements (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    ArrayBindingPattern : [ Elisionopt BindingRestElement ]
+    1. If Elision is present, then
+       a. Let status be the result of performing
+          IteratorDestructuringAssignmentEvaluation of Elision with
+          iteratorRecord as the argument.
+       b. ReturnIfAbrupt(status).
+    2. Return the result of performing IteratorBindingInitialization for
+       BindingRestElement with iteratorRecord and environment as arguments.
+---*/
+var values = [1, 2, 3, 4, 5];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function fn() {
+  for await (let [ , , ...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 3);
+    assert.sameValue(x[1], 4);
+    assert.sameValue(x[2], 5);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-id-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-id-exhausted.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: RestElement applied to an exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    BindingRestElement : ... BindingIdentifier
+    1. Let lhs be ResolveBinding(StringValue of BindingIdentifier,
+       environment).
+    2. ReturnIfAbrupt(lhs). 3. Let A be ArrayCreate(0). 4. Let n=0. 5. Repeat,
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. If environment is undefined, return PutValue(lhs, A).
+          ii. Return InitializeReferencedBinding(lhs, A).
+
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2]];
+})();
+
+async function fn() {
+  for await (let [, , ...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-id.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Lone rest element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    BindingRestElement : ... BindingIdentifier
+    [...] 3. Let A be ArrayCreate(0). [...] 5. Repeat
+       [...]
+       f. Let status be CreateDataProperty(A, ToString (n), nextValue).
+       [...]
+---*/
+var values = [1, 2, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function fn() {
+  for await (let [...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 1);
+    assert.sameValue(x[1], 2);
+    assert.sameValue(x[2], 3);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-ary.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-ary.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Reset element (nested array pattern) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [...[ x ] = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-id.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-id.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Reset element (identifier) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [...x = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-obj.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Reset element (nested object pattern) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (let [...{ x } = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-ary.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-ary.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (let [...[x], y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-id.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-id.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Rest element (identifier) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (let [...x, y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-obj.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (let [...{ x }, y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-obj-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-obj-id.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-obj-id.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Rest element containing an object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (let [...{ length }] of asyncIter) {
+    assert.sameValue(length, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-obj-prop-id.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-obj-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Rest element containing an object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+let length = "outer";
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[7, 8, 9]];
+})();
+
+async function fn() {
+  for await (let [...{ 0: v, 1: w, 2: x, 3: y, length: z }] of asyncIter) {
+    assert.sameValue(v, 7);
+    assert.sameValue(w, 8);
+    assert.sameValue(x, 9);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 3);
+
+    assert.sameValue(length, "outer", "the length prop is not set as a binding name");
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-empty.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-empty.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: No property access occurs for an "empty" object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    Runtime Semantics: BindingInitialization
+
+    ObjectBindingPattern : { }
+
+    1. Return NormalCompletion(empty).
+---*/
+var accessCount = 0;
+var obj = Object.defineProperty({}, 'attr', {
+  get: function() {
+    accessCount += 1;
+  }
+});
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [obj];
+})();
+
+async function fn() {
+  for await (let {} of asyncIter) {
+    assert.sameValue(accessCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-arrow.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-arrow.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: SingleNameBinding assigns `name` to arrow functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (let { arrow = () => {} } of asyncIter) {
+    assert.sameValue(arrow.name, 'arrow');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-class.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-class.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" classes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (let { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } of asyncIter) {
+    assert.sameValue(cls.name, 'cls');
+    assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-cover.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-cover.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" functions "through" cover grammar (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (let { cover = (function () {}), xCover = (0, function() {})  } of asyncIter) {
+    assert.sameValue(cover.name, 'cover');
+    assert.notSameValue(xCover.name, 'xCover');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-fn.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-fn.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (let { fn = function () {}, xFn = function x() {} } of asyncIter) {
+    assert.sameValue(fn.name, 'fn');
+    assert.notSameValue(xFn.name, 'xFn');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-gen.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-gen.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" generator functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (let { gen = function* () {}, xGen = function* x() {} } of asyncIter) {
+    assert.sameValue(gen.name, 'gen');
+    assert.notSameValue(xGen.name, 'xGen');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-skipped.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+    [...]
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: null, x: 0, y: false, z: '' }];
+})();
+
+async function fn() {
+  for await (let { w = counter(), x = counter(), y = counter(), z = counter() } of asyncIter) {
+    assert.sameValue(w, null);
+    assert.sameValue(x, 0);
+    assert.sameValue(y, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-trailing-comma.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function fn() {
+  for await (let { x, } of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-ary-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-ary-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary-init.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Object binding pattern with "nested" array binding pattern using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (let { w: [x, y, z] = [4, 5, 6] } of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-ary-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-ary-trailing-comma.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: [45] }];
+})();
+
+async function fn() {
+  for await (let { x: [y], } of asyncIter) {
+    assert.sameValue(y,45);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-ary.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Object binding pattern with "nested" array binding pattern not using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       [...]
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: [7, undefined, ] }];
+})();
+
+async function fn() {
+  for await (let { w: [x, y, z] = [4, 5, 6] } of asyncIter) {
+    assert.sameValue(x, 7);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, undefined);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-id-init-skipped.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    BindingElement : BindingPattern Initializeropt
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+    [...]
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ s: null, u: 0, w: false, y: '' }];
+})();
+
+async function fn() {
+  for await (let { s: t = counter(), u: v = counter(), w: x = counter(), y: z = counter() } of asyncIter) {
+    assert.sameValue(t, null);
+    assert.sameValue(v, 0);
+    assert.sameValue(x, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    assert.throws(ReferenceError, function() {
+      s;
+    });
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-id-init.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-init.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Binding as specified via property name, identifier, and initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ }];
+})();
+
+async function fn() {
+  for await (let { x: y = 33 } of asyncIter) {
+    assert.sameValue(y, 33);
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-id-trailing-comma.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function fn() {
+  for await (let { x: y, } of asyncIter) {
+    assert.sameValue(y, 23);
+
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-id.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Binding as specified via property name and identifier (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function fn() {
+  for await (let { x: y } of asyncIter) {
+    assert.sameValue(y, 23);
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-obj-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-obj-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-obj-init.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Object binding pattern with "nested" object binding pattern using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: undefined }];
+})();
+
+async function fn() {
+  for await (let { w: { x, y, z } = { x: 4, y: 5, z: 6 } } of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-prop-obj.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Object binding pattern with "nested" object binding pattern not using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       [...]
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: { x: undefined, z: 7 } }];
+})();
+
+async function fn() {
+  for await (let { w: { x, y, z } = { x: 4, y: 5, z: 6 } } of asyncIter) {
+    assert.sameValue(x, undefined);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 7);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-getter.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-getter.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Getter is called when obj is being deconstructed to a rest Object (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var count = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ get v() { count++; return 2; } }];
+})();
+
+async function fn() {
+  for await (let {...x} of asyncIter) {
+    assert.sameValue(x.v, 2);
+    assert.sameValue(count, 1);
+
+    verifyEnumerable(x, "v");
+    verifyWritable(x, "v");
+    verifyConfigurable(x, "v");
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-nested-obj.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-nested-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var obj = {a: 3, b: 4};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{a: 1, b: 2, c: 3, d: 4, e: 5}];
+})();
+
+async function fn() {
+  for await (let {a, b, ...{c, e}} of asyncIter) {
+    assert.sameValue(a, 1);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 3);
+    assert.sameValue(e, 5);
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-obj-nested-rest.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-obj-nested-rest.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{a: 1, b: 2, c: 3, d: 4, e: 5}];
+})();
+
+async function fn() {
+  for await (let {a, b, ...{c, ...rest}} of asyncIter) {
+    assert.sameValue(a, 1);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 3);
+
+    assert.sameValue(rest.d, 4);
+    assert.sameValue(rest.e, 5);
+
+    verifyEnumerable(rest, "d");
+    verifyWritable(rest, "d");
+    verifyConfigurable(rest, "d");
+
+    verifyEnumerable(rest, "e");
+    verifyWritable(rest, "e");
+    verifyConfigurable(rest, "e");
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-obj-own-property.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-obj-own-property.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Rest object contains just soruce object's own properties (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var o = Object.create({ x: 1, y: 2 });
+o.z = 3;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [o];
+})();
+
+async function fn() {
+  for await (let { x, ...{y , z} } of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 3);
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-skip-non-enumerable.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-skip-non-enumerable.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Rest object doesn't contain non-enumerable properties (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var o = {a: 3, b: 4};
+Object.defineProperty(o, "x", { value: 4, enumerable: false });
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [o];
+})();
+
+async function fn() {
+  for await (let {...rest} of asyncIter) {
+    assert.sameValue(rest.a, 3);
+    assert.sameValue(rest.b, 4);
+    assert.sameValue(rest.x, undefined);
+
+    verifyEnumerable(rest, "a");
+    verifyWritable(rest, "a");
+    verifyConfigurable(rest, "a");
+
+    verifyEnumerable(rest, "b");
+    verifyWritable(rest, "b");
+    verifyConfigurable(rest, "b");
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-val-obj.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-val-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-let-async.template
+/*---
+description: Rest object contains just unextracted data (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{x: 1, y: 2, a: 5, b: 3}];
+})();
+
+async function fn() {
+  for await (let {a, b, ...rest} of asyncIter) {
+    assert.sameValue(rest.x, 1);
+    assert.sameValue(rest.y, 2);
+    assert.sameValue(rest.a, undefined);
+    assert.sameValue(rest.b, undefined);
+
+    verifyEnumerable(rest, "x");
+    verifyWritable(rest, "x");
+    verifyConfigurable(rest, "x");
+
+    verifyEnumerable(rest, "y");
+    verifyWritable(rest, "y");
+    verifyConfigurable(rest, "y");
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-init-iter-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-init-iter-close.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-close.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Iterator is closed when not exhausted by pattern evaluation (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.5 Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, return ? IteratorClose(iterator,
+       result).
+    [...]
+
+---*/
+var doneCallCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { value: null, done: false };
+    },
+    return: function() {
+      doneCallCount += 1;
+      return {};
+    }
+  };
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (var [x] of asyncIter) {
+    assert.sameValue(doneCallCount, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-init-iter-no-close.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-init-iter-no-close.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-no-close.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Iterator is not closed when exhausted by pattern evaluation (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.5 Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, return ? IteratorClose(iterator,
+       result).
+    [...]
+
+---*/
+var doneCallCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { value: null, done: true };
+    },
+    return: function() {
+      doneCallCount += 1;
+      return {};
+    }
+  };
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (var [x] of asyncIter) {
+    assert.sameValue(doneCallCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-name-iter-val.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-name-iter-val.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-name-iter-val.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: SingleNameBinding with normal value iteration (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (var [x, y, z] of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-elem-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-elem-init.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elem-init.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [[x, y, z] = [4, 5, 6]] of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-elem-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-elem-iter.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elem-iter.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[7, 8, 9]]];
+})();
+
+async function fn() {
+  for await (var [[x, y, z] = [4, 5, 6]] of asyncIter) {
+    assert.sameValue(x, 7);
+    assert.sameValue(y, 8);
+    assert.sameValue(z, 9);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-elision-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-elision-init.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elision-init.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [[,] = g()] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-elision-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-elision-iter.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elision-iter.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+
+---*/
+var callCount = 0;
+function* g() {
+  callCount += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[]]];
+})();
+
+async function fn() {
+  for await (var [[,] = g()] of asyncIter) {
+    assert.sameValue(callCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-empty-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-empty-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-empty-init.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var initCount = 0;
+var iterCount = 0;
+var iter = function*() { iterCount += 1; }();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [[] = function() { initCount += 1; return iter; }()] of asyncIter) {
+    assert.sameValue(initCount, 1);
+    assert.sameValue(iterCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-empty-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-empty-iter.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-empty-iter.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var initCount = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[23]]];
+})();
+
+async function fn() {
+  for await (var [[] = function() { initCount += 1; }()] of asyncIter) {
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-rest-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-rest-init.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-rest-init.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var values = [2, 1, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [[...x] = values] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x[0], 2);
+    assert.sameValue(x[1], 1);
+    assert.sameValue(x[2], 3);
+    assert.sameValue(x.length, 3);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-rest-iter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-ary-rest-iter.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-rest-iter.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var values = [2, 1, 3];
+var initCount = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[values]];
+})();
+
+async function fn() {
+  for await (var [[...x] = function() { initCount += 1; }()] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x[0], 2);
+    assert.sameValue(x[1], 1);
+    assert.sameValue(x[2], 3);
+    assert.sameValue(x.length, 3);
+    assert.notSameValue(x, values);
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-exhausted.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Destructuring initializer with an exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-arrow.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-arrow.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: SingleNameBinding does assign name to arrow functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [arrow = () => {}] of asyncIter) {
+    assert.sameValue(arrow.name, 'arrow');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-class.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-class.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" classes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] of asyncIter) {
+    assert.sameValue(cls.name, 'cls');
+    assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-cover.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-cover.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: SingleNameBinding does assign name to "anonymous" functions "through" cover grammar (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [cover = (function () {}), xCover = (0, function() {})] of asyncIter) {
+    assert.sameValue(cover.name, 'cover');
+    assert.notSameValue(xCover.name, 'xCover');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-fn.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-fn.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [fn = function () {}, xFn = function x() {}] of asyncIter) {
+    assert.sameValue(fn.name, 'fn');
+    assert.notSameValue(xFn.name, 'xFn');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-gen.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-gen.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" generator functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [gen = function* () {}, xGen = function* x() {}] of asyncIter) {
+    assert.sameValue(gen.name, 'gen');
+    assert.notSameValue(xGen.name, 'xGen');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-hole.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-hole.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-hole.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Destructuring initializer with a "hole" (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    SingleNameBinding : BindingIdentifier Initializeropt
+    [...] 6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v). 8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[,]];
+})();
+
+async function fn() {
+  for await (var [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+    // another statement
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-skipped.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[null, 0, false, '']];
+})();
+
+async function fn() {
+  for await (var [w = counter(), x = counter(), y = counter(), z = counter()] of asyncIter) {
+    assert.sameValue(w, null);
+    assert.sameValue(x, 0);
+    assert.sameValue(y, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-undef.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-undef.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-undef.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Destructuring initializer with an undefined value (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[undefined]];
+})();
+
+async function fn() {
+  for await (var [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-iter-complete.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-iter-complete.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-complete.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: SingleNameBinding when value iteration completes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [x] of asyncIter) {
+    assert.sameValue(x, undefined);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-iter-done.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-iter-done.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-done.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: SingleNameBinding when value iteration was completed previously (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [_, x] of asyncIter) {
+    assert.sameValue(x, undefined);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-iter-val.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-iter-val.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: SingleNameBinding when value iteration was completed previously (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (var [x, y, z] of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-obj-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-obj-id-init.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-id-init.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [{ x, y, z } = { x: 44, y: 55, z: 66 }] of asyncIter) {
+    assert.sameValue(x, 44);
+    assert.sameValue(y, 55);
+    assert.sameValue(z, 66);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-obj-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-obj-id.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-id.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[{ x: 11, y: 22, z: 33 }]];
+})();
+
+async function fn() {
+  for await (var [{ x, y, z } = { x: 44, y: 55, z: 66 }] of asyncIter) {
+    assert.sameValue(x, 11);
+    assert.sameValue(y, 22);
+    assert.sameValue(z, 33);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-obj-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-obj-prop-id-init.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-prop-id-init.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [{ u: v, w: x, y: z } = { u: 444, w: 555, y: 666 }] of asyncIter) {
+    assert.sameValue(v, 444);
+    assert.sameValue(x, 555);
+    assert.sameValue(z, 666);
+
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-obj-prop-id.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[{ u: 777, w: 888, y: 999 }]];
+})();
+
+async function fn() {
+  for await (var [{ u: v, w: x, y: z } = { u: 444, w: 555, y: 666 }] of asyncIter) {
+    assert.sameValue(v, 777);
+    assert.sameValue(x, 888);
+    assert.sameValue(z, 999);
+
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elision-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elision-exhausted.js
@@ -1,0 +1,73 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Elision accepts exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       [...]
+    2. Return NormalCompletion(empty).
+
+---*/
+var iter = function*() {}();
+iter.next();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (var [,] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elision.js
@@ -1,0 +1,82 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Elision advances iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+    2. Return NormalCompletion(empty).
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [g()];
+})();
+
+async function fn() {
+  for await (var [,] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-empty.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-empty.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: No iteration occurs for an "empty" array binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ ]
+
+    1. Return NormalCompletion(empty).
+
+---*/
+var iterations = 0;
+var iter = function*() {
+  iterations += 1;
+}();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (var [] of asyncIter) {
+    assert.sameValue(iterations, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-ary-elem.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-ary-elem.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-elem.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Rest element containing an array BindingElementList pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[3, 4, 5]];
+})();
+
+async function fn() {
+  for await (var [...[x, y, z]] of asyncIter) {
+    assert.sameValue(x, 3);
+    assert.sameValue(y, 4);
+    assert.sameValue(z, 5);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-ary-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-ary-elision.js
@@ -1,0 +1,95 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-elision.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Rest element containing an elision (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+    2. Return NormalCompletion(empty).
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [g()];
+})();
+
+async function fn() {
+  for await (var [...[,]] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-ary-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-ary-empty.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-empty.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Rest element containing an "empty" array pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ ]
+
+    1. Return NormalCompletion(empty).
+
+---*/
+var iterations = 0;
+var iter = function*() {
+  iterations += 1;
+}();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function fn() {
+  for await (var [...[]] of asyncIter) {
+    assert.sameValue(iterations, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-ary-rest.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-ary-rest.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-rest.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Rest element containing a rest element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+var values = [1, 2, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function fn() {
+  for await (var [...[...x]] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 1);
+    assert.sameValue(x[1], 2);
+    assert.sameValue(x[2], 3);
+    assert.notSameValue(x, values);
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-id-elision.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-id-elision.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-elision.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Rest element following elision elements (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    ArrayBindingPattern : [ Elisionopt BindingRestElement ]
+    1. If Elision is present, then
+       a. Let status be the result of performing
+          IteratorDestructuringAssignmentEvaluation of Elision with
+          iteratorRecord as the argument.
+       b. ReturnIfAbrupt(status).
+    2. Return the result of performing IteratorBindingInitialization for
+       BindingRestElement with iteratorRecord and environment as arguments.
+---*/
+var values = [1, 2, 3, 4, 5];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function fn() {
+  for await (var [ , , ...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 3);
+    assert.sameValue(x[1], 4);
+    assert.sameValue(x[2], 5);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-id-exhausted.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-id-exhausted.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: RestElement applied to an exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    BindingRestElement : ... BindingIdentifier
+    1. Let lhs be ResolveBinding(StringValue of BindingIdentifier,
+       environment).
+    2. ReturnIfAbrupt(lhs). 3. Let A be ArrayCreate(0). 4. Let n=0. 5. Repeat,
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. If environment is undefined, return PutValue(lhs, A).
+          ii. Return InitializeReferencedBinding(lhs, A).
+
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2]];
+})();
+
+async function fn() {
+  for await (var [, , ...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-id.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Lone rest element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    BindingRestElement : ... BindingIdentifier
+    [...] 3. Let A be ArrayCreate(0). [...] 5. Repeat
+       [...]
+       f. Let status be CreateDataProperty(A, ToString (n), nextValue).
+       [...]
+---*/
+var values = [1, 2, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function fn() {
+  for await (var [...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 1);
+    assert.sameValue(x[1], 2);
+    assert.sameValue(x[2], 3);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-ary.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-ary.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Reset element (nested array pattern) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [...[ x ] = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-id.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-id.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Reset element (identifier) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [...x = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-obj.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Reset element (nested object pattern) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function fn() {
+  for await (var [...{ x } = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-not-final-ary.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-ary.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (var [...[x], y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-not-final-id.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-id.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Rest element (identifier) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (var [...x, y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-not-final-obj.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (var [...{ x }, y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-obj-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-obj-id.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-obj-id.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Rest element containing an object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function fn() {
+  for await (var [...{ length }] of asyncIter) {
+    assert.sameValue(length, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-obj-prop-id.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-obj-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Rest element containing an object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+let length = "outer";
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[7, 8, 9]];
+})();
+
+async function fn() {
+  for await (var [...{ 0: v, 1: w, 2: x, 3: y, length: z }] of asyncIter) {
+    assert.sameValue(v, 7);
+    assert.sameValue(w, 8);
+    assert.sameValue(x, 9);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 3);
+
+    assert.sameValue(length, "outer", "the length prop is not set as a binding name");
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-empty.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-empty.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: No property access occurs for an "empty" object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    Runtime Semantics: BindingInitialization
+
+    ObjectBindingPattern : { }
+
+    1. Return NormalCompletion(empty).
+---*/
+var accessCount = 0;
+var obj = Object.defineProperty({}, 'attr', {
+  get: function() {
+    accessCount += 1;
+  }
+});
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [obj];
+})();
+
+async function fn() {
+  for await (var {} of asyncIter) {
+    assert.sameValue(accessCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-arrow.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-arrow.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: SingleNameBinding assigns `name` to arrow functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (var { arrow = () => {} } of asyncIter) {
+    assert.sameValue(arrow.name, 'arrow');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-class.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-class.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" classes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (var { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } of asyncIter) {
+    assert.sameValue(cls.name, 'cls');
+    assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-cover.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-cover.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" functions "through" cover grammar (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (var { cover = (function () {}), xCover = (0, function() {})  } of asyncIter) {
+    assert.sameValue(cover.name, 'cover');
+    assert.notSameValue(xCover.name, 'xCover');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-fn.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-fn.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (var { fn = function () {}, xFn = function x() {} } of asyncIter) {
+    assert.sameValue(fn.name, 'fn');
+    assert.notSameValue(xFn.name, 'xFn');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-gen.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-gen.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" generator functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (var { gen = function* () {}, xGen = function* x() {} } of asyncIter) {
+    assert.sameValue(gen.name, 'gen');
+    assert.notSameValue(xGen.name, 'xGen');
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-skipped.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+    [...]
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: null, x: 0, y: false, z: '' }];
+})();
+
+async function fn() {
+  for await (var { w = counter(), x = counter(), y = counter(), z = counter() } of asyncIter) {
+    assert.sameValue(w, null);
+    assert.sameValue(x, 0);
+    assert.sameValue(y, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-trailing-comma.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function fn() {
+  for await (var { x, } of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-ary-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-ary-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary-init.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Object binding pattern with "nested" array binding pattern using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function fn() {
+  for await (var { w: [x, y, z] = [4, 5, 6] } of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-ary-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-ary-trailing-comma.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: [45] }];
+})();
+
+async function fn() {
+  for await (var { x: [y], } of asyncIter) {
+    assert.sameValue(y,45);
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-ary.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Object binding pattern with "nested" array binding pattern not using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       [...]
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: [7, undefined, ] }];
+})();
+
+async function fn() {
+  for await (var { w: [x, y, z] = [4, 5, 6] } of asyncIter) {
+    assert.sameValue(x, 7);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, undefined);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-id-init-skipped.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    BindingElement : BindingPattern Initializeropt
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+    [...]
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ s: null, u: 0, w: false, y: '' }];
+})();
+
+async function fn() {
+  for await (var { s: t = counter(), u: v = counter(), w: x = counter(), y: z = counter() } of asyncIter) {
+    assert.sameValue(t, null);
+    assert.sameValue(v, 0);
+    assert.sameValue(x, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    assert.throws(ReferenceError, function() {
+      s;
+    });
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-id-init.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-init.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Binding as specified via property name, identifier, and initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ }];
+})();
+
+async function fn() {
+  for await (var { x: y = 33 } of asyncIter) {
+    assert.sameValue(y, 33);
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-id-trailing-comma.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function fn() {
+  for await (var { x: y, } of asyncIter) {
+    assert.sameValue(y, 23);
+
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-id.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Binding as specified via property name and identifier (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function fn() {
+  for await (var { x: y } of asyncIter) {
+    assert.sameValue(y, 23);
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-obj-init.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-obj-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-obj-init.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Object binding pattern with "nested" object binding pattern using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: undefined }];
+})();
+
+async function fn() {
+  for await (var { w: { x, y, z } = { x: 4, y: 5, z: 6 } } of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-obj.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Object binding pattern with "nested" object binding pattern not using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       [...]
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: { x: undefined, z: 7 } }];
+})();
+
+async function fn() {
+  for await (var { w: { x, y, z } = { x: 4, y: 5, z: 6 } } of asyncIter) {
+    assert.sameValue(x, undefined);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 7);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-rest-getter.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-getter.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Getter is called when obj is being deconstructed to a rest Object (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var count = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ get v() { count++; return 2; } }];
+})();
+
+async function fn() {
+  for await (var {...x} of asyncIter) {
+    assert.sameValue(x.v, 2);
+    assert.sameValue(count, 1);
+
+    verifyEnumerable(x, "v");
+    verifyWritable(x, "v");
+    verifyConfigurable(x, "v");
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-rest-nested-obj.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-nested-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var obj = {a: 3, b: 4};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{a: 1, b: 2, c: 3, d: 4, e: 5}];
+})();
+
+async function fn() {
+  for await (var {a, b, ...{c, e}} of asyncIter) {
+    assert.sameValue(a, 1);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 3);
+    assert.sameValue(e, 5);
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-rest-obj-nested-rest.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-obj-nested-rest.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{a: 1, b: 2, c: 3, d: 4, e: 5}];
+})();
+
+async function fn() {
+  for await (var {a, b, ...{c, ...rest}} of asyncIter) {
+    assert.sameValue(a, 1);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 3);
+
+    assert.sameValue(rest.d, 4);
+    assert.sameValue(rest.e, 5);
+
+    verifyEnumerable(rest, "d");
+    verifyWritable(rest, "d");
+    verifyConfigurable(rest, "d");
+
+    verifyEnumerable(rest, "e");
+    verifyWritable(rest, "e");
+    verifyConfigurable(rest, "e");
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-rest-obj-own-property.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-obj-own-property.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Rest object contains just soruce object's own properties (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var o = Object.create({ x: 1, y: 2 });
+o.z = 3;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [o];
+})();
+
+async function fn() {
+  for await (var { x, ...{y , z} } of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 3);
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-rest-skip-non-enumerable.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-skip-non-enumerable.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Rest object doesn't contain non-enumerable properties (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var o = {a: 3, b: 4};
+Object.defineProperty(o, "x", { value: 4, enumerable: false });
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [o];
+})();
+
+async function fn() {
+  for await (var {...rest} of asyncIter) {
+    assert.sameValue(rest.a, 3);
+    assert.sameValue(rest.b, 4);
+    assert.sameValue(rest.x, undefined);
+
+    verifyEnumerable(rest, "a");
+    verifyWritable(rest, "a");
+    verifyConfigurable(rest, "a");
+
+    verifyEnumerable(rest, "b");
+    verifyWritable(rest, "b");
+    verifyConfigurable(rest, "b");
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-rest-val-obj.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-val-obj.case
+// - src/dstr-binding/default/for-await-of-async-func-var-async.template
+/*---
+description: Rest object contains just unextracted data (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{x: 1, y: 2, a: 5, b: 3}];
+})();
+
+async function fn() {
+  for await (var {a, b, ...rest} of asyncIter) {
+    assert.sameValue(rest.x, 1);
+    assert.sameValue(rest.y, 2);
+    assert.sameValue(rest.a, undefined);
+    assert.sameValue(rest.b, undefined);
+
+    verifyEnumerable(rest, "x");
+    verifyWritable(rest, "x");
+    verifyConfigurable(rest, "x");
+
+    verifyEnumerable(rest, "y");
+    verifyWritable(rest, "y");
+    verifyConfigurable(rest, "y");
+
+
+    iterCount += 1;
+  }
+}
+
+fn()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-init-iter-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-init-iter-close.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-close.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Iterator is closed when not exhausted by pattern evaluation (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.5 Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, return ? IteratorClose(iterator,
+       result).
+    [...]
+
+---*/
+var doneCallCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { value: null, done: false };
+    },
+    return: function() {
+      doneCallCount += 1;
+      return {};
+    }
+  };
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (const [x] of asyncIter) {
+    assert.sameValue(doneCallCount, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-init-iter-no-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-init-iter-no-close.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-no-close.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Iterator is not closed when exhausted by pattern evaluation (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.5 Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, return ? IteratorClose(iterator,
+       result).
+    [...]
+
+---*/
+var doneCallCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { value: null, done: true };
+    },
+    return: function() {
+      doneCallCount += 1;
+      return {};
+    }
+  };
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (const [x] of asyncIter) {
+    assert.sameValue(doneCallCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-name-iter-val.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-name-iter-val.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-name-iter-val.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: SingleNameBinding with normal value iteration (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (const [x, y, z] of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-elem-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-elem-init.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elem-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [[x, y, z] = [4, 5, 6]] of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-elem-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-elem-iter.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elem-iter.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[7, 8, 9]]];
+})();
+
+async function *fn() {
+  for await (const [[x, y, z] = [4, 5, 6]] of asyncIter) {
+    assert.sameValue(x, 7);
+    assert.sameValue(y, 8);
+    assert.sameValue(z, 9);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-elision-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-elision-init.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elision-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [[,] = g()] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-elision-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-elision-iter.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elision-iter.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+
+---*/
+var callCount = 0;
+function* g() {
+  callCount += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[]]];
+})();
+
+async function *fn() {
+  for await (const [[,] = g()] of asyncIter) {
+    assert.sameValue(callCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-empty-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-empty-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-empty-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var initCount = 0;
+var iterCount = 0;
+var iter = function*() { iterCount += 1; }();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [[] = function() { initCount += 1; return iter; }()] of asyncIter) {
+    assert.sameValue(initCount, 1);
+    assert.sameValue(iterCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-empty-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-empty-iter.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-empty-iter.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var initCount = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[23]]];
+})();
+
+async function *fn() {
+  for await (const [[] = function() { initCount += 1; }()] of asyncIter) {
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-rest-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-rest-init.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-rest-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var values = [2, 1, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [[...x] = values] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x[0], 2);
+    assert.sameValue(x[1], 1);
+    assert.sameValue(x[2], 3);
+    assert.sameValue(x.length, 3);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-rest-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-ary-rest-iter.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-rest-iter.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var values = [2, 1, 3];
+var initCount = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[values]];
+})();
+
+async function *fn() {
+  for await (const [[...x] = function() { initCount += 1; }()] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x[0], 2);
+    assert.sameValue(x[1], 1);
+    assert.sameValue(x[2], 3);
+    assert.sameValue(x.length, 3);
+    assert.notSameValue(x, values);
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-exhausted.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Destructuring initializer with an exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-arrow.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-arrow.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: SingleNameBinding does assign name to arrow functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [arrow = () => {}] of asyncIter) {
+    assert.sameValue(arrow.name, 'arrow');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-class.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-class.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" classes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] of asyncIter) {
+    assert.sameValue(cls.name, 'cls');
+    assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-cover.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-cover.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: SingleNameBinding does assign name to "anonymous" functions "through" cover grammar (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [cover = (function () {}), xCover = (0, function() {})] of asyncIter) {
+    assert.sameValue(cover.name, 'cover');
+    assert.notSameValue(xCover.name, 'xCover');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-fn.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-fn.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [fn = function () {}, xFn = function x() {}] of asyncIter) {
+    assert.sameValue(fn.name, 'fn');
+    assert.notSameValue(xFn.name, 'xFn');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-gen.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-gen.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" generator functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [gen = function* () {}, xGen = function* x() {}] of asyncIter) {
+    assert.sameValue(gen.name, 'gen');
+    assert.notSameValue(xGen.name, 'xGen');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-hole.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-hole.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-hole.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Destructuring initializer with a "hole" (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    SingleNameBinding : BindingIdentifier Initializeropt
+    [...] 6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v). 8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[,]];
+})();
+
+async function *fn() {
+  for await (const [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+    // another statement
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-skipped.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[null, 0, false, '']];
+})();
+
+async function *fn() {
+  for await (const [w = counter(), x = counter(), y = counter(), z = counter()] of asyncIter) {
+    assert.sameValue(w, null);
+    assert.sameValue(x, 0);
+    assert.sameValue(y, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-undef.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-undef.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-undef.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Destructuring initializer with an undefined value (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[undefined]];
+})();
+
+async function *fn() {
+  for await (const [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-iter-complete.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-iter-complete.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-complete.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: SingleNameBinding when value iteration completes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [x] of asyncIter) {
+    assert.sameValue(x, undefined);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-iter-done.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-iter-done.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-done.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: SingleNameBinding when value iteration was completed previously (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [_, x] of asyncIter) {
+    assert.sameValue(x, undefined);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-iter-val.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-iter-val.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: SingleNameBinding when value iteration was completed previously (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (const [x, y, z] of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-obj-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-obj-id-init.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-id-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [{ x, y, z } = { x: 44, y: 55, z: 66 }] of asyncIter) {
+    assert.sameValue(x, 44);
+    assert.sameValue(y, 55);
+    assert.sameValue(z, 66);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-obj-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-obj-id.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[{ x: 11, y: 22, z: 33 }]];
+})();
+
+async function *fn() {
+  for await (const [{ x, y, z } = { x: 44, y: 55, z: 66 }] of asyncIter) {
+    assert.sameValue(x, 11);
+    assert.sameValue(y, 22);
+    assert.sameValue(z, 33);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-obj-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-obj-prop-id-init.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-prop-id-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [{ u: v, w: x, y: z } = { u: 444, w: 555, y: 666 }] of asyncIter) {
+    assert.sameValue(v, 444);
+    assert.sameValue(x, 555);
+    assert.sameValue(z, 666);
+
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-obj-prop-id.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[{ u: 777, w: 888, y: 999 }]];
+})();
+
+async function *fn() {
+  for await (const [{ u: v, w: x, y: z } = { u: 444, w: 555, y: 666 }] of asyncIter) {
+    assert.sameValue(v, 777);
+    assert.sameValue(x, 888);
+    assert.sameValue(z, 999);
+
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elision-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elision-exhausted.js
@@ -1,0 +1,73 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Elision accepts exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       [...]
+    2. Return NormalCompletion(empty).
+
+---*/
+var iter = function*() {}();
+iter.next();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (const [,] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elision.js
@@ -1,0 +1,82 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Elision advances iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+    2. Return NormalCompletion(empty).
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [g()];
+})();
+
+async function *fn() {
+  for await (const [,] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-empty.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-empty.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: No iteration occurs for an "empty" array binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ ]
+
+    1. Return NormalCompletion(empty).
+
+---*/
+var iterations = 0;
+var iter = function*() {
+  iterations += 1;
+}();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (const [] of asyncIter) {
+    assert.sameValue(iterations, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-ary-elem.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-ary-elem.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-elem.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Rest element containing an array BindingElementList pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[3, 4, 5]];
+})();
+
+async function *fn() {
+  for await (const [...[x, y, z]] of asyncIter) {
+    assert.sameValue(x, 3);
+    assert.sameValue(y, 4);
+    assert.sameValue(z, 5);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-ary-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-ary-elision.js
@@ -1,0 +1,95 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-elision.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Rest element containing an elision (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+    2. Return NormalCompletion(empty).
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [g()];
+})();
+
+async function *fn() {
+  for await (const [...[,]] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-ary-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-ary-empty.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-empty.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Rest element containing an "empty" array pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ ]
+
+    1. Return NormalCompletion(empty).
+
+---*/
+var iterations = 0;
+var iter = function*() {
+  iterations += 1;
+}();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (const [...[]] of asyncIter) {
+    assert.sameValue(iterations, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-ary-rest.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-ary-rest.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-rest.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Rest element containing a rest element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+var values = [1, 2, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function *fn() {
+  for await (const [...[...x]] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 1);
+    assert.sameValue(x[1], 2);
+    assert.sameValue(x[2], 3);
+    assert.notSameValue(x, values);
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-id-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-id-elision.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-elision.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Rest element following elision elements (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    ArrayBindingPattern : [ Elisionopt BindingRestElement ]
+    1. If Elision is present, then
+       a. Let status be the result of performing
+          IteratorDestructuringAssignmentEvaluation of Elision with
+          iteratorRecord as the argument.
+       b. ReturnIfAbrupt(status).
+    2. Return the result of performing IteratorBindingInitialization for
+       BindingRestElement with iteratorRecord and environment as arguments.
+---*/
+var values = [1, 2, 3, 4, 5];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function *fn() {
+  for await (const [ , , ...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 3);
+    assert.sameValue(x[1], 4);
+    assert.sameValue(x[2], 5);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-id-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-id-exhausted.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: RestElement applied to an exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    BindingRestElement : ... BindingIdentifier
+    1. Let lhs be ResolveBinding(StringValue of BindingIdentifier,
+       environment).
+    2. ReturnIfAbrupt(lhs). 3. Let A be ArrayCreate(0). 4. Let n=0. 5. Repeat,
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. If environment is undefined, return PutValue(lhs, A).
+          ii. Return InitializeReferencedBinding(lhs, A).
+
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2]];
+})();
+
+async function *fn() {
+  for await (const [, , ...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-id.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Lone rest element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    BindingRestElement : ... BindingIdentifier
+    [...] 3. Let A be ArrayCreate(0). [...] 5. Repeat
+       [...]
+       f. Let status be CreateDataProperty(A, ToString (n), nextValue).
+       [...]
+---*/
+var values = [1, 2, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function *fn() {
+  for await (const [...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 1);
+    assert.sameValue(x[1], 2);
+    assert.sameValue(x[2], 3);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-ary.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-ary.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Reset element (nested array pattern) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [...[ x ] = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-id.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Reset element (identifier) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [...x = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-obj.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Reset element (nested object pattern) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (const [...{ x } = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-ary.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-ary.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (const [...[x], y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-id.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Rest element (identifier) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (const [...x, y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-obj.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (const [...{ x }, y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-obj-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-obj-id.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-obj-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Rest element containing an object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (const [...{ length }] of asyncIter) {
+    assert.sameValue(length, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-obj-prop-id.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-obj-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Rest element containing an object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+let length = "outer";
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[7, 8, 9]];
+})();
+
+async function *fn() {
+  for await (const [...{ 0: v, 1: w, 2: x, 3: y, length: z }] of asyncIter) {
+    assert.sameValue(v, 7);
+    assert.sameValue(w, 8);
+    assert.sameValue(x, 9);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 3);
+
+    assert.sameValue(length, "outer", "the length prop is not set as a binding name");
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-empty.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-empty.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: No property access occurs for an "empty" object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    Runtime Semantics: BindingInitialization
+
+    ObjectBindingPattern : { }
+
+    1. Return NormalCompletion(empty).
+---*/
+var accessCount = 0;
+var obj = Object.defineProperty({}, 'attr', {
+  get: function() {
+    accessCount += 1;
+  }
+});
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [obj];
+})();
+
+async function *fn() {
+  for await (const {} of asyncIter) {
+    assert.sameValue(accessCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-arrow.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-arrow.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: SingleNameBinding assigns `name` to arrow functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (const { arrow = () => {} } of asyncIter) {
+    assert.sameValue(arrow.name, 'arrow');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-class.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-class.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" classes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (const { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } of asyncIter) {
+    assert.sameValue(cls.name, 'cls');
+    assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-cover.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-cover.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" functions "through" cover grammar (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (const { cover = (function () {}), xCover = (0, function() {})  } of asyncIter) {
+    assert.sameValue(cover.name, 'cover');
+    assert.notSameValue(xCover.name, 'xCover');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-fn.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-fn.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (const { fn = function () {}, xFn = function x() {} } of asyncIter) {
+    assert.sameValue(fn.name, 'fn');
+    assert.notSameValue(xFn.name, 'xFn');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-gen.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-gen.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" generator functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (const { gen = function* () {}, xGen = function* x() {} } of asyncIter) {
+    assert.sameValue(gen.name, 'gen');
+    assert.notSameValue(xGen.name, 'xGen');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-skipped.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+    [...]
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: null, x: 0, y: false, z: '' }];
+})();
+
+async function *fn() {
+  for await (const { w = counter(), x = counter(), y = counter(), z = counter() } of asyncIter) {
+    assert.sameValue(w, null);
+    assert.sameValue(x, 0);
+    assert.sameValue(y, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-trailing-comma.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function *fn() {
+  for await (const { x, } of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-ary-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-ary-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Object binding pattern with "nested" array binding pattern using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (const { w: [x, y, z] = [4, 5, 6] } of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-ary-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-ary-trailing-comma.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: [45] }];
+})();
+
+async function *fn() {
+  for await (const { x: [y], } of asyncIter) {
+    assert.sameValue(y,45);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-ary.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Object binding pattern with "nested" array binding pattern not using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       [...]
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: [7, undefined, ] }];
+})();
+
+async function *fn() {
+  for await (const { w: [x, y, z] = [4, 5, 6] } of asyncIter) {
+    assert.sameValue(x, 7);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, undefined);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-id-init-skipped.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    BindingElement : BindingPattern Initializeropt
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+    [...]
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ s: null, u: 0, w: false, y: '' }];
+})();
+
+async function *fn() {
+  for await (const { s: t = counter(), u: v = counter(), w: x = counter(), y: z = counter() } of asyncIter) {
+    assert.sameValue(t, null);
+    assert.sameValue(v, 0);
+    assert.sameValue(x, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    assert.throws(ReferenceError, function() {
+      s;
+    });
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-id-init.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Binding as specified via property name, identifier, and initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ }];
+})();
+
+async function *fn() {
+  for await (const { x: y = 33 } of asyncIter) {
+    assert.sameValue(y, 33);
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-id-trailing-comma.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function *fn() {
+  for await (const { x: y, } of asyncIter) {
+    assert.sameValue(y, 23);
+
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-id.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Binding as specified via property name and identifier (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function *fn() {
+  for await (const { x: y } of asyncIter) {
+    assert.sameValue(y, 23);
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-obj-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-obj-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-obj-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Object binding pattern with "nested" object binding pattern using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: undefined }];
+})();
+
+async function *fn() {
+  for await (const { w: { x, y, z } = { x: 4, y: 5, z: 6 } } of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-prop-obj.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Object binding pattern with "nested" object binding pattern not using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       [...]
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: { x: undefined, z: 7 } }];
+})();
+
+async function *fn() {
+  for await (const { w: { x, y, z } = { x: 4, y: 5, z: 6 } } of asyncIter) {
+    assert.sameValue(x, undefined);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 7);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-getter.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-getter.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Getter is called when obj is being deconstructed to a rest Object (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var count = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ get v() { count++; return 2; } }];
+})();
+
+async function *fn() {
+  for await (const {...x} of asyncIter) {
+    assert.sameValue(x.v, 2);
+    assert.sameValue(count, 1);
+
+    verifyEnumerable(x, "v");
+    verifyWritable(x, "v");
+    verifyConfigurable(x, "v");
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-nested-obj.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-nested-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var obj = {a: 3, b: 4};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{a: 1, b: 2, c: 3, d: 4, e: 5}];
+})();
+
+async function *fn() {
+  for await (const {a, b, ...{c, e}} of asyncIter) {
+    assert.sameValue(a, 1);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 3);
+    assert.sameValue(e, 5);
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-obj-nested-rest.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-obj-nested-rest.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{a: 1, b: 2, c: 3, d: 4, e: 5}];
+})();
+
+async function *fn() {
+  for await (const {a, b, ...{c, ...rest}} of asyncIter) {
+    assert.sameValue(a, 1);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 3);
+
+    assert.sameValue(rest.d, 4);
+    assert.sameValue(rest.e, 5);
+
+    verifyEnumerable(rest, "d");
+    verifyWritable(rest, "d");
+    verifyConfigurable(rest, "d");
+
+    verifyEnumerable(rest, "e");
+    verifyWritable(rest, "e");
+    verifyConfigurable(rest, "e");
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-obj-own-property.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-obj-own-property.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Rest object contains just soruce object's own properties (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var o = Object.create({ x: 1, y: 2 });
+o.z = 3;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [o];
+})();
+
+async function *fn() {
+  for await (const { x, ...{y , z} } of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 3);
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-skip-non-enumerable.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-skip-non-enumerable.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Rest object doesn't contain non-enumerable properties (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var o = {a: 3, b: 4};
+Object.defineProperty(o, "x", { value: 4, enumerable: false });
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [o];
+})();
+
+async function *fn() {
+  for await (const {...rest} of asyncIter) {
+    assert.sameValue(rest.a, 3);
+    assert.sameValue(rest.b, 4);
+    assert.sameValue(rest.x, undefined);
+
+    verifyEnumerable(rest, "a");
+    verifyWritable(rest, "a");
+    verifyConfigurable(rest, "a");
+
+    verifyEnumerable(rest, "b");
+    verifyWritable(rest, "b");
+    verifyConfigurable(rest, "b");
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-val-obj.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-val-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-const-async.template
+/*---
+description: Rest object contains just unextracted data (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{x: 1, y: 2, a: 5, b: 3}];
+})();
+
+async function *fn() {
+  for await (const {a, b, ...rest} of asyncIter) {
+    assert.sameValue(rest.x, 1);
+    assert.sameValue(rest.y, 2);
+    assert.sameValue(rest.a, undefined);
+    assert.sameValue(rest.b, undefined);
+
+    verifyEnumerable(rest, "x");
+    verifyWritable(rest, "x");
+    verifyConfigurable(rest, "x");
+
+    verifyEnumerable(rest, "y");
+    verifyWritable(rest, "y");
+    verifyConfigurable(rest, "y");
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-init-iter-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-init-iter-close.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-close.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Iterator is closed when not exhausted by pattern evaluation (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.5 Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, return ? IteratorClose(iterator,
+       result).
+    [...]
+
+---*/
+var doneCallCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { value: null, done: false };
+    },
+    return: function() {
+      doneCallCount += 1;
+      return {};
+    }
+  };
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (let [x] of asyncIter) {
+    assert.sameValue(doneCallCount, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-init-iter-no-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-init-iter-no-close.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-no-close.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Iterator is not closed when exhausted by pattern evaluation (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.5 Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, return ? IteratorClose(iterator,
+       result).
+    [...]
+
+---*/
+var doneCallCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { value: null, done: true };
+    },
+    return: function() {
+      doneCallCount += 1;
+      return {};
+    }
+  };
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (let [x] of asyncIter) {
+    assert.sameValue(doneCallCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-name-iter-val.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-name-iter-val.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-name-iter-val.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: SingleNameBinding with normal value iteration (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (let [x, y, z] of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-elem-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-elem-init.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elem-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [[x, y, z] = [4, 5, 6]] of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-elem-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-elem-iter.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elem-iter.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[7, 8, 9]]];
+})();
+
+async function *fn() {
+  for await (let [[x, y, z] = [4, 5, 6]] of asyncIter) {
+    assert.sameValue(x, 7);
+    assert.sameValue(y, 8);
+    assert.sameValue(z, 9);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-elision-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-elision-init.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elision-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [[,] = g()] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-elision-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-elision-iter.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elision-iter.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+
+---*/
+var callCount = 0;
+function* g() {
+  callCount += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[]]];
+})();
+
+async function *fn() {
+  for await (let [[,] = g()] of asyncIter) {
+    assert.sameValue(callCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-empty-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-empty-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-empty-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var initCount = 0;
+var iterCount = 0;
+var iter = function*() { iterCount += 1; }();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [[] = function() { initCount += 1; return iter; }()] of asyncIter) {
+    assert.sameValue(initCount, 1);
+    assert.sameValue(iterCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-empty-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-empty-iter.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-empty-iter.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var initCount = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[23]]];
+})();
+
+async function *fn() {
+  for await (let [[] = function() { initCount += 1; }()] of asyncIter) {
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-rest-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-rest-init.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-rest-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var values = [2, 1, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [[...x] = values] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x[0], 2);
+    assert.sameValue(x[1], 1);
+    assert.sameValue(x[2], 3);
+    assert.sameValue(x.length, 3);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-rest-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-ary-rest-iter.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-rest-iter.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var values = [2, 1, 3];
+var initCount = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[values]];
+})();
+
+async function *fn() {
+  for await (let [[...x] = function() { initCount += 1; }()] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x[0], 2);
+    assert.sameValue(x[1], 1);
+    assert.sameValue(x[2], 3);
+    assert.sameValue(x.length, 3);
+    assert.notSameValue(x, values);
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-exhausted.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Destructuring initializer with an exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-arrow.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-arrow.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: SingleNameBinding does assign name to arrow functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [arrow = () => {}] of asyncIter) {
+    assert.sameValue(arrow.name, 'arrow');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-class.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-class.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" classes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] of asyncIter) {
+    assert.sameValue(cls.name, 'cls');
+    assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-cover.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-cover.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: SingleNameBinding does assign name to "anonymous" functions "through" cover grammar (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [cover = (function () {}), xCover = (0, function() {})] of asyncIter) {
+    assert.sameValue(cover.name, 'cover');
+    assert.notSameValue(xCover.name, 'xCover');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-fn.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-fn.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [fn = function () {}, xFn = function x() {}] of asyncIter) {
+    assert.sameValue(fn.name, 'fn');
+    assert.notSameValue(xFn.name, 'xFn');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-gen.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-gen.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" generator functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [gen = function* () {}, xGen = function* x() {}] of asyncIter) {
+    assert.sameValue(gen.name, 'gen');
+    assert.notSameValue(xGen.name, 'xGen');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-hole.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-hole.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-hole.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Destructuring initializer with a "hole" (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    SingleNameBinding : BindingIdentifier Initializeropt
+    [...] 6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v). 8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[,]];
+})();
+
+async function *fn() {
+  for await (let [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+    // another statement
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-skipped.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[null, 0, false, '']];
+})();
+
+async function *fn() {
+  for await (let [w = counter(), x = counter(), y = counter(), z = counter()] of asyncIter) {
+    assert.sameValue(w, null);
+    assert.sameValue(x, 0);
+    assert.sameValue(y, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-undef.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-undef.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-undef.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Destructuring initializer with an undefined value (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[undefined]];
+})();
+
+async function *fn() {
+  for await (let [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-iter-complete.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-iter-complete.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-complete.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: SingleNameBinding when value iteration completes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [x] of asyncIter) {
+    assert.sameValue(x, undefined);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-iter-done.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-iter-done.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-done.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: SingleNameBinding when value iteration was completed previously (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [_, x] of asyncIter) {
+    assert.sameValue(x, undefined);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-iter-val.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-iter-val.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: SingleNameBinding when value iteration was completed previously (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (let [x, y, z] of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-obj-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-obj-id-init.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-id-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [{ x, y, z } = { x: 44, y: 55, z: 66 }] of asyncIter) {
+    assert.sameValue(x, 44);
+    assert.sameValue(y, 55);
+    assert.sameValue(z, 66);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-obj-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-obj-id.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[{ x: 11, y: 22, z: 33 }]];
+})();
+
+async function *fn() {
+  for await (let [{ x, y, z } = { x: 44, y: 55, z: 66 }] of asyncIter) {
+    assert.sameValue(x, 11);
+    assert.sameValue(y, 22);
+    assert.sameValue(z, 33);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-obj-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-obj-prop-id-init.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-prop-id-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [{ u: v, w: x, y: z } = { u: 444, w: 555, y: 666 }] of asyncIter) {
+    assert.sameValue(v, 444);
+    assert.sameValue(x, 555);
+    assert.sameValue(z, 666);
+
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-obj-prop-id.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[{ u: 777, w: 888, y: 999 }]];
+})();
+
+async function *fn() {
+  for await (let [{ u: v, w: x, y: z } = { u: 444, w: 555, y: 666 }] of asyncIter) {
+    assert.sameValue(v, 777);
+    assert.sameValue(x, 888);
+    assert.sameValue(z, 999);
+
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elision-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elision-exhausted.js
@@ -1,0 +1,73 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Elision accepts exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       [...]
+    2. Return NormalCompletion(empty).
+
+---*/
+var iter = function*() {}();
+iter.next();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (let [,] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elision.js
@@ -1,0 +1,82 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Elision advances iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+    2. Return NormalCompletion(empty).
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [g()];
+})();
+
+async function *fn() {
+  for await (let [,] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-empty.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-empty.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: No iteration occurs for an "empty" array binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ ]
+
+    1. Return NormalCompletion(empty).
+
+---*/
+var iterations = 0;
+var iter = function*() {
+  iterations += 1;
+}();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (let [] of asyncIter) {
+    assert.sameValue(iterations, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-ary-elem.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-ary-elem.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-elem.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Rest element containing an array BindingElementList pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[3, 4, 5]];
+})();
+
+async function *fn() {
+  for await (let [...[x, y, z]] of asyncIter) {
+    assert.sameValue(x, 3);
+    assert.sameValue(y, 4);
+    assert.sameValue(z, 5);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-ary-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-ary-elision.js
@@ -1,0 +1,95 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-elision.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Rest element containing an elision (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+    2. Return NormalCompletion(empty).
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [g()];
+})();
+
+async function *fn() {
+  for await (let [...[,]] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-ary-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-ary-empty.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-empty.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Rest element containing an "empty" array pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ ]
+
+    1. Return NormalCompletion(empty).
+
+---*/
+var iterations = 0;
+var iter = function*() {
+  iterations += 1;
+}();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (let [...[]] of asyncIter) {
+    assert.sameValue(iterations, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-ary-rest.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-ary-rest.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-rest.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Rest element containing a rest element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+var values = [1, 2, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function *fn() {
+  for await (let [...[...x]] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 1);
+    assert.sameValue(x[1], 2);
+    assert.sameValue(x[2], 3);
+    assert.notSameValue(x, values);
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-id-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-id-elision.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-elision.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Rest element following elision elements (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    ArrayBindingPattern : [ Elisionopt BindingRestElement ]
+    1. If Elision is present, then
+       a. Let status be the result of performing
+          IteratorDestructuringAssignmentEvaluation of Elision with
+          iteratorRecord as the argument.
+       b. ReturnIfAbrupt(status).
+    2. Return the result of performing IteratorBindingInitialization for
+       BindingRestElement with iteratorRecord and environment as arguments.
+---*/
+var values = [1, 2, 3, 4, 5];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function *fn() {
+  for await (let [ , , ...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 3);
+    assert.sameValue(x[1], 4);
+    assert.sameValue(x[2], 5);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-id-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-id-exhausted.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: RestElement applied to an exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    BindingRestElement : ... BindingIdentifier
+    1. Let lhs be ResolveBinding(StringValue of BindingIdentifier,
+       environment).
+    2. ReturnIfAbrupt(lhs). 3. Let A be ArrayCreate(0). 4. Let n=0. 5. Repeat,
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. If environment is undefined, return PutValue(lhs, A).
+          ii. Return InitializeReferencedBinding(lhs, A).
+
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2]];
+})();
+
+async function *fn() {
+  for await (let [, , ...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-id.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Lone rest element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    BindingRestElement : ... BindingIdentifier
+    [...] 3. Let A be ArrayCreate(0). [...] 5. Repeat
+       [...]
+       f. Let status be CreateDataProperty(A, ToString (n), nextValue).
+       [...]
+---*/
+var values = [1, 2, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function *fn() {
+  for await (let [...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 1);
+    assert.sameValue(x[1], 2);
+    assert.sameValue(x[2], 3);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-ary.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-ary.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Reset element (nested array pattern) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [...[ x ] = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-id.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Reset element (identifier) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [...x = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-obj.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Reset element (nested object pattern) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (let [...{ x } = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-ary.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-ary.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (let [...[x], y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-id.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Rest element (identifier) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (let [...x, y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-obj.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (let [...{ x }, y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-obj-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-obj-id.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-obj-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Rest element containing an object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (let [...{ length }] of asyncIter) {
+    assert.sameValue(length, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-obj-prop-id.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-obj-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Rest element containing an object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+let length = "outer";
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[7, 8, 9]];
+})();
+
+async function *fn() {
+  for await (let [...{ 0: v, 1: w, 2: x, 3: y, length: z }] of asyncIter) {
+    assert.sameValue(v, 7);
+    assert.sameValue(w, 8);
+    assert.sameValue(x, 9);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 3);
+
+    assert.sameValue(length, "outer", "the length prop is not set as a binding name");
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-empty.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-empty.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: No property access occurs for an "empty" object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    Runtime Semantics: BindingInitialization
+
+    ObjectBindingPattern : { }
+
+    1. Return NormalCompletion(empty).
+---*/
+var accessCount = 0;
+var obj = Object.defineProperty({}, 'attr', {
+  get: function() {
+    accessCount += 1;
+  }
+});
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [obj];
+})();
+
+async function *fn() {
+  for await (let {} of asyncIter) {
+    assert.sameValue(accessCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-arrow.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-arrow.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: SingleNameBinding assigns `name` to arrow functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (let { arrow = () => {} } of asyncIter) {
+    assert.sameValue(arrow.name, 'arrow');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-class.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-class.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" classes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (let { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } of asyncIter) {
+    assert.sameValue(cls.name, 'cls');
+    assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-cover.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-cover.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" functions "through" cover grammar (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (let { cover = (function () {}), xCover = (0, function() {})  } of asyncIter) {
+    assert.sameValue(cover.name, 'cover');
+    assert.notSameValue(xCover.name, 'xCover');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-fn.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-fn.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (let { fn = function () {}, xFn = function x() {} } of asyncIter) {
+    assert.sameValue(fn.name, 'fn');
+    assert.notSameValue(xFn.name, 'xFn');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-gen.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-gen.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" generator functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (let { gen = function* () {}, xGen = function* x() {} } of asyncIter) {
+    assert.sameValue(gen.name, 'gen');
+    assert.notSameValue(xGen.name, 'xGen');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-skipped.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+    [...]
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: null, x: 0, y: false, z: '' }];
+})();
+
+async function *fn() {
+  for await (let { w = counter(), x = counter(), y = counter(), z = counter() } of asyncIter) {
+    assert.sameValue(w, null);
+    assert.sameValue(x, 0);
+    assert.sameValue(y, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-trailing-comma.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function *fn() {
+  for await (let { x, } of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-ary-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-ary-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Object binding pattern with "nested" array binding pattern using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (let { w: [x, y, z] = [4, 5, 6] } of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-ary-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-ary-trailing-comma.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: [45] }];
+})();
+
+async function *fn() {
+  for await (let { x: [y], } of asyncIter) {
+    assert.sameValue(y,45);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-ary.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Object binding pattern with "nested" array binding pattern not using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       [...]
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: [7, undefined, ] }];
+})();
+
+async function *fn() {
+  for await (let { w: [x, y, z] = [4, 5, 6] } of asyncIter) {
+    assert.sameValue(x, 7);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, undefined);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-id-init-skipped.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    BindingElement : BindingPattern Initializeropt
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+    [...]
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ s: null, u: 0, w: false, y: '' }];
+})();
+
+async function *fn() {
+  for await (let { s: t = counter(), u: v = counter(), w: x = counter(), y: z = counter() } of asyncIter) {
+    assert.sameValue(t, null);
+    assert.sameValue(v, 0);
+    assert.sameValue(x, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    assert.throws(ReferenceError, function() {
+      s;
+    });
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-id-init.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Binding as specified via property name, identifier, and initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ }];
+})();
+
+async function *fn() {
+  for await (let { x: y = 33 } of asyncIter) {
+    assert.sameValue(y, 33);
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-id-trailing-comma.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function *fn() {
+  for await (let { x: y, } of asyncIter) {
+    assert.sameValue(y, 23);
+
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-id.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Binding as specified via property name and identifier (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function *fn() {
+  for await (let { x: y } of asyncIter) {
+    assert.sameValue(y, 23);
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-obj-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-obj-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-obj-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Object binding pattern with "nested" object binding pattern using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: undefined }];
+})();
+
+async function *fn() {
+  for await (let { w: { x, y, z } = { x: 4, y: 5, z: 6 } } of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-prop-obj.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Object binding pattern with "nested" object binding pattern not using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       [...]
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: { x: undefined, z: 7 } }];
+})();
+
+async function *fn() {
+  for await (let { w: { x, y, z } = { x: 4, y: 5, z: 6 } } of asyncIter) {
+    assert.sameValue(x, undefined);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 7);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-getter.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-getter.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Getter is called when obj is being deconstructed to a rest Object (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var count = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ get v() { count++; return 2; } }];
+})();
+
+async function *fn() {
+  for await (let {...x} of asyncIter) {
+    assert.sameValue(x.v, 2);
+    assert.sameValue(count, 1);
+
+    verifyEnumerable(x, "v");
+    verifyWritable(x, "v");
+    verifyConfigurable(x, "v");
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-nested-obj.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-nested-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var obj = {a: 3, b: 4};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{a: 1, b: 2, c: 3, d: 4, e: 5}];
+})();
+
+async function *fn() {
+  for await (let {a, b, ...{c, e}} of asyncIter) {
+    assert.sameValue(a, 1);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 3);
+    assert.sameValue(e, 5);
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-obj-nested-rest.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-obj-nested-rest.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{a: 1, b: 2, c: 3, d: 4, e: 5}];
+})();
+
+async function *fn() {
+  for await (let {a, b, ...{c, ...rest}} of asyncIter) {
+    assert.sameValue(a, 1);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 3);
+
+    assert.sameValue(rest.d, 4);
+    assert.sameValue(rest.e, 5);
+
+    verifyEnumerable(rest, "d");
+    verifyWritable(rest, "d");
+    verifyConfigurable(rest, "d");
+
+    verifyEnumerable(rest, "e");
+    verifyWritable(rest, "e");
+    verifyConfigurable(rest, "e");
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-obj-own-property.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-obj-own-property.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Rest object contains just soruce object's own properties (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var o = Object.create({ x: 1, y: 2 });
+o.z = 3;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [o];
+})();
+
+async function *fn() {
+  for await (let { x, ...{y , z} } of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 3);
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-skip-non-enumerable.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-skip-non-enumerable.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Rest object doesn't contain non-enumerable properties (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var o = {a: 3, b: 4};
+Object.defineProperty(o, "x", { value: 4, enumerable: false });
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [o];
+})();
+
+async function *fn() {
+  for await (let {...rest} of asyncIter) {
+    assert.sameValue(rest.a, 3);
+    assert.sameValue(rest.b, 4);
+    assert.sameValue(rest.x, undefined);
+
+    verifyEnumerable(rest, "a");
+    verifyWritable(rest, "a");
+    verifyConfigurable(rest, "a");
+
+    verifyEnumerable(rest, "b");
+    verifyWritable(rest, "b");
+    verifyConfigurable(rest, "b");
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-val-obj.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-val-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-let-async.template
+/*---
+description: Rest object contains just unextracted data (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{x: 1, y: 2, a: 5, b: 3}];
+})();
+
+async function *fn() {
+  for await (let {a, b, ...rest} of asyncIter) {
+    assert.sameValue(rest.x, 1);
+    assert.sameValue(rest.y, 2);
+    assert.sameValue(rest.a, undefined);
+    assert.sameValue(rest.b, undefined);
+
+    verifyEnumerable(rest, "x");
+    verifyWritable(rest, "x");
+    verifyConfigurable(rest, "x");
+
+    verifyEnumerable(rest, "y");
+    verifyWritable(rest, "y");
+    verifyConfigurable(rest, "y");
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-init-iter-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-init-iter-close.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-close.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Iterator is closed when not exhausted by pattern evaluation (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.5 Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, return ? IteratorClose(iterator,
+       result).
+    [...]
+
+---*/
+var doneCallCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { value: null, done: false };
+    },
+    return: function() {
+      doneCallCount += 1;
+      return {};
+    }
+  };
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (var [x] of asyncIter) {
+    assert.sameValue(doneCallCount, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-init-iter-no-close.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-init-iter-no-close.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-no-close.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Iterator is not closed when exhausted by pattern evaluation (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.5 Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, return ? IteratorClose(iterator,
+       result).
+    [...]
+
+---*/
+var doneCallCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { value: null, done: true };
+    },
+    return: function() {
+      doneCallCount += 1;
+      return {};
+    }
+  };
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (var [x] of asyncIter) {
+    assert.sameValue(doneCallCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-name-iter-val.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-name-iter-val.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-name-iter-val.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: SingleNameBinding with normal value iteration (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (var [x, y, z] of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-elem-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-elem-init.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elem-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [[x, y, z] = [4, 5, 6]] of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-elem-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-elem-iter.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elem-iter.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[7, 8, 9]]];
+})();
+
+async function *fn() {
+  for await (var [[x, y, z] = [4, 5, 6]] of asyncIter) {
+    assert.sameValue(x, 7);
+    assert.sameValue(y, 8);
+    assert.sameValue(z, 9);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-elision-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-elision-init.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elision-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [[,] = g()] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-elision-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-elision-iter.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-elision-iter.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+
+---*/
+var callCount = 0;
+function* g() {
+  callCount += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[]]];
+})();
+
+async function *fn() {
+  for await (var [[,] = g()] of asyncIter) {
+    assert.sameValue(callCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-empty-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-empty-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-empty-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var initCount = 0;
+var iterCount = 0;
+var iter = function*() { iterCount += 1; }();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [[] = function() { initCount += 1; return iter; }()] of asyncIter) {
+    assert.sameValue(initCount, 1);
+    assert.sameValue(iterCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-empty-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-empty-iter.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-empty-iter.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var initCount = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[[23]]];
+})();
+
+async function *fn() {
+  for await (var [[] = function() { initCount += 1; }()] of asyncIter) {
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-rest-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-rest-init.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-rest-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var values = [2, 1, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [[...x] = values] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x[0], 2);
+    assert.sameValue(x[1], 1);
+    assert.sameValue(x[2], 3);
+    assert.sameValue(x.length, 3);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-rest-iter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-ary-rest-iter.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-ary-rest-iter.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: BindingElement with array binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       [...]
+       e. Else,
+          i. Let v be IteratorValue(next).
+          [...]
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+var values = [2, 1, 3];
+var initCount = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[values]];
+})();
+
+async function *fn() {
+  for await (var [[...x] = function() { initCount += 1; }()] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x[0], 2);
+    assert.sameValue(x[1], 1);
+    assert.sameValue(x[2], 3);
+    assert.sameValue(x.length, 3);
+    assert.notSameValue(x, values);
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-exhausted.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Destructuring initializer with an exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-arrow.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-arrow.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: SingleNameBinding does assign name to arrow functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [arrow = () => {}] of asyncIter) {
+    assert.sameValue(arrow.name, 'arrow');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-class.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-class.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" classes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [cls = class {}, xCls = class X {}, xCls2 = class { static name() {} }] of asyncIter) {
+    assert.sameValue(cls.name, 'cls');
+    assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-cover.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-cover.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: SingleNameBinding does assign name to "anonymous" functions "through" cover grammar (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [cover = (function () {}), xCover = (0, function() {})] of asyncIter) {
+    assert.sameValue(cover.name, 'cover');
+    assert.notSameValue(xCover.name, 'xCover');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-fn.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-fn.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [fn = function () {}, xFn = function x() {}] of asyncIter) {
+    assert.sameValue(fn.name, 'fn');
+    assert.notSameValue(xFn.name, 'xFn');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-gen.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-fn-name-gen.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" generator functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [gen = function* () {}, xGen = function* x() {}] of asyncIter) {
+    assert.sameValue(gen.name, 'gen');
+    assert.notSameValue(xGen.name, 'xGen');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-hole.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-hole.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-hole.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Destructuring initializer with a "hole" (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    SingleNameBinding : BindingIdentifier Initializeropt
+    [...] 6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v). 8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[,]];
+})();
+
+async function *fn() {
+  for await (var [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+    // another statement
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-skipped.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[null, 0, false, '']];
+})();
+
+async function *fn() {
+  for await (var [w = counter(), x = counter(), y = counter(), z = counter()] of asyncIter) {
+    assert.sameValue(w, null);
+    assert.sameValue(x, 0);
+    assert.sameValue(y, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-undef.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-undef.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-init-undef.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Destructuring initializer with an undefined value (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       [...]
+    7. If environment is undefined, return PutValue(lhs, v).
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[undefined]];
+})();
+
+async function *fn() {
+  for await (var [x = 23] of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-iter-complete.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-iter-complete.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-complete.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: SingleNameBinding when value iteration completes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [x] of asyncIter) {
+    assert.sameValue(x, undefined);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-iter-done.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-iter-done.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-done.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: SingleNameBinding when value iteration was completed previously (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       [...]
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [_, x] of asyncIter) {
+    assert.sameValue(x, undefined);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-iter-val.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-iter-val.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: SingleNameBinding when value iteration was completed previously (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (var [x, y, z] of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-obj-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-obj-id-init.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-id-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [{ x, y, z } = { x: 44, y: 55, z: 66 }] of asyncIter) {
+    assert.sameValue(x, 44);
+    assert.sameValue(y, 55);
+    assert.sameValue(z, 66);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-obj-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-obj-id.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[{ x: 11, y: 22, z: 33 }]];
+})();
+
+async function *fn() {
+  for await (var [{ x, y, z } = { x: 44, y: 55, z: 66 }] of asyncIter) {
+    assert.sameValue(x, 11);
+    assert.sameValue(y, 22);
+    assert.sameValue(z, 33);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-obj-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-obj-prop-id-init.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-prop-id-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [{ u: v, w: x, y: z } = { u: 444, w: 555, y: 666 }] of asyncIter) {
+    assert.sameValue(v, 444);
+    assert.sameValue(x, 555);
+    assert.sameValue(z, 666);
+
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-obj-prop-id.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-obj-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: BindingElement with object binding pattern and initializer is not used (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingElement : BindingPatternInitializer opt
+
+    [...]
+    2. If iteratorRecord.[[done]] is true, let v be undefined.
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be ? GetValue(defaultValue).
+    4. Return the result of performing BindingInitialization of BindingPattern
+       with v and environment as the arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[{ u: 777, w: 888, y: 999 }]];
+})();
+
+async function *fn() {
+  for await (var [{ u: v, w: x, y: z } = { u: 444, w: 555, y: 666 }] of asyncIter) {
+    assert.sameValue(v, 777);
+    assert.sameValue(x, 888);
+    assert.sameValue(z, 999);
+
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elision-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elision-exhausted.js
@@ -1,0 +1,73 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Elision accepts exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       [...]
+    2. Return NormalCompletion(empty).
+
+---*/
+var iter = function*() {}();
+iter.next();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (var [,] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elision.js
@@ -1,0 +1,82 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elision.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Elision advances iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+    2. Return NormalCompletion(empty).
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [g()];
+})();
+
+async function *fn() {
+  for await (var [,] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-empty.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-empty.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: No iteration occurs for an "empty" array binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ ]
+
+    1. Return NormalCompletion(empty).
+
+---*/
+var iterations = 0;
+var iter = function*() {
+  iterations += 1;
+}();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (var [] of asyncIter) {
+    assert.sameValue(iterations, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-ary-elem.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-ary-elem.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-elem.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Rest element containing an array BindingElementList pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    4. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+       e. Else,
+          [...]
+          i. Let v be IteratorValue(next).
+          ii. If v is an abrupt completion, set
+              iteratorRecord.[[done]] to true.
+          iii. ReturnIfAbrupt(v).
+    5. If iteratorRecord.[[done]] is true, let v be undefined.
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[3, 4, 5]];
+})();
+
+async function *fn() {
+  for await (var [...[x, y, z]] of asyncIter) {
+    assert.sameValue(x, 3);
+    assert.sameValue(y, 4);
+    assert.sameValue(z, 5);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-ary-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-ary-elision.js
@@ -1,0 +1,95 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-elision.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Rest element containing an elision (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ Elision ]
+
+    1. Return the result of performing
+       IteratorDestructuringAssignmentEvaluation of Elision with iteratorRecord
+       as the argument.
+
+    12.14.5.3 Runtime Semantics: IteratorDestructuringAssignmentEvaluation
+
+    Elision : ,
+
+    1. If iteratorRecord.[[done]] is false, then
+       a. Let next be IteratorStep(iteratorRecord.[[iterator]]).
+       b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+       c. ReturnIfAbrupt(next).
+       d. If next is false, set iteratorRecord.[[done]] to true.
+    2. Return NormalCompletion(empty).
+
+---*/
+var first = 0;
+var second = 0;
+function* g() {
+  first += 1;
+  yield;
+  second += 1;
+};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [g()];
+})();
+
+async function *fn() {
+  for await (var [...[,]] of asyncIter) {
+    assert.sameValue(first, 1);
+    assert.sameValue(second, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-ary-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-ary-empty.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-empty.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Rest element containing an "empty" array pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [generators, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    ArrayBindingPattern : [ ]
+
+    1. Return NormalCompletion(empty).
+
+---*/
+var iterations = 0;
+var iter = function*() {
+  iterations += 1;
+}();
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [iter];
+})();
+
+async function *fn() {
+  for await (var [...[]] of asyncIter) {
+    assert.sameValue(iterations, 1);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-ary-rest.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-ary-rest.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-ary-rest.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Rest element containing a rest element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+var values = [1, 2, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function *fn() {
+  for await (var [...[...x]] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 1);
+    assert.sameValue(x[1], 2);
+    assert.sameValue(x[2], 3);
+    assert.notSameValue(x, values);
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-id-elision.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-id-elision.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-elision.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Rest element following elision elements (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    ArrayBindingPattern : [ Elisionopt BindingRestElement ]
+    1. If Elision is present, then
+       a. Let status be the result of performing
+          IteratorDestructuringAssignmentEvaluation of Elision with
+          iteratorRecord as the argument.
+       b. ReturnIfAbrupt(status).
+    2. Return the result of performing IteratorBindingInitialization for
+       BindingRestElement with iteratorRecord and environment as arguments.
+---*/
+var values = [1, 2, 3, 4, 5];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function *fn() {
+  for await (var [ , , ...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 3);
+    assert.sameValue(x[1], 4);
+    assert.sameValue(x[2], 5);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-id-exhausted.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-id-exhausted.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-exhausted.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: RestElement applied to an exhausted iterator (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    BindingRestElement : ... BindingIdentifier
+    1. Let lhs be ResolveBinding(StringValue of BindingIdentifier,
+       environment).
+    2. ReturnIfAbrupt(lhs). 3. Let A be ArrayCreate(0). 4. Let n=0. 5. Repeat,
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. If environment is undefined, return PutValue(lhs, A).
+          ii. Return InitializeReferencedBinding(lhs, A).
+
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2]];
+})();
+
+async function *fn() {
+  for await (var [, , ...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-id.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Lone rest element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+    BindingRestElement : ... BindingIdentifier
+    [...] 3. Let A be ArrayCreate(0). [...] 5. Repeat
+       [...]
+       f. Let status be CreateDataProperty(A, ToString (n), nextValue).
+       [...]
+---*/
+var values = [1, 2, 3];
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [values];
+})();
+
+async function *fn() {
+  for await (var [...x] of asyncIter) {
+    assert(Array.isArray(x));
+    assert.sameValue(x.length, 3);
+    assert.sameValue(x[0], 1);
+    assert.sameValue(x[1], 2);
+    assert.sameValue(x[2], 3);
+    assert.notSameValue(x, values);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-ary.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-ary.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Reset element (nested array pattern) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [...[ x ] = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-id.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Reset element (identifier) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [...x = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-obj.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-init-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Reset element (nested object pattern) does not support initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[]];
+})();
+
+async function *fn() {
+  for await (var [...{ x } = []] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-not-final-ary.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-ary.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (var [...[x], y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-not-final-id.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Rest element (identifier) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (var [...x, y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-not-final-obj.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-not-final-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+negative:
+  phase: early
+  type: SyntaxError
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+    ArrayBindingPattern[Yield] :
+        [ Elisionopt BindingRestElement[?Yield]opt ]
+        [ BindingElementList[?Yield] ]
+        [ BindingElementList[?Yield] , Elisionopt BindingRestElement[?Yield]opt ]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (var [...{ x }, y] of asyncIter) {
+    
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-obj-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-obj-id.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-obj-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Rest element containing an object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[1, 2, 3]];
+})();
+
+async function *fn() {
+  for await (var [...{ length }] of asyncIter) {
+    assert.sameValue(length, 3);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-obj-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-obj-prop-id.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-obj-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Rest element containing an object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.6 Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingPattern
+
+    1. Let A be ArrayCreate(0).
+    [...]
+    3. Repeat
+       [...]
+       b. If iteratorRecord.[[done]] is true, then
+          i. Return the result of performing BindingInitialization of
+             BindingPattern with A and environment as the arguments.
+       [...]
+---*/
+let length = "outer";
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [[7, 8, 9]];
+})();
+
+async function *fn() {
+  for await (var [...{ 0: v, 1: w, 2: x, 3: y, length: z }] of asyncIter) {
+    assert.sameValue(v, 7);
+    assert.sameValue(w, 8);
+    assert.sameValue(x, 9);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 3);
+
+    assert.sameValue(length, "outer", "the length prop is not set as a binding name");
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-empty.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-empty.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-empty.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: No property access occurs for an "empty" object binding pattern (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    Runtime Semantics: BindingInitialization
+
+    ObjectBindingPattern : { }
+
+    1. Return NormalCompletion(empty).
+---*/
+var accessCount = 0;
+var obj = Object.defineProperty({}, 'attr', {
+  get: function() {
+    accessCount += 1;
+  }
+});
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [obj];
+})();
+
+async function *fn() {
+  for await (var {} of asyncIter) {
+    assert.sameValue(accessCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-arrow.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-arrow.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-arrow.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: SingleNameBinding assigns `name` to arrow functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (var { arrow = () => {} } of asyncIter) {
+    assert.sameValue(arrow.name, 'arrow');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-class.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-class.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-class.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" classes (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (var { cls = class {}, xCls = class X {}, xCls2 = class { static name() {} } } of asyncIter) {
+    assert.sameValue(cls.name, 'cls');
+    assert.notSameValue(xCls.name, 'xCls');
+    assert.notSameValue(xCls2.name, 'xCls2');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-cover.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-cover.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-cover.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: SingleNameBinding assigns `name` to "anonymous" functions "through" cover grammar (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (var { cover = (function () {}), xCover = (0, function() {})  } of asyncIter) {
+    assert.sameValue(cover.name, 'cover');
+    assert.notSameValue(xCover.name, 'xCover');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-fn.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-fn.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-fn.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (var { fn = function () {}, xFn = function x() {} } of asyncIter) {
+    assert.sameValue(fn.name, 'fn');
+    assert.notSameValue(xFn.name, 'xFn');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-gen.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-gen.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-fn-name-gen.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: SingleNameBinding assigns name to "anonymous" generator functions (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+       d. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          i. Let hasNameProperty be HasOwnProperty(v, "name").
+          ii. ReturnIfAbrupt(hasNameProperty).
+          iii. If hasNameProperty is false, perform SetFunctionName(v,
+               bindingId).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (var { gen = function* () {}, xGen = function* x() {} } of asyncIter) {
+    assert.sameValue(gen.name, 'gen');
+    assert.notSameValue(xGen.name, 'xGen');
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-skipped.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    6. If Initializer is present and v is undefined, then
+       [...]
+    [...]
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: null, x: 0, y: false, z: '' }];
+})();
+
+async function *fn() {
+  for await (var { w = counter(), x = counter(), y = counter(), z = counter() } of asyncIter) {
+    assert.sameValue(w, null);
+    assert.sameValue(x, 0);
+    assert.sameValue(y, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-trailing-comma.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-id-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function *fn() {
+  for await (var { x, } of asyncIter) {
+    assert.sameValue(x, 23);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-ary-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-ary-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Object binding pattern with "nested" array binding pattern using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{}];
+})();
+
+async function *fn() {
+  for await (var { w: [x, y, z] = [4, 5, 6] } of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-ary-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-ary-trailing-comma.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: [45] }];
+})();
+
+async function *fn() {
+  for await (var { x: [y], } of asyncIter) {
+    assert.sameValue(y,45);
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-ary.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-ary.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Object binding pattern with "nested" array binding pattern not using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       [...]
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: [7, undefined, ] }];
+})();
+
+async function *fn() {
+  for await (var { w: [x, y, z] = [4, 5, 6] } of asyncIter) {
+    assert.sameValue(x, 7);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, undefined);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-id-init-skipped.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-id-init-skipped.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-init-skipped.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Destructuring initializer is not evaluated when value is not `undefined` (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    BindingElement : BindingPattern Initializeropt
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+    [...]
+---*/
+var initCount = 0;
+function counter() {
+  initCount += 1;
+}
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ s: null, u: 0, w: false, y: '' }];
+})();
+
+async function *fn() {
+  for await (var { s: t = counter(), u: v = counter(), w: x = counter(), y: z = counter() } of asyncIter) {
+    assert.sameValue(t, null);
+    assert.sameValue(v, 0);
+    assert.sameValue(x, false);
+    assert.sameValue(z, '');
+    assert.sameValue(initCount, 0);
+
+    assert.throws(ReferenceError, function() {
+      s;
+    });
+    assert.throws(ReferenceError, function() {
+      u;
+    });
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+    assert.throws(ReferenceError, function() {
+      y;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-id-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-id-init.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Binding as specified via property name, identifier, and initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ }];
+})();
+
+async function *fn() {
+  for await (var { x: y = 33 } of asyncIter) {
+    assert.sameValue(y, 33);
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-id-trailing-comma.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-id-trailing-comma.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id-trailing-comma.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Trailing comma is allowed following BindingPropertyList (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3 Destructuring Binding Patterns
+
+    ObjectBindingPattern[Yield] :
+        { }
+        { BindingPropertyList[?Yield] }
+        { BindingPropertyList[?Yield] , }
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function *fn() {
+  for await (var { x: y, } of asyncIter) {
+    assert.sameValue(y, 23);
+
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-id.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-id.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Binding as specified via property name and identifier (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializeropt
+
+    [...]
+    8. Return InitializeReferencedBinding(lhs, v).
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ x: 23 }];
+})();
+
+async function *fn() {
+  for await (var { x: y } of asyncIter) {
+    assert.sameValue(y, 23);
+    assert.throws(ReferenceError, function() {
+      x;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-obj-init.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-obj-init.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-obj-init.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Object binding pattern with "nested" object binding pattern using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       a. Let defaultValue be the result of evaluating Initializer.
+       b. Let v be GetValue(defaultValue).
+       c. ReturnIfAbrupt(v).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: undefined }];
+})();
+
+async function *fn() {
+  for await (var { w: { x, y, z } = { x: 4, y: 5, z: 6 } } of asyncIter) {
+    assert.sameValue(x, 4);
+    assert.sameValue(y, 5);
+    assert.sameValue(z, 6);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-prop-obj.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-prop-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Object binding pattern with "nested" object binding pattern not using initializer (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    13.3.3.7 Runtime Semantics: KeyedBindingInitialization
+
+    [...]
+    3. If Initializer is present and v is undefined, then
+       [...]
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing v and environment as arguments.
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ w: { x: undefined, z: 7 } }];
+})();
+
+async function *fn() {
+  for await (var { w: { x, y, z } = { x: 4, y: 5, z: 6 } } of asyncIter) {
+    assert.sameValue(x, undefined);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 7);
+
+    assert.throws(ReferenceError, function() {
+      w;
+    });
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-rest-getter.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-rest-getter.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-getter.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Getter is called when obj is being deconstructed to a rest Object (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var count = 0;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{ get v() { count++; return 2; } }];
+})();
+
+async function *fn() {
+  for await (var {...x} of asyncIter) {
+    assert.sameValue(x.v, 2);
+    assert.sameValue(count, 1);
+
+    verifyEnumerable(x, "v");
+    verifyWritable(x, "v");
+    verifyConfigurable(x, "v");
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-rest-nested-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-rest-nested-obj.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-nested-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment. (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var obj = {a: 3, b: 4};
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{a: 1, b: 2, c: 3, d: 4, e: 5}];
+})();
+
+async function *fn() {
+  for await (var {a, b, ...{c, e}} of asyncIter) {
+    assert.sameValue(a, 1);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 3);
+    assert.sameValue(e, 5);
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-rest-obj-nested-rest.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-rest-obj-nested-rest.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-obj-nested-rest.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: When DestructuringAssignmentTarget is an object literal, it should be parsed parsed as a DestructuringAssignmentPattern and evaluated as a destructuring assignment and object rest desconstruction is allowed in that case. (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{a: 1, b: 2, c: 3, d: 4, e: 5}];
+})();
+
+async function *fn() {
+  for await (var {a, b, ...{c, ...rest}} of asyncIter) {
+    assert.sameValue(a, 1);
+    assert.sameValue(b, 2);
+    assert.sameValue(c, 3);
+
+    assert.sameValue(rest.d, 4);
+    assert.sameValue(rest.e, 5);
+
+    verifyEnumerable(rest, "d");
+    verifyWritable(rest, "d");
+    verifyConfigurable(rest, "d");
+
+    verifyEnumerable(rest, "e");
+    verifyWritable(rest, "e");
+    verifyConfigurable(rest, "e");
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-rest-obj-own-property.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-rest-obj-own-property.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-obj-own-property.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Rest object contains just soruce object's own properties (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var o = Object.create({ x: 1, y: 2 });
+o.z = 3;
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [o];
+})();
+
+async function *fn() {
+  for await (var { x, ...{y , z} } of asyncIter) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, undefined);
+    assert.sameValue(z, 3);
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-rest-skip-non-enumerable.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-rest-skip-non-enumerable.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-skip-non-enumerable.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Rest object doesn't contain non-enumerable properties (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+var o = {a: 3, b: 4};
+Object.defineProperty(o, "x", { value: 4, enumerable: false });
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [o];
+})();
+
+async function *fn() {
+  for await (var {...rest} of asyncIter) {
+    assert.sameValue(rest.a, 3);
+    assert.sameValue(rest.b, 4);
+    assert.sameValue(rest.x, undefined);
+
+    verifyEnumerable(rest, "a");
+    verifyWritable(rest, "a");
+    verifyConfigurable(rest, "a");
+
+    verifyEnumerable(rest, "b");
+    verifyWritable(rest, "b");
+    verifyConfigurable(rest, "b");
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-rest-val-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-rest-val-obj.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/obj-ptrn-rest-val-obj.case
+// - src/dstr-binding/default/for-await-of-async-gen-var-async.template
+/*---
+description: Rest object contains just unextracted data (for-await-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [object-rest, destructuring-binding, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+        for await ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    2. Return ? ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+        lexicalBinding, labelSet, async).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. Let destructuring be IsDestructuring of lhs.
+    [...]
+    6. Repeat
+       [...]
+       j. If destructuring is false, then
+          [...]
+       k. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+---*/
+
+var iterCount = 0;
+var asyncIter = (async function*() {
+  yield* [{x: 1, y: 2, a: 5, b: 3}];
+})();
+
+async function *fn() {
+  for await (var {a, b, ...rest} of asyncIter) {
+    assert.sameValue(rest.x, 1);
+    assert.sameValue(rest.y, 2);
+    assert.sameValue(rest.a, undefined);
+    assert.sameValue(rest.b, undefined);
+
+    verifyEnumerable(rest, "x");
+    verifyWritable(rest, "x");
+    verifyConfigurable(rest, "x");
+
+    verifyEnumerable(rest, "y");
+    verifyWritable(rest, "y");
+    verifyConfigurable(rest, "y");
+
+
+    iterCount += 1;
+  }
+}
+
+fn().next()
+  .then(() => assert.sameValue(iterCount, 1, 'iteration occurred as expected'), $DONE)
+  .then($DONE, $DONE);


### PR DESCRIPTION
I've got some failures here on V8 6.0.0, while SpiderMonkey is running flawlessly here. 