### PR TITLE
Adding case to computed property

### DIFF
--- a/src/dstr-assignment/obj-rest-computed-property.case
+++ b/src/dstr-assignment/obj-rest-computed-property.case
@@ -1,0 +1,38 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: >
+    Destructuring field can be a computed property, i.e it can be defined 
+    only at runtime. Rest operantion needs to skip these properties as well.
+template: default
+esid: pending
+includes: [propertyHelper.js]
+features: [object-rest]
+---*/
+
+//- setup
+var a = "foo";
+//- elems
+{[a]:b, ...rest}
+//- vals
+{ foo: 1, bar: 2, baz: 3 }
+//- body
+assert.sameValue(b, 1);
+assert.sameValue(rest.bar, 2);
+assert.sameValue(rest.baz, 3);
+
+assert.sameValue(Object.getOwnPropertyDescriptor(rest, "foo"), undefined);
+
+verifyProperty(rest, "bar", {
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(rest, "baz", {
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/assignment/dstr-obj-rest-computed-property.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-computed-property.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-assignment/obj-rest-computed-property.case
+// - src/dstr-assignment/default/assignment-expr.template
+/*---
+description: Destructuring field can be a computed property, i.e it can be defined  only at runtime. Rest operantion needs to skip these properties as well. (AssignmentExpression)
+esid: sec-variable-statement-runtime-semantics-evaluation
+es6id: 13.3.2.4
+features: [object-rest, destructuring-binding]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    VariableDeclaration : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let rval be GetValue(rhs).
+    3. ReturnIfAbrupt(rval).
+    4. Return the result of performing BindingInitialization for
+       BindingPattern passing rval and undefined as arguments.
+---*/
+var a = "foo";
+
+var result;
+var vals = { foo: 1, bar: 2, baz: 3 };
+
+result = {[a]:b, ...rest} = vals;
+
+assert.sameValue(b, 1);
+assert.sameValue(rest.bar, 2);
+assert.sameValue(rest.baz, 3);
+
+assert.sameValue(Object.getOwnPropertyDescriptor(rest, "foo"), undefined);
+
+verifyProperty(rest, "bar", {
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(rest, "baz", {
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+assert.sameValue(result, vals);

--- a/test/language/statements/for-of/dstr-obj-rest-computed-property.js
+++ b/test/language/statements/for-of/dstr-obj-rest-computed-property.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-assignment/obj-rest-computed-property.case
+// - src/dstr-assignment/default/for-of.template
+/*---
+description: Destructuring field can be a computed property, i.e it can be defined  only at runtime. Rest operantion needs to skip these properties as well. (For..of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+es6id: 13.7.5.11
+features: [object-rest, destructuring-binding]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    IterationStatement :
+      for ( LeftHandSideExpression of AssignmentExpression ) Statement
+
+    1. Let keyResult be the result of performing ? ForIn/OfHeadEvaluation(« »,
+       AssignmentExpression, iterate).
+    2. Return ? ForIn/OfBodyEvaluation(LeftHandSideExpression, Statement,
+       keyResult, assignment, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. If destructuring is true and if lhsKind is assignment, then
+       a. Assert: lhs is a LeftHandSideExpression.
+       b. Let assignmentPattern be the parse of the source text corresponding to
+          lhs using AssignmentPattern as the goal symbol.
+    [...]
+---*/
+var a = "foo";
+
+var counter = 0;
+
+for ({[a]:b, ...rest} of [{ foo: 1, bar: 2, baz: 3 }]) {
+  assert.sameValue(b, 1);
+  assert.sameValue(rest.bar, 2);
+  assert.sameValue(rest.baz, 3);
+
+  assert.sameValue(Object.getOwnPropertyDescriptor(rest, "foo"), undefined);
+
+  verifyProperty(rest, "bar", {
+    enumerable: true,
+    writable: true,
+    configurable: true
+  });
+
+  verifyProperty(rest, "baz", {
+    enumerable: true,
+    writable: true,
+    configurable: true
+  });
+
+  counter += 1;
+}
+
+assert.sameValue(counter, 1);


### PR DESCRIPTION
I'm adding a missing case using computed properties.

It closes #1035.