### PR TITLE
async-iteration: yield Promise.reject(value) -> next() results in a rejected promise for value. Ref gh-1052

### DIFF
--- a/src/async-generators/yield-promise-reject-next-catch.case
+++ b/src/async-generators/yield-promise-reject-next-catch.case
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: yield Promise.reject(value) is treated as throw value
+template: default
+flags: [async]
+---*/
+
+//- setup
+let error = new Error();
+//- body
+yield Promise.reject(error);
+yield "unreachable";
+//- assertions
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}).catch(rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+});

--- a/src/async-generators/yield-promise-reject-next-for-await-of-async-iterator.case
+++ b/src/async-generators/yield-promise-reject-next-for-await-of-async-iterator.case
@@ -1,0 +1,33 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: yield * [Promise.reject(value)] is treated as throw value
+template: default
+flags: [async]
+---*/
+
+//- setup
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+//- body
+for await (let line of readFile()) {
+  yield line;
+}
+//- assertions
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);

--- a/src/async-generators/yield-promise-reject-next-for-await-of-sync-iterator.case
+++ b/src/async-generators/yield-promise-reject-next-for-await-of-sync-iterator.case
@@ -1,0 +1,32 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: yield Promise.reject(value) in for-await-of is treated as throw value
+template: default
+flags: [async]
+---*/
+
+//- setup
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+//- body
+for await (let value of iterable) {
+  yield value;
+}
+//- assertions
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);

--- a/src/async-generators/yield-promise-reject-next-yield-star-async-iterator.case
+++ b/src/async-generators/yield-promise-reject-next-yield-star-async-iterator.case
@@ -1,0 +1,31 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: yield * (async iterator) is treated as throw value
+template: default
+flags: [async]
+---*/
+
+//- setup
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+//- body
+yield * readFile();
+
+//- assertions
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).then($DONE, $DONE);

--- a/src/async-generators/yield-promise-reject-next-yield-star-sync-iterator.case
+++ b/src/async-generators/yield-promise-reject-next-yield-star-sync-iterator.case
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: yield * (async iterator) is treated as throw value
+template: default
+flags: [async]
+---*/
+
+//- setup
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+//- body
+yield * iterable;
+//- assertions
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);

--- a/src/async-generators/yield-promise-reject-next.case
+++ b/src/async-generators/yield-promise-reject-next.case
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: yield Promise.reject(value) is treated as throw value
+template: default
+flags: [async]
+---*/
+
+//- setup
+let error = new Error();
+//- body
+yield Promise.reject(error);
+yield "unreachable";
+//- assertions
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);

--- a/test/language/expressions/async-generator/named-yield-promise-reject-next-catch.js
+++ b/test/language/expressions/async-generator/named-yield-promise-reject-next-catch.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-catch.case
+// - src/async-generators/default/async-expression-named.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Named async generator expression)
+esid: prod-AsyncGeneratorExpression
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorExpression :
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+
+var callCount = 0;
+
+var gen = async function *g() {
+  callCount += 1;
+  yield Promise.reject(error);
+  yield "unreachable";
+};
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}).catch(rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+});
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/async-generator/named-yield-promise-reject-next-for-await-of-async-iterator.js
+++ b/test/language/expressions/async-generator/named-yield-promise-reject-next-for-await-of-async-iterator.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-async-iterator.case
+// - src/async-generators/default/async-expression-named.template
+/*---
+description: yield * [Promise.reject(value)] is treated as throw value (Named async generator expression)
+esid: prod-AsyncGeneratorExpression
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorExpression :
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+
+var callCount = 0;
+
+var gen = async function *g() {
+  callCount += 1;
+  for await (let line of readFile()) {
+    yield line;
+  }
+};
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/async-generator/named-yield-promise-reject-next-for-await-of-sync-iterator.js
+++ b/test/language/expressions/async-generator/named-yield-promise-reject-next-for-await-of-sync-iterator.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-sync-iterator.case
+// - src/async-generators/default/async-expression-named.template
+/*---
+description: yield Promise.reject(value) in for-await-of is treated as throw value (Named async generator expression)
+esid: prod-AsyncGeneratorExpression
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorExpression :
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+
+var callCount = 0;
+
+var gen = async function *g() {
+  callCount += 1;
+  for await (let value of iterable) {
+    yield value;
+  }
+};
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/async-generator/named-yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/expressions/async-generator/named-yield-promise-reject-next-yield-star-async-iterator.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-async-iterator.case
+// - src/async-generators/default/async-expression-named.template
+/*---
+description: yield * (async iterator) is treated as throw value (Named async generator expression)
+esid: prod-AsyncGeneratorExpression
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorExpression :
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+
+var callCount = 0;
+
+var gen = async function *g() {
+  callCount += 1;
+  yield * readFile();
+
+};
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).then($DONE, $DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/async-generator/named-yield-promise-reject-next-yield-star-sync-iterator.js
+++ b/test/language/expressions/async-generator/named-yield-promise-reject-next-yield-star-sync-iterator.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-sync-iterator.case
+// - src/async-generators/default/async-expression-named.template
+/*---
+description: yield * (async iterator) is treated as throw value (Named async generator expression)
+esid: prod-AsyncGeneratorExpression
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorExpression :
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+
+var callCount = 0;
+
+var gen = async function *g() {
+  callCount += 1;
+  yield * iterable;
+};
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/async-generator/named-yield-promise-reject-next.js
+++ b/test/language/expressions/async-generator/named-yield-promise-reject-next.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next.case
+// - src/async-generators/default/async-expression-named.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Named async generator expression)
+esid: prod-AsyncGeneratorExpression
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorExpression :
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+
+var callCount = 0;
+
+var gen = async function *g() {
+  callCount += 1;
+  yield Promise.reject(error);
+  yield "unreachable";
+};
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/async-generator/yield-promise-reject-next-catch.js
+++ b/test/language/expressions/async-generator/yield-promise-reject-next-catch.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-catch.case
+// - src/async-generators/default/async-expression.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Unnamed async generator expression)
+esid: prod-AsyncGeneratorExpression
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorExpression :
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+
+var callCount = 0;
+
+var gen = async function *() {
+  callCount += 1;
+  yield Promise.reject(error);
+  yield "unreachable";
+};
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}).catch(rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+});
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/async-generator/yield-promise-reject-next-for-await-of-async-iterator.js
+++ b/test/language/expressions/async-generator/yield-promise-reject-next-for-await-of-async-iterator.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-async-iterator.case
+// - src/async-generators/default/async-expression.template
+/*---
+description: yield * [Promise.reject(value)] is treated as throw value (Unnamed async generator expression)
+esid: prod-AsyncGeneratorExpression
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorExpression :
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+
+var callCount = 0;
+
+var gen = async function *() {
+  callCount += 1;
+  for await (let line of readFile()) {
+    yield line;
+  }
+};
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/async-generator/yield-promise-reject-next-for-await-of-sync-iterator.js
+++ b/test/language/expressions/async-generator/yield-promise-reject-next-for-await-of-sync-iterator.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-sync-iterator.case
+// - src/async-generators/default/async-expression.template
+/*---
+description: yield Promise.reject(value) in for-await-of is treated as throw value (Unnamed async generator expression)
+esid: prod-AsyncGeneratorExpression
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorExpression :
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+
+var callCount = 0;
+
+var gen = async function *() {
+  callCount += 1;
+  for await (let value of iterable) {
+    yield value;
+  }
+};
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/async-generator/yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/expressions/async-generator/yield-promise-reject-next-yield-star-async-iterator.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-async-iterator.case
+// - src/async-generators/default/async-expression.template
+/*---
+description: yield * (async iterator) is treated as throw value (Unnamed async generator expression)
+esid: prod-AsyncGeneratorExpression
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorExpression :
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+
+var callCount = 0;
+
+var gen = async function *() {
+  callCount += 1;
+  yield * readFile();
+
+};
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).then($DONE, $DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/async-generator/yield-promise-reject-next-yield-star-sync-iterator.js
+++ b/test/language/expressions/async-generator/yield-promise-reject-next-yield-star-sync-iterator.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-sync-iterator.case
+// - src/async-generators/default/async-expression.template
+/*---
+description: yield * (async iterator) is treated as throw value (Unnamed async generator expression)
+esid: prod-AsyncGeneratorExpression
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorExpression :
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+
+var callCount = 0;
+
+var gen = async function *() {
+  callCount += 1;
+  yield * iterable;
+};
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/async-generator/yield-promise-reject-next.js
+++ b/test/language/expressions/async-generator/yield-promise-reject-next.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next.case
+// - src/async-generators/default/async-expression.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Unnamed async generator expression)
+esid: prod-AsyncGeneratorExpression
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorExpression :
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+
+var callCount = 0;
+
+var gen = async function *() {
+  callCount += 1;
+  yield Promise.reject(error);
+  yield "unreachable";
+};
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/class/async-gen-method-static-yield-promise-reject-next-catch.js
+++ b/test/language/expressions/class/async-gen-method-static-yield-promise-reject-next-catch.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-catch.case
+// - src/async-generators/default/async-class-expr-static-method.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Static async generator method as a ClassExpression element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      static MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+
+var callCount = 0;
+
+var C = class { static async *gen() {
+    callCount += 1;
+    yield Promise.reject(error);
+    yield "unreachable";
+}}
+
+var gen = C.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}).catch(rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+});
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/class/async-gen-method-static-yield-promise-reject-next-for-await-of-async-iterator.js
+++ b/test/language/expressions/class/async-gen-method-static-yield-promise-reject-next-for-await-of-async-iterator.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-async-iterator.case
+// - src/async-generators/default/async-class-expr-static-method.template
+/*---
+description: yield * [Promise.reject(value)] is treated as throw value (Static async generator method as a ClassExpression element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      static MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+
+var callCount = 0;
+
+var C = class { static async *gen() {
+    callCount += 1;
+    for await (let line of readFile()) {
+      yield line;
+    }
+}}
+
+var gen = C.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/class/async-gen-method-static-yield-promise-reject-next-for-await-of-sync-iterator.js
+++ b/test/language/expressions/class/async-gen-method-static-yield-promise-reject-next-for-await-of-sync-iterator.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-sync-iterator.case
+// - src/async-generators/default/async-class-expr-static-method.template
+/*---
+description: yield Promise.reject(value) in for-await-of is treated as throw value (Static async generator method as a ClassExpression element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      static MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+
+var callCount = 0;
+
+var C = class { static async *gen() {
+    callCount += 1;
+    for await (let value of iterable) {
+      yield value;
+    }
+}}
+
+var gen = C.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/class/async-gen-method-static-yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/expressions/class/async-gen-method-static-yield-promise-reject-next-yield-star-async-iterator.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-async-iterator.case
+// - src/async-generators/default/async-class-expr-static-method.template
+/*---
+description: yield * (async iterator) is treated as throw value (Static async generator method as a ClassExpression element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      static MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+
+var callCount = 0;
+
+var C = class { static async *gen() {
+    callCount += 1;
+    yield * readFile();
+
+}}
+
+var gen = C.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).then($DONE, $DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/class/async-gen-method-static-yield-promise-reject-next-yield-star-sync-iterator.js
+++ b/test/language/expressions/class/async-gen-method-static-yield-promise-reject-next-yield-star-sync-iterator.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-sync-iterator.case
+// - src/async-generators/default/async-class-expr-static-method.template
+/*---
+description: yield * (async iterator) is treated as throw value (Static async generator method as a ClassExpression element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      static MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+
+var callCount = 0;
+
+var C = class { static async *gen() {
+    callCount += 1;
+    yield * iterable;
+}}
+
+var gen = C.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/class/async-gen-method-static-yield-promise-reject-next.js
+++ b/test/language/expressions/class/async-gen-method-static-yield-promise-reject-next.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next.case
+// - src/async-generators/default/async-class-expr-static-method.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Static async generator method as a ClassExpression element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      static MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+
+var callCount = 0;
+
+var C = class { static async *gen() {
+    callCount += 1;
+    yield Promise.reject(error);
+    yield "unreachable";
+}}
+
+var gen = C.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/class/async-gen-method-yield-promise-reject-next-catch.js
+++ b/test/language/expressions/class/async-gen-method-yield-promise-reject-next-catch.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-catch.case
+// - src/async-generators/default/async-class-expr-method.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Async generator method as a ClassExpression element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+
+var callCount = 0;
+
+var C = class { async *gen() {
+    callCount += 1;
+    yield Promise.reject(error);
+    yield "unreachable";
+}}
+
+var gen = C.prototype.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}).catch(rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+});
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/class/async-gen-method-yield-promise-reject-next-for-await-of-async-iterator.js
+++ b/test/language/expressions/class/async-gen-method-yield-promise-reject-next-for-await-of-async-iterator.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-async-iterator.case
+// - src/async-generators/default/async-class-expr-method.template
+/*---
+description: yield * [Promise.reject(value)] is treated as throw value (Async generator method as a ClassExpression element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+
+var callCount = 0;
+
+var C = class { async *gen() {
+    callCount += 1;
+    for await (let line of readFile()) {
+      yield line;
+    }
+}}
+
+var gen = C.prototype.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/class/async-gen-method-yield-promise-reject-next-for-await-of-sync-iterator.js
+++ b/test/language/expressions/class/async-gen-method-yield-promise-reject-next-for-await-of-sync-iterator.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-sync-iterator.case
+// - src/async-generators/default/async-class-expr-method.template
+/*---
+description: yield Promise.reject(value) in for-await-of is treated as throw value (Async generator method as a ClassExpression element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+
+var callCount = 0;
+
+var C = class { async *gen() {
+    callCount += 1;
+    for await (let value of iterable) {
+      yield value;
+    }
+}}
+
+var gen = C.prototype.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/class/async-gen-method-yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/expressions/class/async-gen-method-yield-promise-reject-next-yield-star-async-iterator.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-async-iterator.case
+// - src/async-generators/default/async-class-expr-method.template
+/*---
+description: yield * (async iterator) is treated as throw value (Async generator method as a ClassExpression element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+
+var callCount = 0;
+
+var C = class { async *gen() {
+    callCount += 1;
+    yield * readFile();
+
+}}
+
+var gen = C.prototype.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).then($DONE, $DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/class/async-gen-method-yield-promise-reject-next-yield-star-sync-iterator.js
+++ b/test/language/expressions/class/async-gen-method-yield-promise-reject-next-yield-star-sync-iterator.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-sync-iterator.case
+// - src/async-generators/default/async-class-expr-method.template
+/*---
+description: yield * (async iterator) is treated as throw value (Async generator method as a ClassExpression element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+
+var callCount = 0;
+
+var C = class { async *gen() {
+    callCount += 1;
+    yield * iterable;
+}}
+
+var gen = C.prototype.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/class/async-gen-method-yield-promise-reject-next.js
+++ b/test/language/expressions/class/async-gen-method-yield-promise-reject-next.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next.case
+// - src/async-generators/default/async-class-expr-method.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Async generator method as a ClassExpression element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+
+var callCount = 0;
+
+var C = class { async *gen() {
+    callCount += 1;
+    yield Promise.reject(error);
+    yield "unreachable";
+}}
+
+var gen = C.prototype.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/object/method-definition/async-gen-yield-promise-reject-next-catch.js
+++ b/test/language/expressions/object/method-definition/async-gen-yield-promise-reject-next-catch.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-catch.case
+// - src/async-generators/default/async-obj-method.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Async generator method)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+var callCount = 0;
+
+var gen = {
+  async *method() {
+    callCount += 1;
+    yield Promise.reject(error);
+    yield "unreachable";
+  }
+}.method;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}).catch(rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+});
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/object/method-definition/async-gen-yield-promise-reject-next-for-await-of-async-iterator.js
+++ b/test/language/expressions/object/method-definition/async-gen-yield-promise-reject-next-for-await-of-async-iterator.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-async-iterator.case
+// - src/async-generators/default/async-obj-method.template
+/*---
+description: yield * [Promise.reject(value)] is treated as throw value (Async generator method)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+var callCount = 0;
+
+var gen = {
+  async *method() {
+    callCount += 1;
+    for await (let line of readFile()) {
+      yield line;
+    }
+  }
+}.method;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/object/method-definition/async-gen-yield-promise-reject-next-for-await-of-sync-iterator.js
+++ b/test/language/expressions/object/method-definition/async-gen-yield-promise-reject-next-for-await-of-sync-iterator.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-sync-iterator.case
+// - src/async-generators/default/async-obj-method.template
+/*---
+description: yield Promise.reject(value) in for-await-of is treated as throw value (Async generator method)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+var callCount = 0;
+
+var gen = {
+  async *method() {
+    callCount += 1;
+    for await (let value of iterable) {
+      yield value;
+    }
+  }
+}.method;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/object/method-definition/async-gen-yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/expressions/object/method-definition/async-gen-yield-promise-reject-next-yield-star-async-iterator.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-async-iterator.case
+// - src/async-generators/default/async-obj-method.template
+/*---
+description: yield * (async iterator) is treated as throw value (Async generator method)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+var callCount = 0;
+
+var gen = {
+  async *method() {
+    callCount += 1;
+    yield * readFile();
+
+  }
+}.method;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).then($DONE, $DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/object/method-definition/async-gen-yield-promise-reject-next-yield-star-sync-iterator.js
+++ b/test/language/expressions/object/method-definition/async-gen-yield-promise-reject-next-yield-star-sync-iterator.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-sync-iterator.case
+// - src/async-generators/default/async-obj-method.template
+/*---
+description: yield * (async iterator) is treated as throw value (Async generator method)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+var callCount = 0;
+
+var gen = {
+  async *method() {
+    callCount += 1;
+    yield * iterable;
+  }
+}.method;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/object/method-definition/async-gen-yield-promise-reject-next.js
+++ b/test/language/expressions/object/method-definition/async-gen-yield-promise-reject-next.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next.case
+// - src/async-generators/default/async-obj-method.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Async generator method)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+var callCount = 0;
+
+var gen = {
+  async *method() {
+    callCount += 1;
+    yield Promise.reject(error);
+    yield "unreachable";
+  }
+}.method;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/async-generator/yield-promise-reject-next-catch.js
+++ b/test/language/statements/async-generator/yield-promise-reject-next-catch.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-catch.case
+// - src/async-generators/default/async-declaration.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Async generator Function declaration)
+esid: prod-AsyncGeneratorDeclaration
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorDeclaration:
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+
+var callCount = 0;
+
+async function *gen() {
+  callCount += 1;
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}).catch(rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+});
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/async-generator/yield-promise-reject-next-for-await-of-async-iterator.js
+++ b/test/language/statements/async-generator/yield-promise-reject-next-for-await-of-async-iterator.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-async-iterator.case
+// - src/async-generators/default/async-declaration.template
+/*---
+description: yield * [Promise.reject(value)] is treated as throw value (Async generator Function declaration)
+esid: prod-AsyncGeneratorDeclaration
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorDeclaration:
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+
+var callCount = 0;
+
+async function *gen() {
+  callCount += 1;
+  for await (let line of readFile()) {
+    yield line;
+  }
+}
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/async-generator/yield-promise-reject-next-for-await-of-sync-iterator.js
+++ b/test/language/statements/async-generator/yield-promise-reject-next-for-await-of-sync-iterator.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-sync-iterator.case
+// - src/async-generators/default/async-declaration.template
+/*---
+description: yield Promise.reject(value) in for-await-of is treated as throw value (Async generator Function declaration)
+esid: prod-AsyncGeneratorDeclaration
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorDeclaration:
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+
+var callCount = 0;
+
+async function *gen() {
+  callCount += 1;
+  for await (let value of iterable) {
+    yield value;
+  }
+}
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/async-generator/yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/statements/async-generator/yield-promise-reject-next-yield-star-async-iterator.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-async-iterator.case
+// - src/async-generators/default/async-declaration.template
+/*---
+description: yield * (async iterator) is treated as throw value (Async generator Function declaration)
+esid: prod-AsyncGeneratorDeclaration
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorDeclaration:
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+
+var callCount = 0;
+
+async function *gen() {
+  callCount += 1;
+  yield * readFile();
+
+}
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).then($DONE, $DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/async-generator/yield-promise-reject-next-yield-star-sync-iterator.js
+++ b/test/language/statements/async-generator/yield-promise-reject-next-yield-star-sync-iterator.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-sync-iterator.case
+// - src/async-generators/default/async-declaration.template
+/*---
+description: yield * (async iterator) is treated as throw value (Async generator Function declaration)
+esid: prod-AsyncGeneratorDeclaration
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorDeclaration:
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+
+var callCount = 0;
+
+async function *gen() {
+  callCount += 1;
+  yield * iterable;
+}
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/async-generator/yield-promise-reject-next.js
+++ b/test/language/statements/async-generator/yield-promise-reject-next.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next.case
+// - src/async-generators/default/async-declaration.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Async generator Function declaration)
+esid: prod-AsyncGeneratorDeclaration
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    Async Generator Function Definitions
+
+    AsyncGeneratorDeclaration:
+      async [no LineTerminator here] function * BindingIdentifier ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+
+var callCount = 0;
+
+async function *gen() {
+  callCount += 1;
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/class/async-gen-method-static-yield-promise-reject-next-catch.js
+++ b/test/language/statements/class/async-gen-method-static-yield-promise-reject-next-catch.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-catch.case
+// - src/async-generators/default/async-class-decl-static-method.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Static async generator method as a ClassDeclaration element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      static MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+
+var callCount = 0;
+
+class C { static async *gen() {
+    callCount += 1;
+    yield Promise.reject(error);
+    yield "unreachable";
+}}
+
+var gen = C.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}).catch(rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+});
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/class/async-gen-method-static-yield-promise-reject-next-for-await-of-async-iterator.js
+++ b/test/language/statements/class/async-gen-method-static-yield-promise-reject-next-for-await-of-async-iterator.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-async-iterator.case
+// - src/async-generators/default/async-class-decl-static-method.template
+/*---
+description: yield * [Promise.reject(value)] is treated as throw value (Static async generator method as a ClassDeclaration element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      static MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+
+var callCount = 0;
+
+class C { static async *gen() {
+    callCount += 1;
+    for await (let line of readFile()) {
+      yield line;
+    }
+}}
+
+var gen = C.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/class/async-gen-method-static-yield-promise-reject-next-for-await-of-sync-iterator.js
+++ b/test/language/statements/class/async-gen-method-static-yield-promise-reject-next-for-await-of-sync-iterator.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-sync-iterator.case
+// - src/async-generators/default/async-class-decl-static-method.template
+/*---
+description: yield Promise.reject(value) in for-await-of is treated as throw value (Static async generator method as a ClassDeclaration element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      static MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+
+var callCount = 0;
+
+class C { static async *gen() {
+    callCount += 1;
+    for await (let value of iterable) {
+      yield value;
+    }
+}}
+
+var gen = C.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/class/async-gen-method-static-yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/statements/class/async-gen-method-static-yield-promise-reject-next-yield-star-async-iterator.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-async-iterator.case
+// - src/async-generators/default/async-class-decl-static-method.template
+/*---
+description: yield * (async iterator) is treated as throw value (Static async generator method as a ClassDeclaration element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      static MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+
+var callCount = 0;
+
+class C { static async *gen() {
+    callCount += 1;
+    yield * readFile();
+
+}}
+
+var gen = C.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).then($DONE, $DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/class/async-gen-method-static-yield-promise-reject-next-yield-star-sync-iterator.js
+++ b/test/language/statements/class/async-gen-method-static-yield-promise-reject-next-yield-star-sync-iterator.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-sync-iterator.case
+// - src/async-generators/default/async-class-decl-static-method.template
+/*---
+description: yield * (async iterator) is treated as throw value (Static async generator method as a ClassDeclaration element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      static MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+
+var callCount = 0;
+
+class C { static async *gen() {
+    callCount += 1;
+    yield * iterable;
+}}
+
+var gen = C.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/class/async-gen-method-static-yield-promise-reject-next.js
+++ b/test/language/statements/class/async-gen-method-static-yield-promise-reject-next.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next.case
+// - src/async-generators/default/async-class-decl-static-method.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Static async generator method as a ClassDeclaration element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      static MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+
+var callCount = 0;
+
+class C { static async *gen() {
+    callCount += 1;
+    yield Promise.reject(error);
+    yield "unreachable";
+}}
+
+var gen = C.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/class/async-gen-method-yield-promise-reject-next-catch.js
+++ b/test/language/statements/class/async-gen-method-yield-promise-reject-next-catch.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-catch.case
+// - src/async-generators/default/async-class-decl-method.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Async Generator method as a ClassDeclaration element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+
+var callCount = 0;
+
+class C { async *gen() {
+    callCount += 1;
+    yield Promise.reject(error);
+    yield "unreachable";
+}}
+
+var gen = C.prototype.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}).catch(rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+});
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/class/async-gen-method-yield-promise-reject-next-for-await-of-async-iterator.js
+++ b/test/language/statements/class/async-gen-method-yield-promise-reject-next-for-await-of-async-iterator.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-async-iterator.case
+// - src/async-generators/default/async-class-decl-method.template
+/*---
+description: yield * [Promise.reject(value)] is treated as throw value (Async Generator method as a ClassDeclaration element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+
+var callCount = 0;
+
+class C { async *gen() {
+    callCount += 1;
+    for await (let line of readFile()) {
+      yield line;
+    }
+}}
+
+var gen = C.prototype.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/class/async-gen-method-yield-promise-reject-next-for-await-of-sync-iterator.js
+++ b/test/language/statements/class/async-gen-method-yield-promise-reject-next-for-await-of-sync-iterator.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-for-await-of-sync-iterator.case
+// - src/async-generators/default/async-class-decl-method.template
+/*---
+description: yield Promise.reject(value) in for-await-of is treated as throw value (Async Generator method as a ClassDeclaration element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+
+var callCount = 0;
+
+class C { async *gen() {
+    callCount += 1;
+    for await (let value of iterable) {
+      yield value;
+    }
+}}
+
+var gen = C.prototype.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/class/async-gen-method-yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/statements/class/async-gen-method-yield-promise-reject-next-yield-star-async-iterator.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-async-iterator.case
+// - src/async-generators/default/async-class-decl-method.template
+/*---
+description: yield * (async iterator) is treated as throw value (Async Generator method as a ClassDeclaration element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+async function * readFile() {
+  yield Promise.reject(error);
+  yield "unreachable";
+}
+
+
+var callCount = 0;
+
+class C { async *gen() {
+    callCount += 1;
+    yield * readFile();
+
+}}
+
+var gen = C.prototype.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).then($DONE, $DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/class/async-gen-method-yield-promise-reject-next-yield-star-sync-iterator.js
+++ b/test/language/statements/class/async-gen-method-yield-promise-reject-next-yield-star-sync-iterator.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next-yield-star-sync-iterator.case
+// - src/async-generators/default/async-class-decl-method.template
+/*---
+description: yield * (async iterator) is treated as throw value (Async Generator method as a ClassDeclaration element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+let iterable = [
+  Promise.reject(error),
+  "unreachable"
+];
+
+
+var callCount = 0;
+
+class C { async *gen() {
+    callCount += 1;
+    yield * iterable;
+}}
+
+var gen = C.prototype.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);

--- a/test/language/statements/class/async-gen-method-yield-promise-reject-next.js
+++ b/test/language/statements/class/async-gen-method-yield-promise-reject-next.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/async-generators/yield-promise-reject-next.case
+// - src/async-generators/default/async-class-decl-method.template
+/*---
+description: yield Promise.reject(value) is treated as throw value (Async Generator method as a ClassDeclaration element)
+esid: prod-AsyncGeneratorMethod
+features: [async-iteration]
+flags: [generated, async]
+info: |
+    ClassElement :
+      MethodDefinition
+
+    MethodDefinition :
+      AsyncGeneratorMethod
+
+    Async Generator Function Definitions
+
+    AsyncGeneratorMethod :
+      async [no LineTerminator here] * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+---*/
+let error = new Error();
+
+
+var callCount = 0;
+
+class C { async *gen() {
+    callCount += 1;
+    yield Promise.reject(error);
+    yield "unreachable";
+}}
+
+var gen = C.prototype.gen;
+
+var iter = gen();
+
+iter.next().then(() => {
+  throw new Test262Error("Promise incorrectly resolved.");
+}, rejectValue => {
+  // yield Promise.reject(error);
+  assert.sameValue(rejectValue, error);
+
+  iter.next().then(({done, value}) => {
+    // iter is closed now.
+    assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
+    assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
+  }).then($DONE, $DONE);
+}).catch($DONE);
+
+assert.sameValue(callCount, 1);


### PR DESCRIPTION
~~WIP, Do Not Merge~~

- http://tc39.github.io/tc39-notes/2017-05_may-25.html#15iva-revisiting-async-generator-yield-behavior
- http://tc39.github.io/tc39-notes/2017-05_may-25.html#conclusionresolution-15iva-revisiting-async-generator-yield-behavior

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>