### PR TITLE
{Array,%TypedArray%}.prototype.sort should throw on a non-undefined non-function

### DIFF
--- a/test/built-ins/Array/prototype/sort/comparefn-nonfunction-call-throws.js
+++ b/test/built-ins/Array/prototype/sort/comparefn-nonfunction-call-throws.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2017 Jordan Harband. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.sort
+description: throws on a non-undefined non-function
+info: >
+  22.1.3.25 Array.prototype.sort ( comparefn )
+
+  Upon entry, the following steps are performed to initialize evaluation
+  of the sort function:
+
+  ...
+  1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
+  ...
+---*/
+
+var sample = [1, 2, 3];
+
+assert.throws(TypeError, function() {
+ sample.sort(null);
+});
+
+assert.throws(TypeError, function() {
+  sample.sort(true);
+});
+
+assert.throws(TypeError, function() {
+  sample.sort(false);
+});
+
+assert.throws(TypeError, function() {
+  sample.sort('');
+});
+
+assert.throws(TypeError, function() {
+  sample.sort(/a/g);
+});
+
+assert.throws(TypeError, function() {
+  sample.sort(42);
+});
+
+assert.throws(TypeError, function() {
+  sample.sort([]);
+});
+
+assert.throws(TypeError, function() {
+  sample.sort({});
+});

--- a/test/built-ins/TypedArray/prototype/sort/comparefn-nonfunction-call-throws.js
+++ b/test/built-ins/TypedArray/prototype/sort/comparefn-nonfunction-call-throws.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2017 Jordan Harband. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.sort
+description: throws on a non-undefined non-function
+info: >
+  22.2.3.26 %TypedArray%.prototype.sort ( comparefn )
+
+  Upon entry, the following steps are performed to initialize evaluation
+  of the sort function. These steps are used instead of the entry steps
+  in 22.1.3.25:
+
+  ...
+  1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
+  ...
+
+includes: [testTypedArray.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA([42, 43, 44, 45, 46]);
+
+  assert.throws(TypeError, function() {
+    sample.sort(null);
+  });
+
+  assert.throws(TypeError, function() {
+    sample.sort(true);
+  });
+
+  assert.throws(TypeError, function() {
+    sample.sort(false);
+  });
+
+  assert.throws(TypeError, function() {
+    sample.sort('');
+  });
+
+  assert.throws(TypeError, function() {
+    sample.sort(/a/g);
+  });
+
+  assert.throws(TypeError, function() {
+    sample.sort(42);
+  });
+
+  assert.throws(TypeError, function() {
+    sample.sort([]);
+  });
+
+  assert.throws(TypeError, function() {
+    sample.sort({});
+  });
+});


### PR DESCRIPTION
Per TC39 consensus on  https://github.com/tc39/ecma262/pull/785/