### PR TITLE
Add initial set of class field tests (from V8's test-parsing.cc)

### DIFF
--- a/src/class-fields/computed-name-empty-var-computed-name-empty-function.case
+++ b/src/class-fields/computed-name-empty-var-computed-name-empty-function.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed name var not initialized, computed name function
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a']; ['b'](){}
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/computed-name-empty-var-empty-function.case
+++ b/src/class-fields/computed-name-empty-var-empty-function.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed name var not initialized, empty function
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a']; b(){}
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/computed-name-empty-var-empty-var.case
+++ b/src/class-fields/computed-name-empty-var-empty-var.case
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed name var not initialized, var not initialized
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a']; b
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(this.b, undefined);
+  verifyEnumerable(this, "b");
+  verifyWritable(this, "b");
+  verifyConfigurable(this, "b");

--- a/src/class-fields/computed-name-empty-var-generator-empty-function.case
+++ b/src/class-fields/computed-name-empty-var-generator-empty-function.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed name var not initialized, generator empty function
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a']; *b(){}
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/computed-name-empty-var-new-line-asi.case
+++ b/src/class-fields/computed-name-empty-var-new-line-asi.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: computed name empty var and newline (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a']
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");

--- a/src/class-fields/computed-name-empty-var-new-line-computed-name-empty-function-asi.case
+++ b/src/class-fields/computed-name-empty-var-new-line-computed-name-empty-function-asi.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: computed name empty var and newline, computed name empty function (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a']
+  ['b'](){}
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/computed-name-empty-var-new-line-empty-function-asi.case
+++ b/src/class-fields/computed-name-empty-var-new-line-empty-function-asi.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: computed name empty var and newline, empty function (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a']
+  b(){}
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/computed-name-empty-var-new-line-empty-var-asi.case
+++ b/src/class-fields/computed-name-empty-var-new-line-empty-var-asi.case
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: computed name empty var and newline, empty var (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a']
+  b
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(this.b, undefined);
+  verifyEnumerable(this, "b");
+  verifyWritable(this, "b");
+  verifyConfigurable(this, "b");

--- a/src/class-fields/computed-name-empty-var-new-line-generator-empty-function-asi.case
+++ b/src/class-fields/computed-name-empty-var-new-line-generator-empty-function-asi.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: computed name empty var and newline, generator empty function (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a']
+  *b(){}
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/computed-name-empty-var.case
+++ b/src/class-fields/computed-name-empty-var.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed name var not initialized
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a'];
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");

--- a/src/class-fields/computed-name-zero-initializer-new-line-empty-bar-asi.case
+++ b/src/class-fields/computed-name-zero-initializer-new-line-empty-bar-asi.case
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: computed name zero initialized var and newline, empty var (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a'] = 0
+  b
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(this.b, undefined);
+  verifyEnumerable(this, "b");
+  verifyWritable(this, "b");
+  verifyConfigurable(this, "b");

--- a/src/class-fields/computed-name-zero-initializer-new-line-empty-function-asi.case
+++ b/src/class-fields/computed-name-zero-initializer-new-line-empty-function-asi.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: computed name zero initialized var and newline, empty function (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a'] = 0
+  b(){}
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/computed-name-zero-initializer-new-line-empty-var-asi.case
+++ b/src/class-fields/computed-name-zero-initializer-new-line-empty-var-asi.case
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: computed name zero initialized var and newline, empty var (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a'] = 0
+  b
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(this.b, undefined);
+  verifyEnumerable(this, "b");
+  verifyWritable(this, "b");
+  verifyConfigurable(this, "b");

--- a/src/class-fields/computed-name-zero-initializer-var-computed-name-empty-function.case
+++ b/src/class-fields/computed-name-zero-initializer-var-computed-name-empty-function.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed name var zero initialized, computed name empty function
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a'] = 0; ['b'](){}
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/computed-name-zero-initializer-var-empty-function.case
+++ b/src/class-fields/computed-name-zero-initializer-var-empty-function.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed name var zero initialized, empty function
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a'] = 0; b(){}
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/computed-name-zero-initializer-var-empty-var.case
+++ b/src/class-fields/computed-name-zero-initializer-var-empty-var.case
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed name var zero initialized, empty var
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a'] = 0; b
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(this.b, undefined);
+  verifyEnumerable(this, "b");
+  verifyWritable(this, "b");
+  verifyConfigurable(this, "b");

--- a/src/class-fields/computed-name-zero-initializer-var-generator-empty-function.case
+++ b/src/class-fields/computed-name-zero-initializer-var-generator-empty-function.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed name var zero initialized, generator empty function
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a'] = 0; *b(){}
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/computed-name-zero-initializer-var-new-line-asi.case
+++ b/src/class-fields/computed-name-zero-initializer-var-new-line-asi.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: computed name zero initialized var and newline (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a'] = 0
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");

--- a/src/class-fields/computed-name-zero-initializer-var.case
+++ b/src/class-fields/computed-name-zero-initializer-var.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed name var zero initialized
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  ['a'] = 0;
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");

--- a/src/class-fields/default/cls-decl-extends.template
+++ b/src/class-fields/default/cls-decl-extends.template
@@ -1,0 +1,18 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/class-field-extends-
+name: class fields
+---*/
+
+class Base {}
+class C extends Base {
+  /*{ body }*/
+  constructor() {
+    super();
+    /*{ assertions }*/
+  }
+}
+
+const c = new C();

--- a/src/class-fields/default/cls-decl.template
+++ b/src/class-fields/default/cls-decl.template
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/class-field-
+name: class fields
+---*/
+
+class C {
+  /*{ body }*/
+  constructor() {
+    /*{ assertions }*/
+  }
+}
+
+const c = new C();

--- a/src/class-fields/double-empty-var.case
+++ b/src/class-fields/double-empty-var.case
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Empty var, empty var
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a; b;
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(this.b, undefined);
+  verifyEnumerable(this, "b");
+  verifyWritable(this, "b");
+  verifyConfigurable(this, "b");

--- a/src/class-fields/empty-string-var.case
+++ b/src/class-fields/empty-string-var.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Empty string var
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  'a';
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");

--- a/src/class-fields/empty-var-computed-name-empty-function.case
+++ b/src/class-fields/empty-var-computed-name-empty-function.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: empty var, computed name empty function
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a; ['b'](){}
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/empty-var-empty-function.case
+++ b/src/class-fields/empty-var-empty-function.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Empty var, empty function
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a; b(){}
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/empty-var-generator-empty-function.case
+++ b/src/class-fields/empty-var-generator-empty-function.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Empty var, generator empty function
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a; *b(){}
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/empty-var-new-line-asi.case
+++ b/src/class-fields/empty-var-new-line-asi.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: empty var and newline (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");

--- a/src/class-fields/empty-var-new-line-computed-name-function-asi.case
+++ b/src/class-fields/empty-var-new-line-computed-name-function-asi.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: empty var and newline, computed name empty function (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a
+  ['b'](){}
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/empty-var-new-line-empty-function-asi.case
+++ b/src/class-fields/empty-var-new-line-empty-function-asi.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: empty var and newline, empty function (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a
+  b(){}
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/empty-var-new-line-empty-var-new-line-asi.case
+++ b/src/class-fields/empty-var-new-line-empty-var-new-line-asi.case
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: empty var and newline, empty var and newline (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a
+  b
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(this.b, undefined);
+  verifyEnumerable(this, "b");
+  verifyWritable(this, "b");
+  verifyConfigurable(this, "b");

--- a/src/class-fields/empty-var-new-line-generator-empty-function-asi.case
+++ b/src/class-fields/empty-var-new-line-generator-empty-function-asi.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: empty var and newline, generator empty function (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a
+  *b(){}
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/empty-var.case
+++ b/src/class-fields/empty-var.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Empty var
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a;
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");

--- a/src/class-fields/string-zero-initializer-var.case
+++ b/src/class-fields/string-zero-initializer-var.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: string var zero initializer
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  'a' = 0;
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");

--- a/src/class-fields/undefined-initializer-var.case
+++ b/src/class-fields/undefined-initializer-var.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Empty var
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a = undefined;
+
+//- assertions
+  assert.sameValue(this.a, undefined);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");

--- a/src/class-fields/yield-var.case
+++ b/src/class-fields/yield-var.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: yield var
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  yield
+
+//- assertions
+  assert.sameValue(this.yield, undefined);
+  verifyEnumerable(this, "yield");
+  verifyWritable(this, "yield");
+  verifyConfigurable(this, "yield");

--- a/src/class-fields/yield-zero-initializer-var.case
+++ b/src/class-fields/yield-zero-initializer-var.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: yield var zero initialized
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  yield = 0
+
+//- assertions
+  assert.sameValue(this.yield, 0);
+  verifyEnumerable(this, "yield");
+  verifyWritable(this, "yield");
+  verifyConfigurable(this, "yield");

--- a/src/class-fields/zero-empty-var.case
+++ b/src/class-fields/zero-empty-var.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: zero var
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  0;
+
+//- assertions
+  assert.sameValue(this["0"], undefined);
+  verifyEnumerable(this, "0");
+  verifyWritable(this, "0");
+  verifyConfigurable(this, "0");

--- a/src/class-fields/zero-initializer-var-computed-name-empty-function.case
+++ b/src/class-fields/zero-initializer-var-computed-name-empty-function.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: zero initialized var, computed name empty function
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a = 0; ['b'](){}
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/zero-initializer-var-empty-function.case
+++ b/src/class-fields/zero-initializer-var-empty-function.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: zero initialized var, empty function
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a = 0; b(){}
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/zero-initializer-var-empty-var.case
+++ b/src/class-fields/zero-initializer-var-empty-var.case
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: zero initialized var, empty var
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a = 0; b
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(this.b, undefined);
+  verifyEnumerable(this, "b");
+  verifyWritable(this, "b");
+  verifyConfigurable(this, "b");

--- a/src/class-fields/zero-initializer-var-generator-empty-function.case
+++ b/src/class-fields/zero-initializer-var-generator-empty-function.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: zero initialized var, generator empty function
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a = 0; *b(){}
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/zero-initializer-var-new-line-asi.case
+++ b/src/class-fields/zero-initializer-var-new-line-asi.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: zero initialized var and newline (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a = 0
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");

--- a/src/class-fields/zero-initializer-var-new-line-empty-function-asi.case
+++ b/src/class-fields/zero-initializer-var-new-line-empty-function-asi.case
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: zero initialized var and newline, empty function (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a = 0
+  b(){}
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(typeof Object.getPrototypeOf(this).b, "function");
+  verifyNotEnumerable(Object.getPrototypeOf(this), "b");
+  verifyConfigurable(Object.getPrototypeOf(this), "b");

--- a/src/class-fields/zero-initializer-var-new-line-empty-var-asi.case
+++ b/src/class-fields/zero-initializer-var-new-line-empty-var-asi.case
@@ -1,0 +1,31 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: zero initialized var and newline, empty var (ASI)
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a = 0
+  b
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");
+
+  assert.sameValue(this.b, undefined);
+  verifyEnumerable(this, "b");
+  verifyWritable(this, "b");
+  verifyConfigurable(this, "b");

--- a/src/class-fields/zero-initializer-var.case
+++ b/src/class-fields/zero-initializer-var.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: zero initialized var
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  a = 0;
+
+//- assertions
+  assert.sameValue(this.a, 0);
+  verifyEnumerable(this, "a");
+  verifyWritable(this, "a");
+  verifyConfigurable(this, "a");

--- a/src/class-fields/zero-zero-initializer-var.case
+++ b/src/class-fields/zero-zero-initializer-var.case
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: zero initialized zero var
+info: |
+  1.1 New Productions
+
+  [...]
+
+  FieldDefinitionList [Yield, Await]:
+    FieldDefinition [?Yield, ?Await]
+    FieldDefinitionList  [?Yield, ?Await], FieldDefinition [?Yield, ?Await]
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- body
+  0 = 0;
+
+//- assertions
+  assert.sameValue(this["0"], 0);
+  verifyEnumerable(this, "0");
+  verifyWritable(this, "0");
+  verifyConfigurable(this, "0");


### PR DESCRIPTION
At this point this requires Babel for testing, but most tests in this
commit won't pass until this is fixed:
https://github.com/babel/babel/issues/5056