### PR TITLE
Adding Symbol to Array.prototype.sort "throws on a non-undefined non-function"

### DIFF
--- a/test/built-ins/Array/prototype/sort/comparefn-nonfunction-call-throws.js
+++ b/test/built-ins/Array/prototype/sort/comparefn-nonfunction-call-throws.js
@@ -47,3 +47,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   sample.sort({});
 });
+
+assert.throws(TypeError, function() {
+  sample.sort(Symbol());
+});


### PR DESCRIPTION
Signed-off-by: Rick Waldron <waldron.rick@gmail.com>