### PR TITLE
Add basic Symbol constructor tests

### DIFF
--- a/test/built-ins/Symbol/length.js
+++ b/test/built-ins/Symbol/length.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 Aleksey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-symbol-constructor
+description: >
+  Properties of the Symbol Constructor
+
+  Besides the length property (whose value is 0)
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Symbol.length, 0, "The value of `Symbol.length` is `0`");
+
+verifyNotEnumerable(Symbol, "length");
+verifyNotWritable(Symbol, "length");
+verifyConfigurable(Symbol, "length");

--- a/test/built-ins/Symbol/name.js
+++ b/test/built-ins/Symbol/name.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2017 Aleksey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-symbol-constructor
+description: >
+  Symbol ( [ description ] )
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(Symbol.name, "Symbol", "The value of `Symbol.name` is `'Symbol'`");
+
+verifyNotEnumerable(Symbol, "name");
+verifyNotWritable(Symbol, "name");
+verifyConfigurable(Symbol, "name");

--- a/test/built-ins/Symbol/symbol.js
+++ b/test/built-ins/Symbol/symbol.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2017 Aleksey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-symbol-constructor
+description: >
+  The Symbol constructor is the %Symbol% intrinsic object and the initial
+  value of the Symbol property of the global object.
+
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(this, "Symbol");
+verifyWritable(this, "Symbol");
+verifyConfigurable(this, "Symbol");


### PR DESCRIPTION
Older V8s used to have wrong `Symbol.length` [bug tracker](https://bugs.chromium.org/p/v8/issues/detail?id=4882)