### PR TITLE
Restore migration to assert.sameValue

### DIFF
--- a/test/annexB/built-ins/RegExp/RegExp-control-escape-russian-letter.js
+++ b/test/annexB/built-ins/RegExp/RegExp-control-escape-russian-letter.js
@@ -42,17 +42,11 @@ for (let letter of invalidControls()) {
     var char = letter.charCodeAt(0);
     var str = String.fromCharCode(char % 32);
     var arr = re.exec(str);
+    assert.sameValue(arr, null, `Character ${letter} unreasonably wrapped around as a control character`);
+  }
+  arr = re.exec(source.substring(1));
+  assert.sameValue(arr, null, `invalid \\c escape matched c rather than \\c when followed by ${letter}`);
 
-    if (arr !== null) {
-      $ERROR(`Character ${letter} unreasonably wrapped around as a control character`);
-    }
-  }
-  arr = re.exec(source.substring(1))
-  if (arr !== null) {
-    $ERROR(`invalid \\c escape matched c rather than \\c when followed by ${letter}`);
-  }
-  arr = re.exec(source)
-  if (arr === null) {
-    $ERROR(`invalid \\c escape failed to match \\c when followed by ${letter}`);
-  }
+  arr = re.exec(source);
+  assert.notSameValue(arr, null, `invalid \\c escape failed to match \\c when followed by ${letter}`);
 }


### PR DESCRIPTION
In order to get https://github.com/tc39/test262/pull/945 resolved, I discarded @leobalter's minor assertion API migration changes. This patch restores the semantics intended by @leobalter's original patch. 

@littledan might want to reword the messages... 

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>