### PR TITLE
update contributing.md to make esid a required tag for new feature tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Test262 supports the following tags:
  - [**negative**](#negative)
  - [**es5id**](#es5id)
  - [**es6id**](#es6id)
- - [**esid**](#esid) (required)
+ - [**esid**](#esid) (required for new tests)
  - [**includes**](#includes)
  - [**timeout**](#timeout)
  - [**author**](#author)
@@ -61,7 +61,7 @@ Test262 supports the following tags:
 #### description
 **description**: [string]
 
-This one of two required frontmatter tags. It should be a short, one-line
+This is one of two required frontmatter tags. It should be a short, one-line
 description of the purpose of this testcase.  This is the string displayed by
 the browser runnner.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Test262 supports the following tags:
  - [**negative**](#negative)
  - [**es5id**](#es5id)
  - [**es6id**](#es6id)
- - [**esid**](#esid)
+ - [**esid**](#esid) (required)
  - [**includes**](#includes)
  - [**timeout**](#timeout)
  - [**author**](#author)
@@ -61,7 +61,7 @@ Test262 supports the following tags:
 #### description
 **description**: [string]
 
-This is the only required frontmatter tag. It should be a short, one-line
+This one of two required frontmatter tags. It should be a short, one-line
 description of the purpose of this testcase.  This is the string displayed by
 the browser runnner.
 
@@ -106,7 +106,7 @@ This tag identifies the section number from the portion of the ECMAScript 6 stan
 #### esid
 **esid**: [spec-id]
 
-This tag identifies the hash ID from the portion of the ECMAScript draft which is most recent to the date the test was added. It represents the anchors on the generated HTML version of the specs. E.g.: `esid: sec-typedarray-length`. This tag might be used to replace a `es6id` or further.
+This tag is required for all new feature tests. This tag identifies the hash ID from the portion of the ECMAScript draft which is most recent to the date the test was added. It represents the anchors on the generated HTML version of the specs. E.g.: `esid: sec-typedarray-length`. This tag might be used to replace a `es6id` or further.
 
 When writing a new test for a Stage 3+ spec not yet published on the draft, the `pending` value can be used while a hash ID is not available.
 


### PR DESCRIPTION
For an upcoming project, we need esid to consistently exist in the front matter. It can be set as `pending` for tests that do not have specs published on the site yet. 