### PR TITLE
Fix tests for toFixed and toExponential

### DIFF
--- a/test/built-ins/Number/prototype/toExponential/range.js
+++ b/test/built-ins/Number/prototype/toExponential/range.js
@@ -13,7 +13,7 @@ info: >
 ---*/
 
 assert.sameValue((3).toExponential(0), "3e+0");
-assert.throws(RangeError, () => (3).toExponential(0));
+assert.throws(RangeError, () => (3).toExponential(-1));
 
 assert.sameValue((3).toExponential(100), "3.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e+0");
 assert.throws(RangeError, () => (3).toExponential(101));

--- a/test/built-ins/Number/prototype/toFixed/range.js
+++ b/test/built-ins/Number/prototype/toFixed/range.js
@@ -3,17 +3,17 @@
 
 /*---
 esid: sec-number.prototype.tofixed
-description: Number.prototype.toFixed permits fractionDigits from -20 to 100
+description: Number.prototype.toFixed permits fractionDigits from 0 to 100
 info: >
   Number.prototype.toFixed ( fractionDigits )
 
   ...
-  3. If _f_ &lt; -20 or _f_ &gt; 100, throw a *RangeError* exception.
+  3. If _f_ &lt; 0 or _f_ &gt; 100, throw a *RangeError* exception.
   ...
 ---*/
 
-assert.sameValue((3).toFixed(-20), "0");
-assert.throws(RangeError, () => (3).toFixed(-21));
+assert.sameValue((3).toFixed(-0), "3");
+assert.throws(RangeError, () => (3).toFixed(-1));
 
 assert.sameValue((3).toFixed(100), "3.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
 assert.throws(RangeError, () => (3).toFixed(101));


### PR DESCRIPTION
toExponential had a typo, and toFixed was against an earlier version
of the specification proposal. The tests pass against a version of V8
which attempts to implement the new spec.