### PR TITLE
Correct tests for strict mode early errors

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -7,3 +7,8 @@
 # test/language/made-up-file.js FRONTMATTER LICENSE
 #
 # Note that lines prefixed with the "hash" symbol (#) will be ignored.
+test/language/directive-prologue/10.1.1-5gs.js NEGATIVE
+test/language/directive-prologue/10.1.1-2gs.js NEGATIVE
+test/language/directive-prologue/14.1-5gs.js NEGATIVE
+test/language/directive-prologue/14.1-4gs.js NEGATIVE
+test/language/directive-prologue/10.1.1-8gs.js NEGATIVE

--- a/test/language/directive-prologue/10.1.1-2gs.js
+++ b/test/language/directive-prologue/10.1.1-2gs.js
@@ -12,8 +12,6 @@ negative:
 flags: [raw]
 ---*/
 
-throw "Test262: This statement should not be evaluated.";
-
 "use strict"
 throw new Error("This code should not execute");
 var public = 1;

--- a/test/language/directive-prologue/10.1.1-5gs.js
+++ b/test/language/directive-prologue/10.1.1-5gs.js
@@ -12,8 +12,6 @@ negative:
 flags: [raw]
 ---*/
 
-throw "Test262: This statement should not be evaluated.";
-
 "use strict";
 throw new Error("This code should not execute");
 var public = 1;

--- a/test/language/directive-prologue/10.1.1-8gs.js
+++ b/test/language/directive-prologue/10.1.1-8gs.js
@@ -14,4 +14,5 @@ flags: [raw]
 
 "use strict";
 "use strict";
+throw new Error("This code should not execute");
 var public = 1;

--- a/test/language/directive-prologue/10.1.1-8gs.js
+++ b/test/language/directive-prologue/10.1.1-8gs.js
@@ -12,8 +12,6 @@ negative:
 flags: [raw]
 ---*/
 
-throw "Test262: This statement should not be evaluated.";
-
 "use strict";
 "use strict";
 var public = 1;

--- a/test/language/directive-prologue/14.1-4gs.js
+++ b/test/language/directive-prologue/14.1-4gs.js
@@ -12,8 +12,6 @@ negative:
 flags: [raw]
 ---*/
 
-throw "Test262: This statement should not be evaluated.";
-
 "use strict";
 throw new Error("This code should not execute");
 eval = 42;

--- a/test/language/directive-prologue/14.1-5gs.js
+++ b/test/language/directive-prologue/14.1-5gs.js
@@ -12,8 +12,6 @@ negative:
 flags: [raw]
 ---*/
 
-throw "Test262: This statement should not be evaluated.";
-
 "a";
 "use strict";
 "c";


### PR DESCRIPTION
This is intended to resolve gh-1085. I've manually verified the appropriateness
of the new `throw` statement for all "early error" tests that include a "use
strict" directive, as identified by the following UNIX command:

    $ grep -E 'phase:\s*early' src/ test/ -rl --null | xargs -0 grep 'use strict' -l
    test/language/directive-prologue/10.1.1-5gs.js
    test/language/directive-prologue/10.1.1-2gs.js
    test/language/directive-prologue/10.1.1-8gs.js
    test/language/directive-prologue/14.1-5gs.js
    test/language/directive-prologue/14.1-4gs.js
    test/language/expressions/arrow-function/syntax/early-errors/use-strict-with-non-simple-param.js
    test/language/expressions/object/method-definition/early-errors-object-method-NSPL-with-USD.js
    test/language/expressions/object/method-definition/use-strict-with-non-simple-param.js
    test/language/expressions/object/method-definition/setter-use-strict-with-non-simple-param.js
    test/language/expressions/object/method-definition/generator-use-strict-with-non-simple-param.js
    test/language/expressions/async-generator/early-errors-expression-NSPL-with-USD.js
    test/language/expressions/generators/use-strict-with-non-simple-param.js
    test/language/expressions/async-function/early-errors-expression-NSPL-with-USD.js
    test/language/expressions/async-arrow-function/early-errors-arrow-NSPL-with-USD.js
    test/language/expressions/function/use-strict-with-non-simple-param.js
    test/language/statements/generators/use-strict-with-non-simple-param.js
    test/language/statements/let/redeclaration-error-from-within-strict-mode-function.js
    test/language/statements/const/redeclaration-error-from-within-strict-mode-function-const.js
    test/language/statements/async-function/early-errors-declaration-NSPL-with-USD.js
    test/language/statements/class/definition/early-errors-class-method-NSPL-with-USD.js
    test/language/statements/function/use-strict-with-non-simple-param.js

Note that while we could technically satisfy the linter by throwing the
expected string value, I have chosen to leave the existing `throw` statements
as they are and instead create entries in the linter's white list file. In the
future, the linter may be extended to ensure that the `"use strict"` directive
precedes any executable code; white listing these files now means that such an
improvement will not trigger linting errors.