### PR TITLE
update pending esids in AsyncFunction tests

### DIFF
--- a/test/built-ins/AsyncFunction/AsyncFunction-construct.js
+++ b/test/built-ins/AsyncFunction/AsyncFunction-construct.js
@@ -3,7 +3,7 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
+esid: sec-async-function-constructor
 description: >
   %AsyncFunction% creates functions with or without new and handles arguments
   similarly to functions.

--- a/test/built-ins/AsyncFunction/AsyncFunction-is-subclass.js
+++ b/test/built-ins/AsyncFunction/AsyncFunction-is-subclass.js
@@ -3,7 +3,7 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
+esid: sec-async-function-constructor
 description: >
   %AsyncFunction% is a subclass of Function
 ---*/

--- a/test/built-ins/AsyncFunction/AsyncFunction-length.js
+++ b/test/built-ins/AsyncFunction/AsyncFunction-length.js
@@ -3,7 +3,7 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
+esid: sec-async-function-constructor-length
 description: >
   %AsyncFunction% has a length of 1 with writable false, enumerable false, configurable true.
 includes: [propertyHelper.js]

--- a/test/built-ins/AsyncFunction/AsyncFunction-name.js
+++ b/test/built-ins/AsyncFunction/AsyncFunction-name.js
@@ -3,7 +3,7 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
+esid: sec-async-function-constructor-properties
 description: >
   %AsyncFunction% has a name of "AsyncFunction".
 includes: [propertyHelper.js]

--- a/test/built-ins/AsyncFunction/AsyncFunction-prototype.js
+++ b/test/built-ins/AsyncFunction/AsyncFunction-prototype.js
@@ -3,7 +3,7 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
+esid: sec-async-function-constructor-prototype
 description: AsyncFunction has a prototype property with writable false, enumerable false, configurable false.
 includes: [propertyHelper.js]
 ---*/

--- a/test/built-ins/AsyncFunction/AsyncFunction.js
+++ b/test/built-ins/AsyncFunction/AsyncFunction.js
@@ -3,7 +3,7 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
+esid: sec-async-function-objects
 description: >
   %AsyncFunction% exists and is a function
 ---*/

--- a/test/built-ins/AsyncFunction/AsyncFunctionPrototype-is-extensible.js
+++ b/test/built-ins/AsyncFunction/AsyncFunctionPrototype-is-extensible.js
@@ -3,7 +3,7 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
+esid: sec-sync-function-prototype-properties
 description: >
   %AsyncFunctionPrototype% has a [[Extensible]] of true
 ---*/

--- a/test/built-ins/AsyncFunction/AsyncFunctionPrototype-prototype.js
+++ b/test/built-ins/AsyncFunction/AsyncFunctionPrototype-prototype.js
@@ -3,7 +3,7 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
+esid: sec-sync-function-prototype-properties
 description: AsyncFunction.prototype has a [[prototype]] of Function.prototype
 ---*/
 var AsyncFunction = async function foo() { }.constructor;

--- a/test/built-ins/AsyncFunction/AsyncFunctionPrototype-to-string.js
+++ b/test/built-ins/AsyncFunction/AsyncFunctionPrototype-to-string.js
@@ -3,7 +3,7 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
+esid: sec-async-function-prototype-properties-toStringTag
 description: >
   %AsyncFunctionPrototype% has a Symbol.toStringTag property of "AsyncFunction"
 includes: [propertyHelper.js]

--- a/test/built-ins/AsyncFunction/instance-construct-throws.js
+++ b/test/built-ins/AsyncFunction/instance-construct-throws.js
@@ -3,7 +3,7 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
+esid: sec-async-function-instances
 description: >
   Async function instances are not constructors and do not have a
   [[Construct]] slot.

--- a/test/built-ins/AsyncFunction/instance-has-name.js
+++ b/test/built-ins/AsyncFunction/instance-has-name.js
@@ -3,7 +3,7 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
+esid: sec-async-function-instances-name
 description: Async function declarations have a name property
 includes: [propertyHelper.js]
 ---*/

--- a/test/built-ins/AsyncFunction/instance-length.js
+++ b/test/built-ins/AsyncFunction/instance-length.js
@@ -3,7 +3,7 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
+esid: sec-async-function-instances-length
 description: >
   Async functions have a length property that is the number of expected
   arguments.

--- a/test/built-ins/AsyncFunction/instance-prototype-property.js
+++ b/test/built-ins/AsyncFunction/instance-prototype-property.js
@@ -3,7 +3,7 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
+esid: sec-async-function-instances
 description: >
   Async function instances do not have a prototype property.
 ---*/

--- a/test/built-ins/AsyncFunction/is-not-a-global.js
+++ b/test/built-ins/AsyncFunction/is-not-a-global.js
@@ -3,7 +3,7 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
+esid: sec-async-function-constructor-properties
 description: >
   %AsyncFunction% is not exposed as a global
 ---*/


### PR DESCRIPTION
@leobalter @rwaldron 
This is a case of where there was a "pending" esid that needed to be updated.  I tried to match as best I could to the docs. The only thing I couldn't match very well was for the test: "is not a global"