### PR TITLE
Relax [[DefineOwnProperty]] on module namespace exotic objects.

### DIFF
--- a/test/language/module-code/namespace/internals/define-own-property.js
+++ b/test/language/module-code/namespace/internals/define-own-property.js
@@ -3,9 +3,8 @@
 /*---
 esid: sec-module-namespace-exotic-objects-defineownproperty-p-desc
 description: >
-    The [[DefineOwnProperty]] internal method consistently returns `false`
-info: |
-    1. Return false.
+    The [[DefineOwnProperty]] internal method returns `true` if no change is
+    requested, and `false` otherwise.
 flags: [module]
 features: [Reflect, Symbol, Symbol.toStringTag]
 ---*/
@@ -17,63 +16,101 @@ export { local2 as renamed };
 export { local1 as indirect } from './define-own-property.js';
 var sym = Symbol('test262');
 
-assert.sameValue(
-  Reflect.defineProperty(ns, 'local1', {}),
-  false,
-  'Reflect.defineProperty: local1'
-);
-assert.throws(TypeError, function() {
-  Object.defineProperty(ns, 'local1', {});
-}, 'Object.defineProperty: local1');
+const exported = ['local1', 'renamed', 'indirect'];
+
+
+// Non-existant properties.
+
+for (const key of ['local2', 0, sym, Symbol.iterator]) {
+  assert.sameValue(
+    Reflect.defineProperty(ns, key, {}),
+    false,
+    'Reflect.defineProperty: ' + key.toString()
+  );
+  assert.throws(TypeError, function() {
+    Object.defineProperty(ns, key, {});
+  }, 'Object.defineProperty: ' + key.toString());
+}
+
+
+// Own properties. No change requested.
+
+for (const key of ([...exported, Symbol.toStringTag])) {
+  assert.sameValue(
+    Reflect.defineProperty(ns, key, {}),
+    true,
+    'Reflect.defineProperty: ' + key.toString()
+  );
+  assert.sameValue(
+    Object.defineProperty(ns, key, {}),
+    ns,
+    'Object.defineProperty: ' + key.toString()
+  );
+
+}
 
 assert.sameValue(
-  Reflect.defineProperty(ns, 'local2', {}),
-  false,
-  'Reflect.defineProperty: local2'
+  Reflect.defineProperty(ns, 'indirect',
+      {writable: true, enumerable: true, configurable: false}),
+  true,
+  'Reflect.defineProperty: indirect'
 );
-assert.throws(TypeError, function() {
-  Object.defineProperty(ns, 'local2', {});
-}, 'Object.defineProperty: local2');
+assert.sameValue(
+  Object.defineProperty(ns, 'indirect',
+      {writable: true, enumerable: true, configurable: false}),
+  ns,
+  'Object.defineProperty: indirect'
+);
 
 assert.sameValue(
-  Reflect.defineProperty(ns, 'renamed', {}),
-  false,
-  'Reflect.defineProperty: renamed'
+  Reflect.defineProperty(ns, Symbol.toStringTag,
+      {value: "Module", writable: false, enumerable: false,
+       configurable: false}),
+  true,
+  'Reflect.defineProperty: Symbol.toStringTag'
 );
-assert.throws(TypeError, function() {
-  Object.defineProperty(ns, 'renamed', {});
-}, 'Object.defineProperty: renamed');
+assert.sameValue(
+  Object.defineProperty(ns, Symbol.toStringTag,
+      {value: "Module", writable: false, enumerable: false,
+       configurable: false}),
+  ns,
+  'Object.defineProperty: Symbol.toStringTag'
+);
+
+
+// Own properties. Change requested.
+
+for (const key of ([...exported, Symbol.toStringTag])) {
+  assert.sameValue(
+    Reflect.defineProperty(ns, key, {value: 123}),
+    false,
+    'Reflect.defineProperty: ' + key.toString()
+  );
+  assert.throws(TypeError, function() {
+    Object.defineProperty(ns, key, {value: 123});
+  }, 'Object.defineProperty: ' + key.toString());
+}
 
 assert.sameValue(
-  Reflect.defineProperty(ns, 'indirect', {}),
+  Reflect.defineProperty(ns, 'indirect',
+      {writable: true, enumerable: true, configurable: true}),
   false,
   'Reflect.defineProperty: indirect'
 );
 assert.throws(TypeError, function() {
-  Object.defineProperty(ns, 'indirect', {});
+  Object.defineProperty(ns, 'indirect',
+      {writable: true, enumerable: true, configurable: true});
 }, 'Object.defineProperty: indirect');
 
 assert.sameValue(
-  Reflect.defineProperty(ns, 'default', {}),
-  false,
-  'Reflect.defineProperty: default'
-);
-assert.throws(TypeError, function() {
-  Object.defineProperty(ns, 'default', {});
-}, 'Object.defineProperty: default');
-
-assert.sameValue(
-  Reflect.defineProperty(ns, Symbol.toStringTag, {}),
+  Reflect.defineProperty(ns, Symbol.toStringTag,
+      {value: "module", writable: false, enumerable: false,
+       configurable: false}),
   false,
   'Reflect.defineProperty: Symbol.toStringTag'
 );
 assert.throws(TypeError, function() {
-  Object.defineProperty(ns, Symbol.toStringTag, {});
+  Object.defineProperty(ns, Symbol.toStringTag,
+      {value: "module", writable: false, enumerable: false,
+       configurable: false});
 }, 'Object.defineProperty: Symbol.toStringTag');
-
-assert.sameValue(
-  Reflect.defineProperty(ns, sym, {}), false, 'Reflect.defineProperty: sym'
-);
-assert.throws(TypeError, function() {
-  Object.defineProperty(ns, sym, {});
-}, 'Object.defineProperty: symbol');


### PR DESCRIPTION
See https://github.com/tc39/ecma262/pull/858.