### PR TITLE
Class fields

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -11,6 +11,10 @@
 # https://github.com/tc39/proposal-bigint
 BigInt
 
+# Class Fields
+# https://github.com/tc39/proposal-class-fields
+class-fields
+
 # Promise.prototype.finally
 # https://github.com/tc39/proposal-promise-finally
 Promise.prototype.finally

--- a/features.txt
+++ b/features.txt
@@ -66,6 +66,7 @@ arrow-function
 async-functions
 caller
 class
+computed-property-names
 const
 DataView
 DataView.prototype.getFloat32

--- a/src/class-fields/computed-names.case
+++ b/src/class-fields/computed-names.case
@@ -1,0 +1,70 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: prod-FieldDefinition
+desc: Computed property names
+info: |
+  ClassElement:
+    ...
+    FieldDefinition ;
+
+  FieldDefinition:
+    ClassElementName Initializer_opt
+
+  ClassElementName:
+    PropertyName
+template: default
+includes: [propertyHelper.js]
+features: [computed-property-names]
+---*/
+
+//- setup
+var x = "b";
+
+//- fields
+static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"]
+//- assertions
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/src/class-fields/computed-symbol-names.case
+++ b/src/class-fields/computed-symbol-names.case
@@ -1,0 +1,55 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: prod-FieldDefinition
+desc: Computed property symbol names
+info: |
+  ClassElement:
+    ...
+    FieldDefinition ;
+
+  FieldDefinition:
+    ClassElementName Initializer_opt
+
+  ClassElementName:
+    PropertyName
+template: default
+includes: [propertyHelper.js]
+features: [Symbol, computed-property-names]
+---*/
+
+//- setup
+var x = Symbol();
+var y = Symbol();
+
+//- fields
+[x]; [y] = 42
+//- assertions
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/src/class-fields/conventions.md
+++ b/src/class-fields/conventions.md
@@ -1,0 +1,8 @@
+# Conventions for the class fields templates and cases
+
+Templates should produce a class named `C` and instantiate it to an object named `c`.
+
+## Known template fields:
+
+* fields: it should contain the list of class fields, inserted in the class body. Please, avoid closing a field with a trailing semi-colon, this might prevent ASI checks properly.
+* assertions: it should contain the assertions to run after the class object is instantiated.

--- a/src/class-fields/default/cls-decl-after-same-line-async-gen.template
+++ b/src/class-fields/default/cls-decl-after-same-line-async-gen.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-same-line-async-gen-
+name: field definitions after an async generator in the same line
+features: [class-fields, async-iteration]
+flags: [async]
+---*/
+
+class C {
+  async *m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/src/class-fields/default/cls-decl-after-same-line-async-method.template
+++ b/src/class-fields/default/cls-decl-after-same-line-async-method.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-same-line-async-method-
+name: field definitions after an async method in the same line
+features: [class-fields, async-functions]
+flags: [async]
+---*/
+
+class C {
+  async m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/src/class-fields/default/cls-decl-after-same-line-gen.template
+++ b/src/class-fields/default/cls-decl-after-same-line-gen.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-after-same-line-gen-
+name: field definitions after a generator in the same line
+features: [class-fields]
+---*/
+
+class C {
+  *m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-decl-after-same-line-method.template
+++ b/src/class-fields/default/cls-decl-after-same-line-method.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-after-same-line-method-
+name: field definitions after a method in the same line
+features: [class-fields]
+---*/
+
+class C {
+  m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-decl-after-same-line-static-async-gen.template
+++ b/src/class-fields/default/cls-decl-after-same-line-static-async-gen.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-after-same-line-static-async-gen-
+name: field definitions after a static async generator in the same line
+features: [class-fields, async-iteration]
+flags: [async]
+---*/
+
+class C {
+  static async *m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/src/class-fields/default/cls-decl-after-same-line-static-async-method.template
+++ b/src/class-fields/default/cls-decl-after-same-line-static-async-method.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-after-same-line-static-async-method-
+name: field definitions after a static async method in the same line
+features: [class-fields, async-functions]
+flags: [async]
+---*/
+
+class C {
+  static async m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/src/class-fields/default/cls-decl-after-same-line-static-gen.template
+++ b/src/class-fields/default/cls-decl-after-same-line-static-gen.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-after-same-line-static-gen-
+name: field definitions after a static generator in the same line
+features: [class-fields]
+---*/
+
+class C {
+  static *m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-decl-after-same-line-static-method.template
+++ b/src/class-fields/default/cls-decl-after-same-line-static-method.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-after-same-line-static-method-
+name: field definitions after a static method in the same line
+features: [class-fields]
+---*/
+
+class C {
+  static m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-decl-multiple-definitions.template
+++ b/src/class-fields/default/cls-decl-multiple-definitions.template
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-multiple-definitions-
+name: multiple fields definitions
+features: [class-fields]
+---*/
+
+class C {
+  foo = "foobar";
+  m() { return 42 }
+  /*{ fields }*/
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-decl-multiple-stacked-definitions.template
+++ b/src/class-fields/default/cls-decl-multiple-stacked-definitions.template
@@ -1,0 +1,44 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-multiple-stacked-definitions-
+name: multiple stacked fields definitions through ASI
+features: [class-fields]
+---*/
+
+class C {
+  /*{ fields }*/
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-decl-new-no-sc-line-method.template
+++ b/src/class-fields/default/cls-decl-new-no-sc-line-method.template
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-new-no-sc-line-method-
+name: field definitions followed by a method in a new line without a semicolon
+features: [class-fields]
+---*/
+
+class C {
+  /*{ fields }*/
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-decl-new-sc-line-generator.template
+++ b/src/class-fields/default/cls-decl-new-sc-line-generator.template
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-new-sc-line-gen-
+name: field definitions followed by a method in a new line with a semicolon
+features: [class-fields, generators]
+---*/
+
+class C {
+  /*{ fields }*/;
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-decl-new-sc-line-method.template
+++ b/src/class-fields/default/cls-decl-new-sc-line-method.template
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-new-sc-line-method-
+name: field definitions followed by a method in a new line with a semicolon
+features: [class-fields]
+---*/
+
+class C {
+  /*{ fields }*/;
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-decl-regular-definitions.template
+++ b/src/class-fields/default/cls-decl-regular-definitions.template
@@ -1,0 +1,16 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-regular-definitions-
+name: regular fields defintion
+features: [class-fields]
+---*/
+
+class C {
+  /*{ fields }*/
+}
+
+var c = new C();
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-decl-same-line-generator.template
+++ b/src/class-fields/default/cls-decl-same-line-generator.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-same-line-gen-
+name: field definitions followed by a generator method in the same line
+features: [class-fields, generators]
+---*/
+
+class C {
+  /*{ fields }*/; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-decl-same-line-method.template
+++ b/src/class-fields/default/cls-decl-same-line-method.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-same-line-method-
+name: field definitions followed by a method in the same line
+features: [class-fields]
+---*/
+
+class C {
+  /*{ fields }*/; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-decl-wrapped-in-sc.template
+++ b/src/class-fields/default/cls-decl-wrapped-in-sc.template
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-wrapped-in-sc-
+name: fields definition wrapped in semicolons
+features: [class-fields]
+---*/
+
+class C {
+  ;;;;
+  ;;;;;;/*{ fields }*/;;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-expr-after-same-line-async-gen.template
+++ b/src/class-fields/default/cls-expr-after-same-line-async-gen.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-same-line-async-gen-
+name: field definitions after an async generator in the same line
+features: [class-fields, async-iteration]
+flags: [async]
+---*/
+
+var C = class {
+  async *m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/src/class-fields/default/cls-expr-after-same-line-async-method.template
+++ b/src/class-fields/default/cls-expr-after-same-line-async-method.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-same-line-async-method-
+name: field definitions after an async method in the same line
+features: [class-fields, async-functions]
+flags: [async]
+---*/
+
+var C = class {
+  async m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/src/class-fields/default/cls-expr-after-same-line-gen.template
+++ b/src/class-fields/default/cls-expr-after-same-line-gen.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-after-same-line-gen-
+name: field definitions after a generator in the same line
+features: [class-fields]
+---*/
+
+var C = class {
+  *m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-expr-after-same-line-method.template
+++ b/src/class-fields/default/cls-expr-after-same-line-method.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-after-same-line-method-
+name: field definitions after a method in the same line
+features: [class-fields]
+---*/
+
+var C = class {
+  m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-expr-after-same-line-static-async-gen.template
+++ b/src/class-fields/default/cls-expr-after-same-line-static-async-gen.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-after-same-line-static-async-gen-
+name: field definitions after a static async generator in the same line
+features: [class-fields, async-iteration]
+flags: [async]
+---*/
+
+var C = class {
+  static async *m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/src/class-fields/default/cls-expr-after-same-line-static-async-method.template
+++ b/src/class-fields/default/cls-expr-after-same-line-static-async-method.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-after-same-line-static-async-method-
+name: field definitions after a static async method in the same line
+features: [class-fields, async-functions]
+flags: [async]
+---*/
+
+var C = class {
+  static async m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/src/class-fields/default/cls-expr-after-same-line-static-gen.template
+++ b/src/class-fields/default/cls-expr-after-same-line-static-gen.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-after-same-line-static-gen-
+name: field definitions after a static generator in the same line
+features: [class-fields]
+---*/
+
+var C = class {
+  static *m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-expr-after-same-line-static-method.template
+++ b/src/class-fields/default/cls-expr-after-same-line-static-method.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-after-same-line-static-method-
+name: field definitions after a static method in the same line
+features: [class-fields]
+---*/
+
+var C = class {
+  static m() { return 42; } /*{ fields }*/;
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-expr-multiple-definitions.template
+++ b/src/class-fields/default/cls-expr-multiple-definitions.template
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-multiple-definitions-
+name: multiple fields definitions
+features: [class-fields]
+---*/
+
+var C = class {
+  foo = "foobar";
+  m() { return 42 }
+  /*{ fields }*/
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-expr-multiple-stacked-definitions.template
+++ b/src/class-fields/default/cls-expr-multiple-stacked-definitions.template
@@ -1,0 +1,44 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-multiple-stacked-definitions-
+name: multiple stacked fields definitions through ASI
+features: [class-fields]
+---*/
+
+var C = class {
+  /*{ fields }*/
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-expr-new-no-sc-line-method.template
+++ b/src/class-fields/default/cls-expr-new-no-sc-line-method.template
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-new-no-sc-line-method-
+name: field definitions followed by a method in a new line without a semicolon
+features: [class-fields]
+---*/
+
+var C = class {
+  /*{ fields }*/
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-expr-new-sc-line-generator.template
+++ b/src/class-fields/default/cls-expr-new-sc-line-generator.template
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-new-sc-line-gen-
+name: field definitions followed by a method in a new line with a semicolon
+features: [class-fields, generators]
+---*/
+
+var C = class {
+  /*{ fields }*/;
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-expr-new-sc-line-method.template
+++ b/src/class-fields/default/cls-expr-new-sc-line-method.template
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-new-sc-line-method-
+name: field definitions followed by a method in a new line with a semicolon
+features: [class-fields]
+---*/
+
+var C = class {
+  /*{ fields }*/;
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-expr-regular-definitions.template
+++ b/src/class-fields/default/cls-expr-regular-definitions.template
@@ -1,0 +1,16 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-regular-definitions-
+name: regular fields defintion
+features: [class-fields]
+---*/
+
+var C = class {
+  /*{ fields }*/
+}
+
+var c = new C();
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-expr-same-line-generator.template
+++ b/src/class-fields/default/cls-expr-same-line-generator.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-same-line-gen-
+name: field definitions followed by a generator method in the same line
+features: [class-fields, generators]
+---*/
+
+var C = class {
+  /*{ fields }*/; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-expr-same-line-method.template
+++ b/src/class-fields/default/cls-expr-same-line-method.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-same-line-method-
+name: field definitions followed by a method in the same line
+features: [class-fields]
+---*/
+
+var C = class {
+  /*{ fields }*/; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+/*{ assertions }*/

--- a/src/class-fields/default/cls-expr-wrapped-in-sc.template
+++ b/src/class-fields/default/cls-expr-wrapped-in-sc.template
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/fields-wrapped-in-sc-
+name: fields definition wrapped in semicolons
+features: [class-fields]
+---*/
+
+var C = class {
+  ;;;;
+  ;;;;;;/*{ fields }*/;;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+/*{ assertions }*/

--- a/src/class-fields/error/cls-decl-new-no-sc-line-generator.template
+++ b/src/class-fields/error/cls-decl-new-no-sc-line-generator.template
@@ -1,0 +1,16 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/fields-new-no-sc-line-gen-
+name: ASI prevents a following generator method
+features: [class-fields, generators]
+negative:
+  type: SyntaxError
+  phase: early
+---*/
+
+class C {
+  /*{ fields }*/
+  *m() { return 42; }
+}

--- a/src/class-fields/info.txt
+++ b/src/class-fields/info.txt
@@ -1,0 +1,16 @@
+  ClassElement:
+    MethodDefinition
+    static MethodDefinition
+    FieldDefinition ;
+    static FieldDefinition ;
+    ;
+
+  FieldDefinition:
+    ClassElementName Initializer_opt
+
+  ClassElementName:
+    PropertyName
+    PrivateName
+
+  PrivateName ::
+    # IdentifierName

--- a/src/class-fields/literal-names.case
+++ b/src/class-fields/literal-names.case
@@ -1,0 +1,57 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: prod-FieldDefinition
+desc: Literal property names
+info: |
+  ClassElement:
+    ...
+    FieldDefinition ;
+
+  FieldDefinition:
+    ClassElementName Initializer_opt
+
+  ClassElementName:
+    PropertyName
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- setup
+const fn = function() {}
+
+//- fields
+a; b = 42;
+c = fn
+//- assertions
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/src/class-fields/static-computed-names.case
+++ b/src/class-fields/static-computed-names.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: prod-FieldDefinition
+desc: Static Computed property names
+info: |
+  ClassElement:
+    ...
+    FieldDefinition ;
+    static FieldDefinition ;
+
+  FieldDefinition:
+    ClassElementName Initializer_opt
+
+  ClassElementName:
+    PropertyName
+template: default
+includes: [propertyHelper.js]
+features: [computed-property-names]
+---*/
+
+//- fields
+static ["a"] = 42; ["a"] = 39
+//- assertions
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/src/class-fields/static-computed-symbol-names.case
+++ b/src/class-fields/static-computed-symbol-names.case
@@ -1,0 +1,55 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: prod-FieldDefinition
+desc: Static computed property symbol names
+info: |
+  ClassElement:
+    ...
+    FieldDefinition ;
+
+  FieldDefinition:
+    ClassElementName Initializer_opt
+
+  ClassElementName:
+    PropertyName
+template: default
+includes: [propertyHelper.js]
+features: [Symbol, computed-property-names]
+---*/
+
+//- setup
+var x = Symbol();
+var y = Symbol();
+
+//- fields
+[x]; [y] = 42
+//- assertions
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/src/class-fields/static-literal-names.case
+++ b/src/class-fields/static-literal-names.case
@@ -1,0 +1,57 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: prod-FieldDefinition
+desc: Static literal property names
+info: |
+  ClassElement:
+    ...
+    FieldDefinition ;
+
+  FieldDefinition:
+    ClassElementName Initializer_opt
+
+  ClassElementName:
+    PropertyName
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- setup
+const fn = function() {}
+
+//- fields
+static a; b = 42;
+static c = fn
+//- assertions
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/src/class-fields/string-literal-names.case
+++ b/src/class-fields/string-literal-names.case
@@ -1,0 +1,33 @@
+// Copyright (C) 2017 the V8 project authors, 2017 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: prod-FieldDefinition
+desc: String literal names
+info: |
+  ClassElement:
+    ...
+    FieldDefinition ;
+
+  FieldDefinition:
+    ClassElementName Initializer_opt
+
+  ClassElementName:
+    PropertyName
+template: default
+includes: [propertyHelper.js]
+---*/
+
+//- fields
+'a'; "b"; 'c' = 39;
+"d" = 42
+//- assertions
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-after-same-line-gen-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-computed-names.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-gen.template
+/*---
+description: Computed property names (field definitions after a generator in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  *m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-after-same-line-gen-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-gen.template
+/*---
+description: Computed property symbol names (field definitions after a generator in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-after-same-line-gen-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-gen.template
+/*---
+description: Literal property names (field definitions after a generator in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  *m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-after-same-line-gen-static-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-static-computed-names.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-gen.template
+/*---
+description: Static Computed property names (field definitions after a generator in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  *m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-after-same-line-gen-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-static-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-gen.template
+/*---
+description: Static computed property symbol names (field definitions after a generator in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-after-same-line-gen-static-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-static-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-gen.template
+/*---
+description: Static literal property names (field definitions after a generator in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  *m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-after-same-line-gen-string-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-string-literal-names.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-gen.template
+/*---
+description: String literal names (field definitions after a generator in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  *m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-after-same-line-method-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-method-computed-names.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-method.template
+/*---
+description: Computed property names (field definitions after a method in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-after-same-line-method-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-method-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-method.template
+/*---
+description: Computed property symbol names (field definitions after a method in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-after-same-line-method-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-method-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-method.template
+/*---
+description: Literal property names (field definitions after a method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-after-same-line-method-static-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-method-static-computed-names.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-method.template
+/*---
+description: Static Computed property names (field definitions after a method in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-after-same-line-method-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-method-static-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-method.template
+/*---
+description: Static computed property symbol names (field definitions after a method in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-after-same-line-method-static-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-method-static-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-method.template
+/*---
+description: Static literal property names (field definitions after a method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-after-same-line-method-string-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-method-string-literal-names.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-method.template
+/*---
+description: String literal names (field definitions after a method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-after-same-line-static-async-gen-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-gen-computed-names.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-async-gen.template
+/*---
+description: Computed property names (field definitions after a static async generator in the same line)
+features: [computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  static async *m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-gen-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-gen-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-async-gen.template
+/*---
+description: Computed property symbol names (field definitions after a static async generator in the same line)
+features: [Symbol, computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  static async *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-gen-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-gen-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-async-gen.template
+/*---
+description: Literal property names (field definitions after a static async generator in the same line)
+features: [class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static async *m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-gen-static-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-gen-static-computed-names.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-async-gen.template
+/*---
+description: Static Computed property names (field definitions after a static async generator in the same line)
+features: [computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static async *m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-gen-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-gen-static-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-async-gen.template
+/*---
+description: Static computed property symbol names (field definitions after a static async generator in the same line)
+features: [Symbol, computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  static async *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-gen-static-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-gen-static-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-async-gen.template
+/*---
+description: Static literal property names (field definitions after a static async generator in the same line)
+features: [class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static async *m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-gen-string-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-gen-string-literal-names.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-async-gen.template
+/*---
+description: String literal names (field definitions after a static async generator in the same line)
+features: [class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static async *m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-method-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-method-computed-names.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-async-method.template
+/*---
+description: Computed property names (field definitions after a static async method in the same line)
+features: [computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  static async m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-method-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-method-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-async-method.template
+/*---
+description: Computed property symbol names (field definitions after a static async method in the same line)
+features: [Symbol, computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  static async m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-method-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-method-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-async-method.template
+/*---
+description: Literal property names (field definitions after a static async method in the same line)
+features: [class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static async m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-method-static-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-method-static-computed-names.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-async-method.template
+/*---
+description: Static Computed property names (field definitions after a static async method in the same line)
+features: [computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static async m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-method-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-method-static-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-async-method.template
+/*---
+description: Static computed property symbol names (field definitions after a static async method in the same line)
+features: [Symbol, computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  static async m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-method-static-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-method-static-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-async-method.template
+/*---
+description: Static literal property names (field definitions after a static async method in the same line)
+features: [class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static async m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-method-string-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-method-string-literal-names.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-async-method.template
+/*---
+description: String literal names (field definitions after a static async method in the same line)
+features: [class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static async m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-gen-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-computed-names.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-gen.template
+/*---
+description: Computed property names (field definitions after a static generator in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  static *m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-after-same-line-static-gen-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-gen.template
+/*---
+description: Computed property symbol names (field definitions after a static generator in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  static *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-after-same-line-static-gen-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-gen.template
+/*---
+description: Literal property names (field definitions after a static generator in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static *m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-after-same-line-static-gen-static-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-static-computed-names.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-gen.template
+/*---
+description: Static Computed property names (field definitions after a static generator in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static *m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-after-same-line-static-gen-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-static-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-gen.template
+/*---
+description: Static computed property symbol names (field definitions after a static generator in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  static *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-after-same-line-static-gen-static-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-static-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-gen.template
+/*---
+description: Static literal property names (field definitions after a static generator in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static *m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-after-same-line-static-gen-string-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-string-literal-names.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-gen.template
+/*---
+description: String literal names (field definitions after a static generator in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static *m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-after-same-line-static-method-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-method-computed-names.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-method.template
+/*---
+description: Computed property names (field definitions after a static method in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  static m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-after-same-line-static-method-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-method-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-method.template
+/*---
+description: Computed property symbol names (field definitions after a static method in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  static m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-after-same-line-static-method-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-method-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-method.template
+/*---
+description: Literal property names (field definitions after a static method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-after-same-line-static-method-static-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-method-static-computed-names.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-method.template
+/*---
+description: Static Computed property names (field definitions after a static method in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-after-same-line-static-method-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-method-static-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-method.template
+/*---
+description: Static computed property symbol names (field definitions after a static method in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  static m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-after-same-line-static-method-static-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-method-static-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-method.template
+/*---
+description: Static literal property names (field definitions after a static method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-after-same-line-static-method-string-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-method-string-literal-names.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-static-method.template
+/*---
+description: String literal names (field definitions after a static method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-multiple-definitions-computed-names.js
+++ b/test/language/expressions/class/fields-multiple-definitions-computed-names.js
@@ -1,0 +1,119 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-multiple-definitions.template
+/*---
+description: Computed property names (multiple fields definitions)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  foo = "foobar";
+  m() { return 42 }
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"]
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-multiple-definitions-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-multiple-definitions-computed-symbol-names.js
@@ -1,0 +1,104 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-multiple-definitions.template
+/*---
+description: Computed property symbol names (multiple fields definitions)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  foo = "foobar";
+  m() { return 42 }
+  [x]; [y] = 42
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-multiple-definitions-literal-names.js
+++ b/test/language/expressions/class/fields-multiple-definitions-literal-names.js
@@ -1,0 +1,107 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-multiple-definitions.template
+/*---
+description: Literal property names (multiple fields definitions)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  foo = "foobar";
+  m() { return 42 }
+  a; b = 42;
+  c = fn
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-multiple-definitions-static-computed-names.js
+++ b/test/language/expressions/class/fields-multiple-definitions-static-computed-names.js
@@ -1,0 +1,90 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-multiple-definitions.template
+/*---
+description: Static Computed property names (multiple fields definitions)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  foo = "foobar";
+  m() { return 42 }
+  static ["a"] = 42; ["a"] = 39
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-multiple-definitions-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-multiple-definitions-static-computed-symbol-names.js
@@ -1,0 +1,104 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-multiple-definitions.template
+/*---
+description: Static computed property symbol names (multiple fields definitions)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  foo = "foobar";
+  m() { return 42 }
+  [x]; [y] = 42
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-multiple-definitions-static-literal-names.js
+++ b/test/language/expressions/class/fields-multiple-definitions-static-literal-names.js
@@ -1,0 +1,107 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-multiple-definitions.template
+/*---
+description: Static literal property names (multiple fields definitions)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  foo = "foobar";
+  m() { return 42 }
+  static a; b = 42;
+  static c = fn
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-multiple-definitions-string-literal-names.js
+++ b/test/language/expressions/class/fields-multiple-definitions-string-literal-names.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-multiple-definitions.template
+/*---
+description: String literal names (multiple fields definitions)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  foo = "foobar";
+  m() { return 42 }
+  'a'; "b"; 'c' = 39;
+  "d" = 42
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-multiple-stacked-definitions-computed-names.js
+++ b/test/language/expressions/class/fields-multiple-stacked-definitions-computed-names.js
@@ -1,0 +1,101 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-multiple-stacked-definitions.template
+/*---
+description: Computed property names (multiple stacked fields definitions through ASI)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"]
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-multiple-stacked-definitions-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-multiple-stacked-definitions-computed-symbol-names.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-multiple-stacked-definitions.template
+/*---
+description: Computed property symbol names (multiple stacked fields definitions through ASI)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  [x]; [y] = 42
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-multiple-stacked-definitions-literal-names.js
+++ b/test/language/expressions/class/fields-multiple-stacked-definitions-literal-names.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-multiple-stacked-definitions.template
+/*---
+description: Literal property names (multiple stacked fields definitions through ASI)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  a; b = 42;
+  c = fn
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-multiple-stacked-definitions-static-computed-names.js
+++ b/test/language/expressions/class/fields-multiple-stacked-definitions-static-computed-names.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-multiple-stacked-definitions.template
+/*---
+description: Static Computed property names (multiple stacked fields definitions through ASI)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static ["a"] = 42; ["a"] = 39
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-multiple-stacked-definitions-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-multiple-stacked-definitions-static-computed-symbol-names.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-multiple-stacked-definitions.template
+/*---
+description: Static computed property symbol names (multiple stacked fields definitions through ASI)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  [x]; [y] = 42
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-multiple-stacked-definitions-static-literal-names.js
+++ b/test/language/expressions/class/fields-multiple-stacked-definitions-static-literal-names.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-multiple-stacked-definitions.template
+/*---
+description: Static literal property names (multiple stacked fields definitions through ASI)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static a; b = 42;
+  static c = fn
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-multiple-stacked-definitions-string-literal-names.js
+++ b/test/language/expressions/class/fields-multiple-stacked-definitions-string-literal-names.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-multiple-stacked-definitions.template
+/*---
+description: String literal names (multiple stacked fields definitions through ASI)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  'a'; "b"; 'c' = 39;
+  "d" = 42
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-new-no-sc-line-method-computed-names.js
+++ b/test/language/expressions/class/fields-new-no-sc-line-method-computed-names.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-new-no-sc-line-method.template
+/*---
+description: Computed property names (field definitions followed by a method in a new line without a semicolon)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"]
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-new-no-sc-line-method-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-new-no-sc-line-method-computed-symbol-names.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-new-no-sc-line-method.template
+/*---
+description: Computed property symbol names (field definitions followed by a method in a new line without a semicolon)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  [x]; [y] = 42
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-new-no-sc-line-method-literal-names.js
+++ b/test/language/expressions/class/fields-new-no-sc-line-method-literal-names.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-new-no-sc-line-method.template
+/*---
+description: Literal property names (field definitions followed by a method in a new line without a semicolon)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  a; b = 42;
+  c = fn
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-new-no-sc-line-method-static-computed-names.js
+++ b/test/language/expressions/class/fields-new-no-sc-line-method-static-computed-names.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-new-no-sc-line-method.template
+/*---
+description: Static Computed property names (field definitions followed by a method in a new line without a semicolon)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static ["a"] = 42; ["a"] = 39
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-new-no-sc-line-method-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-new-no-sc-line-method-static-computed-symbol-names.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-new-no-sc-line-method.template
+/*---
+description: Static computed property symbol names (field definitions followed by a method in a new line without a semicolon)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  [x]; [y] = 42
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-new-no-sc-line-method-static-literal-names.js
+++ b/test/language/expressions/class/fields-new-no-sc-line-method-static-literal-names.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-new-no-sc-line-method.template
+/*---
+description: Static literal property names (field definitions followed by a method in a new line without a semicolon)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static a; b = 42;
+  static c = fn
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-new-no-sc-line-method-string-literal-names.js
+++ b/test/language/expressions/class/fields-new-no-sc-line-method-string-literal-names.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-new-no-sc-line-method.template
+/*---
+description: String literal names (field definitions followed by a method in a new line without a semicolon)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  'a'; "b"; 'c' = 39;
+  "d" = 42
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-new-sc-line-gen-computed-names.js
+++ b/test/language/expressions/class/fields-new-sc-line-gen-computed-names.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-new-sc-line-generator.template
+/*---
+description: Computed property names (field definitions followed by a method in a new line with a semicolon)
+features: [computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-new-sc-line-gen-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-new-sc-line-gen-computed-symbol-names.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-new-sc-line-generator.template
+/*---
+description: Computed property symbol names (field definitions followed by a method in a new line with a semicolon)
+features: [Symbol, computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  [x]; [y] = 42;
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-new-sc-line-gen-literal-names.js
+++ b/test/language/expressions/class/fields-new-sc-line-gen-literal-names.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-new-sc-line-generator.template
+/*---
+description: Literal property names (field definitions followed by a method in a new line with a semicolon)
+features: [class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  a; b = 42;
+  c = fn;
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-new-sc-line-gen-static-computed-names.js
+++ b/test/language/expressions/class/fields-new-sc-line-gen-static-computed-names.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-new-sc-line-generator.template
+/*---
+description: Static Computed property names (field definitions followed by a method in a new line with a semicolon)
+features: [computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static ["a"] = 42; ["a"] = 39;
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-new-sc-line-gen-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-new-sc-line-gen-static-computed-symbol-names.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-new-sc-line-generator.template
+/*---
+description: Static computed property symbol names (field definitions followed by a method in a new line with a semicolon)
+features: [Symbol, computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  [x]; [y] = 42;
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-new-sc-line-gen-static-literal-names.js
+++ b/test/language/expressions/class/fields-new-sc-line-gen-static-literal-names.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-new-sc-line-generator.template
+/*---
+description: Static literal property names (field definitions followed by a method in a new line with a semicolon)
+features: [class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static a; b = 42;
+  static c = fn;
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-new-sc-line-gen-string-literal-names.js
+++ b/test/language/expressions/class/fields-new-sc-line-gen-string-literal-names.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-new-sc-line-generator.template
+/*---
+description: String literal names (field definitions followed by a method in a new line with a semicolon)
+features: [class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  'a'; "b"; 'c' = 39;
+  "d" = 42;
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-new-sc-line-method-computed-names.js
+++ b/test/language/expressions/class/fields-new-sc-line-method-computed-names.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-new-sc-line-method.template
+/*---
+description: Computed property names (field definitions followed by a method in a new line with a semicolon)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-new-sc-line-method-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-new-sc-line-method-computed-symbol-names.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-new-sc-line-method.template
+/*---
+description: Computed property symbol names (field definitions followed by a method in a new line with a semicolon)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  [x]; [y] = 42;
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-new-sc-line-method-literal-names.js
+++ b/test/language/expressions/class/fields-new-sc-line-method-literal-names.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-new-sc-line-method.template
+/*---
+description: Literal property names (field definitions followed by a method in a new line with a semicolon)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  a; b = 42;
+  c = fn;
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-new-sc-line-method-static-computed-names.js
+++ b/test/language/expressions/class/fields-new-sc-line-method-static-computed-names.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-new-sc-line-method.template
+/*---
+description: Static Computed property names (field definitions followed by a method in a new line with a semicolon)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static ["a"] = 42; ["a"] = 39;
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-new-sc-line-method-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-new-sc-line-method-static-computed-symbol-names.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-new-sc-line-method.template
+/*---
+description: Static computed property symbol names (field definitions followed by a method in a new line with a semicolon)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  [x]; [y] = 42;
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-new-sc-line-method-static-literal-names.js
+++ b/test/language/expressions/class/fields-new-sc-line-method-static-literal-names.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-new-sc-line-method.template
+/*---
+description: Static literal property names (field definitions followed by a method in a new line with a semicolon)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static a; b = 42;
+  static c = fn;
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-new-sc-line-method-string-literal-names.js
+++ b/test/language/expressions/class/fields-new-sc-line-method-string-literal-names.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-new-sc-line-method.template
+/*---
+description: String literal names (field definitions followed by a method in a new line with a semicolon)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  'a'; "b"; 'c' = 39;
+  "d" = 42;
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-regular-definitions-computed-names.js
+++ b/test/language/expressions/class/fields-regular-definitions-computed-names.js
@@ -1,0 +1,73 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-regular-definitions.template
+/*---
+description: Computed property names (regular fields defintion)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"]
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-regular-definitions-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-regular-definitions-computed-symbol-names.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-regular-definitions.template
+/*---
+description: Computed property symbol names (regular fields defintion)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  [x]; [y] = 42
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-regular-definitions-literal-names.js
+++ b/test/language/expressions/class/fields-regular-definitions-literal-names.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-regular-definitions.template
+/*---
+description: Literal property names (regular fields defintion)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  a; b = 42;
+  c = fn
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-regular-definitions-static-computed-names.js
+++ b/test/language/expressions/class/fields-regular-definitions-static-computed-names.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-regular-definitions.template
+/*---
+description: Static Computed property names (regular fields defintion)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static ["a"] = 42; ["a"] = 39
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-regular-definitions-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-regular-definitions-static-computed-symbol-names.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-regular-definitions.template
+/*---
+description: Static computed property symbol names (regular fields defintion)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  [x]; [y] = 42
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-regular-definitions-static-literal-names.js
+++ b/test/language/expressions/class/fields-regular-definitions-static-literal-names.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-regular-definitions.template
+/*---
+description: Static literal property names (regular fields defintion)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static a; b = 42;
+  static c = fn
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-regular-definitions-string-literal-names.js
+++ b/test/language/expressions/class/fields-regular-definitions-string-literal-names.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-regular-definitions.template
+/*---
+description: String literal names (regular fields defintion)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  'a'; "b"; 'c' = 39;
+  "d" = 42
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-same-line-async-gen-computed-names.js
+++ b/test/language/expressions/class/fields-same-line-async-gen-computed-names.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-async-gen.template
+/*---
+description: Computed property names (field definitions after an async generator in the same line)
+features: [computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  async *m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-gen-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-same-line-async-gen-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-async-gen.template
+/*---
+description: Computed property symbol names (field definitions after an async generator in the same line)
+features: [Symbol, computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  async *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-gen-literal-names.js
+++ b/test/language/expressions/class/fields-same-line-async-gen-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-async-gen.template
+/*---
+description: Literal property names (field definitions after an async generator in the same line)
+features: [class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  async *m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-gen-static-computed-names.js
+++ b/test/language/expressions/class/fields-same-line-async-gen-static-computed-names.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-async-gen.template
+/*---
+description: Static Computed property names (field definitions after an async generator in the same line)
+features: [computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  async *m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-gen-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-same-line-async-gen-static-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-async-gen.template
+/*---
+description: Static computed property symbol names (field definitions after an async generator in the same line)
+features: [Symbol, computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  async *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-gen-static-literal-names.js
+++ b/test/language/expressions/class/fields-same-line-async-gen-static-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-async-gen.template
+/*---
+description: Static literal property names (field definitions after an async generator in the same line)
+features: [class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  async *m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-gen-string-literal-names.js
+++ b/test/language/expressions/class/fields-same-line-async-gen-string-literal-names.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-async-gen.template
+/*---
+description: String literal names (field definitions after an async generator in the same line)
+features: [class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  async *m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-method-computed-names.js
+++ b/test/language/expressions/class/fields-same-line-async-method-computed-names.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-async-method.template
+/*---
+description: Computed property names (field definitions after an async method in the same line)
+features: [computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  async m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-method-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-same-line-async-method-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-async-method.template
+/*---
+description: Computed property symbol names (field definitions after an async method in the same line)
+features: [Symbol, computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  async m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-method-literal-names.js
+++ b/test/language/expressions/class/fields-same-line-async-method-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-async-method.template
+/*---
+description: Literal property names (field definitions after an async method in the same line)
+features: [class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  async m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-method-static-computed-names.js
+++ b/test/language/expressions/class/fields-same-line-async-method-static-computed-names.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-after-same-line-async-method.template
+/*---
+description: Static Computed property names (field definitions after an async method in the same line)
+features: [computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  async m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-method-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-same-line-async-method-static-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-after-same-line-async-method.template
+/*---
+description: Static computed property symbol names (field definitions after an async method in the same line)
+features: [Symbol, computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  async m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-method-static-literal-names.js
+++ b/test/language/expressions/class/fields-same-line-async-method-static-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-async-method.template
+/*---
+description: Static literal property names (field definitions after an async method in the same line)
+features: [class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  async m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-method-string-literal-names.js
+++ b/test/language/expressions/class/fields-same-line-async-method-string-literal-names.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-after-same-line-async-method.template
+/*---
+description: String literal names (field definitions after an async method in the same line)
+features: [class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  async m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-gen-computed-names.js
+++ b/test/language/expressions/class/fields-same-line-gen-computed-names.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-same-line-generator.template
+/*---
+description: Computed property names (field definitions followed by a generator method in the same line)
+features: [computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"]; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-same-line-gen-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-same-line-gen-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-same-line-generator.template
+/*---
+description: Computed property symbol names (field definitions followed by a generator method in the same line)
+features: [Symbol, computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  [x]; [y] = 42; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-same-line-gen-literal-names.js
+++ b/test/language/expressions/class/fields-same-line-gen-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-same-line-generator.template
+/*---
+description: Literal property names (field definitions followed by a generator method in the same line)
+features: [class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  a; b = 42;
+  c = fn; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-same-line-gen-static-computed-names.js
+++ b/test/language/expressions/class/fields-same-line-gen-static-computed-names.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-same-line-generator.template
+/*---
+description: Static Computed property names (field definitions followed by a generator method in the same line)
+features: [computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static ["a"] = 42; ["a"] = 39; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-same-line-gen-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-same-line-gen-static-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-same-line-generator.template
+/*---
+description: Static computed property symbol names (field definitions followed by a generator method in the same line)
+features: [Symbol, computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  [x]; [y] = 42; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-same-line-gen-static-literal-names.js
+++ b/test/language/expressions/class/fields-same-line-gen-static-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-same-line-generator.template
+/*---
+description: Static literal property names (field definitions followed by a generator method in the same line)
+features: [class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static a; b = 42;
+  static c = fn; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-same-line-gen-string-literal-names.js
+++ b/test/language/expressions/class/fields-same-line-gen-string-literal-names.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-same-line-generator.template
+/*---
+description: String literal names (field definitions followed by a generator method in the same line)
+features: [class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  'a'; "b"; 'c' = 39;
+  "d" = 42; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-same-line-method-computed-names.js
+++ b/test/language/expressions/class/fields-same-line-method-computed-names.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-same-line-method.template
+/*---
+description: Computed property names (field definitions followed by a method in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"]; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-same-line-method-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-same-line-method-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-same-line-method.template
+/*---
+description: Computed property symbol names (field definitions followed by a method in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  [x]; [y] = 42; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-same-line-method-literal-names.js
+++ b/test/language/expressions/class/fields-same-line-method-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-same-line-method.template
+/*---
+description: Literal property names (field definitions followed by a method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  a; b = 42;
+  c = fn; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-same-line-method-static-computed-names.js
+++ b/test/language/expressions/class/fields-same-line-method-static-computed-names.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-same-line-method.template
+/*---
+description: Static Computed property names (field definitions followed by a method in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  static ["a"] = 42; ["a"] = 39; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-same-line-method-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-same-line-method-static-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-same-line-method.template
+/*---
+description: Static computed property symbol names (field definitions followed by a method in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  [x]; [y] = 42; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-same-line-method-static-literal-names.js
+++ b/test/language/expressions/class/fields-same-line-method-static-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-same-line-method.template
+/*---
+description: Static literal property names (field definitions followed by a method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  static a; b = 42;
+  static c = fn; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-same-line-method-string-literal-names.js
+++ b/test/language/expressions/class/fields-same-line-method-string-literal-names.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-same-line-method.template
+/*---
+description: String literal names (field definitions followed by a method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  'a'; "b"; 'c' = 39;
+  "d" = 42; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-wrapped-in-sc-computed-names.js
+++ b/test/language/expressions/class/fields-wrapped-in-sc-computed-names.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-expr-wrapped-in-sc.template
+/*---
+description: Computed property names (fields definition wrapped in semicolons)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+var C = class {
+  ;;;;
+  ;;;;;;static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-wrapped-in-sc-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-wrapped-in-sc-computed-symbol-names.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-expr-wrapped-in-sc.template
+/*---
+description: Computed property symbol names (fields definition wrapped in semicolons)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  ;;;;
+  ;;;;;;[x]; [y] = 42;;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-wrapped-in-sc-literal-names.js
+++ b/test/language/expressions/class/fields-wrapped-in-sc-literal-names.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-expr-wrapped-in-sc.template
+/*---
+description: Literal property names (fields definition wrapped in semicolons)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  ;;;;
+  ;;;;;;a; b = 42;
+  c = fn;;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-wrapped-in-sc-static-computed-names.js
+++ b/test/language/expressions/class/fields-wrapped-in-sc-static-computed-names.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-expr-wrapped-in-sc.template
+/*---
+description: Static Computed property names (fields definition wrapped in semicolons)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  ;;;;
+  ;;;;;;static ["a"] = 42; ["a"] = 39;;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/expressions/class/fields-wrapped-in-sc-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-wrapped-in-sc-static-computed-symbol-names.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-expr-wrapped-in-sc.template
+/*---
+description: Static computed property symbol names (fields definition wrapped in semicolons)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+var C = class {
+  ;;;;
+  ;;;;;;[x]; [y] = 42;;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/expressions/class/fields-wrapped-in-sc-static-literal-names.js
+++ b/test/language/expressions/class/fields-wrapped-in-sc-static-literal-names.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-expr-wrapped-in-sc.template
+/*---
+description: Static literal property names (fields definition wrapped in semicolons)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+var C = class {
+  ;;;;
+  ;;;;;;static a; b = 42;
+  static c = fn;;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/expressions/class/fields-wrapped-in-sc-string-literal-names.js
+++ b/test/language/expressions/class/fields-wrapped-in-sc-string-literal-names.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-expr-wrapped-in-sc.template
+/*---
+description: String literal names (fields definition wrapped in semicolons)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+var C = class {
+  ;;;;
+  ;;;;;;'a'; "b"; 'c' = 39;
+  "d" = 42;;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-after-same-line-gen-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-gen-computed-names.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-gen.template
+/*---
+description: Computed property names (field definitions after a generator in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  *m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-after-same-line-gen-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-gen-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-gen.template
+/*---
+description: Computed property symbol names (field definitions after a generator in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-after-same-line-gen-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-gen-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-gen.template
+/*---
+description: Literal property names (field definitions after a generator in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  *m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-after-same-line-gen-static-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-gen-static-computed-names.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-gen.template
+/*---
+description: Static Computed property names (field definitions after a generator in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  *m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-after-same-line-gen-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-gen-static-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-gen.template
+/*---
+description: Static computed property symbol names (field definitions after a generator in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-after-same-line-gen-static-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-gen-static-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-gen.template
+/*---
+description: Static literal property names (field definitions after a generator in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  *m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-after-same-line-gen-string-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-gen-string-literal-names.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-gen.template
+/*---
+description: String literal names (field definitions after a generator in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  *m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-after-same-line-method-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-method-computed-names.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-method.template
+/*---
+description: Computed property names (field definitions after a method in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-after-same-line-method-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-method-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-method.template
+/*---
+description: Computed property symbol names (field definitions after a method in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-after-same-line-method-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-method-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-method.template
+/*---
+description: Literal property names (field definitions after a method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-after-same-line-method-static-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-method-static-computed-names.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-method.template
+/*---
+description: Static Computed property names (field definitions after a method in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-after-same-line-method-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-method-static-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-method.template
+/*---
+description: Static computed property symbol names (field definitions after a method in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-after-same-line-method-static-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-method-static-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-method.template
+/*---
+description: Static literal property names (field definitions after a method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-after-same-line-method-string-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-method-string-literal-names.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-method.template
+/*---
+description: String literal names (field definitions after a method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-after-same-line-static-async-gen-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-gen-computed-names.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-async-gen.template
+/*---
+description: Computed property names (field definitions after a static async generator in the same line)
+features: [computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  static async *m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-gen-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-gen-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-async-gen.template
+/*---
+description: Computed property symbol names (field definitions after a static async generator in the same line)
+features: [Symbol, computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  static async *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-gen-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-gen-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-async-gen.template
+/*---
+description: Literal property names (field definitions after a static async generator in the same line)
+features: [class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static async *m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-gen-static-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-gen-static-computed-names.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-async-gen.template
+/*---
+description: Static Computed property names (field definitions after a static async generator in the same line)
+features: [computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static async *m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-gen-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-gen-static-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-async-gen.template
+/*---
+description: Static computed property symbol names (field definitions after a static async generator in the same line)
+features: [Symbol, computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  static async *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-gen-static-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-gen-static-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-async-gen.template
+/*---
+description: Static literal property names (field definitions after a static async generator in the same line)
+features: [class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static async *m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-gen-string-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-gen-string-literal-names.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-async-gen.template
+/*---
+description: String literal names (field definitions after a static async generator in the same line)
+features: [class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static async *m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-method-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-method-computed-names.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-async-method.template
+/*---
+description: Computed property names (field definitions after a static async method in the same line)
+features: [computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  static async m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-method-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-method-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-async-method.template
+/*---
+description: Computed property symbol names (field definitions after a static async method in the same line)
+features: [Symbol, computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  static async m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-method-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-method-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-async-method.template
+/*---
+description: Literal property names (field definitions after a static async method in the same line)
+features: [class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static async m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-method-static-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-method-static-computed-names.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-async-method.template
+/*---
+description: Static Computed property names (field definitions after a static async method in the same line)
+features: [computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static async m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-method-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-method-static-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-async-method.template
+/*---
+description: Static computed property symbol names (field definitions after a static async method in the same line)
+features: [Symbol, computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  static async m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-method-static-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-method-static-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-async-method.template
+/*---
+description: Static literal property names (field definitions after a static async method in the same line)
+features: [class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static async m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-method-string-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-method-string-literal-names.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-async-method.template
+/*---
+description: String literal names (field definitions after a static async method in the same line)
+features: [class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static async m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-gen-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-computed-names.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-gen.template
+/*---
+description: Computed property names (field definitions after a static generator in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  static *m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-after-same-line-static-gen-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-gen.template
+/*---
+description: Computed property symbol names (field definitions after a static generator in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  static *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-after-same-line-static-gen-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-gen.template
+/*---
+description: Literal property names (field definitions after a static generator in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static *m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-after-same-line-static-gen-static-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-static-computed-names.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-gen.template
+/*---
+description: Static Computed property names (field definitions after a static generator in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static *m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-after-same-line-static-gen-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-static-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-gen.template
+/*---
+description: Static computed property symbol names (field definitions after a static generator in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  static *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-after-same-line-static-gen-static-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-static-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-gen.template
+/*---
+description: Static literal property names (field definitions after a static generator in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static *m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-after-same-line-static-gen-string-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-string-literal-names.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-gen.template
+/*---
+description: String literal names (field definitions after a static generator in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static *m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-after-same-line-static-method-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-method-computed-names.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-method.template
+/*---
+description: Computed property names (field definitions after a static method in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  static m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-after-same-line-static-method-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-method-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-method.template
+/*---
+description: Computed property symbol names (field definitions after a static method in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  static m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-after-same-line-static-method-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-method-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-method.template
+/*---
+description: Literal property names (field definitions after a static method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-after-same-line-static-method-static-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-method-static-computed-names.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-method.template
+/*---
+description: Static Computed property names (field definitions after a static method in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-after-same-line-static-method-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-method-static-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-method.template
+/*---
+description: Static computed property symbol names (field definitions after a static method in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  static m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-after-same-line-static-method-static-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-method-static-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-method.template
+/*---
+description: Static literal property names (field definitions after a static method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-after-same-line-static-method-string-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-method-string-literal-names.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-static-method.template
+/*---
+description: String literal names (field definitions after a static method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-multiple-definitions-computed-names.js
+++ b/test/language/statements/class/fields-multiple-definitions-computed-names.js
@@ -1,0 +1,119 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-multiple-definitions.template
+/*---
+description: Computed property names (multiple fields definitions)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  foo = "foobar";
+  m() { return 42 }
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"]
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-multiple-definitions-computed-symbol-names.js
+++ b/test/language/statements/class/fields-multiple-definitions-computed-symbol-names.js
@@ -1,0 +1,104 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-multiple-definitions.template
+/*---
+description: Computed property symbol names (multiple fields definitions)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  foo = "foobar";
+  m() { return 42 }
+  [x]; [y] = 42
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-multiple-definitions-literal-names.js
+++ b/test/language/statements/class/fields-multiple-definitions-literal-names.js
@@ -1,0 +1,107 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-multiple-definitions.template
+/*---
+description: Literal property names (multiple fields definitions)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  foo = "foobar";
+  m() { return 42 }
+  a; b = 42;
+  c = fn
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-multiple-definitions-static-computed-names.js
+++ b/test/language/statements/class/fields-multiple-definitions-static-computed-names.js
@@ -1,0 +1,90 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-multiple-definitions.template
+/*---
+description: Static Computed property names (multiple fields definitions)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  foo = "foobar";
+  m() { return 42 }
+  static ["a"] = 42; ["a"] = 39
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-multiple-definitions-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-multiple-definitions-static-computed-symbol-names.js
@@ -1,0 +1,104 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-multiple-definitions.template
+/*---
+description: Static computed property symbol names (multiple fields definitions)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  foo = "foobar";
+  m() { return 42 }
+  [x]; [y] = 42
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-multiple-definitions-static-literal-names.js
+++ b/test/language/statements/class/fields-multiple-definitions-static-literal-names.js
@@ -1,0 +1,107 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-multiple-definitions.template
+/*---
+description: Static literal property names (multiple fields definitions)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  foo = "foobar";
+  m() { return 42 }
+  static a; b = 42;
+  static c = fn
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-multiple-definitions-string-literal-names.js
+++ b/test/language/statements/class/fields-multiple-definitions-string-literal-names.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-multiple-definitions.template
+/*---
+description: String literal names (multiple fields definitions)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  foo = "foobar";
+  m() { return 42 }
+  'a'; "b"; 'c' = 39;
+  "d" = 42
+  m2() { return 39 }
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-multiple-stacked-definitions-computed-names.js
+++ b/test/language/statements/class/fields-multiple-stacked-definitions-computed-names.js
@@ -1,0 +1,101 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-multiple-stacked-definitions.template
+/*---
+description: Computed property names (multiple stacked fields definitions through ASI)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"]
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-multiple-stacked-definitions-computed-symbol-names.js
+++ b/test/language/statements/class/fields-multiple-stacked-definitions-computed-symbol-names.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-multiple-stacked-definitions.template
+/*---
+description: Computed property symbol names (multiple stacked fields definitions through ASI)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  [x]; [y] = 42
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-multiple-stacked-definitions-literal-names.js
+++ b/test/language/statements/class/fields-multiple-stacked-definitions-literal-names.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-multiple-stacked-definitions.template
+/*---
+description: Literal property names (multiple stacked fields definitions through ASI)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  a; b = 42;
+  c = fn
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-multiple-stacked-definitions-static-computed-names.js
+++ b/test/language/statements/class/fields-multiple-stacked-definitions-static-computed-names.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-multiple-stacked-definitions.template
+/*---
+description: Static Computed property names (multiple stacked fields definitions through ASI)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static ["a"] = 42; ["a"] = 39
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-multiple-stacked-definitions-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-multiple-stacked-definitions-static-computed-symbol-names.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-multiple-stacked-definitions.template
+/*---
+description: Static computed property symbol names (multiple stacked fields definitions through ASI)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  [x]; [y] = 42
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-multiple-stacked-definitions-static-literal-names.js
+++ b/test/language/statements/class/fields-multiple-stacked-definitions-static-literal-names.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-multiple-stacked-definitions.template
+/*---
+description: Static literal property names (multiple stacked fields definitions through ASI)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static a; b = 42;
+  static c = fn
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-multiple-stacked-definitions-string-literal-names.js
+++ b/test/language/statements/class/fields-multiple-stacked-definitions-string-literal-names.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-multiple-stacked-definitions.template
+/*---
+description: String literal names (multiple stacked fields definitions through ASI)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  'a'; "b"; 'c' = 39;
+  "d" = 42
+  foo = "foobar"
+  bar = "barbaz";
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-new-no-sc-line-method-computed-names.js
+++ b/test/language/statements/class/fields-new-no-sc-line-method-computed-names.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-new-no-sc-line-method.template
+/*---
+description: Computed property names (field definitions followed by a method in a new line without a semicolon)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"]
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-new-no-sc-line-method-computed-symbol-names.js
+++ b/test/language/statements/class/fields-new-no-sc-line-method-computed-symbol-names.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-new-no-sc-line-method.template
+/*---
+description: Computed property symbol names (field definitions followed by a method in a new line without a semicolon)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  [x]; [y] = 42
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-new-no-sc-line-method-literal-names.js
+++ b/test/language/statements/class/fields-new-no-sc-line-method-literal-names.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-new-no-sc-line-method.template
+/*---
+description: Literal property names (field definitions followed by a method in a new line without a semicolon)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  a; b = 42;
+  c = fn
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-new-no-sc-line-method-static-computed-names.js
+++ b/test/language/statements/class/fields-new-no-sc-line-method-static-computed-names.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-new-no-sc-line-method.template
+/*---
+description: Static Computed property names (field definitions followed by a method in a new line without a semicolon)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static ["a"] = 42; ["a"] = 39
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-new-no-sc-line-method-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-new-no-sc-line-method-static-computed-symbol-names.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-new-no-sc-line-method.template
+/*---
+description: Static computed property symbol names (field definitions followed by a method in a new line without a semicolon)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  [x]; [y] = 42
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-new-no-sc-line-method-static-literal-names.js
+++ b/test/language/statements/class/fields-new-no-sc-line-method-static-literal-names.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-new-no-sc-line-method.template
+/*---
+description: Static literal property names (field definitions followed by a method in a new line without a semicolon)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static a; b = 42;
+  static c = fn
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-new-no-sc-line-method-string-literal-names.js
+++ b/test/language/statements/class/fields-new-no-sc-line-method-string-literal-names.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-new-no-sc-line-method.template
+/*---
+description: String literal names (field definitions followed by a method in a new line without a semicolon)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  'a'; "b"; 'c' = 39;
+  "d" = 42
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-new-sc-line-gen-computed-names.js
+++ b/test/language/statements/class/fields-new-sc-line-gen-computed-names.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-new-sc-line-generator.template
+/*---
+description: Computed property names (field definitions followed by a method in a new line with a semicolon)
+features: [computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-new-sc-line-gen-computed-symbol-names.js
+++ b/test/language/statements/class/fields-new-sc-line-gen-computed-symbol-names.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-new-sc-line-generator.template
+/*---
+description: Computed property symbol names (field definitions followed by a method in a new line with a semicolon)
+features: [Symbol, computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  [x]; [y] = 42;
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-new-sc-line-gen-literal-names.js
+++ b/test/language/statements/class/fields-new-sc-line-gen-literal-names.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-new-sc-line-generator.template
+/*---
+description: Literal property names (field definitions followed by a method in a new line with a semicolon)
+features: [class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  a; b = 42;
+  c = fn;
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-new-sc-line-gen-static-computed-names.js
+++ b/test/language/statements/class/fields-new-sc-line-gen-static-computed-names.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-new-sc-line-generator.template
+/*---
+description: Static Computed property names (field definitions followed by a method in a new line with a semicolon)
+features: [computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static ["a"] = 42; ["a"] = 39;
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-new-sc-line-gen-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-new-sc-line-gen-static-computed-symbol-names.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-new-sc-line-generator.template
+/*---
+description: Static computed property symbol names (field definitions followed by a method in a new line with a semicolon)
+features: [Symbol, computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  [x]; [y] = 42;
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-new-sc-line-gen-static-literal-names.js
+++ b/test/language/statements/class/fields-new-sc-line-gen-static-literal-names.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-new-sc-line-generator.template
+/*---
+description: Static literal property names (field definitions followed by a method in a new line with a semicolon)
+features: [class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static a; b = 42;
+  static c = fn;
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-new-sc-line-gen-string-literal-names.js
+++ b/test/language/statements/class/fields-new-sc-line-gen-string-literal-names.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-new-sc-line-generator.template
+/*---
+description: String literal names (field definitions followed by a method in a new line with a semicolon)
+features: [class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  'a'; "b"; 'c' = 39;
+  "d" = 42;
+  *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.g().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-new-sc-line-method-computed-names.js
+++ b/test/language/statements/class/fields-new-sc-line-method-computed-names.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-new-sc-line-method.template
+/*---
+description: Computed property names (field definitions followed by a method in a new line with a semicolon)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-new-sc-line-method-computed-symbol-names.js
+++ b/test/language/statements/class/fields-new-sc-line-method-computed-symbol-names.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-new-sc-line-method.template
+/*---
+description: Computed property symbol names (field definitions followed by a method in a new line with a semicolon)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  [x]; [y] = 42;
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-new-sc-line-method-literal-names.js
+++ b/test/language/statements/class/fields-new-sc-line-method-literal-names.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-new-sc-line-method.template
+/*---
+description: Literal property names (field definitions followed by a method in a new line with a semicolon)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  a; b = 42;
+  c = fn;
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-new-sc-line-method-static-computed-names.js
+++ b/test/language/statements/class/fields-new-sc-line-method-static-computed-names.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-new-sc-line-method.template
+/*---
+description: Static Computed property names (field definitions followed by a method in a new line with a semicolon)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static ["a"] = 42; ["a"] = 39;
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-new-sc-line-method-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-new-sc-line-method-static-computed-symbol-names.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-new-sc-line-method.template
+/*---
+description: Static computed property symbol names (field definitions followed by a method in a new line with a semicolon)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  [x]; [y] = 42;
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-new-sc-line-method-static-literal-names.js
+++ b/test/language/statements/class/fields-new-sc-line-method-static-literal-names.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-new-sc-line-method.template
+/*---
+description: Static literal property names (field definitions followed by a method in a new line with a semicolon)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static a; b = 42;
+  static c = fn;
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-new-sc-line-method-string-literal-names.js
+++ b/test/language/statements/class/fields-new-sc-line-method-string-literal-names.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-new-sc-line-method.template
+/*---
+description: String literal names (field definitions followed by a method in a new line with a semicolon)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  'a'; "b"; 'c' = 39;
+  "d" = 42;
+  m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-regular-definitions-computed-names.js
+++ b/test/language/statements/class/fields-regular-definitions-computed-names.js
@@ -1,0 +1,73 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-regular-definitions.template
+/*---
+description: Computed property names (regular fields defintion)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"]
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-regular-definitions-computed-symbol-names.js
+++ b/test/language/statements/class/fields-regular-definitions-computed-symbol-names.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-regular-definitions.template
+/*---
+description: Computed property symbol names (regular fields defintion)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  [x]; [y] = 42
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-regular-definitions-literal-names.js
+++ b/test/language/statements/class/fields-regular-definitions-literal-names.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-regular-definitions.template
+/*---
+description: Literal property names (regular fields defintion)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  a; b = 42;
+  c = fn
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-regular-definitions-static-computed-names.js
+++ b/test/language/statements/class/fields-regular-definitions-static-computed-names.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-regular-definitions.template
+/*---
+description: Static Computed property names (regular fields defintion)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static ["a"] = 42; ["a"] = 39
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-regular-definitions-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-regular-definitions-static-computed-symbol-names.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-regular-definitions.template
+/*---
+description: Static computed property symbol names (regular fields defintion)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  [x]; [y] = 42
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-regular-definitions-static-literal-names.js
+++ b/test/language/statements/class/fields-regular-definitions-static-literal-names.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-regular-definitions.template
+/*---
+description: Static literal property names (regular fields defintion)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static a; b = 42;
+  static c = fn
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-regular-definitions-string-literal-names.js
+++ b/test/language/statements/class/fields-regular-definitions-string-literal-names.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-regular-definitions.template
+/*---
+description: String literal names (regular fields defintion)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  'a'; "b"; 'c' = 39;
+  "d" = 42
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-same-line-async-gen-computed-names.js
+++ b/test/language/statements/class/fields-same-line-async-gen-computed-names.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-async-gen.template
+/*---
+description: Computed property names (field definitions after an async generator in the same line)
+features: [computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  async *m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-gen-computed-symbol-names.js
+++ b/test/language/statements/class/fields-same-line-async-gen-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-async-gen.template
+/*---
+description: Computed property symbol names (field definitions after an async generator in the same line)
+features: [Symbol, computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  async *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-gen-literal-names.js
+++ b/test/language/statements/class/fields-same-line-async-gen-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-async-gen.template
+/*---
+description: Literal property names (field definitions after an async generator in the same line)
+features: [class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  async *m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-gen-static-computed-names.js
+++ b/test/language/statements/class/fields-same-line-async-gen-static-computed-names.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-async-gen.template
+/*---
+description: Static Computed property names (field definitions after an async generator in the same line)
+features: [computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  async *m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-gen-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-same-line-async-gen-static-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-async-gen.template
+/*---
+description: Static computed property symbol names (field definitions after an async generator in the same line)
+features: [Symbol, computed-property-names, class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  async *m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-gen-static-literal-names.js
+++ b/test/language/statements/class/fields-same-line-async-gen-static-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-async-gen.template
+/*---
+description: Static literal property names (field definitions after an async generator in the same line)
+features: [class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  async *m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-gen-string-literal-names.js
+++ b/test/language/statements/class/fields-same-line-async-gen-string-literal-names.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-async-gen.template
+/*---
+description: String literal names (field definitions after an async generator in the same line)
+features: [class-fields, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  async *m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-method-computed-names.js
+++ b/test/language/statements/class/fields-same-line-async-method-computed-names.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-async-method.template
+/*---
+description: Computed property names (field definitions after an async method in the same line)
+features: [computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  async m() { return 42; } static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-method-computed-symbol-names.js
+++ b/test/language/statements/class/fields-same-line-async-method-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-async-method.template
+/*---
+description: Computed property symbol names (field definitions after an async method in the same line)
+features: [Symbol, computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  async m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-method-literal-names.js
+++ b/test/language/statements/class/fields-same-line-async-method-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-async-method.template
+/*---
+description: Literal property names (field definitions after an async method in the same line)
+features: [class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  async m() { return 42; } a; b = 42;
+  c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-method-static-computed-names.js
+++ b/test/language/statements/class/fields-same-line-async-method-static-computed-names.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-after-same-line-async-method.template
+/*---
+description: Static Computed property names (field definitions after an async method in the same line)
+features: [computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  async m() { return 42; } static ["a"] = 42; ["a"] = 39;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-method-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-same-line-async-method-static-computed-symbol-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-after-same-line-async-method.template
+/*---
+description: Static computed property symbol names (field definitions after an async method in the same line)
+features: [Symbol, computed-property-names, class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  async m() { return 42; } [x]; [y] = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-method-static-literal-names.js
+++ b/test/language/statements/class/fields-same-line-async-method-static-literal-names.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-async-method.template
+/*---
+description: Static literal property names (field definitions after an async method in the same line)
+features: [class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  async m() { return 42; } static a; b = 42;
+  static c = fn;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-method-string-literal-names.js
+++ b/test/language/statements/class/fields-same-line-async-method-string-literal-names.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-after-same-line-async-method.template
+/*---
+description: String literal names (field definitions after an async method in the same line)
+features: [class-fields, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  async m() { return 42; } 'a'; "b"; 'c' = 39;
+  "d" = 42;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-gen-computed-names.js
+++ b/test/language/statements/class/fields-same-line-gen-computed-names.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-same-line-generator.template
+/*---
+description: Computed property names (field definitions followed by a generator method in the same line)
+features: [computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"]; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-same-line-gen-computed-symbol-names.js
+++ b/test/language/statements/class/fields-same-line-gen-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-same-line-generator.template
+/*---
+description: Computed property symbol names (field definitions followed by a generator method in the same line)
+features: [Symbol, computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  [x]; [y] = 42; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-same-line-gen-literal-names.js
+++ b/test/language/statements/class/fields-same-line-gen-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-same-line-generator.template
+/*---
+description: Literal property names (field definitions followed by a generator method in the same line)
+features: [class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  a; b = 42;
+  c = fn; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-same-line-gen-static-computed-names.js
+++ b/test/language/statements/class/fields-same-line-gen-static-computed-names.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-same-line-generator.template
+/*---
+description: Static Computed property names (field definitions followed by a generator method in the same line)
+features: [computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static ["a"] = 42; ["a"] = 39; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-same-line-gen-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-same-line-gen-static-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-same-line-generator.template
+/*---
+description: Static computed property symbol names (field definitions followed by a generator method in the same line)
+features: [Symbol, computed-property-names, class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  [x]; [y] = 42; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-same-line-gen-static-literal-names.js
+++ b/test/language/statements/class/fields-same-line-gen-static-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-same-line-generator.template
+/*---
+description: Static literal property names (field definitions followed by a generator method in the same line)
+features: [class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static a; b = 42;
+  static c = fn; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-same-line-gen-string-literal-names.js
+++ b/test/language/statements/class/fields-same-line-gen-string-literal-names.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-same-line-generator.template
+/*---
+description: String literal names (field definitions followed by a generator method in the same line)
+features: [class-fields, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  'a'; "b"; 'c' = 39;
+  "d" = 42; *m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-same-line-method-computed-names.js
+++ b/test/language/statements/class/fields-same-line-method-computed-names.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-same-line-method.template
+/*---
+description: Computed property names (field definitions followed by a method in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"]; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-same-line-method-computed-symbol-names.js
+++ b/test/language/statements/class/fields-same-line-method-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-same-line-method.template
+/*---
+description: Computed property symbol names (field definitions followed by a method in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  [x]; [y] = 42; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-same-line-method-literal-names.js
+++ b/test/language/statements/class/fields-same-line-method-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-same-line-method.template
+/*---
+description: Literal property names (field definitions followed by a method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  a; b = 42;
+  c = fn; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-same-line-method-static-computed-names.js
+++ b/test/language/statements/class/fields-same-line-method-static-computed-names.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-same-line-method.template
+/*---
+description: Static Computed property names (field definitions followed by a method in the same line)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  static ["a"] = 42; ["a"] = 39; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-same-line-method-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-same-line-method-static-computed-symbol-names.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-same-line-method.template
+/*---
+description: Static computed property symbol names (field definitions followed by a method in the same line)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  [x]; [y] = 42; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-same-line-method-static-literal-names.js
+++ b/test/language/statements/class/fields-same-line-method-static-literal-names.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-same-line-method.template
+/*---
+description: Static literal property names (field definitions followed by a method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  static a; b = 42;
+  static c = fn; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-same-line-method-string-literal-names.js
+++ b/test/language/statements/class/fields-same-line-method-string-literal-names.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-same-line-method.template
+/*---
+description: String literal names (field definitions followed by a method in the same line)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  'a'; "b"; 'c' = 39;
+  "d" = 42; m() { return 42; }
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-wrapped-in-sc-computed-names.js
+++ b/test/language/statements/class/fields-wrapped-in-sc-computed-names.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-names.case
+// - src/class-fields/default/cls-decl-wrapped-in-sc.template
+/*---
+description: Computed property names (fields definition wrapped in semicolons)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = "b";
+
+
+
+class C {
+  ;;;;
+  ;;;;;;static ["a"] = 39; [x] = 42; [10] = "meep"; ["not initialized"];;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "10"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "10"), false);
+
+verifyProperty(c, "10", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "not initialized"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "not initialized"), false);
+
+verifyProperty(c, "not initialized", {
+  value: "meep",
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-wrapped-in-sc-computed-symbol-names.js
+++ b/test/language/statements/class/fields-wrapped-in-sc-computed-symbol-names.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/computed-symbol-names.case
+// - src/class-fields/default/cls-decl-wrapped-in-sc.template
+/*---
+description: Computed property symbol names (fields definition wrapped in semicolons)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  ;;;;
+  ;;;;;;[x]; [y] = 42;;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-wrapped-in-sc-literal-names.js
+++ b/test/language/statements/class/fields-wrapped-in-sc-literal-names.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/literal-names.case
+// - src/class-fields/default/cls-decl-wrapped-in-sc.template
+/*---
+description: Literal property names (fields definition wrapped in semicolons)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  ;;;;
+  ;;;;;;a; b = 42;
+  c = fn;;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "c"), false);
+
+verifyProperty(c, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-wrapped-in-sc-static-computed-names.js
+++ b/test/language/statements/class/fields-wrapped-in-sc-static-computed-names.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-names.case
+// - src/class-fields/default/cls-decl-wrapped-in-sc.template
+/*---
+description: Static Computed property names (fields definition wrapped in semicolons)
+features: [computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+      static FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  ;;;;
+  ;;;;;;static ["a"] = 42; ["a"] = 39;;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+
+verifyProperty(C, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "a", {
+  value: 39,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});

--- a/test/language/statements/class/fields-wrapped-in-sc-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-wrapped-in-sc-static-computed-symbol-names.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-computed-symbol-names.case
+// - src/class-fields/default/cls-decl-wrapped-in-sc.template
+/*---
+description: Static computed property symbol names (fields definition wrapped in semicolons)
+features: [Symbol, computed-property-names, class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+var x = Symbol();
+var y = Symbol();
+
+
+
+class C {
+  ;;;;
+  ;;;;;;[x]; [y] = 42;;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, x), false);
+assert.sameValue(Object.hasOwnProperty.call(C, x), false);
+
+verifyProperty(c, x, {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, y), false);
+assert.sameValue(Object.hasOwnProperty.call(C, y), false);
+
+verifyProperty(c, y, {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "x"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "x"), false);
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "y"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "y"), false);

--- a/test/language/statements/class/fields-wrapped-in-sc-static-literal-names.js
+++ b/test/language/statements/class/fields-wrapped-in-sc-static-literal-names.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/static-literal-names.case
+// - src/class-fields/default/cls-decl-wrapped-in-sc.template
+/*---
+description: Static literal property names (fields definition wrapped in semicolons)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+const fn = function() {}
+
+
+
+class C {
+  ;;;;
+  ;;;;;;static a; b = 42;
+  static c = fn;;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "a"), false);
+
+verifyProperty(C, "a", {
+  value: undefined,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "b"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "b"), false);
+
+verifyProperty(c, "b", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "c"), false);
+assert.sameValue(Object.hasOwnProperty.call(c, "c"), false);
+
+verifyProperty(C, "c", {
+  value: fn,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+

--- a/test/language/statements/class/fields-wrapped-in-sc-string-literal-names.js
+++ b/test/language/statements/class/fields-wrapped-in-sc-string-literal-names.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/class-fields/string-literal-names.case
+// - src/class-fields/default/cls-decl-wrapped-in-sc.template
+/*---
+description: String literal names (fields definition wrapped in semicolons)
+features: [class-fields]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassElement:
+      ...
+      FieldDefinition ;
+
+    FieldDefinition:
+      ClassElementName Initializer_opt
+
+    ClassElementName:
+      PropertyName
+
+---*/
+
+
+class C {
+  ;;;;
+  ;;;;;;'a'; "b"; 'c' = 39;
+  "d" = 42;;;;;;;
+  ;;;;
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "a"), false);
+assert.sameValue(Object.hasOwnProperty.call(C, "a"), false);
+
+verifyProperty(c, "a", {
+  value: 42,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});


### PR DESCRIPTION
I'm working on on the class fields tests. The syntax has changed in the proposal and I'm also fixing this.

I'm also planning to add tests for private names but probably in a follow up PR, although, the templates might be good for them as well.

In this new template/case strategy I'm trying to stick with _cases_ for the class fields themselves, as the templates provide structural variations to hold them properly.

This should replace #1151 