### PR TITLE
Add tests for invalid BigInt MVs

### DIFF
--- a/test/language/literals/bigint/mv-is-not-integer-dil-dot-dds.js
+++ b/test/language/literals/bigint/mv-is-not-integer-dil-dot-dds.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 The V8 Project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-numeric-literal-static-semantics-early-errors
+description: > 
+  It is a Syntax Error if the MV is not an integer. (decimalIntegerLiteral dot decimalDigits)
+info: |
+  Static Semantics: BigInt Value
+
+  NumericLiteral :: NumericLiteralBase NumericLiteralSuffix
+
+  1. Assert: NumericLiteralSuffix is n.
+  2. Let the value of NumericLiteral be the MV of NumericLiteralBase represented as BigInt.
+
+  DecimalLiteral ::
+    DecimalIntegerLiteral . DecimalDigits_opt
+    . DecimalDigits
+features: [BigInt]
+negative:
+  phase: early
+  type: SyntaxError
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+2017.8n;

--- a/test/language/literals/bigint/mv-is-not-integer-dot-dds.js
+++ b/test/language/literals/bigint/mv-is-not-integer-dot-dds.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 The V8 Project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-numeric-literal-static-semantics-early-errors
+description: > 
+  It is a Syntax Error if the MV is not an integer. (dot decimalDigits)
+info: |
+  Static Semantics: BigInt Value
+
+  NumericLiteral :: NumericLiteralBase NumericLiteralSuffix
+
+  1. Assert: NumericLiteralSuffix is n.
+  2. Let the value of NumericLiteral be the MV of NumericLiteralBase represented as BigInt.
+
+  DecimalLiteral ::
+    DecimalIntegerLiteral . DecimalDigits_opt
+    . DecimalDigits
+features: [BigInt]
+negative:
+  phase: early
+  type: SyntaxError
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+.0000000001n;


### PR DESCRIPTION
I also have tests on hold for valid literals but I want to wait until a final decision for https://github.com/tc39/proposal-bigint/issues/77 before releasing them.

cc @littledan (this is an easy one to review)