### PR TITLE
Fixes for async iteration tests

### DIFF
--- a/src/async-generators/yield-promise-reject-next-yield-star-async-iterator.case
+++ b/src/async-generators/yield-promise-reject-next-yield-star-async-iterator.case
@@ -28,4 +28,4 @@ iter.next().then(() => {
     assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
     assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
   }).then($DONE, $DONE);
-}).then($DONE, $DONE);
+}, $DONE).catch($DONE);

--- a/src/dstr-assignment-for-await/array-elem-iter-rtrn-close-null.case
+++ b/src/dstr-assignment-for-await/array-elem-iter-rtrn-close-null.case
@@ -4,6 +4,12 @@
 desc: >
     IteratorClose throws a TypeError when `return` returns a non-Object value
 info: |
+    AssignmentElement : DestructuringAssignmentTarget Initializer
+    1. If DestructuringAssignmentTarget is neither an ObjectLiteral nor an ArrayLiteral, then
+      a. Let lref be the result of evaluating DestructuringAssignmentTarget.
+      b. ReturnIfAbrupt(lref).
+    [...]
+
     ArrayAssignmentPattern : [ AssignmentElementList ]
 
     [...]
@@ -43,7 +49,12 @@ iterable
 //- body
 unreachable += 1;
 //- teardown
-iter.next().then(() => $DONE('Promise incorrectly fulfilled.'), ({ constructor }) => {
-  assert.sameValue(unreachable, 0);
-  assert.sameValue(constructor, TypeError);
-}).then($DONE, $DONE);
+iter.next().then(result => {
+  assert.sameValue(result.value, undefined);
+  assert.sameValue(result.done, false);
+
+  iter.return().then(() => $DONE('Promise incorrectly fulfilled.'), ({ constructor }) => {
+    assert.sameValue(unreachable, 0);
+    assert.sameValue(constructor, TypeError);
+  }).then($DONE, $DONE);
+}, $DONE).catch($DONE);

--- a/src/dstr-assignment-for-await/array-elem-put-const.case
+++ b/src/dstr-assignment-for-await/array-elem-put-const.case
@@ -15,3 +15,8 @@ const c = null;
 [ c ]
 //- vals
 [1]
+//- teardown
+promise.then(() => $DONE('Promise incorrectly fulfilled.'), ({ constructor }) => {
+  assert.sameValue(iterCount, 0);
+  assert.sameValue(constructor, TypeError);
+}).then($DONE, $DONE);

--- a/src/dstr-assignment-for-await/array-elem-trlg-iter-elision-iter-nrml-close-null.case
+++ b/src/dstr-assignment-for-await/array-elem-trlg-iter-elision-iter-nrml-close-null.case
@@ -57,3 +57,9 @@ TypeError
 [ x , , ]
 //- vals
 iterable
+//- teardown
+promise.then(() => $DONE('Promise incorrectly fulfilled.'), ({ constructor }) => {
+  assert.sameValue(iterCount, 0);
+  assert.sameValue(nextCount, 2);
+  assert.sameValue(constructor, TypeError);
+}).then($DONE, $DONE);

--- a/src/dstr-assignment-for-await/array-elem-trlg-iter-rest-nrml-close-skip.case
+++ b/src/dstr-assignment-for-await/array-elem-trlg-iter-rest-nrml-close-skip.case
@@ -52,4 +52,4 @@ iter.next().then(() => {
     assert.sameValue(x, 1, 'x');
     assert.sameValue(y.length, 0, 'y.length');
   }).then($DONE, $DONE);
-}).then($DONE, $DONE);
+}, $DONE).catch($DONE);

--- a/test/language/expressions/async-generator/named-yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/expressions/async-generator/named-yield-promise-reject-next-yield-star-async-iterator.js
@@ -42,6 +42,6 @@ iter.next().then(() => {
     assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
     assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
   }).then($DONE, $DONE);
-}).then($DONE, $DONE);
+}, $DONE).catch($DONE);
 
 assert.sameValue(callCount, 1);

--- a/test/language/expressions/async-generator/yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/expressions/async-generator/yield-promise-reject-next-yield-star-async-iterator.js
@@ -42,6 +42,6 @@ iter.next().then(() => {
     assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
     assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
   }).then($DONE, $DONE);
-}).then($DONE, $DONE);
+}, $DONE).catch($DONE);
 
 assert.sameValue(callCount, 1);

--- a/test/language/expressions/class/async-gen-method-static-yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/expressions/class/async-gen-method-static-yield-promise-reject-next-yield-star-async-iterator.js
@@ -49,6 +49,6 @@ iter.next().then(() => {
     assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
     assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
   }).then($DONE, $DONE);
-}).then($DONE, $DONE);
+}, $DONE).catch($DONE);
 
 assert.sameValue(callCount, 1);

--- a/test/language/expressions/class/async-gen-method-yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/expressions/class/async-gen-method-yield-promise-reject-next-yield-star-async-iterator.js
@@ -49,6 +49,6 @@ iter.next().then(() => {
     assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
     assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
   }).then($DONE, $DONE);
-}).then($DONE, $DONE);
+}, $DONE).catch($DONE);
 
 assert.sameValue(callCount, 1);

--- a/test/language/expressions/object/method-definition/async-gen-yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/expressions/object/method-definition/async-gen-yield-promise-reject-next-yield-star-async-iterator.js
@@ -42,6 +42,6 @@ iter.next().then(() => {
     assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
     assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
   }).then($DONE, $DONE);
-}).then($DONE, $DONE);
+}, $DONE).catch($DONE);
 
 assert.sameValue(callCount, 1);

--- a/test/language/statements/async-generator/yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/statements/async-generator/yield-promise-reject-next-yield-star-async-iterator.js
@@ -42,6 +42,6 @@ iter.next().then(() => {
     assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
     assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
   }).then($DONE, $DONE);
-}).then($DONE, $DONE);
+}, $DONE).catch($DONE);
 
 assert.sameValue(callCount, 1);

--- a/test/language/statements/class/async-gen-method-static-yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/statements/class/async-gen-method-static-yield-promise-reject-next-yield-star-async-iterator.js
@@ -49,6 +49,6 @@ iter.next().then(() => {
     assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
     assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
   }).then($DONE, $DONE);
-}).then($DONE, $DONE);
+}, $DONE).catch($DONE);
 
 assert.sameValue(callCount, 1);

--- a/test/language/statements/class/async-gen-method-yield-promise-reject-next-yield-star-async-iterator.js
+++ b/test/language/statements/class/async-gen-method-yield-promise-reject-next-yield-star-async-iterator.js
@@ -49,6 +49,6 @@ iter.next().then(() => {
     assert.sameValue(done, true, "The value of IteratorResult.done is `true`");
     assert.sameValue(value, undefined, "The value of IteratorResult.value is `undefined`");
   }).then($DONE, $DONE);
-}).then($DONE, $DONE);
+}, $DONE).catch($DONE);
 
 assert.sameValue(callCount, 1);

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-put-const.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-put-const.js
@@ -35,3 +35,8 @@ async function fn() {
 }
 
 let promise = fn();
+
+promise.then(() => $DONE('Promise incorrectly fulfilled.'), ({ constructor }) => {
+  assert.sameValue(iterCount, 0);
+  assert.sameValue(constructor, TypeError);
+}).then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-trlg-iter-elision-iter-nrml-close-null.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-trlg-iter-elision-iter-nrml-close-null.js
@@ -76,3 +76,9 @@ async function fn() {
 }
 
 let promise = fn();
+
+promise.then(() => $DONE('Promise incorrectly fulfilled.'), ({ constructor }) => {
+  assert.sameValue(iterCount, 0);
+  assert.sameValue(nextCount, 2);
+  assert.sameValue(constructor, TypeError);
+}).then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-decl-dstr-array-elem-iter-rtrn-close-null.js
+++ b/test/language/statements/for-await-of/async-gen-decl-dstr-array-elem-iter-rtrn-close-null.js
@@ -24,6 +24,12 @@ info: |
           lhs using AssignmentPattern as the goal symbol.
     [...]
 
+    AssignmentElement : DestructuringAssignmentTarget Initializer
+    1. If DestructuringAssignmentTarget is neither an ObjectLiteral nor an ArrayLiteral, then
+      a. Let lref be the result of evaluating DestructuringAssignmentTarget.
+      b. ReturnIfAbrupt(lref).
+    [...]
+
     ArrayAssignmentPattern : [ AssignmentElementList ]
 
     [...]
@@ -61,7 +67,12 @@ async function * fn() {
 
 let iter = fn();
 
-iter.next().then(() => $DONE('Promise incorrectly fulfilled.'), ({ constructor }) => {
-  assert.sameValue(unreachable, 0);
-  assert.sameValue(constructor, TypeError);
-}).then($DONE, $DONE);
+iter.next().then(result => {
+  assert.sameValue(result.value, undefined);
+  assert.sameValue(result.done, false);
+
+  iter.return().then(() => $DONE('Promise incorrectly fulfilled.'), ({ constructor }) => {
+    assert.sameValue(unreachable, 0);
+    assert.sameValue(constructor, TypeError);
+  }).then($DONE, $DONE);
+}, $DONE).catch($DONE);

--- a/test/language/statements/for-await-of/async-gen-decl-dstr-array-elem-put-const.js
+++ b/test/language/statements/for-await-of/async-gen-decl-dstr-array-elem-put-const.js
@@ -35,3 +35,8 @@ async function * fn() {
 }
 
 let promise = fn().next();
+
+promise.then(() => $DONE('Promise incorrectly fulfilled.'), ({ constructor }) => {
+  assert.sameValue(iterCount, 0);
+  assert.sameValue(constructor, TypeError);
+}).then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-decl-dstr-array-elem-trlg-iter-elision-iter-nrml-close-null.js
+++ b/test/language/statements/for-await-of/async-gen-decl-dstr-array-elem-trlg-iter-elision-iter-nrml-close-null.js
@@ -76,3 +76,9 @@ async function * fn() {
 }
 
 let promise = fn().next();
+
+promise.then(() => $DONE('Promise incorrectly fulfilled.'), ({ constructor }) => {
+  assert.sameValue(iterCount, 0);
+  assert.sameValue(nextCount, 2);
+  assert.sameValue(constructor, TypeError);
+}).then($DONE, $DONE);

--- a/test/language/statements/for-await-of/async-gen-decl-dstr-array-elem-trlg-iter-rest-nrml-close-skip.js
+++ b/test/language/statements/for-await-of/async-gen-decl-dstr-array-elem-trlg-iter-rest-nrml-close-skip.js
@@ -71,4 +71,4 @@ iter.next().then(() => {
     assert.sameValue(x, 1, 'x');
     assert.sameValue(y.length, 0, 'y.length');
   }).then($DONE, $DONE);
-}).then($DONE, $DONE);
+}, $DONE).catch($DONE);


### PR DESCRIPTION
Note: The dstr-assignment-for-await/array-elem-iter-rtrn-close-null.case tests may not succeed in all engines, because some engines call IteratorNext before resolving the destructuring assignment target.