### PR TITLE
Make 'wait' tests resilient on slow test systems

### DIFF
--- a/test/built-ins/Atomics/wait/did-timeout.js
+++ b/test/built-ins/Atomics/wait/did-timeout.js
@@ -24,7 +24,7 @@ var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 
 $262.agent.broadcast(ia.buffer);
 assert.sameValue(getReport(), "timed-out");
-assert.sameValue(Math.abs((getReport()|0) >= 500 - $ATOMICS_MAX_TIME_EPSILON, true);
+assert.sameValue((getReport()|0) >= 500 - $ATOMICS_MAX_TIME_EPSILON, true);
 
 function getReport() {
     var r;

--- a/test/built-ins/Atomics/wait/did-timeout.js
+++ b/test/built-ins/Atomics/wait/did-timeout.js
@@ -15,7 +15,7 @@ $262.agent.receiveBroadcast(function (sab, id) {
   var ia = new Int32Array(sab);
   var then = Date.now();
   $262.agent.report(Atomics.wait(ia, 0, 0, 500)); // Timeout 500ms
-  $262.agent.report(Date.now() - then);
+  $262.agent.report(Date.now() - then);           // Actual time can be more than 500ms
   $262.agent.leaving();
 })
 `);
@@ -24,11 +24,11 @@ var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 
 $262.agent.broadcast(ia.buffer);
 assert.sameValue(getReport(), "timed-out");
-assert.sameValue(Math.abs((getReport()|0) - 500) < $ATOMICS_MAX_TIME_EPSILON, true);
+assert.sameValue(Math.abs((getReport()|0) >= 500 - $ATOMICS_MAX_TIME_EPSILON, true);
 
 function getReport() {
     var r;
     while ((r = $262.agent.getReport()) == null)
-	$262.agent.sleep(100);
+        $262.agent.sleep(100);
     return r;
 }

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup.js
@@ -15,7 +15,7 @@ $262.agent.receiveBroadcast(function (sab, id) {
   var ia = new Int32Array(sab);
   var then = Date.now();
   Atomics.wait(ia, 0, 0);
-  var diff = Date.now() - then;        // Should be about 1000 ms
+  var diff = Date.now() - then;        // Should be about 1000 ms but can be more
   $262.agent.report(diff);
   $262.agent.leaving();
 })
@@ -25,10 +25,10 @@ var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 
 $262.agent.broadcast(ia.buffer);
 $262.agent.sleep(500);                // Give the agent a chance to wait
-Atomics.store(ia, 0, 1);        // Change the value, should not wake the agent
+Atomics.store(ia, 0, 1);              // Change the value, should not wake the agent
 $262.agent.sleep(500);                // Wait some more so that we can tell
-Atomics.wake(ia, 0);                // Really wake it up
-assert.sameValue(Math.abs((getReport()|0) - 1000) < $ATOMICS_MAX_TIME_EPSILON, true);
+Atomics.wake(ia, 0);                  // Really wake it up
+assert.sameValue((getReport()|0) >= 1000 - $ATOMICS_MAX_TIME_EPSILON, true);
 
 function getReport() {
     var r;


### PR DESCRIPTION
We have a couple of tests that check that when we wait in Atomics.wait and the wait is either broken by a wakeup or by a timeout, then the time waited is within a fairly small window of the waiting/timeout time.  On slow or overloaded tests systems these tests will fail spuriously because the actual time waited is greater.

These changes therefore make sure that the time waited is at least the expected time (minus epsilon), but there is no longer an upper bound.