### PR TITLE
Remove arrow function syntax from harness/assert.js

### DIFF
--- a/harness/assert.js
+++ b/harness/assert.js
@@ -91,5 +91,5 @@ assert.throws.early = function(err, code) {
   let wrappedCode = `function wrapperFn() { ${code} }`;
   let ieval = eval;
 
-  assert.throws(err, () => { Function(wrappedCode); }, `Function: ${code}`);
+  assert.throws(err, function() { Function(wrappedCode); }, `Function: ${code}`);
 };


### PR DESCRIPTION
After conversations in #1215, we need to catch up with the code that was previously
produced before we set the features flags requirements.