### PR TITLE
Add cross-realm feature

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -69,6 +69,7 @@ caller
 class
 computed-property-names
 const
+cross-realm
 DataView
 DataView.prototype.getFloat32
 DataView.prototype.getFloat64

--- a/test/built-ins/Array/from/proto-from-ctor-realm.js
+++ b/test/built-ins/Array/from/proto-from-ctor-realm.js
@@ -19,6 +19,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
+features: [cross-realm]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Array/length/define-own-prop-length-overflow-realm.js
+++ b/test/built-ins/Array/length/define-own-prop-length-overflow-realm.js
@@ -10,6 +10,7 @@ info: |
   [...]
   2. If P is "length", then
      a. Return ? ArraySetLength(A, Desc).
+features: [cross-realm]
 ---*/
 
 var OArray = $262.createRealm().global.Array;

--- a/test/built-ins/Array/of/proto-from-ctor-realm.js
+++ b/test/built-ins/Array/of/proto-from-ctor-realm.js
@@ -18,6 +18,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
+features: [cross-realm]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Array/proto-from-ctor-realm.js
+++ b/test/built-ins/Array/proto-from-ctor-realm.js
@@ -18,7 +18,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Array/prototype/concat/create-proto-from-ctor-realm-array.js
+++ b/test/built-ins/Array/prototype/concat/create-proto-from-ctor-realm-array.js
@@ -20,7 +20,7 @@ info: |
           i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
              be undefined.
     [...]
-features: [Symbol.species]
+features: [cross-realm, Symbol.species]
 ---*/
 
 var array = [];

--- a/test/built-ins/Array/prototype/concat/create-proto-from-ctor-realm-non-array.js
+++ b/test/built-ins/Array/prototype/concat/create-proto-from-ctor-realm-non-array.js
@@ -20,7 +20,7 @@ info: |
           i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
              be undefined.
     [...]
-features: [Symbol.species]
+features: [cross-realm, Symbol.species]
 ---*/
 
 var array = [];

--- a/test/built-ins/Array/prototype/filter/create-proto-from-ctor-realm-array.js
+++ b/test/built-ins/Array/prototype/filter/create-proto-from-ctor-realm-array.js
@@ -21,7 +21,7 @@ info: |
           i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
              be undefined.
     [...]
-features: [Symbol.species]
+features: [cross-realm, Symbol.species]
 ---*/
 
 var array = [];

--- a/test/built-ins/Array/prototype/filter/create-proto-from-ctor-realm-non-array.js
+++ b/test/built-ins/Array/prototype/filter/create-proto-from-ctor-realm-non-array.js
@@ -21,7 +21,7 @@ info: |
           i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
              be undefined.
     [...]
-features: [Symbol.species]
+features: [cross-realm, Symbol.species]
 ---*/
 
 var array = [];

--- a/test/built-ins/Array/prototype/map/create-proto-from-ctor-realm-array.js
+++ b/test/built-ins/Array/prototype/map/create-proto-from-ctor-realm-array.js
@@ -21,7 +21,7 @@ info: |
           i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
              be undefined.
     [...]
-features: [Symbol.species]
+features: [cross-realm, Symbol.species]
 ---*/
 
 var array = [];

--- a/test/built-ins/Array/prototype/map/create-proto-from-ctor-realm-non-array.js
+++ b/test/built-ins/Array/prototype/map/create-proto-from-ctor-realm-non-array.js
@@ -21,7 +21,7 @@ info: |
           i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
              be undefined.
     [...]
-features: [Symbol.species]
+features: [cross-realm, Symbol.species]
 ---*/
 
 var array = [];

--- a/test/built-ins/Array/prototype/slice/create-proto-from-ctor-realm-array.js
+++ b/test/built-ins/Array/prototype/slice/create-proto-from-ctor-realm-array.js
@@ -21,7 +21,7 @@ info: |
           i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
              be undefined.
     [...]
-features: [Symbol.species]
+features: [cross-realm, Symbol.species]
 ---*/
 
 var array = [];

--- a/test/built-ins/Array/prototype/slice/create-proto-from-ctor-realm-non-array.js
+++ b/test/built-ins/Array/prototype/slice/create-proto-from-ctor-realm-non-array.js
@@ -21,7 +21,7 @@ info: |
           i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
              be undefined.
     [...]
-features: [Symbol.species]
+features: [cross-realm, Symbol.species]
 ---*/
 
 var array = [];

--- a/test/built-ins/Array/prototype/splice/create-proto-from-ctor-realm-array.js
+++ b/test/built-ins/Array/prototype/splice/create-proto-from-ctor-realm-array.js
@@ -21,7 +21,7 @@ info: |
           i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
              be undefined.
     [...]
-features: [Symbol.species]
+features: [cross-realm, Symbol.species]
 ---*/
 
 var array = [];

--- a/test/built-ins/Array/prototype/splice/create-proto-from-ctor-realm-non-array.js
+++ b/test/built-ins/Array/prototype/splice/create-proto-from-ctor-realm-non-array.js
@@ -21,7 +21,7 @@ info: |
           i. If SameValue(C, realmC.[[Intrinsics]].[[%Array%]]) is true, let C
              be undefined.
     [...]
-features: [Symbol.species]
+features: [cross-realm, Symbol.species]
 ---*/
 
 var array = [];

--- a/test/built-ins/ArrayBuffer/proto-from-ctor-realm.js
+++ b/test/built-ins/ArrayBuffer/proto-from-ctor-realm.js
@@ -16,7 +16,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Boolean/proto-from-ctor-realm.js
+++ b/test/built-ins/Boolean/proto-from-ctor-realm.js
@@ -18,7 +18,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/DataView/proto-from-ctor-realm-sab.js
+++ b/test/built-ins/DataView/proto-from-ctor-realm-sab.js
@@ -20,7 +20,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect, SharedArrayBuffer]
+features: [cross-realm, Reflect, SharedArrayBuffer]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/DataView/proto-from-ctor-realm.js
+++ b/test/built-ins/DataView/proto-from-ctor-realm.js
@@ -19,7 +19,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Date/proto-from-ctor-realm-one.js
+++ b/test/built-ins/Date/proto-from-ctor-realm-one.js
@@ -20,7 +20,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Date/proto-from-ctor-realm-two.js
+++ b/test/built-ins/Date/proto-from-ctor-realm-two.js
@@ -20,7 +20,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Date/proto-from-ctor-realm-zero.js
+++ b/test/built-ins/Date/proto-from-ctor-realm-zero.js
@@ -19,7 +19,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Error/proto-from-ctor-realm.js
+++ b/test/built-ins/Error/proto-from-ctor-realm.js
@@ -18,7 +18,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Function/call-bind-this-realm-undef.js
+++ b/test/built-ins/Function/call-bind-this-realm-undef.js
@@ -19,6 +19,7 @@ info: >
         ii. Let globalEnvRec be globalEnv's EnvironmentRecord.
         iii. Let thisValue be globalEnvRec.[[GlobalThisValue]].
   [...]
+features: [cross-realm]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Function/call-bind-this-realm-value.js
+++ b/test/built-ins/Function/call-bind-this-realm-value.js
@@ -20,6 +20,7 @@ info: >
         i. Let thisValue be ! ToObject(thisArgument).
         ii. NOTE ToObject produces wrapper objects using calleeRealm.
   [...]
+features: [cross-realm]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Function/internals/Call/class-ctor-realm.js
+++ b/test/built-ins/Function/internals/Call/class-ctor-realm.js
@@ -10,7 +10,7 @@ info: |
   [...]
   2. If F's [[FunctionKind]] internal slot is "classConstructor", throw a
      TypeError exception.
-features: [class]
+features: [cross-realm, class]
 ---*/
 
 var C = $262.createRealm().global.eval('0, class {}');

--- a/test/built-ins/Function/internals/Construct/base-ctor-revoked-proxy-realm.js
+++ b/test/built-ins/Function/internals/Construct/base-ctor-revoked-proxy-realm.js
@@ -37,7 +37,7 @@ info: |
   4. If obj is a Proxy exotic object, then
      a. If the value of the [[ProxyHandler]] internal slot of obj is null,
         throw a TypeError exception.
-features: [Proxy]
+features: [cross-realm, Proxy]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Function/internals/Construct/derived-return-val-realm.js
+++ b/test/built-ins/Function/internals/Construct/derived-return-val-realm.js
@@ -14,7 +14,7 @@ info: |
       b. If kind is "base", return NormalCompletion(thisArgument).
       c. If result.[[Value]] is not undefined, throw a TypeError exception.
   [...]
-features: [class]
+features: [cross-realm, class]
 ---*/
 
 var C = $262.createRealm().global.eval(

--- a/test/built-ins/Function/internals/Construct/derived-this-uninitialized-realm.js
+++ b/test/built-ins/Function/internals/Construct/derived-this-uninitialized-realm.js
@@ -15,7 +15,7 @@ info: |
   [...]
   3. If envRec.[[ThisBindingStatus]] is "uninitialized", throw a ReferenceError
      exception.
-features: [class]
+features: [cross-realm, class]
 ---*/
 
 var C = $262.createRealm().global.eval(

--- a/test/built-ins/Function/proto-from-ctor-realm.js
+++ b/test/built-ins/Function/proto-from-ctor-realm.js
@@ -26,7 +26,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Function/prototype/bind/get-fn-realm.js
+++ b/test/built-ins/Function/prototype/bind/get-fn-realm.js
@@ -13,6 +13,7 @@ info: |
     3. If obj is a Bound Function exotic object, then
        a. Let target be obj's [[BoundTargetFunction]] internal slot.
        b. Return ? GetFunctionRealm(target).
+features: [cross-realm]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Function/prototype/bind/proto-from-ctor-realm.js
+++ b/test/built-ins/Function/prototype/bind/proto-from-ctor-realm.js
@@ -16,7 +16,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/GeneratorFunction/proto-from-ctor-realm.js
+++ b/test/built-ins/GeneratorFunction/proto-from-ctor-realm.js
@@ -26,7 +26,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var GeneratorFunction = Object.getPrototypeOf(function* () {}).constructor;

--- a/test/built-ins/Map/proto-from-ctor-realm.js
+++ b/test/built-ins/Map/proto-from-ctor-realm.js
@@ -18,7 +18,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Number/proto-from-ctor-realm.js
+++ b/test/built-ins/Number/proto-from-ctor-realm.js
@@ -18,7 +18,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Object/proto-from-ctor.js
+++ b/test/built-ins/Object/proto-from-ctor.js
@@ -16,7 +16,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Promise/proto-from-ctor-realm.js
+++ b/test/built-ins/Promise/proto-from-ctor-realm.js
@@ -20,7 +20,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Proxy/apply/arguments-realm.js
+++ b/test/built-ins/Proxy/apply/arguments-realm.js
@@ -9,6 +9,7 @@ info: |
   [...]
   7. Let argArray be CreateArrayFromList(argumentsList).
   8. Return ? Call(trap, handler, « target, thisArgument, argArray »).
+features: [cross-realm]
 ---*/
 
 var f = $262.createRealm().global.eval(

--- a/test/built-ins/Proxy/apply/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/apply/trap-is-not-callable-realm.js
@@ -6,6 +6,7 @@ es6id: 9.5.13
 description: >
   Throws if trap is not callable (honoring the Realm of the current execution
   context)
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/construct/arguments-realm.js
+++ b/test/built-ins/Proxy/construct/arguments-realm.js
@@ -10,6 +10,7 @@ info: |
   7. Let argArray be CreateArrayFromList(argumentsList).
   8. Let newObj be ? Call(trap, handler, « target, argArray, newTarget »).
   [...]
+features: [cross-realm]
 ---*/
 
 var C = $262.createRealm().global.eval(

--- a/test/built-ins/Proxy/construct/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/construct/trap-is-not-callable-realm.js
@@ -6,6 +6,7 @@ es6id: 9.5.14
 description: >
   Throws if trap is not callable (honoring the Realm of the current execution
   context)
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/construct/trap-is-undefined-proto-from-ctor-realm.js
+++ b/test/built-ins/Proxy/construct/trap-is-undefined-proto-from-ctor-realm.js
@@ -20,7 +20,7 @@ info: >
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect.construct]
+features: [cross-realm, Reflect.construct]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Proxy/defineProperty/desc-realm.js
+++ b/test/built-ins/Proxy/defineProperty/desc-realm.js
@@ -21,6 +21,7 @@ info: |
   2. Let obj be ObjectCreate(%ObjectPrototype%).
   ...
   11. Return obj.
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/defineProperty/null-handler-realm.js
+++ b/test/built-ins/Proxy/defineProperty/null-handler-realm.js
@@ -10,6 +10,7 @@ info: |
   1. Assert: IsPropertyKey(P) is true.
   2. Let handler be O.[[ProxyHandler]].
   3. If handler is null, throw a TypeError exception.
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/defineProperty/targetdesc-configurable-desc-not-configurable-realm.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-configurable-desc-not-configurable-realm.js
@@ -15,6 +15,7 @@ info: |
         b. If settingConfigFalse is true and targetDesc.[[Configurable]] is
         true, throw a TypeError exception.
     ...
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor-not-configurable-target-realm.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor-not-configurable-target-realm.js
@@ -14,6 +14,7 @@ info: |
         a. If IsCompatiblePropertyDescriptor(extensibleTarget, Desc ,
         targetDesc) is false, throw a TypeError exception.
     ...
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor-realm.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor-realm.js
@@ -15,6 +15,7 @@ info: |
         a. If IsCompatiblePropertyDescriptor(extensibleTarget, Desc ,
         targetDesc) is false, throw a TypeError exception.
     ...
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/defineProperty/targetdesc-undefined-not-configurable-descriptor-realm.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-undefined-not-configurable-descriptor-realm.js
@@ -15,6 +15,7 @@ info: |
         ...
         b. If settingConfigFalse is true, throw a TypeError exception.
     ...
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/defineProperty/targetdesc-undefined-target-is-not-extensible-realm.js
+++ b/test/built-ins/Proxy/defineProperty/targetdesc-undefined-target-is-not-extensible-realm.js
@@ -14,6 +14,7 @@ info: |
     19. If targetDesc is undefined, then
         a. If extensibleTarget is false, throw a TypeError exception.
     ...
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/defineProperty/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/defineProperty/trap-is-not-callable-realm.js
@@ -17,6 +17,7 @@ info: |
         2. Let func be GetV(O, P).
         5. If IsCallable(func) is false, throw a TypeError exception.
         ...
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/deleteProperty/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/deleteProperty/trap-is-not-callable-realm.js
@@ -15,6 +15,7 @@ info: |
     7.3.9 GetMethod (O, P)
 
     5. If IsCallable(func) is false, throw a TypeError exception.
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/get-fn-realm.js
+++ b/test/built-ins/Proxy/get-fn-realm.js
@@ -16,6 +16,7 @@ info: |
           throw a TypeError exception.
        b. Let proxyTarget be the value of obj's [[ProxyTarget]] internal slot.
        c. Return ? GetFunctionRealm(proxyTarget).
+features: [cross-realm]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Proxy/get/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/get/trap-is-not-callable-realm.js
@@ -15,6 +15,7 @@ info: |
     7.3.9 GetMethod (O, P)
 
     5. If IsCallable(func) is false, throw a TypeError exception.
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/result-type-is-not-object-nor-undefined-realm.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/result-type-is-not-object-nor-undefined-realm.js
@@ -10,6 +10,7 @@ info: |
   [...]
   9. If Type(trapResultObj) is neither Object nor Undefined, throw a TypeError
      exception.
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/trap-is-not-callable-realm.js
@@ -20,6 +20,7 @@ info: |
         2. Let func be GetV(O, P).
         5. If IsCallable(func) is false, throw a TypeError exception.
         ...
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/getPrototypeOf/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/getPrototypeOf/trap-is-not-callable-realm.js
@@ -6,6 +6,7 @@ es6id: 9.5.1
 description: >
   Throws if trap is not callable (honoring the Realm of the current execution
   context)
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/has/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/has/trap-is-not-callable-realm.js
@@ -17,6 +17,7 @@ info: |
         2. Let func be GetV(O, P).
         5. If IsCallable(func) is false, throw a TypeError exception.
         ...
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/isExtensible/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/isExtensible/trap-is-not-callable-realm.js
@@ -19,6 +19,7 @@ info: |
         2. Let func be GetV(O, P).
         5. If IsCallable(func) is false, throw a TypeError exception.
         ...
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/ownKeys/return-not-list-object-throws-realm.js
+++ b/test/built-ins/Proxy/ownKeys/return-not-list-object-throws-realm.js
@@ -17,7 +17,7 @@ info: |
 
     2. If Type(obj) is not Object, throw a TypeError exception.
 
-features: [Symbol]
+features: [cross-realm, Symbol]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Proxy/ownKeys/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/ownKeys/trap-is-not-callable-realm.js
@@ -15,6 +15,7 @@ info: |
     7.3.9 GetMethod (O, P)
 
     4. If IsCallable(func) is false, throw a TypeError exception.
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/preventExtensions/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/preventExtensions/trap-is-not-callable-realm.js
@@ -19,6 +19,7 @@ info: |
         2. Let func be GetV(O, P).
         5. If IsCallable(func) is false, throw a TypeError exception.
         ...
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/set/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/set/trap-is-not-callable-realm.js
@@ -15,6 +15,7 @@ info: |
     7.3.9 GetMethod (O, P)
 
     5. If IsCallable(func) is false, throw a TypeError exception.
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/Proxy/setPrototypeOf/trap-is-not-callable-realm.js
+++ b/test/built-ins/Proxy/setPrototypeOf/trap-is-not-callable-realm.js
@@ -20,6 +20,7 @@ info: |
         2. Let func be GetV(O, P).
         5. If IsCallable(func) is false, throw a TypeError exception.
         ...
+features: [cross-realm]
 ---*/
 
 var OProxy = $262.createRealm().global.Proxy;

--- a/test/built-ins/RegExp/proto-from-ctor-realm.js
+++ b/test/built-ins/RegExp/proto-from-ctor-realm.js
@@ -19,7 +19,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/RegExp/prototype/Symbol.split/splitter-proto-from-ctor-realm.js
+++ b/test/built-ins/RegExp/prototype/Symbol.split/splitter-proto-from-ctor-realm.js
@@ -15,7 +15,7 @@ info: >
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Symbol.species, Symbol.split]
+features: [cross-realm, Symbol.species, Symbol.split]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Set/proto-from-ctor-realm.js
+++ b/test/built-ins/Set/proto-from-ctor-realm.js
@@ -18,7 +18,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/SharedArrayBuffer/proto-from-ctor-realm.js
+++ b/test/built-ins/SharedArrayBuffer/proto-from-ctor-realm.js
@@ -17,7 +17,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/String/proto-from-ctor-realm.js
+++ b/test/built-ins/String/proto-from-ctor-realm.js
@@ -17,7 +17,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/Symbol/for/cross-realm.js
+++ b/test/built-ins/Symbol/for/cross-realm.js
@@ -8,7 +8,7 @@ info: >
     The GlobalSymbolRegistry is a List that is globally available. It is shared
     by all realms. Prior to the evaluation of any ECMAScript code it is
     initialized as a new empty List.
-features: [Symbol]
+features: [cross-realm, Symbol]
 ---*/
 
 var OSymbol = $262.createRealm().global.Symbol;

--- a/test/built-ins/Symbol/hasInstance/cross-realm.js
+++ b/test/built-ins/Symbol/hasInstance/cross-realm.js
@@ -7,7 +7,7 @@ description: Value shared by all realms
 info: >
   Unless otherwise specified, well-known symbols values are shared by all
   realms.
-features: [Symbol.hasInstance]
+features: [cross-realm, Symbol.hasInstance]
 ---*/
 
 var OSymbol = $262.createRealm().global.Symbol;

--- a/test/built-ins/Symbol/isConcatSpreadable/cross-realm.js
+++ b/test/built-ins/Symbol/isConcatSpreadable/cross-realm.js
@@ -7,7 +7,7 @@ description: Value shared by all realms
 info: >
   Unless otherwise specified, well-known symbols values are shared by all
   realms.
-features: [Symbol.isConcatSpreadable]
+features: [cross-realm, Symbol.isConcatSpreadable]
 ---*/
 
 var OSymbol = $262.createRealm().global.Symbol;

--- a/test/built-ins/Symbol/iterator/cross-realm.js
+++ b/test/built-ins/Symbol/iterator/cross-realm.js
@@ -7,7 +7,7 @@ description: Value shared by all realms
 info: >
   Unless otherwise specified, well-known symbols values are shared by all
   realms.
-features: [Symbol.iterator]
+features: [cross-realm, Symbol.iterator]
 ---*/
 
 var OSymbol = $262.createRealm().global.Symbol;

--- a/test/built-ins/Symbol/keyFor/cross-realm.js
+++ b/test/built-ins/Symbol/keyFor/cross-realm.js
@@ -8,7 +8,7 @@ info: >
     The GlobalSymbolRegistry is a List that is globally available. It is shared
     by all realms. Prior to the evaluation of any ECMAScript code it is
     initialized as a new empty List.
-features: [Symbol]
+features: [cross-realm, Symbol]
 ---*/
 
 var OSymbol = $262.createRealm().global.Symbol;

--- a/test/built-ins/Symbol/match/cross-realm.js
+++ b/test/built-ins/Symbol/match/cross-realm.js
@@ -7,7 +7,7 @@ description: Value shared by all realms
 info: >
   Unless otherwise specified, well-known symbols values are shared by all
   realms.
-features: [Symbol.match]
+features: [cross-realm, Symbol.match]
 ---*/
 
 var OSymbol = $262.createRealm().global.Symbol;

--- a/test/built-ins/Symbol/replace/cross-realm.js
+++ b/test/built-ins/Symbol/replace/cross-realm.js
@@ -7,7 +7,7 @@ description: Value shared by all realms
 info: >
   Unless otherwise specified, well-known symbols values are shared by all
   realms.
-features: [Symbol.replace]
+features: [cross-realm, Symbol.replace]
 ---*/
 
 var OSymbol = $262.createRealm().global.Symbol;

--- a/test/built-ins/Symbol/search/cross-realm.js
+++ b/test/built-ins/Symbol/search/cross-realm.js
@@ -7,7 +7,7 @@ description: Value shared by all realms
 info: >
   Unless otherwise specified, well-known symbols values are shared by all
   realms.
-features: [Symbol.search]
+features: [cross-realm, Symbol.search]
 ---*/
 
 var OSymbol = $262.createRealm().global.Symbol;

--- a/test/built-ins/Symbol/species/cross-realm.js
+++ b/test/built-ins/Symbol/species/cross-realm.js
@@ -7,7 +7,7 @@ description: Value shared by all realms
 info: >
   Unless otherwise specified, well-known symbols values are shared by all
   realms.
-features: [Symbol.species]
+features: [cross-realm, Symbol.species]
 ---*/
 
 var OSymbol = $262.createRealm().global.Symbol;

--- a/test/built-ins/Symbol/split/cross-realm.js
+++ b/test/built-ins/Symbol/split/cross-realm.js
@@ -7,7 +7,7 @@ description: Value shared by all realms
 info: >
   Unless otherwise specified, well-known symbols values are shared by all
   realms.
-features: [Symbol.split]
+features: [cross-realm, Symbol.split]
 ---*/
 
 var OSymbol = $262.createRealm().global.Symbol;

--- a/test/built-ins/Symbol/toPrimitive/cross-realm.js
+++ b/test/built-ins/Symbol/toPrimitive/cross-realm.js
@@ -7,7 +7,7 @@ description: Value shared by all realms
 info: >
   Unless otherwise specified, well-known symbols values are shared by all
   realms.
-features: [Symbol.split]
+features: [cross-realm, Symbol.split]
 ---*/
 
 var OSymbol = $262.createRealm().global.Symbol;

--- a/test/built-ins/Symbol/toStringTag/cross-realm.js
+++ b/test/built-ins/Symbol/toStringTag/cross-realm.js
@@ -7,7 +7,7 @@ description: Value shared by all realms
 info: >
   Unless otherwise specified, well-known symbols values are shared by all
   realms.
-features: [Symbol.toStringTag]
+features: [cross-realm, Symbol.toStringTag]
 ---*/
 
 var OSymbol = $262.createRealm().global.Symbol;

--- a/test/built-ins/Symbol/unscopables/cross-realm.js
+++ b/test/built-ins/Symbol/unscopables/cross-realm.js
@@ -7,7 +7,7 @@ description: Value shared by all realms
 info: >
   Unless otherwise specified, well-known symbols values are shared by all
   realms.
-features: [Symbol.unscopables]
+features: [cross-realm, Symbol.unscopables]
 ---*/
 
 var OSymbol = $262.createRealm().global.Symbol;

--- a/test/built-ins/ThrowTypeError/distinct-cross-realm.js
+++ b/test/built-ins/ThrowTypeError/distinct-cross-realm.js
@@ -9,6 +9,7 @@ info: >
 
   The %ThrowTypeError% intrinsic is an anonymous built-in function
   object that is defined once for each realm.
+features: [cross-realm]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/TypedArrays/buffer-arg-proto-from-ctor-realm-sab.js
+++ b/test/built-ins/TypedArrays/buffer-arg-proto-from-ctor-realm-sab.js
@@ -24,7 +24,7 @@ info: |
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     5. Return proto.
 includes: [testTypedArray.js]
-features: [SharedArrayBuffer, Reflect, TypedArray]
+features: [cross-realm, SharedArrayBuffer, Reflect, TypedArray]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/TypedArrays/buffer-arg-proto-from-ctor-realm.js
+++ b/test/built-ins/TypedArrays/buffer-arg-proto-from-ctor-realm.js
@@ -23,7 +23,7 @@ info: |
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     5. Return proto.
 includes: [testTypedArray.js]
-features: [Reflect, TypedArray]
+features: [cross-realm, Reflect, TypedArray]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/TypedArrays/internals/DefineOwnProperty/detached-buffer-realm.js
+++ b/test/built-ins/TypedArrays/internals/DefineOwnProperty/detached-buffer-realm.js
@@ -24,7 +24,7 @@ info: >
   5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
   ...
 includes: [testTypedArray.js, detachArrayBuffer.js]
-features: [Reflect, TypedArray]
+features: [cross-realm, Reflect, TypedArray]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/TypedArrays/internals/Get/detached-buffer-realm.js
+++ b/test/built-ins/TypedArrays/internals/Get/detached-buffer-realm.js
@@ -15,7 +15,7 @@ info: >
       i. Return ? IntegerIndexedElementGet(O, numericIndex).
   ...
 includes: [testTypedArray.js, detachArrayBuffer.js]
-features: [TypedArray]
+features: [cross-realm, TypedArray]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/TypedArrays/internals/GetOwnProperty/detached-buffer-realm.js
+++ b/test/built-ins/TypedArrays/internals/GetOwnProperty/detached-buffer-realm.js
@@ -22,7 +22,7 @@ info: >
   4. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
   ...
 includes: [testTypedArray.js, detachArrayBuffer.js]
-features: [TypedArray]
+features: [cross-realm, TypedArray]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/TypedArrays/internals/HasProperty/detached-buffer-realm.js
+++ b/test/built-ins/TypedArrays/internals/HasProperty/detached-buffer-realm.js
@@ -16,7 +16,7 @@ info: >
       ii. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
   ...
 includes: [testTypedArray.js, detachArrayBuffer.js]
-features: [Reflect, TypedArray]
+features: [cross-realm, Reflect, TypedArray]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/TypedArrays/internals/Set/detached-buffer-realm.js
+++ b/test/built-ins/TypedArrays/internals/Set/detached-buffer-realm.js
@@ -23,7 +23,7 @@ info: >
   5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
   ...
 includes: [testTypedArray.js, detachArrayBuffer.js]
-features: [TypedArray]
+features: [cross-realm, TypedArray]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/TypedArrays/length-arg-proto-from-ctor-realm.js
+++ b/test/built-ins/TypedArrays/length-arg-proto-from-ctor-realm.js
@@ -22,7 +22,7 @@ info: |
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     5. Return proto.
 includes: [testTypedArray.js]
-features: [Reflect, TypedArray]
+features: [cross-realm, Reflect, TypedArray]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/TypedArrays/no-args-proto-from-ctor-realm.js
+++ b/test/built-ins/TypedArrays/no-args-proto-from-ctor-realm.js
@@ -22,7 +22,7 @@ info: |
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     5. Return proto.
 includes: [testTypedArray.js]
-features: [Reflect, TypedArray]
+features: [cross-realm, Reflect, TypedArray]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/TypedArrays/object-arg-proto-from-ctor-realm.js
+++ b/test/built-ins/TypedArrays/object-arg-proto-from-ctor-realm.js
@@ -23,7 +23,7 @@ info: |
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     5. Return proto.
 includes: [testTypedArray.js]
-features: [Reflect, TypedArray]
+features: [cross-realm, Reflect, TypedArray]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-custom-species-proto-from-ctor-realm.js
+++ b/test/built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-custom-species-proto-from-ctor-realm.js
@@ -34,7 +34,7 @@ info: >
      b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
   ...
 includes: [testTypedArray.js]
-features: [Symbol.species, TypedArray]
+features: [cross-realm, Symbol.species, TypedArray]
 ---*/
 
 var sample1 = new Int8Array();

--- a/test/built-ins/TypedArrays/typedarray-arg-proto-from-ctor-realm.js
+++ b/test/built-ins/TypedArrays/typedarray-arg-proto-from-ctor-realm.js
@@ -23,7 +23,7 @@ info: |
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     5. Return proto.
 includes: [testTypedArray.js]
-features: [Reflect, TypedArray]
+features: [cross-realm, Reflect, TypedArray]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-custom-proto-from-ctor-realm.js
+++ b/test/built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-custom-proto-from-ctor-realm.js
@@ -46,7 +46,7 @@ info: >
      b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
   ...
 includes: [testTypedArray.js]
-features: [Symbol.species, TypedArray]
+features: [cross-realm, Symbol.species, TypedArray]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/WeakMap/proto-from-ctor-realm.js
+++ b/test/built-ins/WeakMap/proto-from-ctor-realm.js
@@ -18,7 +18,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/built-ins/WeakSet/proto-from-ctor-realm.js
+++ b/test/built-ins/WeakSet/proto-from-ctor-realm.js
@@ -18,7 +18,7 @@ info: |
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/language/eval-code/indirect/realm.js
+++ b/test/language/eval-code/indirect/realm.js
@@ -23,6 +23,7 @@ info: |
   [...]
   24. Let result be EvalDeclarationInstantiation(body, varEnv, lexEnv,
       strictEval).
+features: [cross-realm]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/language/expressions/call/eval-realm-indirect.js
+++ b/test/language/expressions/call/eval-realm-indirect.js
@@ -11,6 +11,7 @@ info: |
        a. If SameValue(func, %eval%) is true, then
           [...]
 flags: [noStrict]
+features: [cross-realm]
 ---*/
 
 var x = 'outside';

--- a/test/language/expressions/generators/eval-body-proto-realm.js
+++ b/test/language/expressions/generators/eval-body-proto-realm.js
@@ -18,6 +18,7 @@ info: >
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
+features: [cross-realm]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/language/expressions/new/non-ctor-err-realm.js
+++ b/test/language/expressions/new/non-ctor-err-realm.js
@@ -16,6 +16,7 @@ info: |
   12.3.3.1.1 Runtime Semantics: EvaluateNew
 
   7. If IsConstructor(constructor) is false, throw a TypeError exception.
+features: [cross-realm]
 ---*/
 
 var otherParseInt = $262.createRealm().global.parseInt;

--- a/test/language/expressions/super/realm.js
+++ b/test/language/expressions/super/realm.js
@@ -19,7 +19,7 @@ info: >
        a. Let realm be ? GetFunctionRealm(constructor).
        b. Let proto be realm's intrinsic object named intrinsicDefaultProto.
     [...]
-features: [Reflect]
+features: [cross-realm, Reflect]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/language/expressions/tagged-template/cache-realm.js
+++ b/test/language/expressions/tagged-template/cache-realm.js
@@ -28,6 +28,7 @@ info: |
         a, If e.[[Strings]] and rawStrings contain the same values in the same
            order, then
            i. Return e.[[Array]].
+features: [cross-realm]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/language/types/reference/get-value-prop-base-primitive-realm.js
+++ b/test/language/types/reference/get-value-prop-base-primitive-realm.js
@@ -14,7 +14,7 @@ info: >
         i. Assert: In this case, base will never be null or undefined.
         ii. Let base be ToObject(base).
      b. Return ? base.[[Get]](GetReferencedName(V), GetThisValue(V)).
-features: [Symbol]
+features: [cross-realm, Symbol]
 ---*/
 
 var other = $262.createRealm().global;

--- a/test/language/types/reference/put-value-prop-base-primitive-realm.js
+++ b/test/language/types/reference/put-value-prop-base-primitive-realm.js
@@ -18,7 +18,7 @@ info: >
      c. If succeeded is false and IsStrictReference(V) is true, throw a
         TypeError exception.
      d. Return.
-features: [Symbol, Proxy]
+features: [cross-realm, Symbol, Proxy]
 ---*/
 
 var other = $262.createRealm().global;


### PR DESCRIPTION
This comes as a question as if we should flag tests requiring support for multiple realm operations. Adding this feature should be useful for filtering purposes.