### PR TITLE
BigInt ToBoolean type coercion test

### DIFF
--- a/harness/typeCoercion.js
+++ b/harness/typeCoercion.js
@@ -112,6 +112,46 @@ function testCoercibleToIntegerFromInteger(nominalInteger, test) {
   }
 }
 
+function testCoercibleToBooleanFalse(test) {
+  test(undefined);
+  test(null);
+  test(false);
+  test(0);
+  test(-0);
+  test(NaN);
+  test(0n);
+  test("");
+}
+
+function testCoercibleToBooleanTrue(test) {
+  test(true);
+  test(1);
+  test(-1);
+  test(Infinity);
+  test(-Infinity);
+  test(1n);
+  test("a");
+  test("true");
+  test("false");
+  test("0");
+  test(Symbol("1"));
+  test({});
+  test([]);
+
+  // ToBoolean does not call ToPrimitive.
+  // In all of these cases, it's just an object, which is truthy.
+  testPrimitiveWrappers(false, "number", test);
+  testPrimitiveWrappers(true, "number", test);
+  testPrimitiveWrappers(false, "string", test);
+  testPrimitiveWrappers(true, "string", test);
+
+  function notReallyAnError(error, value) {
+    test(value);
+  }
+  testNotCoercibleToPrimitive("number", notReallyAnError);
+  testNotCoercibleToPrimitive("string", notReallyAnError);
+}
+
 function testPrimitiveWrappers(primitiveValue, hint, test) {
   if (primitiveValue != null) {
     // null and undefined result in {} rather than a proper wrapper,

--- a/harness/typeCoercion.js
+++ b/harness/typeCoercion.js
@@ -231,10 +231,8 @@ function testNotCoercibleToNumber(test) {
   // ToNumber: Symbol -> TypeError
   testPrimitiveValue(Symbol("1"));
 
-  if (typeof BigInt !== "undefined") {
-    // ToNumber: BigInt -> TypeError
-    testPrimitiveValue(BigInt(0));
-  }
+  // ToNumber: BigInt -> TypeError
+  testPrimitiveValue(0n);
 
   // ToPrimitive
   testNotCoercibleToPrimitive("number", test);
@@ -293,10 +291,7 @@ function testCoercibleToString(test) {
   testPrimitiveValue(-Infinity, "-Infinity");
   testPrimitiveValue("", "");
   testPrimitiveValue("foo", "foo");
-
-  if (typeof BigInt !== "undefined") {
-    testPrimitiveValue(BigInt(0), "0");
-  }
+  testPrimitiveValue(0n, "0");
 
   // toString of a few objects
   test([], "");

--- a/harness/typeCoercion.js
+++ b/harness/typeCoercion.js
@@ -291,13 +291,10 @@ function testCoercibleToString(test) {
   testPrimitiveValue(-0, "0");
   testPrimitiveValue(Infinity, "Infinity");
   testPrimitiveValue(-Infinity, "-Infinity");
-  testPrimitiveValue(123.456, "123.456");
-  testPrimitiveValue(-123.456, "-123.456");
   testPrimitiveValue("", "");
   testPrimitiveValue("foo", "foo");
 
   if (typeof BigInt !== "undefined") {
-    // BigInt -> TypeError
     testPrimitiveValue(BigInt(0), "0");
   }
 
@@ -406,4 +403,6 @@ function testNotCoercibleToBigInt(test) {
   testStringValue("0o8");
   testStringValue("0xg");
   testStringValue("1n");
+
+  testNotCoercibleToPrimitive("number", test);
 }

--- a/test/built-ins/Boolean/toboolean.js
+++ b/test/built-ins/Boolean/toboolean.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-boolean-constructor-boolean-value
+description: ToBoolean type coercion tests via Boolean()
+info: >
+  Boolean ( value )
+
+  1. Let b be ToBoolean(value).
+  2. If NewTarget is undefined, return b.
+
+features: [BigInt, Symbol, Symbol.toPrimitive]
+includes: [typeCoercion.js]
+---*/
+
+testCoercibleToBooleanFalse(function(falsy) {
+  assert.sameValue(Boolean(falsy), false);
+});
+
+testCoercibleToBooleanTrue(function(truthy) {
+  assert.sameValue(Boolean(truthy), true);
+});
+
+// `Boolean(value)` (without `new`) never throws.


### PR DESCRIPTION
Add ToBoolean support to typeCoercion.js harness, and test `0n` -> `false`, `1n` -> `true` among other tests.