### PR TITLE
Added test case to consider rest ordering field access

### DIFF
--- a/src/dstr-assignment/obj-rest-order.case
+++ b/src/dstr-assignment/obj-rest-order.case
@@ -1,0 +1,23 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Rest operation follows [[OwnPropertyKeys]] order
+template: default
+esid: pending
+includes: [compareArray.js]
+features: [Symbol, object-rest]
+---*/
+
+//- setup
+var rest;
+var calls = [];
+var o = { get z() { calls.push('z') }, get a() { calls.push('a') } };
+Object.defineProperty(o, 1, { get: () => { calls.push(1) }, enumerable: true });
+Object.defineProperty(o, Symbol('foo'), { get: () => { calls.push("Symbol(foo)") }, enumerable: true });
+//- elems
+{...rest}
+//- vals
+o
+//- body
+assert(compareArray(calls, [1, 'z', 'a', "Symbol(foo)"]));
+assert.sameValue(Object.keys(rest).length, 3);

--- a/test/language/expressions/assignment/dstr-obj-rest-order.js
+++ b/test/language/expressions/assignment/dstr-obj-rest-order.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-assignment/obj-rest-order.case
+// - src/dstr-assignment/default/assignment-expr.template
+/*---
+description: Rest operation follows [[OwnPropertyKeys]] order (AssignmentExpression)
+esid: sec-variable-statement-runtime-semantics-evaluation
+es6id: 13.3.2.4
+features: [Symbol, object-rest, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    VariableDeclaration : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let rval be GetValue(rhs).
+    3. ReturnIfAbrupt(rval).
+    4. Return the result of performing BindingInitialization for
+       BindingPattern passing rval and undefined as arguments.
+---*/
+var rest;
+var calls = [];
+var o = { get z() { calls.push('z') }, get a() { calls.push('a') } };
+Object.defineProperty(o, 1, { get: () => { calls.push(1) }, enumerable: true });
+Object.defineProperty(o, Symbol('foo'), { get: () => { calls.push("Symbol(foo)") }, enumerable: true });
+
+var result;
+var vals = o;
+
+result = {...rest} = vals;
+
+assert(compareArray(calls, [1, 'z', 'a', "Symbol(foo)"]));
+assert.sameValue(Object.keys(rest).length, 3);
+
+assert.sameValue(result, vals);

--- a/test/language/statements/for-of/dstr-obj-rest-order.js
+++ b/test/language/statements/for-of/dstr-obj-rest-order.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-assignment/obj-rest-order.case
+// - src/dstr-assignment/default/for-of.template
+/*---
+description: Rest operation follows [[OwnPropertyKeys]] order (For..of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+es6id: 13.7.5.11
+features: [Symbol, object-rest, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    IterationStatement :
+      for ( LeftHandSideExpression of AssignmentExpression ) Statement
+
+    1. Let keyResult be the result of performing ? ForIn/OfHeadEvaluation(« »,
+       AssignmentExpression, iterate).
+    2. Return ? ForIn/OfBodyEvaluation(LeftHandSideExpression, Statement,
+       keyResult, assignment, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    4. If destructuring is true and if lhsKind is assignment, then
+       a. Assert: lhs is a LeftHandSideExpression.
+       b. Let assignmentPattern be the parse of the source text corresponding to
+          lhs using AssignmentPattern as the goal symbol.
+    [...]
+---*/
+var rest;
+var calls = [];
+var o = { get z() { calls.push('z') }, get a() { calls.push('a') } };
+Object.defineProperty(o, 1, { get: () => { calls.push(1) }, enumerable: true });
+Object.defineProperty(o, Symbol('foo'), { get: () => { calls.push("Symbol(foo)") }, enumerable: true });
+
+var counter = 0;
+
+for ({...rest} of [o]) {
+  assert(compareArray(calls, [1, 'z', 'a', "Symbol(foo)"]));
+  assert.sameValue(Object.keys(rest).length, 3);
+  counter += 1;
+}
+
+assert.sameValue(counter, 1);


### PR DESCRIPTION
It closes #1132

We already have this test cases for Object Spread, and the same ordering needs to be tested on Object Rest Destructuring. I'm also sending generated tests.