### PR TITLE
[bigint] ToNumeric type coercion tests via "-UnaryExpression"

### DIFF
--- a/harness/typeCoercion.js
+++ b/harness/typeCoercion.js
@@ -112,6 +112,46 @@ function testCoercibleToIntegerFromInteger(nominalInteger, test) {
   }
 }
 
+function testCoercibleToBooleanFalse(test) {
+  test(undefined);
+  test(null);
+  test(false);
+  test(0);
+  test(-0);
+  test(NaN);
+  test(0n);
+  test("");
+}
+
+function testCoercibleToBooleanTrue(test) {
+  test(true);
+  test(1);
+  test(-1);
+  test(Infinity);
+  test(-Infinity);
+  test(1n);
+  test("a");
+  test("true");
+  test("false");
+  test("0");
+  test(Symbol("1"));
+  test({});
+  test([]);
+
+  // ToBoolean does not call ToPrimitive.
+  // In all of these cases, it's just an object, which is truthy.
+  testPrimitiveWrappers(false, "number", test);
+  testPrimitiveWrappers(true, "number", test);
+  testPrimitiveWrappers(false, "string", test);
+  testPrimitiveWrappers(true, "string", test);
+
+  function notReallyAnError(error, value) {
+    test(value);
+  }
+  testNotCoercibleToPrimitive("number", notReallyAnError);
+  testNotCoercibleToPrimitive("string", notReallyAnError);
+}
+
 function testPrimitiveWrappers(primitiveValue, hint, test) {
   if (primitiveValue != null) {
     // null and undefined result in {} rather than a proper wrapper,

--- a/harness/typeCoercion.js
+++ b/harness/typeCoercion.js
@@ -231,10 +231,8 @@ function testNotCoercibleToNumber(test) {
   // ToNumber: Symbol -> TypeError
   testPrimitiveValue(Symbol("1"));
 
-  if (typeof BigInt !== "undefined") {
-    // ToNumber: BigInt -> TypeError
-    testPrimitiveValue(BigInt(0));
-  }
+  // ToNumber: BigInt -> TypeError
+  testPrimitiveValue(0n);
 
   // ToPrimitive
   testNotCoercibleToPrimitive("number", test);
@@ -293,10 +291,7 @@ function testCoercibleToString(test) {
   testPrimitiveValue(-Infinity, "-Infinity");
   testPrimitiveValue("", "");
   testPrimitiveValue("foo", "foo");
-
-  if (typeof BigInt !== "undefined") {
-    testPrimitiveValue(BigInt(0), "0");
-  }
+  testPrimitiveValue(0n, "0");
 
   // toString of a few objects
   test([], "");

--- a/harness/typeCoercion.js
+++ b/harness/typeCoercion.js
@@ -291,13 +291,10 @@ function testCoercibleToString(test) {
   testPrimitiveValue(-0, "0");
   testPrimitiveValue(Infinity, "Infinity");
   testPrimitiveValue(-Infinity, "-Infinity");
-  testPrimitiveValue(123.456, "123.456");
-  testPrimitiveValue(-123.456, "-123.456");
   testPrimitiveValue("", "");
   testPrimitiveValue("foo", "foo");
 
   if (typeof BigInt !== "undefined") {
-    // BigInt -> TypeError
     testPrimitiveValue(BigInt(0), "0");
   }
 
@@ -406,4 +403,6 @@ function testNotCoercibleToBigInt(test) {
   testStringValue("0o8");
   testStringValue("0xg");
   testStringValue("1n");
+
+  testNotCoercibleToPrimitive("number", test);
 }

--- a/harness/typeCoercion.js
+++ b/harness/typeCoercion.js
@@ -259,7 +259,7 @@ function testNotCoercibleToInteger(test) {
   testNotCoercibleToNumber(test);
 }
 
-function testNotCoercibleToNumber(test) {
+function testNotCoercibleToNumber(test, skipBigInt) {
   function testPrimitiveValue(value) {
     test(TypeError, value);
     // ToPrimitive
@@ -271,8 +271,10 @@ function testNotCoercibleToNumber(test) {
   // ToNumber: Symbol -> TypeError
   testPrimitiveValue(Symbol("1"));
 
-  // ToNumber: BigInt -> TypeError
-  testPrimitiveValue(0n);
+  if (skipBigInt !== true) {
+    // ToNumber: BigInt -> TypeError
+    testPrimitiveValue(0n);
+  }
 
   // ToPrimitive
   testNotCoercibleToPrimitive("number", test);
@@ -440,4 +442,24 @@ function testNotCoercibleToBigInt(test) {
   testStringValue("1n");
 
   testNotCoercibleToPrimitive("number", test);
+}
+
+function testCoercibleToNumericNumberZero(test) {
+  // ToNumeric doesn't introduce any cases of 0 except through ToNumber.
+  testCoercibleToNumberZero(test);
+}
+
+function testCoercibleToNumericNumberOne(test) {
+  // ToNumeric doesn't introduce any cases of 1 except through ToNumber.
+  testCoercibleToNumberOne(test);
+}
+
+function testCoercibleToNumericFromBigInt(nominalBigInt, test) {
+  // ToNumeric only returns a BigInt if the result of ToPrimitive is a BigInt.
+  test(nominalBigInt);
+  testPrimitiveWrappers(nominalBigInt, "number", test);
+}
+
+function testNotCoercibleToNumeric(test) {
+  testNotCoercibleToNumber(test, true);
 }

--- a/test/built-ins/Boolean/toboolean.js
+++ b/test/built-ins/Boolean/toboolean.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-boolean-constructor-boolean-value
+description: ToBoolean type coercion tests via Boolean()
+info: >
+  Boolean ( value )
+
+  1. Let b be ToBoolean(value).
+  2. If NewTarget is undefined, return b.
+
+features: [BigInt, Symbol, Symbol.toPrimitive]
+includes: [typeCoercion.js]
+---*/
+
+testCoercibleToBooleanFalse(function(falsy) {
+  assert.sameValue(Boolean(falsy), false);
+});
+
+testCoercibleToBooleanTrue(function(truthy) {
+  assert.sameValue(Boolean(truthy), true);
+});
+
+// `Boolean(value)` (without `new`) never throws.

--- a/test/language/expressions/unary-minus/tonumeric.js
+++ b/test/language/expressions/unary-minus/tonumeric.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: ToNumeric type coercion tests via unary minus
+info: >
+  ToNumeric ( value )
+
+  1. Let primValue be ? ToPrimitive(value, hint Number).
+  2. If Type(primValue) is BigInt, return primValue.
+  3. Return ToNumber(primValue).
+
+features: [BigInt, Symbol, Symbol.toPrimitive]
+includes: [typeCoercion.js]
+---*/
+
+// Sanity check our basic assumptions before starting the test.
+assert.notSameValue(0, 0n);
+assert.notSameValue(0, -0);
+assert.sameValue(0n, -0n);
+
+testCoercibleToNumericNumberZero(function(numberZero) {
+  assert.sameValue(-numberZero, -0);
+});
+
+testCoercibleToNumericNumberOne(function(numberOne) {
+  assert.sameValue(-numberOne, -1);
+});
+
+testCoercibleToNumericFromBigInt(0n, function(bigintZero) {
+  assert.sameValue(-bigintZero, 0n);
+});
+
+testCoercibleToNumericFromBigInt(1n, function(bigintOne) {
+  assert.sameValue(-bigintOne, -1n);
+});
+
+testNotCoercibleToNumeric(function(error, value) {
+  assert.throws(error, function() { return -value; });
+});


### PR DESCRIPTION
With the BigInt spec changes, unary minus uses ToNumeric instead of just ToNumber. This test uses a unary minus expression to test the type coercion corner cases for ToNumeric.

This PR is based on #1241. Not sure I did all the paperwork properly to indicate and facilitate that.