### PR TITLE
Update Intl.NumberFormat.prototype.formatToParts.length to expect 1

### DIFF
--- a/test/intl402/NumberFormat/prototype/formatToParts/length.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/length.js
@@ -6,7 +6,7 @@ description: Intl.NumberFormat.prototype.formatToParts.length.
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.NumberFormat.prototype.formatToParts.length, 0);
+assert.sameValue(Intl.NumberFormat.prototype.formatToParts.length, 1);
 
 verifyNotEnumerable(Intl.NumberFormat.prototype.formatToParts, "length");
 verifyNotWritable(Intl.NumberFormat.prototype.formatToParts, "length");


### PR DESCRIPTION
As per https://github.com/tc39/ecma402/pull/160 the formatToParts.length is set to 1.