### PR TITLE
Introduce version number

### DIFF
--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -4,6 +4,11 @@ All tests are declared as text files located within this project's `test`
 directory. In order to execute Test262 tests, runtimes must observe the
 following semantics.
 
+**Note** When these instructions change in any substantive way, the `version`
+property of the JSON-formatted `package.json` file will be incremented. In this
+way, consumers who are transitioning between revisions of Test262 can more
+easily determine the cause of new test failures.
+
 ## Test Execution
 
 Test262 tests are only valid under the runtime environment conditions described

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "test262",
+  "version": "1.0.0",
+  "description": "Test262 tests conformance to the continually maintained draft future ECMAScript standard found at http://tc39.github.io/ecma262/ , together with any Stage 3 or later TC39 proposals.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tc39/test262.git"
+  },
+  "license": "BSD",
+  "bugs": {
+    "url": "https://github.com/tc39/test262/issues"
+  },
+  "private": true,
+  "homepage": "https://github.com/tc39/test262#readme"
+}


### PR DESCRIPTION
Every day, we're adding new tests that could cause new failures for the projects that run Test262. This means that whenever someone updates their copy of Test262, they may have to accept new failing tests. Projects generally maintain a list of "expected failures" for just this purpose.

Sometimes, we change the way we describe the tests themselves. When we do this, consumers will also run into new failures, but not because they have a bug in their project. They have to update the way they interpret the results to match our new organization.

We maintain a document called "INTERPRETING.md" to help folks understand how to run Test262, but this process is still kind of confusing. That's because consumers initially see new failures, and they have to work backwards to answer the question, "are these because I have a bug or because the rules have changed?"

At the recent TC39 meeting in Boston, we decided to help answer that question more directly by versioning Test262. From now on, whenever we "change the rules," we'll update the `package.json` file with a new version number. We'll continue to update the "INTERPRETING.md" file with the latest instructions, but we'll also describe the changes in a separate "history" file to help folks learn about the changes they need to make.

Commit message:

> Changes to the instructions for interpreting tests will likely produce
> new failures for consumers who are updating between revisions of
> Test262. Introduce a machine-readable convention for signaling
> substantive changes.