### PR TITLE
Update RegExp named capture tests for spec change

### DIFF
--- a/test/built-ins/RegExp/named-groups/string-replace-missing.js
+++ b/test/built-ins/RegExp/named-groups/string-replace-missing.js
@@ -2,24 +2,23 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: SyntaxError is thrown for malformed replacements
+description: If the group doesn't exist, replace with the empty string
 esid: sec-getsubstitution
 features: [regexp-named-groups]
-info: >
-  Runtime Semantics: GetSubstitution( matched, str, position, captures, namedCaptures, replacement )
-
-  Table: Replacement Text Symbol Substitutions
-
-  Unicode Characters: $<
-  Replacement text:
-    2. Otherwise,
-      b. If ? HasProperty(namedCaptures, groupName) is false, throw a SyntaxError exception.
 ---*/
 
 let source = "(?<fst>.)(?<snd>.)|(?<thd>x)";
-for (let flags of ["", "u", "g", "gu"]) {
+for (let flags of ["", "u"]) {
   let re = new RegExp(source, flags);
-  assert.throws(SyntaxError, () => "abcd".replace(re, "$<42$1>"));
-  assert.throws(SyntaxError, () => "abcd".replace(re, "$<fth>"));
-  assert.throws(SyntaxError, () => "abcd".replace(re, "$<$1>"));
+  assert.sameValue("cd", "abcd".replace(re, "$<42$1>"));
+  assert.sameValue("cd", "abcd".replace(re, "$<fth>"));
+  assert.sameValue("cd", "abcd".replace(re, "$<$1>"));
+  assert.sameValue("cd", "abcd".replace(re, "$<>"));
+}
+for (let flags of ["g", "gu"]) {
+  let re = new RegExp(source, flags);
+  assert.sameValue("", "abcd".replace(re, "$<42$1>"));
+  assert.sameValue("", "abcd".replace(re, "$<fth>"));
+  assert.sameValue("", "abcd".replace(re, "$<$1>"));
+  assert.sameValue("", "abcd".replace(re, "$<>"));
 }

--- a/test/built-ins/RegExp/named-groups/string-replace-nocaptures.js
+++ b/test/built-ins/RegExp/named-groups/string-replace-nocaptures.js
@@ -24,6 +24,7 @@ for (let flags of ["", "u"]) {
   assert.sameValue("bacd", "abcd".replace(re, "$2$1"));
   assert.sameValue("cd", "abcd".replace(re, "$3"));
   assert.sameValue("$<sndcd", "abcd".replace(re, "$<snd"));
+  assert.sameValue("$<sndacd", "abcd".replace(re, "$<snd$1"));
   assert.sameValue("$<42a>cd", "abcd".replace(re, "$<42$1>"));
   assert.sameValue("$<fth>cd", "abcd".replace(re, "$<fth>"));
   assert.sameValue("$<a>cd", "abcd".replace(re, "$<$1>"));

--- a/test/built-ins/RegExp/named-groups/string-replace-unclosed.js
+++ b/test/built-ins/RegExp/named-groups/string-replace-unclosed.js
@@ -2,25 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: SyntaxError is thrown for malformed replacements
+description: A missing > following $< means that the $< is taken literally
+  in a replacement string in the context of named capture substitution.
 esid: sec-getsubstitution
 features: [regexp-named-groups]
-info: >
-  Runtime Semantics: GetSubstitution( matched, str, position, captures, namedCaptures, replacement )
-
-  Table: Replacement Text Symbol Substitutions
-
-  Unicode Characters: $<
-  Replacement text:
-    2. Otherwise,
-      a. Scan until the next >, throwing a SyntaxError exception if one is not found, and let the enclosed substring be groupName.
 ---*/
 
 let source = "(?<fst>.)(?<snd>.)|(?<thd>x)";
-for (let flags of ["", "u", "g", "gu"]) {
+for (let flags of ["", "u"]) {
   let re = new RegExp(source, flags);
-  assert.throws(SyntaxError, () => "abcd".replace(re, "$<snd"),
-                "unclosed named group in replacement should throw a SyntaxError");
-  assert.throws(SyntaxError, () => "abcd".replace(re, "$<>"),
-                "empty named group in replacement should throw a SyntaxError");
+  assert.sameValue("$<sndcd", "abcd".replace(re, "$<snd"));
+}
+for (let flags of ["g", "gu"]) {
+  let re = new RegExp(source, flags);
+  assert.sameValue("$<snd$<snd", "abcd".replace(re, "$<snd"));
 }


### PR DESCRIPTION
The RegExp named groups specification has changed to not throw
errors in certain cases. This patch updates the test262 tests to match
the new specification, and throws in an additional test that verifies
the interaction between named group syntax and other replacement.
The tests pass on a version of V8 which implements the new semantics.

https://github.com/tc39/proposal-regexp-named-groups/commit/92ceba518c2ab0d2811c2efa8248ed1b3f8b5506