### PR TITLE
BigInt arithmetic type errors

### DIFF
--- a/harness/typeCoercion.js
+++ b/harness/typeCoercion.js
@@ -409,8 +409,6 @@ function testNotCoercibleToBigInt(test) {
 }
 
 function testNotCoercibleToBigIntAdditionOperand(test) {
-  testNotCoercibleToPrimitive("number", test);
-
   function testPrimitiveValue(error, value) {
     test(error, value);
     testPrimitiveWrappers(value, "number", function (value) {
@@ -428,8 +426,6 @@ function testNotCoercibleToBigIntAdditionOperand(test) {
 }
 
 function testNotCoercibleToBigIntOperand(test) {
-  testNotCoercibleToPrimitive("number", test);
-
   function testPrimitiveValue(error, value) {
     test(error, value);
     testPrimitiveWrappers(value, "number", function (value) {

--- a/harness/typeCoercion.js
+++ b/harness/typeCoercion.js
@@ -407,3 +407,49 @@ function testNotCoercibleToBigInt(test) {
   testStringValue("0xg");
   testStringValue("1n");
 }
+
+function testNotCoercibleToBigIntAdditionOperand(test) {
+  testNotCoercibleToPrimitive("number", test);
+
+  function testPrimitiveValue(error, value) {
+    test(error, value);
+    testPrimitiveWrappers(value, "number", function (value) {
+      test(error, value);
+    });
+  }
+
+  // Undefined, Null, Number, Symbol -> TypeError
+  testPrimitiveValue(TypeError, undefined);
+  testPrimitiveValue(TypeError, null);
+  testPrimitiveValue(TypeError, 0);
+  testPrimitiveValue(TypeError, NaN);
+  testPrimitiveValue(TypeError, Infinity);
+  testPrimitiveValue(TypeError, Symbol("1"));
+}
+
+function testNotCoercibleToBigIntOperand(test) {
+  testNotCoercibleToPrimitive("number", test);
+
+  function testPrimitiveValue(error, value) {
+    test(error, value);
+    testPrimitiveWrappers(value, "number", function (value) {
+      test(error, value);
+    });
+  }
+
+  // Non-BigInt primitive -> TypeError
+  testPrimitiveValue(TypeError, undefined);
+  testPrimitiveValue(TypeError, null);
+  testPrimitiveValue(TypeError, 0);
+  testPrimitiveValue(TypeError, NaN);
+  testPrimitiveValue(TypeError, Infinity);
+  testPrimitiveValue(TypeError, "");
+  testPrimitiveValue(TypeError, "1");
+  testPrimitiveValue(TypeError, Symbol("1"));
+}
+
+function testCoercibleToBigIntOperand(value, test) {
+  test(value);
+  // ToPrimitive
+  testPrimitiveWrappers(value, "number", test);
+}

--- a/test/language/expressions/addition/bigint-err.js
+++ b/test/language/expressions/addition/bigint-err.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2017 Robin Templeton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-addition-operator-plus-runtime-semantics-evaluation
+description: BigInt addition type errors
+info: >
+  The Addition Operator ( + )
+
+  Runtime Semantics: Evaluation
+
+  ...
+  5. Let lprim be ? ToPrimitive(lval).
+  6. Let rprim be ? ToPrimitive(rval).
+  ...
+  8. Let lnum be ? ToNumeric(lprim).
+  9. Let rnum be ? ToNumeric(rprim).
+  10. If Type(lnum) does not equal Type(rnum), throw a TypeError
+  exception.
+includes: [typeCoercion.js]
+features: [BigInt, Symbol, Symbol.toPrimitive, arrow-functions]
+---*/
+
+testNotCoercibleToBigIntAdditionOperand(function (error, value1) {
+  testCoercibleToBigIntOperand(0n, function (value2) {
+    assert.throws(error, () => value1 + value2);
+    assert.throws(error, () => value2 + value1);
+  });
+});

--- a/test/language/expressions/addition/bigint-err.js
+++ b/test/language/expressions/addition/bigint-err.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Robin Templeton. All rights reserved.
+// Copyright (C) 2017 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -18,7 +18,7 @@ info: >
   10. If Type(lnum) does not equal Type(rnum), throw a TypeError
   exception.
 includes: [typeCoercion.js]
-features: [BigInt, Symbol, Symbol.toPrimitive, arrow-functions]
+features: [BigInt, Symbol, Symbol.toPrimitive, arrow-function]
 ---*/
 
 testNotCoercibleToBigIntAdditionOperand(function (error, value1) {

--- a/test/language/expressions/bitwise-and/bigint-err.js
+++ b/test/language/expressions/bitwise-and/bigint-err.js
@@ -2,10 +2,10 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-multiplicative-operators-runtime-semantics-evaluation
-description: BigInt multiplication type errors
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+description: BigInt bitwise and type errors
 info: >
-  Multiplicative Operators
+  Binary Bitwise Operators
 
   Runtime Semantics: Evaluation
 
@@ -21,7 +21,7 @@ features: [BigInt, Symbol, Symbol.toPrimitive, arrow-function]
 
 testNotCoercibleToBigIntOperand(function (error, value1) {
   testCoercibleToBigIntOperand(0n, function (value2) {
-    assert.throws(error, () => value1 * value2);
-    assert.throws(error, () => value2 * value1);
+    assert.throws(error, () => value1 & value2);
+    assert.throws(error, () => value2 & value1);
   });
 });

--- a/test/language/expressions/bitwise-or/bigint-err.js
+++ b/test/language/expressions/bitwise-or/bigint-err.js
@@ -2,10 +2,10 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-multiplicative-operators-runtime-semantics-evaluation
-description: BigInt multiplication type errors
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+description: BigInt bitwise or type errors
 info: >
-  Multiplicative Operators
+  Binary Bitwise Operators
 
   Runtime Semantics: Evaluation
 
@@ -21,7 +21,7 @@ features: [BigInt, Symbol, Symbol.toPrimitive, arrow-function]
 
 testNotCoercibleToBigIntOperand(function (error, value1) {
   testCoercibleToBigIntOperand(0n, function (value2) {
-    assert.throws(error, () => value1 * value2);
-    assert.throws(error, () => value2 * value1);
+    assert.throws(error, () => value1 | value2);
+    assert.throws(error, () => value2 | value1);
   });
 });

--- a/test/language/expressions/bitwise-xor/bigint-err.js
+++ b/test/language/expressions/bitwise-xor/bigint-err.js
@@ -2,10 +2,10 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-multiplicative-operators-runtime-semantics-evaluation
-description: BigInt multiplication type errors
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+description: BigInt bitwise xor type errors
 info: >
-  Multiplicative Operators
+  Binary Bitwise Operators
 
   Runtime Semantics: Evaluation
 
@@ -21,7 +21,7 @@ features: [BigInt, Symbol, Symbol.toPrimitive, arrow-function]
 
 testNotCoercibleToBigIntOperand(function (error, value1) {
   testCoercibleToBigIntOperand(0n, function (value2) {
-    assert.throws(error, () => value1 * value2);
-    assert.throws(error, () => value2 * value1);
+    assert.throws(error, () => value1 ^ value2);
+    assert.throws(error, () => value2 ^ value1);
   });
 });

--- a/test/language/expressions/division/bigint-err.js
+++ b/test/language/expressions/division/bigint-err.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 Robin Templeton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+description: BigInt division type errors
+info: >
+  Multiplicative Operators
+
+  Runtime Semantics: Evaluation
+
+  ...
+  5. Let lnum be ? ToNumeric(leftValue).
+  6. Let rnum be ? ToNumeric(rightValue).
+  7. If Type(lnum) does not equal Type(rnum), throw a TypeError
+  exception.
+  ...
+includes: [typeCoercion.js]
+features: [BigInt, Symbol, Symbol.toPrimitive, arrow-functions]
+---*/
+
+testNotCoercibleToBigIntOperand(function (error, value1) {
+  testCoercibleToBigIntOperand(1n, function (value2) {
+    assert.throws(error, () => value1 / value2);
+    assert.throws(error, () => value2 / value1);
+  });
+});

--- a/test/language/expressions/division/bigint-err.js
+++ b/test/language/expressions/division/bigint-err.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Robin Templeton. All rights reserved.
+// Copyright (C) 2017 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -16,7 +16,7 @@ info: >
   exception.
   ...
 includes: [typeCoercion.js]
-features: [BigInt, Symbol, Symbol.toPrimitive, arrow-functions]
+features: [BigInt, Symbol, Symbol.toPrimitive, arrow-function]
 ---*/
 
 testNotCoercibleToBigIntOperand(function (error, value1) {

--- a/test/language/expressions/exponentiation/bigint-err.js
+++ b/test/language/expressions/exponentiation/bigint-err.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 Robin Templeton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-exp-operator-runtime-semantics-evaluation
+description: BigInt exponentiation type errors
+info: >
+  Exponentiation Operator
+
+  Runtime Semantics: Evaluation
+
+  ...
+  5. Let base be ? ToNumeric(leftValue).
+  6. Let exponent be ? ToNumeric(rightValue).
+  7. If Type(lnum) does not equal Type(rnum), throw a TypeError
+  exception.
+  ...
+includes: [typeCoercion.js]
+features: [BigInt, Symbol, Symbol.toPrimitive, arrow-functions]
+---*/
+
+testNotCoercibleToBigIntOperand(function (error, value1) {
+  testCoercibleToBigIntOperand(1n, function (value2) {
+    assert.throws(error, () => value1 ** value2);
+    assert.throws(error, () => value2 ** value1);
+  });
+});

--- a/test/language/expressions/exponentiation/bigint-err.js
+++ b/test/language/expressions/exponentiation/bigint-err.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Robin Templeton. All rights reserved.
+// Copyright (C) 2017 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -16,7 +16,7 @@ info: >
   exception.
   ...
 includes: [typeCoercion.js]
-features: [BigInt, Symbol, Symbol.toPrimitive, arrow-functions]
+features: [BigInt, Symbol, Symbol.toPrimitive, arrow-function]
 ---*/
 
 testNotCoercibleToBigIntOperand(function (error, value1) {

--- a/test/language/expressions/left-shift/bigint-err.js
+++ b/test/language/expressions/left-shift/bigint-err.js
@@ -2,10 +2,10 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-multiplicative-operators-runtime-semantics-evaluation
-description: BigInt multiplication type errors
+esid: sec-left-shift-operator-runtime-semantics-evaluation
+description: BigInt left shift type errors
 info: >
-  Multiplicative Operators
+  The Left Shift Operator ( << )
 
   Runtime Semantics: Evaluation
 
@@ -21,7 +21,7 @@ features: [BigInt, Symbol, Symbol.toPrimitive, arrow-function]
 
 testNotCoercibleToBigIntOperand(function (error, value1) {
   testCoercibleToBigIntOperand(0n, function (value2) {
-    assert.throws(error, () => value1 * value2);
-    assert.throws(error, () => value2 * value1);
+    assert.throws(error, () => value1 << value2);
+    assert.throws(error, () => value2 << value1);
   });
 });

--- a/test/language/expressions/modulus/bigint-err.js
+++ b/test/language/expressions/modulus/bigint-err.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 Robin Templeton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+description: BigInt remainder type errors
+info: >
+  Multiplicative Operators
+
+  Runtime Semantics: Evaluation
+
+  ...
+  5. Let lnum be ? ToNumeric(leftValue).
+  6. Let rnum be ? ToNumeric(rightValue).
+  7. If Type(lnum) does not equal Type(rnum), throw a TypeError
+  exception.
+  ...
+includes: [typeCoercion.js]
+features: [BigInt, Symbol, Symbol.toPrimitive, arrow-functions]
+---*/
+
+testNotCoercibleToBigIntOperand(function (error, value1) {
+  testCoercibleToBigIntOperand(1n, function (value2) {
+    assert.throws(error, () => value1 % value2);
+    assert.throws(error, () => value2 % value1);
+  });
+});

--- a/test/language/expressions/modulus/bigint-err.js
+++ b/test/language/expressions/modulus/bigint-err.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Robin Templeton. All rights reserved.
+// Copyright (C) 2017 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -16,7 +16,7 @@ info: >
   exception.
   ...
 includes: [typeCoercion.js]
-features: [BigInt, Symbol, Symbol.toPrimitive, arrow-functions]
+features: [BigInt, Symbol, Symbol.toPrimitive, arrow-function]
 ---*/
 
 testNotCoercibleToBigIntOperand(function (error, value1) {

--- a/test/language/expressions/multiplication/bigint-err.js
+++ b/test/language/expressions/multiplication/bigint-err.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 Robin Templeton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+description: BigInt multiplication type errors
+info: >
+  Multiplicative Operators
+
+  Runtime Semantics: Evaluation
+
+  ...
+  5. Let lnum be ? ToNumeric(leftValue).
+  6. Let rnum be ? ToNumeric(rightValue).
+  7. If Type(lnum) does not equal Type(rnum), throw a TypeError
+  exception.
+  ...
+includes: [typeCoercion.js]
+features: [BigInt, Symbol, Symbol.toPrimitive, arrow-functions]
+---*/
+
+testNotCoercibleToBigIntOperand(function (error, value1) {
+  testCoercibleToBigIntOperand(0n, function (value2) {
+    assert.throws(error, () => value1 * value2);
+    assert.throws(error, () => value2 * value1);
+  });
+});

--- a/test/language/expressions/right-shift/bigint-err.js
+++ b/test/language/expressions/right-shift/bigint-err.js
@@ -2,10 +2,10 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-multiplicative-operators-runtime-semantics-evaluation
-description: BigInt multiplication type errors
+esid: sec-signed-right-shift-operator-runtime-semantics-evaluation
+description: BigInt right shift type errors
 info: >
-  Multiplicative Operators
+  The Signed Right Shift Operator ( >> )
 
   Runtime Semantics: Evaluation
 
@@ -21,7 +21,7 @@ features: [BigInt, Symbol, Symbol.toPrimitive, arrow-function]
 
 testNotCoercibleToBigIntOperand(function (error, value1) {
   testCoercibleToBigIntOperand(0n, function (value2) {
-    assert.throws(error, () => value1 * value2);
-    assert.throws(error, () => value2 * value1);
+    assert.throws(error, () => value1 >> value2);
+    assert.throws(error, () => value2 >> value1);
   });
 });

--- a/test/language/expressions/subtraction/bigint-err.js
+++ b/test/language/expressions/subtraction/bigint-err.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Robin Templeton. All rights reserved.
+// Copyright (C) 2017 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -16,7 +16,7 @@ info: >
   exception.
   ...
 includes: [typeCoercion.js]
-features: [BigInt, Symbol, Symbol.toPrimitive, arrow-functions]
+features: [BigInt, Symbol, Symbol.toPrimitive, arrow-function]
 ---*/
 
 testNotCoercibleToBigIntOperand(function (error, value1) {

--- a/test/language/expressions/subtraction/bigint-err.js
+++ b/test/language/expressions/subtraction/bigint-err.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 Robin Templeton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-subtraction-operator-minus-runtime-semantics-evaluation
+description: BigInt subtraction type errors
+info: >
+  The Subtraction Operator ( - )
+
+  Runtime Semantics: Evaluation
+
+  ...
+  5. Let lnum be ? ToNumeric(lval).
+  6. Let rnum be ? ToNumeric(rval).
+  7. If Type(lnum) does not equal Type(rnum), throw a TypeError
+  exception.
+  ...
+includes: [typeCoercion.js]
+features: [BigInt, Symbol, Symbol.toPrimitive, arrow-functions]
+---*/
+
+testNotCoercibleToBigIntOperand(function (error, value1) {
+  testCoercibleToBigIntOperand(0n, function (value2) {
+    assert.throws(error, () => value1 - value2);
+    assert.throws(error, () => value2 - value1);
+  });
+});

--- a/test/language/expressions/unsigned-right-shift/bigint-err.js
+++ b/test/language/expressions/unsigned-right-shift/bigint-err.js
@@ -2,10 +2,10 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-multiplicative-operators-runtime-semantics-evaluation
-description: BigInt multiplication type errors
+esid: sec-unsigned-right-shift-operator-runtime-semantics-evaluation
+description: BigInt unsigned right shift type errors
 info: >
-  Multiplicative Operators
+  The Unsigned Right Shift Operator ( >>> )
 
   Runtime Semantics: Evaluation
 
@@ -21,7 +21,7 @@ features: [BigInt, Symbol, Symbol.toPrimitive, arrow-function]
 
 testNotCoercibleToBigIntOperand(function (error, value1) {
   testCoercibleToBigIntOperand(0n, function (value2) {
-    assert.throws(error, () => value1 * value2);
-    assert.throws(error, () => value2 * value1);
+    assert.throws(error, () => value1 >>> value2);
+    assert.throws(error, () => value2 >>> value1);
   });
 });


### PR DESCRIPTION
Arithmetic expressions with one BigInt operand and one non-BigInt operand should always throw an exception. (The new typeCoercion.js functions are for testing the ToNumeric operation.)