### PR TITLE
Add tests for the case of `<iterator>.return` in the iteration protocol being an object that's uncallable and compares equal to `undefined`

### DIFF
--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -64,6 +64,16 @@ properties of the global scope prior to test execution.
         6. Return Completion(status).
 
   - **`global`** - a reference to the global object on which `$262` was initially defined
+  - **`uncallableAndIsHTMLDDA`** - a function that returns an object *`obj`* for
+    which [Call](https://tc39.github.io/ecma262/#sec-call)(*`obj`*, *any value*, «»)
+    throws a `TypeError`.  (The value of [IsCallable]()(*`obj`*) is unspecified:
+    a callable *`obj`* that throws a `TypeError` or an uncallable *`obj`* works
+    equally well.)  In hosts supporting the
+    [IsHTMLDDA](https://tc39.github.io/ecma262/#sec-IsHTMLDDA-internal-slot)
+    internal slot, *`obj`* must also have such a slot.  (These highly specific
+    behaviors are entirely motivated by the very few tests that use this.  Read
+    them for an explanation.)  Tests that use this function should be marked as
+    using the `uncallableAndIsHTMLDDA` feature.
   - **`agent`** - an ordinary object with the following properties:
     - **`start`** - a function that takes a script source string and runs
       the script in a concurrent agent.  Will block until that agent is

--- a/features.txt
+++ b/features.txt
@@ -117,3 +117,11 @@ u180e
 Uint8Array
 WeakMap
 WeakSet
+
+# Test-harness features requiring host environment/test runner support
+#
+# The rare cases where testing language functionality requires non-standard
+# language features, exposed through global-environment functions on the $262
+# object, go here.
+
+uncallableAndIsHTMLDDA

--- a/test/annexB/language/expressions/yield/star-iterable-return-emulates-undefined-throws-when-called.js
+++ b/test/annexB/language/expressions/yield/star-iterable-return-emulates-undefined-throws-when-called.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: sec-generator-function-definitions-runtime-semantics-evaluation
+description: >
+    If <iterator>.return is an object emulating `undefined` (e.g. `document.all`
+    in browsers), it shouldn't be treated as if it were actually `undefined` by
+    the yield* operator.
+features: [generators, uncallableAndIsHTMLDDA]
+---*/
+
+var iter = {
+  [Symbol.iterator]() { return this; },
+  next() { return {}; },
+  return: $262.uncallableAndIsHTMLDDA(),
+};
+
+var outer = (function*() { yield* iter; })();
+
+outer.next();
+
+assert.throws(TypeError, function() {
+  // This code is expected to throw a TypeError because `iter.return` throws a
+  // TypeError when invoked with `iter` as `this` and no arguments provided.
+  // It's irrelevant that in hosts that support the [[IsHTMLDDA]] internal slot,
+  // this object has that slot: `<iterator>.return` behavior is skipped only if
+  // that property is exactly the value `undefined`, not a value loosely equal
+  // to it.
+  outer.return();
+});

--- a/test/annexB/language/statements/for-of/iterator-close-return-emulates-undefined-throws-when-called.js
+++ b/test/annexB/language/statements/for-of/iterator-close-return-emulates-undefined-throws-when-called.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: sec-iteratorclose
+description: >
+    If <iterator>.return is an object emulating `undefined` (e.g. `document.all`
+    in browsers), it shouldn't be treated as if it were actually `undefined`.
+features: [generators, uncallableAndIsHTMLDDA]
+---*/
+
+var iter = {
+  [Symbol.iterator]() { return this; },
+  next() { return {}; },
+  return: $262.uncallableAndIsHTMLDDA(),
+};
+
+assert.throws(TypeError, function() {
+  // This code is expected to throw a TypeError because `iter.return` throws a
+  // TypeError when invoked with `iter` as `this` and no arguments provided.
+  // It's irrelevant that in hosts that support the [[IsHTMLDDA]] internal slot,
+  // this object has that slot: `<iterator>.return` behavior is skipped only if
+  // that property is exactly the value `undefined`, not a value loosely equal
+  // to it.
+  for (var x of iter)
+    break;
+});


### PR DESCRIPTION
This is generally very cheesy.  But it happens that if you slot in `$262.uncallableAndIsHTMLDDA = () => document.all` in SpiderMonkey, these tests fail right now, because we did a loose-equality check against `undefined` rather than a strict-equality check.  So, it would be nice to have upstream testing of that in case other implementations are similarly buggy.

Note that per the very peculiar requirements of `$262.uncallableAndIsHTMLDDA`, hosts that don't support `document.all` or anything stupid like it can just add

    $262.uncallableAndIsHTMLDDA = function() { return {}; };

to their support files to run these tests.  The `[[IsHTMLDDA]]` aspects could be omitted from the object returned by this function, and it wouldn't change the tests' behaviors.

https://github.com/tc39/test262/blob/master/INTERPRETING.md currently suggests the version in https://github.com/tc39/test262/blob/master/package.json will be incremented for "substantive" changes.  This might or might not be.  If it is, let me know what I should bump it to -- I left it alone because I'm vaguely guessing the feature-guard is enough for hosts' ease of updating here.