### PR TITLE
Make Atomics.wake test cases resilient on slow / overloaded systems

### DIFF
--- a/test/built-ins/Atomics/wake/wake-all-on-loc.js
+++ b/test/built-ins/Atomics/wake/wake-all-on-loc.js
@@ -8,12 +8,20 @@ description: >
   wake waiters on other locations.
 ---*/
 
-for ( var i=0 ; i < 3 ; i++ ) {
+var WAKEUP = 0;                 // Waiters on this will be woken
+var DUMMY = 1;                  // Waiters on this will not be woken
+var RUNNING = 2;                // Accounting of live agents
+var NUMELEM = 3;
+
+var NUMAGENT = 3;
+
+for (var i=0; i < NUMAGENT; i++) {
 $262.agent.start(
 `
 $262.agent.receiveBroadcast(function (sab) {
   var ia = new Int32Array(sab);
-  $262.agent.report("A " + Atomics.wait(ia, 0, 0));
+  Atomics.add(ia, ${RUNNING}, 1);
+  $262.agent.report("A " + Atomics.wait(ia, ${WAKEUP}, 0));
   $262.agent.leaving();
 })
 `);
@@ -23,26 +31,47 @@ $262.agent.start(
 `
 $262.agent.receiveBroadcast(function (sab) {
   var ia = new Int32Array(sab);
-  $262.agent.report("B " + Atomics.wait(ia, 1, 0, 1000)); // We will timeout eventually
+  Atomics.add(ia, ${RUNNING}, 1);
+  // This will always time out.
+  $262.agent.report("B " + Atomics.wait(ia, ${DUMMY}, 0, 1000));
   $262.agent.leaving();
 })
 `);
 
-var ia = new Int32Array(new SharedArrayBuffer(2*Int32Array.BYTES_PER_ELEMENT));
-
+var ia = new Int32Array(new SharedArrayBuffer(NUMELEM * Int32Array.BYTES_PER_ELEMENT));
 $262.agent.broadcast(ia.buffer);
-$262.agent.sleep(500);                              // Give the agents a chance to wait
-assert.sameValue(Atomics.wake(ia, 0), 3);        // Wake all on location 0
-var rs = [getReport(), getReport(), getReport(), getReport()];
-// Do not sort the array -- B should timeout much after the others are woken
-assert.sameValue(rs[0], "A ok");
-assert.sameValue(rs[1], "A ok");
-assert.sameValue(rs[2], "A ok");
-assert.sameValue(rs[3], "B timed-out");
+
+// Wait for agents to be running.
+waitUntil(ia, RUNNING, NUMAGENT+1);
+
+// Then wait some more to give the agents a fair chance to wait.  If we don't,
+// we risk sending the wakeup before agents are sleeping, and we hang.
+$262.agent.sleep(500);
+
+// Wake all waiting on WAKEUP, should be 3 always, they won't time out.
+assert.sameValue(Atomics.wake(ia, WAKEUP), NUMAGENT);
+
+var rs = [];
+for (var i=0; i < NUMAGENT+1; i++)
+    rs.push(getReport());
+rs.sort();
+
+for (var i=0; i < NUMAGENT; i++)
+    assert.sameValue(rs[i], "A ok");
+assert.sameValue(rs[NUMAGENT], "B timed-out");
 
 function getReport() {
     var r;
     while ((r = $262.agent.getReport()) == null)
         $262.agent.sleep(100);
     return r;
+}
+
+function waitUntil(ia, k, value) {
+    var i = 0;
+    while (Atomics.load(ia, k) !== value && i < 15) {
+	$262.agent.sleep(100);
+	i++;
+    }
+    assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
 }

--- a/test/built-ins/Atomics/wake/wake-all.js
+++ b/test/built-ins/Atomics/wake/wake-all.js
@@ -7,31 +7,70 @@ description: >
   Test that Atomics.wake wakes all waiters if that's what the count is.
 ---*/
 
-for ( var i=0 ; i < 3 ; i++ ) {
+var WAKEUP = 0;                 // Waiters on this will be woken
+var DUMMY = 1;                  // Waiters on this will not be woken
+var RUNNING = 2;                // Accounting of live agents
+var NUMELEM = 3;
+
+var NUMAGENT = 3;
+
+for (var i=0; i < NUMAGENT; i++) {
 $262.agent.start(
 `
 $262.agent.receiveBroadcast(function (sab) {
   var ia = new Int32Array(sab);
-  $262.agent.report(Atomics.wait(ia, 0, 0, 1000)); // We may timeout eventually
+  Atomics.add(ia, ${RUNNING}, 1);
+  $262.agent.report("A " + Atomics.wait(ia, ${WAKEUP}, 0));
   $262.agent.leaving();
 })
 `);
 }
 
-var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+$262.agent.start(
+`
+$262.agent.receiveBroadcast(function (sab) {
+  var ia = new Int32Array(sab);
+  Atomics.add(ia, ${RUNNING}, 1);
+  // This will always time out.
+  $262.agent.report("B " + Atomics.wait(ia, ${DUMMY}, 0, 1000));
+  $262.agent.leaving();
+})
+`);
 
+var ia = new Int32Array(new SharedArrayBuffer(NUMELEM * Int32Array.BYTES_PER_ELEMENT));
 $262.agent.broadcast(ia.buffer);
-$262.agent.sleep(500);                              // Give the agents a chance to wait
-assert.sameValue(Atomics.wake(ia, 0), 3);        // Wake all
-var rs = [getReport(), getReport(), getReport()];
+
+// Wait for agents to be running.
+waitUntil(ia, RUNNING, NUMAGENT+1);
+
+// Then wait some more to give the agents a fair chance to wait.  If we don't,
+// we risk sending the wakeup before agents are sleeping, and we hang.
+$262.agent.sleep(500);
+
+// Wake all waiting on WAKEUP, should be 3 always, they won't time out.
+assert.sameValue(Atomics.wake(ia, WAKEUP), NUMAGENT);
+
+var rs = [];
+for (var i=0; i < NUMAGENT+1; i++)
+    rs.push(getReport());
 rs.sort();
-assert.sameValue(rs[0], "ok");
-assert.sameValue(rs[1], "ok");
-assert.sameValue(rs[2], "ok");
+
+for (var i=0; i < NUMAGENT; i++)
+    assert.sameValue(rs[i], "A ok");
+assert.sameValue(rs[NUMAGENT], "B timed-out");
 
 function getReport() {
     var r;
     while ((r = $262.agent.getReport()) == null)
         $262.agent.sleep(100);
     return r;
+}
+
+function waitUntil(ia, k, value) {
+    var i = 0;
+    while (Atomics.load(ia, k) !== value && i < 15) {
+	$262.agent.sleep(100);
+	i++;
+    }
+    assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
 }

--- a/test/built-ins/Atomics/wake/wake-in-order.js
+++ b/test/built-ins/Atomics/wake/wake-in-order.js
@@ -7,34 +7,50 @@ description: >
   Test that Atomics.wake wakes agents in the order they are waiting.
 ---*/
 
+var NUMAGENT = 3;
+
+var WAKEUP = 0;                 // Waiters on this will be woken
+var SPIN = 1;                   // Worker i (zero-based) spins on location SPIN+i
+var RUNNING = SPIN + NUMAGENT;  // Accounting of live agents
+var NUMELEM = RUNNING + 1;
+
 // Create workers and start them all spinning.  We set atomic slots to make
 // them go into a wait, thus controlling the waiting order.  Then we wake them
 // one by one and observe the wakeup order.
 
-for ( var i=0 ; i < 3 ; i++ ) {
+for ( var i=0 ; i < NUMAGENT ; i++ ) {
 $262.agent.start(
 `
 $262.agent.receiveBroadcast(function (sab) {
   var ia = new Int32Array(sab);
-  while (Atomics.load(ia, ${i+1}) == 0);
-  $262.agent.report(${i} + Atomics.wait(ia, 0, 0));
+  Atomics.add(ia, ${RUNNING}, 1);
+  while (Atomics.load(ia, ${SPIN + i}) === 0)
+      /* nothing */ ;
+  $262.agent.report(${i} + Atomics.wait(ia, ${WAKEUP}, 0));
   $262.agent.leaving();
 })
 `);
 }
 
-var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT*4));
+var ia = new Int32Array(new SharedArrayBuffer(NUMELEM * Int32Array.BYTES_PER_ELEMENT));
 $262.agent.broadcast(ia.buffer);
 
+// Wait for agents to be running.
+waitUntil(ia, RUNNING, NUMAGENT);
+
+// Then wait some more to give the agents a fair chance to wait.  If we don't,
+// we risk sending the wakeup before agents are sleeping, and we hang.
+$262.agent.sleep(500);
+
 // Make them sleep in order 0 1 2 on ia[0]
-for ( var i=0 ; i < 3 ; i++ ) {
-  Atomics.store(ia, i+1, 1);
+for ( var i=0 ; i < NUMAGENT ; i++ ) {
+  Atomics.store(ia, SPIN + i, 1);
   $262.agent.sleep(500);
 }
 
 // Wake them up one at a time and check the order is 0 1 2
-for ( var i=0 ; i < 3 ; i++ ) {
-  assert.sameValue(Atomics.wake(ia, 0, 1), 1);
+for ( var i=0 ; i < NUMAGENT ; i++ ) {
+  assert.sameValue(Atomics.wake(ia, WAKEUP, 1), 1);
   assert.sameValue(getReport(), i + "ok");
 }
 
@@ -45,4 +61,11 @@ function getReport() {
     return r;
 }
 
-
+function waitUntil(ia, k, value) {
+    var i = 0;
+    while (Atomics.load(ia, k) !== value && i < 15) {
+        $262.agent.sleep(100);
+        i++;
+    }
+    assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
+}

--- a/test/built-ins/Atomics/wake/wake-one.js
+++ b/test/built-ins/Atomics/wake/wake-one.js
@@ -7,37 +7,65 @@ description: >
   Test that Atomics.wake wakes one waiter if that's what the count is.
 ---*/
 
+var NUMAGENT = 3;
+
+var WAKEUP = 0;                 // Agents wait here
+var RUNNING = 1;                // Accounting of live agents here
+var NUMELEM = 2;
+
+var WAKECOUNT = 1;
+
+for ( var i=0 ; i < NUMAGENT ; i++ ) {
 $262.agent.start(
 `
 $262.agent.receiveBroadcast(function (sab) {
   var ia = new Int32Array(sab);
-  $262.agent.report(Atomics.wait(ia, 0, 0, 1000)); // We may timeout eventually
+  Atomics.add(ia, ${RUNNING}, 1);
+  // Waiters that are not woken will time out eventually.
+  $262.agent.report(Atomics.wait(ia, ${WAKEUP}, 0, 2000));
   $262.agent.leaving();
 })
 `);
+}
 
-$262.agent.start(
-`
-$262.agent.receiveBroadcast(function (sab) {
-  var ia = new Int32Array(sab);
-  $262.agent.report(Atomics.wait(ia, 0, 0, 1000)); // We may timeout eventually
-  $262.agent.leaving();
-})
-`);
-
-var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
-
+var ia = new Int32Array(new SharedArrayBuffer(NUMELEM * Int32Array.BYTES_PER_ELEMENT));
 $262.agent.broadcast(ia.buffer);
-$262.agent.sleep(500);                             // Give the agents a chance to wait
-assert.sameValue(Atomics.wake(ia, 0, 1), 1);    // Wake one
-var rs = [getReport(), getReport()];
+
+// Wait for agents to be running.
+waitUntil(ia, RUNNING, NUMAGENT);
+
+// Then wait some more to give the agents a fair chance to wait.  If we don't,
+// we risk sending the wakeup before agents are sleeping, and we hang.
+$262.agent.sleep(500);
+
+// There's a slight risk we'll fail to wake the desired count, if the preceding
+// sleep() took much longer than anticipated and workers have started timing
+// out.
+assert.sameValue(Atomics.wake(ia, 0, WAKECOUNT), WAKECOUNT);
+
+// Collect and check results
+var rs = [];
+for ( var i=0; i < NUMAGENT; i++ )
+    rs.push(getReport());
 rs.sort();
-assert.sameValue(rs[0], "ok");
-assert.sameValue(rs[1], "timed-out");
+
+for ( var i=0; i < WAKECOUNT; i++ )
+    assert.sameValue(rs[i], "ok");
+for ( var i=WAKECOUNT; i < NUMAGENT; i++ )
+    assert.sameValue(rs[i], "timed-out");
 
 function getReport() {
     var r;
     while ((r = $262.agent.getReport()) == null)
         $262.agent.sleep(100);
     return r;
+}
+
+function waitUntil(ia, k, value) {
+    var i = 0;
+    while (Atomics.load(ia, k) !== value && i < 15) {
+        $262.agent.sleep(100);
+        i++;
+    }
+    assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
 }

--- a/test/built-ins/Atomics/wake/wake-two.js
+++ b/test/built-ins/Atomics/wake/wake-two.js
@@ -7,31 +7,66 @@ description: >
   Test that Atomics.wake wakes two waiters if that's what the count is.
 ---*/
 
-for ( var i=0 ; i < 3 ; i++ ) {
+
+var NUMAGENT = 3;
+
+var WAKEUP = 0;                 // Agents wait here
+var RUNNING = 1;                // Accounting of live agents here
+var NUMELEM = 2;
+
+var WAKECOUNT = 2;
+
+for ( var i=0 ; i < NUMAGENT ; i++ ) {
 $262.agent.start(
 `
 $262.agent.receiveBroadcast(function (sab) {
   var ia = new Int32Array(sab);
-  $262.agent.report(Atomics.wait(ia, 0, 0, 1000)); // We may timeout eventually
+  Atomics.add(ia, ${RUNNING}, 1);
+  // Waiters that are not woken will time out eventually.
+  $262.agent.report(Atomics.wait(ia, ${WAKEUP}, 0, 2000));
   $262.agent.leaving();
 })
 `);
 }
 
-var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
-
+var ia = new Int32Array(new SharedArrayBuffer(NUMELEM * Int32Array.BYTES_PER_ELEMENT));
 $262.agent.broadcast(ia.buffer);
-$262.agent.sleep(500);                             // Give the agents a chance to wait
-assert.sameValue(Atomics.wake(ia, 0, 2), 2);    // Wake two
-var rs = [getReport(), getReport(), getReport()];
+
+// Wait for agents to be running.
+waitUntil(ia, RUNNING, NUMAGENT);
+
+// Then wait some more to give the agents a fair chance to wait.  If we don't,
+// we risk sending the wakeup before agents are sleeping, and we hang.
+$262.agent.sleep(500);
+
+// There's a slight risk we'll fail to wake the desired count, if the preceding
+// sleep() took much longer than anticipated and workers have started timing
+// out.
+assert.sameValue(Atomics.wake(ia, 0, WAKECOUNT), WAKECOUNT);
+
+// Collect and check results
+var rs = [];
+for ( var i=0; i < NUMAGENT; i++ )
+    rs.push(getReport());
 rs.sort();
-assert.sameValue(rs[0], "ok");
-assert.sameValue(rs[1], "ok");
-assert.sameValue(rs[2], "timed-out");
+
+for ( var i=0; i < WAKECOUNT; i++ )
+    assert.sameValue(rs[i], "ok");
+for ( var i=WAKECOUNT; i < NUMAGENT; i++ )
+    assert.sameValue(rs[i], "timed-out");
 
 function getReport() {
     var r;
     while ((r = $262.agent.getReport()) == null)
         $262.agent.sleep(100);
     return r;
+}
+
+function waitUntil(ia, k, value) {
+    var i = 0;
+    while (Atomics.load(ia, k) !== value && i < 15) {
+        $262.agent.sleep(100);
+        i++;
+    }
+    assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
 }


### PR DESCRIPTION
On slow and overloaded systems, it is possible for some of the fixed timeout limits in these tests to be insufficient because worker threads take a long time to become available and they can become available in weird orders.  I fixed some of these issues earlier; here are some more fixes.  The general theme is to always wait until all the worker threads have reported that they are available.  In addition I've cleaned up a little.

These tests are still not perfect, there is still a chance of timing out.  But making them even more robust than here makes it too likely that bugs will be hidden by the robustness mechanisms.