### PR TITLE
Fix Async-from-Sync Iterator tests

### DIFF
--- a/src/async-generators/yield-star-sync-next.case
+++ b/src/async-generators/yield-star-sync-next.case
@@ -184,26 +184,23 @@ iter.next("next-arg-1").then(v => {
   assert.sameValue(log.length, 8, "log.length");
 
   iter.next("next-arg-2").then(v => {
-    assert.sameValue(log[8].name, "get next");
-    assert.sameValue(log[8].thisValue.name, "syncIterator", "get next thisValue");
+    assert.sameValue(log[8].name, "call next");
+    assert.sameValue(log[8].thisValue.name, "syncIterator", "next thisValue");
+    assert.sameValue(log[8].args.length, 1, "next args.length");
+    assert.sameValue(log[8].args[0], "next-arg-2", "next args[0]");
 
-    assert.sameValue(log[9].name, "call next");
-    assert.sameValue(log[9].thisValue.name, "syncIterator", "next thisValue");
-    assert.sameValue(log[9].args.length, 1, "next args.length");
-    assert.sameValue(log[9].args[0], "next-arg-2", "next args[0]");
+    assert.sameValue(log[9].name, "get next done (2)");
+    assert.sameValue(log[9].thisValue.name, "next-result-2", "get next done thisValue");
 
-    assert.sameValue(log[10].name, "get next done (2)");
-    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next done thisValue");
+    assert.sameValue(log[10].name, "get next value (2)");
+    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next value thisValue");
 
-    assert.sameValue(log[11].name, "get next value (2)");
-    assert.sameValue(log[11].thisValue.name, "next-result-2", "get next value thisValue");
-
-    assert.sameValue(log[12].name, "after yield*");
-    assert.sameValue(log[12].value, "next-value-2");
+    assert.sameValue(log[11].name, "after yield*");
+    assert.sameValue(log[11].value, "next-value-2");
 
     assert.sameValue(v.value, "return-value");
     assert.sameValue(v.done, true);
 
-    assert.sameValue(log.length, 13, "log.length");
+    assert.sameValue(log.length, 12, "log.length");
   }).then($DONE, $DONE);
 }).catch($DONE);

--- a/test/language/expressions/async-generator/named-yield-star-sync-next.js
+++ b/test/language/expressions/async-generator/named-yield-star-sync-next.js
@@ -197,27 +197,24 @@ iter.next("next-arg-1").then(v => {
   assert.sameValue(log.length, 8, "log.length");
 
   iter.next("next-arg-2").then(v => {
-    assert.sameValue(log[8].name, "get next");
-    assert.sameValue(log[8].thisValue.name, "syncIterator", "get next thisValue");
+    assert.sameValue(log[8].name, "call next");
+    assert.sameValue(log[8].thisValue.name, "syncIterator", "next thisValue");
+    assert.sameValue(log[8].args.length, 1, "next args.length");
+    assert.sameValue(log[8].args[0], "next-arg-2", "next args[0]");
 
-    assert.sameValue(log[9].name, "call next");
-    assert.sameValue(log[9].thisValue.name, "syncIterator", "next thisValue");
-    assert.sameValue(log[9].args.length, 1, "next args.length");
-    assert.sameValue(log[9].args[0], "next-arg-2", "next args[0]");
+    assert.sameValue(log[9].name, "get next done (2)");
+    assert.sameValue(log[9].thisValue.name, "next-result-2", "get next done thisValue");
 
-    assert.sameValue(log[10].name, "get next done (2)");
-    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next done thisValue");
+    assert.sameValue(log[10].name, "get next value (2)");
+    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next value thisValue");
 
-    assert.sameValue(log[11].name, "get next value (2)");
-    assert.sameValue(log[11].thisValue.name, "next-result-2", "get next value thisValue");
-
-    assert.sameValue(log[12].name, "after yield*");
-    assert.sameValue(log[12].value, "next-value-2");
+    assert.sameValue(log[11].name, "after yield*");
+    assert.sameValue(log[11].value, "next-value-2");
 
     assert.sameValue(v.value, "return-value");
     assert.sameValue(v.done, true);
 
-    assert.sameValue(log.length, 13, "log.length");
+    assert.sameValue(log.length, 12, "log.length");
   }).then($DONE, $DONE);
 }).catch($DONE);
 

--- a/test/language/expressions/async-generator/yield-star-sync-next.js
+++ b/test/language/expressions/async-generator/yield-star-sync-next.js
@@ -197,27 +197,24 @@ iter.next("next-arg-1").then(v => {
   assert.sameValue(log.length, 8, "log.length");
 
   iter.next("next-arg-2").then(v => {
-    assert.sameValue(log[8].name, "get next");
-    assert.sameValue(log[8].thisValue.name, "syncIterator", "get next thisValue");
+    assert.sameValue(log[8].name, "call next");
+    assert.sameValue(log[8].thisValue.name, "syncIterator", "next thisValue");
+    assert.sameValue(log[8].args.length, 1, "next args.length");
+    assert.sameValue(log[8].args[0], "next-arg-2", "next args[0]");
 
-    assert.sameValue(log[9].name, "call next");
-    assert.sameValue(log[9].thisValue.name, "syncIterator", "next thisValue");
-    assert.sameValue(log[9].args.length, 1, "next args.length");
-    assert.sameValue(log[9].args[0], "next-arg-2", "next args[0]");
+    assert.sameValue(log[9].name, "get next done (2)");
+    assert.sameValue(log[9].thisValue.name, "next-result-2", "get next done thisValue");
 
-    assert.sameValue(log[10].name, "get next done (2)");
-    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next done thisValue");
+    assert.sameValue(log[10].name, "get next value (2)");
+    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next value thisValue");
 
-    assert.sameValue(log[11].name, "get next value (2)");
-    assert.sameValue(log[11].thisValue.name, "next-result-2", "get next value thisValue");
-
-    assert.sameValue(log[12].name, "after yield*");
-    assert.sameValue(log[12].value, "next-value-2");
+    assert.sameValue(log[11].name, "after yield*");
+    assert.sameValue(log[11].value, "next-value-2");
 
     assert.sameValue(v.value, "return-value");
     assert.sameValue(v.done, true);
 
-    assert.sameValue(log.length, 13, "log.length");
+    assert.sameValue(log.length, 12, "log.length");
   }).then($DONE, $DONE);
 }).catch($DONE);
 

--- a/test/language/expressions/class/async-gen-method-static-yield-star-sync-next.js
+++ b/test/language/expressions/class/async-gen-method-static-yield-star-sync-next.js
@@ -204,27 +204,24 @@ iter.next("next-arg-1").then(v => {
   assert.sameValue(log.length, 8, "log.length");
 
   iter.next("next-arg-2").then(v => {
-    assert.sameValue(log[8].name, "get next");
-    assert.sameValue(log[8].thisValue.name, "syncIterator", "get next thisValue");
+    assert.sameValue(log[8].name, "call next");
+    assert.sameValue(log[8].thisValue.name, "syncIterator", "next thisValue");
+    assert.sameValue(log[8].args.length, 1, "next args.length");
+    assert.sameValue(log[8].args[0], "next-arg-2", "next args[0]");
 
-    assert.sameValue(log[9].name, "call next");
-    assert.sameValue(log[9].thisValue.name, "syncIterator", "next thisValue");
-    assert.sameValue(log[9].args.length, 1, "next args.length");
-    assert.sameValue(log[9].args[0], "next-arg-2", "next args[0]");
+    assert.sameValue(log[9].name, "get next done (2)");
+    assert.sameValue(log[9].thisValue.name, "next-result-2", "get next done thisValue");
 
-    assert.sameValue(log[10].name, "get next done (2)");
-    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next done thisValue");
+    assert.sameValue(log[10].name, "get next value (2)");
+    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next value thisValue");
 
-    assert.sameValue(log[11].name, "get next value (2)");
-    assert.sameValue(log[11].thisValue.name, "next-result-2", "get next value thisValue");
-
-    assert.sameValue(log[12].name, "after yield*");
-    assert.sameValue(log[12].value, "next-value-2");
+    assert.sameValue(log[11].name, "after yield*");
+    assert.sameValue(log[11].value, "next-value-2");
 
     assert.sameValue(v.value, "return-value");
     assert.sameValue(v.done, true);
 
-    assert.sameValue(log.length, 13, "log.length");
+    assert.sameValue(log.length, 12, "log.length");
   }).then($DONE, $DONE);
 }).catch($DONE);
 

--- a/test/language/expressions/class/async-gen-method-yield-star-sync-next.js
+++ b/test/language/expressions/class/async-gen-method-yield-star-sync-next.js
@@ -204,27 +204,24 @@ iter.next("next-arg-1").then(v => {
   assert.sameValue(log.length, 8, "log.length");
 
   iter.next("next-arg-2").then(v => {
-    assert.sameValue(log[8].name, "get next");
-    assert.sameValue(log[8].thisValue.name, "syncIterator", "get next thisValue");
+    assert.sameValue(log[8].name, "call next");
+    assert.sameValue(log[8].thisValue.name, "syncIterator", "next thisValue");
+    assert.sameValue(log[8].args.length, 1, "next args.length");
+    assert.sameValue(log[8].args[0], "next-arg-2", "next args[0]");
 
-    assert.sameValue(log[9].name, "call next");
-    assert.sameValue(log[9].thisValue.name, "syncIterator", "next thisValue");
-    assert.sameValue(log[9].args.length, 1, "next args.length");
-    assert.sameValue(log[9].args[0], "next-arg-2", "next args[0]");
+    assert.sameValue(log[9].name, "get next done (2)");
+    assert.sameValue(log[9].thisValue.name, "next-result-2", "get next done thisValue");
 
-    assert.sameValue(log[10].name, "get next done (2)");
-    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next done thisValue");
+    assert.sameValue(log[10].name, "get next value (2)");
+    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next value thisValue");
 
-    assert.sameValue(log[11].name, "get next value (2)");
-    assert.sameValue(log[11].thisValue.name, "next-result-2", "get next value thisValue");
-
-    assert.sameValue(log[12].name, "after yield*");
-    assert.sameValue(log[12].value, "next-value-2");
+    assert.sameValue(log[11].name, "after yield*");
+    assert.sameValue(log[11].value, "next-value-2");
 
     assert.sameValue(v.value, "return-value");
     assert.sameValue(v.done, true);
 
-    assert.sameValue(log.length, 13, "log.length");
+    assert.sameValue(log.length, 12, "log.length");
   }).then($DONE, $DONE);
 }).catch($DONE);
 

--- a/test/language/expressions/object/method-definition/async-gen-yield-star-sync-next.js
+++ b/test/language/expressions/object/method-definition/async-gen-yield-star-sync-next.js
@@ -197,27 +197,24 @@ iter.next("next-arg-1").then(v => {
   assert.sameValue(log.length, 8, "log.length");
 
   iter.next("next-arg-2").then(v => {
-    assert.sameValue(log[8].name, "get next");
-    assert.sameValue(log[8].thisValue.name, "syncIterator", "get next thisValue");
+    assert.sameValue(log[8].name, "call next");
+    assert.sameValue(log[8].thisValue.name, "syncIterator", "next thisValue");
+    assert.sameValue(log[8].args.length, 1, "next args.length");
+    assert.sameValue(log[8].args[0], "next-arg-2", "next args[0]");
 
-    assert.sameValue(log[9].name, "call next");
-    assert.sameValue(log[9].thisValue.name, "syncIterator", "next thisValue");
-    assert.sameValue(log[9].args.length, 1, "next args.length");
-    assert.sameValue(log[9].args[0], "next-arg-2", "next args[0]");
+    assert.sameValue(log[9].name, "get next done (2)");
+    assert.sameValue(log[9].thisValue.name, "next-result-2", "get next done thisValue");
 
-    assert.sameValue(log[10].name, "get next done (2)");
-    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next done thisValue");
+    assert.sameValue(log[10].name, "get next value (2)");
+    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next value thisValue");
 
-    assert.sameValue(log[11].name, "get next value (2)");
-    assert.sameValue(log[11].thisValue.name, "next-result-2", "get next value thisValue");
-
-    assert.sameValue(log[12].name, "after yield*");
-    assert.sameValue(log[12].value, "next-value-2");
+    assert.sameValue(log[11].name, "after yield*");
+    assert.sameValue(log[11].value, "next-value-2");
 
     assert.sameValue(v.value, "return-value");
     assert.sameValue(v.done, true);
 
-    assert.sameValue(log.length, 13, "log.length");
+    assert.sameValue(log.length, 12, "log.length");
   }).then($DONE, $DONE);
 }).catch($DONE);
 

--- a/test/language/statements/async-generator/yield-star-sync-next.js
+++ b/test/language/statements/async-generator/yield-star-sync-next.js
@@ -197,27 +197,24 @@ iter.next("next-arg-1").then(v => {
   assert.sameValue(log.length, 8, "log.length");
 
   iter.next("next-arg-2").then(v => {
-    assert.sameValue(log[8].name, "get next");
-    assert.sameValue(log[8].thisValue.name, "syncIterator", "get next thisValue");
+    assert.sameValue(log[8].name, "call next");
+    assert.sameValue(log[8].thisValue.name, "syncIterator", "next thisValue");
+    assert.sameValue(log[8].args.length, 1, "next args.length");
+    assert.sameValue(log[8].args[0], "next-arg-2", "next args[0]");
 
-    assert.sameValue(log[9].name, "call next");
-    assert.sameValue(log[9].thisValue.name, "syncIterator", "next thisValue");
-    assert.sameValue(log[9].args.length, 1, "next args.length");
-    assert.sameValue(log[9].args[0], "next-arg-2", "next args[0]");
+    assert.sameValue(log[9].name, "get next done (2)");
+    assert.sameValue(log[9].thisValue.name, "next-result-2", "get next done thisValue");
 
-    assert.sameValue(log[10].name, "get next done (2)");
-    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next done thisValue");
+    assert.sameValue(log[10].name, "get next value (2)");
+    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next value thisValue");
 
-    assert.sameValue(log[11].name, "get next value (2)");
-    assert.sameValue(log[11].thisValue.name, "next-result-2", "get next value thisValue");
-
-    assert.sameValue(log[12].name, "after yield*");
-    assert.sameValue(log[12].value, "next-value-2");
+    assert.sameValue(log[11].name, "after yield*");
+    assert.sameValue(log[11].value, "next-value-2");
 
     assert.sameValue(v.value, "return-value");
     assert.sameValue(v.done, true);
 
-    assert.sameValue(log.length, 13, "log.length");
+    assert.sameValue(log.length, 12, "log.length");
   }).then($DONE, $DONE);
 }).catch($DONE);
 

--- a/test/language/statements/class/async-gen-method-static-yield-star-sync-next.js
+++ b/test/language/statements/class/async-gen-method-static-yield-star-sync-next.js
@@ -204,27 +204,24 @@ iter.next("next-arg-1").then(v => {
   assert.sameValue(log.length, 8, "log.length");
 
   iter.next("next-arg-2").then(v => {
-    assert.sameValue(log[8].name, "get next");
-    assert.sameValue(log[8].thisValue.name, "syncIterator", "get next thisValue");
+    assert.sameValue(log[8].name, "call next");
+    assert.sameValue(log[8].thisValue.name, "syncIterator", "next thisValue");
+    assert.sameValue(log[8].args.length, 1, "next args.length");
+    assert.sameValue(log[8].args[0], "next-arg-2", "next args[0]");
 
-    assert.sameValue(log[9].name, "call next");
-    assert.sameValue(log[9].thisValue.name, "syncIterator", "next thisValue");
-    assert.sameValue(log[9].args.length, 1, "next args.length");
-    assert.sameValue(log[9].args[0], "next-arg-2", "next args[0]");
+    assert.sameValue(log[9].name, "get next done (2)");
+    assert.sameValue(log[9].thisValue.name, "next-result-2", "get next done thisValue");
 
-    assert.sameValue(log[10].name, "get next done (2)");
-    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next done thisValue");
+    assert.sameValue(log[10].name, "get next value (2)");
+    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next value thisValue");
 
-    assert.sameValue(log[11].name, "get next value (2)");
-    assert.sameValue(log[11].thisValue.name, "next-result-2", "get next value thisValue");
-
-    assert.sameValue(log[12].name, "after yield*");
-    assert.sameValue(log[12].value, "next-value-2");
+    assert.sameValue(log[11].name, "after yield*");
+    assert.sameValue(log[11].value, "next-value-2");
 
     assert.sameValue(v.value, "return-value");
     assert.sameValue(v.done, true);
 
-    assert.sameValue(log.length, 13, "log.length");
+    assert.sameValue(log.length, 12, "log.length");
   }).then($DONE, $DONE);
 }).catch($DONE);
 

--- a/test/language/statements/class/async-gen-method-yield-star-sync-next.js
+++ b/test/language/statements/class/async-gen-method-yield-star-sync-next.js
@@ -204,27 +204,24 @@ iter.next("next-arg-1").then(v => {
   assert.sameValue(log.length, 8, "log.length");
 
   iter.next("next-arg-2").then(v => {
-    assert.sameValue(log[8].name, "get next");
-    assert.sameValue(log[8].thisValue.name, "syncIterator", "get next thisValue");
+    assert.sameValue(log[8].name, "call next");
+    assert.sameValue(log[8].thisValue.name, "syncIterator", "next thisValue");
+    assert.sameValue(log[8].args.length, 1, "next args.length");
+    assert.sameValue(log[8].args[0], "next-arg-2", "next args[0]");
 
-    assert.sameValue(log[9].name, "call next");
-    assert.sameValue(log[9].thisValue.name, "syncIterator", "next thisValue");
-    assert.sameValue(log[9].args.length, 1, "next args.length");
-    assert.sameValue(log[9].args[0], "next-arg-2", "next args[0]");
+    assert.sameValue(log[9].name, "get next done (2)");
+    assert.sameValue(log[9].thisValue.name, "next-result-2", "get next done thisValue");
 
-    assert.sameValue(log[10].name, "get next done (2)");
-    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next done thisValue");
+    assert.sameValue(log[10].name, "get next value (2)");
+    assert.sameValue(log[10].thisValue.name, "next-result-2", "get next value thisValue");
 
-    assert.sameValue(log[11].name, "get next value (2)");
-    assert.sameValue(log[11].thisValue.name, "next-result-2", "get next value thisValue");
-
-    assert.sameValue(log[12].name, "after yield*");
-    assert.sameValue(log[12].value, "next-value-2");
+    assert.sameValue(log[11].name, "after yield*");
+    assert.sameValue(log[11].value, "next-value-2");
 
     assert.sameValue(v.value, "return-value");
     assert.sameValue(v.done, true);
 
-    assert.sameValue(log.length, 13, "log.length");
+    assert.sameValue(log.length, 12, "log.length");
   }).then($DONE, $DONE);
 }).catch($DONE);
 


### PR DESCRIPTION
This change updates test cases to assume that the "next" method is only
loaded from a synchronous iterator once, and is re-used for each call to
Async-from-Sync Iterator.next(), based on tc39/ecma262#988