### PR TITLE
Modify $262.uncallableAndIsHTMLDDA() to $262.fakeDocumentAll, and narrowly/correctly prescribe its requirements consistent with `document.all`'s behavior in HTML

### DIFF
--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -64,16 +64,16 @@ properties of the global scope prior to test execution.
         6. Return Completion(status).
 
   - **`global`** - a reference to the global object on which `$262` was initially defined
-  - **`uncallableAndIsHTMLDDA`** - a function that returns an object *`obj`* for
-    which [Call](https://tc39.github.io/ecma262/#sec-call)(*`obj`*, *any value*, «»)
-    throws a `TypeError`.  (The value of [IsCallable]()(*`obj`*) is unspecified:
-    a callable *`obj`* that throws a `TypeError` or an uncallable *`obj`* works
-    equally well.)  In hosts supporting the
-    [IsHTMLDDA](https://tc39.github.io/ecma262/#sec-IsHTMLDDA-internal-slot)
-    internal slot, *`obj`* must also have such a slot.  (These highly specific
-    behaviors are entirely motivated by the very few tests that use this.  Read
-    them for an explanation.)  Tests that use this function should be marked as
-    using the `uncallableAndIsHTMLDDA` feature.
+  - **`IsHTMLDDA`** - (present only in implementations that can provide it) an
+    object that 1) has an [[IsHTMLDDA]] internal slot, and 2) when called with
+    no arguments or with the single argument `""` returns `null`.  Use this
+    property to test that ECMAScript algorithms aren't mis-implemented to treat
+    `document.all` as being `undefined` or of type Undefined (instead of
+    Object).  (The peculiar second requirement permits testing algorithms when
+    they also call `document.all` with such arguments, so that testing for
+    correct behavior requires knowing how the call behaves.  This is rarely
+    necessary.)  Tests using this function must be tagged with the `IsHTMLDDA`
+    feature so that only hosts supporting this property will run them.
   - **`agent`** - an ordinary object with the following properties:
     - **`start`** - a function that takes a script source string and runs
       the script in a concurrent agent.  Will block until that agent is

--- a/features.txt
+++ b/features.txt
@@ -124,4 +124,4 @@ WeakSet
 # language features, exposed through global-environment functions on the $262
 # object, go here.
 
-uncallableAndIsHTMLDDA
+IsHTMLDDA

--- a/test/annexB/language/expressions/yield/star-iterable-return-emulates-undefined-throws-when-called.js
+++ b/test/annexB/language/expressions/yield/star-iterable-return-emulates-undefined-throws-when-called.js
@@ -2,18 +2,19 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es6id: sec-generator-function-definitions-runtime-semantics-evaluation
+esid: sec-generator-function-definitions-runtime-semantics-evaluation
 description: >
     If <iterator>.return is an object emulating `undefined` (e.g. `document.all`
     in browsers), it shouldn't be treated as if it were actually `undefined` by
     the yield* operator.
-features: [generators, uncallableAndIsHTMLDDA]
+features: [generators, IsHTMLDDA]
 ---*/
 
+var IsHTMLDDA = $262.IsHTMLDDA;
 var iter = {
   [Symbol.iterator]() { return this; },
   next() { return {}; },
-  return: $262.uncallableAndIsHTMLDDA(),
+  return: IsHTMLDDA,
 };
 
 var outer = (function*() { yield* iter; })();
@@ -21,11 +22,10 @@ var outer = (function*() { yield* iter; })();
 outer.next();
 
 assert.throws(TypeError, function() {
-  // This code is expected to throw a TypeError because `iter.return` throws a
-  // TypeError when invoked with `iter` as `this` and no arguments provided.
-  // It's irrelevant that in hosts that support the [[IsHTMLDDA]] internal slot,
-  // this object has that slot: `<iterator>.return` behavior is skipped only if
-  // that property is exactly the value `undefined`, not a value loosely equal
-  // to it.
-  outer.return();
+  // `IsHTMLDDA` is called here with `iter` as `this` and `emptyString` as the
+  // sole argument, and it's specified to return `null` under these conditions.
+  // As `iter`'s iteration isn't ending because of a throw, the iteration
+  // protocol will then throw a `TypeError` because `null` isn't an object.
+  var emptyString = "";
+  outer.return(emptyString);
 });

--- a/test/annexB/language/statements/for-of/iterator-close-return-emulates-undefined-throws-when-called.js
+++ b/test/annexB/language/statements/for-of/iterator-close-return-emulates-undefined-throws-when-called.js
@@ -2,26 +2,24 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es6id: sec-iteratorclose
+esid: sec-iteratorclose
 description: >
     If <iterator>.return is an object emulating `undefined` (e.g. `document.all`
     in browsers), it shouldn't be treated as if it were actually `undefined`.
-features: [generators, uncallableAndIsHTMLDDA]
+features: [generators, IsHTMLDDA]
 ---*/
 
+var IsHTMLDDA = $262.IsHTMLDDA;
 var iter = {
   [Symbol.iterator]() { return this; },
   next() { return {}; },
-  return: $262.uncallableAndIsHTMLDDA(),
+  return: IsHTMLDDA,
 };
 
 assert.throws(TypeError, function() {
-  // This code is expected to throw a TypeError because `iter.return` throws a
-  // TypeError when invoked with `iter` as `this` and no arguments provided.
-  // It's irrelevant that in hosts that support the [[IsHTMLDDA]] internal slot,
-  // this object has that slot: `<iterator>.return` behavior is skipped only if
-  // that property is exactly the value `undefined`, not a value loosely equal
-  // to it.
+  // `IsHTMLDDA` is called here with `iter` as `this` and no arguments, and it's
+  // specified to return `null` under these conditions.  Then the iteration
+  // protocol throws a `TypeError` because `null` isn't an object.
   for (var x of iter)
     break;
 });


### PR DESCRIPTION
The current definitions of this stuff aren't consistent with how HTML defines `document.all`'s behavior, so we gotta fix that.  The three tests that use this functionality have very particular requirements for how this value behaves when called, so define the requirements of this object to narrowly encompass them.

@bakkot is mostly of the opinion that this should just be a browser-only sort of test and use `document.all` specifically.  In practice, however, those of us who work on JS engines get a ton of value out of not having to build the browser to run a test.  That value is well worth the narrowly-defined specificity of the requirements for this.

SpiderMonkey's `objectEmulatingUndefined` won't be adequate to mock this any more (it's not callable), but I can fix it up/rename it to have the necessary additional behaviors.  @bakkot has at least convinced me it's not worth exposing that unless it behaves as much like `document.all` as we need it to.  :-)

See also #1304, to which I don't know how to attach this branch-merge-request without opening an entirely fresh PR for it.