### PR TITLE
Missing generators flags

### DIFF
--- a/src/arguments/default/cls-decl-gen-meth-static.template
+++ b/src/arguments/default/cls-decl-gen-meth-static.template
@@ -11,6 +11,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+features: [generators]
 ---*/
 
 var callCount = 0;

--- a/src/arguments/default/cls-decl-gen-meth.template
+++ b/src/arguments/default/cls-decl-gen-meth.template
@@ -11,6 +11,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+features: [generators]
 ---*/
 
 var callCount = 0;

--- a/src/arguments/default/cls-expr-gen-meth-static.template
+++ b/src/arguments/default/cls-expr-gen-meth-static.template
@@ -11,6 +11,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+features: [generators]
 ---*/
 
 var callCount = 0;

--- a/src/arguments/default/cls-expr-gen-meth.template
+++ b/src/arguments/default/cls-expr-gen-meth.template
@@ -11,6 +11,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+features: [generators]
 ---*/
 
 var callCount = 0;

--- a/src/arguments/default/gen-meth.template
+++ b/src/arguments/default/gen-meth.template
@@ -11,6 +11,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+features: [generators]
 ---*/
 
 var callCount = 0;

--- a/src/class-fields/default/cls-decl-after-same-line-gen.template
+++ b/src/class-fields/default/cls-decl-after-same-line-gen.template
@@ -4,7 +4,7 @@
 /*---
 path: language/statements/class/fields-after-same-line-gen-
 name: field definitions after a generator in the same line
-features: [class-fields]
+features: [generators, class-fields]
 esid: prod-FieldDefinition
 ---*/
 

--- a/src/class-fields/default/cls-decl-after-same-line-static-gen.template
+++ b/src/class-fields/default/cls-decl-after-same-line-static-gen.template
@@ -4,7 +4,7 @@
 /*---
 path: language/statements/class/fields-after-same-line-static-gen-
 name: field definitions after a static generator in the same line
-features: [class-fields]
+features: [generators, class-fields]
 esid: prod-FieldDefinition
 ---*/
 

--- a/src/class-fields/default/cls-expr-after-same-line-gen.template
+++ b/src/class-fields/default/cls-expr-after-same-line-gen.template
@@ -4,7 +4,7 @@
 /*---
 path: language/expressions/class/fields-after-same-line-gen-
 name: field definitions after a generator in the same line
-features: [class-fields]
+features: [generators, class-fields]
 esid: prod-FieldDefinition
 ---*/
 

--- a/src/class-fields/default/cls-expr-after-same-line-static-gen.template
+++ b/src/class-fields/default/cls-expr-after-same-line-static-gen.template
@@ -4,7 +4,7 @@
 /*---
 path: language/expressions/class/fields-after-same-line-static-gen-
 name: field definitions after a static generator in the same line
-features: [class-fields]
+features: [generators, class-fields]
 esid: prod-FieldDefinition
 ---*/
 

--- a/src/function-forms/syntax/async-meth.template
+++ b/src/function-forms/syntax/async-meth.template
@@ -10,6 +10,7 @@ info: |
 
   AsyncMethod :
    async PropertyName ( UniqueFormalParameters ) { AsyncFunctionBody }
+features: [async-iteration]
 ---*/
 
 ({

--- a/test/annexB/built-ins/RegExp/RegExp-control-escape-russian-letter.js
+++ b/test/annexB/built-ins/RegExp/RegExp-control-escape-russian-letter.js
@@ -8,6 +8,7 @@ es6id: B.1.4
 description: >
   "ControlLetter :: RUSSIAN ALPHABET is incorrect"
   Instead, fall back to semantics to match literal "\\c"
+features: [generators]
 ---*/
 
 function* invalidControls() {

--- a/test/annexB/built-ins/RegExp/RegExp-invalid-control-escape-character-class.js
+++ b/test/annexB/built-ins/RegExp/RegExp-invalid-control-escape-character-class.js
@@ -10,6 +10,7 @@ info: >
 
   The production ClassAtomNoDash :: `\` evaluates as follows:
     1. Return the CharSet containing the single character `\`.
+features: [generators]
 ---*/
 
 function* invalidControls() {

--- a/test/built-ins/Function/prototype/toString/GeneratorFunction.js
+++ b/test/built-ins/Function/prototype/toString/GeneratorFunction.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-createdynamicfunction
 description: Function.prototype.toString on a generator function created with the GeneratorFunction constructor
+features: [generators]
 ---*/
 
 let GeneratorFunction = Object.getPrototypeOf(function*(){}).constructor;

--- a/test/language/arguments-object/cls-decl-gen-meth-args-trailing-comma-multiple.js
+++ b/test/language/arguments-object/cls-decl-gen-meth-args-trailing-comma-multiple.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma should not increase the arguments.length, using multiple args (class declaration generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-decl-gen-meth-args-trailing-comma-null.js
+++ b/test/language/arguments-object/cls-decl-gen-meth-args-trailing-comma-null.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma after null should not increase the arguments.length (class declaration generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-decl-gen-meth-args-trailing-comma-single-args.js
+++ b/test/language/arguments-object/cls-decl-gen-meth-args-trailing-comma-single-args.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma should not increase the arguments.length, using a single arg (class declaration generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-decl-gen-meth-args-trailing-comma-undefined.js
+++ b/test/language/arguments-object/cls-decl-gen-meth-args-trailing-comma-undefined.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma after undefined should not increase the arguments.length (class declaration generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-decl-gen-meth-static-args-trailing-comma-multiple.js
+++ b/test/language/arguments-object/cls-decl-gen-meth-static-args-trailing-comma-multiple.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma should not increase the arguments.length, using multiple args (class declaration generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-decl-gen-meth-static-args-trailing-comma-null.js
+++ b/test/language/arguments-object/cls-decl-gen-meth-static-args-trailing-comma-null.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma after null should not increase the arguments.length (class declaration generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-decl-gen-meth-static-args-trailing-comma-single-args.js
+++ b/test/language/arguments-object/cls-decl-gen-meth-static-args-trailing-comma-single-args.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma should not increase the arguments.length, using a single arg (class declaration generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-decl-gen-meth-static-args-trailing-comma-undefined.js
+++ b/test/language/arguments-object/cls-decl-gen-meth-static-args-trailing-comma-undefined.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma after undefined should not increase the arguments.length (class declaration generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-expr-gen-meth-args-trailing-comma-multiple.js
+++ b/test/language/arguments-object/cls-expr-gen-meth-args-trailing-comma-multiple.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma should not increase the arguments.length, using multiple args (class expression generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-expr-gen-meth-args-trailing-comma-null.js
+++ b/test/language/arguments-object/cls-expr-gen-meth-args-trailing-comma-null.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma after null should not increase the arguments.length (class expression generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-expr-gen-meth-args-trailing-comma-single-args.js
+++ b/test/language/arguments-object/cls-expr-gen-meth-args-trailing-comma-single-args.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma should not increase the arguments.length, using a single arg (class expression generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-expr-gen-meth-args-trailing-comma-undefined.js
+++ b/test/language/arguments-object/cls-expr-gen-meth-args-trailing-comma-undefined.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma after undefined should not increase the arguments.length (class expression generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-expr-gen-meth-static-args-trailing-comma-multiple.js
+++ b/test/language/arguments-object/cls-expr-gen-meth-static-args-trailing-comma-multiple.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma should not increase the arguments.length, using multiple args (static class expression generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-expr-gen-meth-static-args-trailing-comma-null.js
+++ b/test/language/arguments-object/cls-expr-gen-meth-static-args-trailing-comma-null.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma after null should not increase the arguments.length (static class expression generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-expr-gen-meth-static-args-trailing-comma-single-args.js
+++ b/test/language/arguments-object/cls-expr-gen-meth-static-args-trailing-comma-single-args.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma should not increase the arguments.length, using a single arg (static class expression generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/cls-expr-gen-meth-static-args-trailing-comma-undefined.js
+++ b/test/language/arguments-object/cls-expr-gen-meth-static-args-trailing-comma-undefined.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma after undefined should not increase the arguments.length (static class expression generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/gen-meth-args-trailing-comma-multiple.js
+++ b/test/language/arguments-object/gen-meth-args-trailing-comma-multiple.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma should not increase the arguments.length, using multiple args (generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/gen-meth-args-trailing-comma-null.js
+++ b/test/language/arguments-object/gen-meth-args-trailing-comma-null.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma after null should not increase the arguments.length (generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/gen-meth-args-trailing-comma-single-args.js
+++ b/test/language/arguments-object/gen-meth-args-trailing-comma-single-args.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma should not increase the arguments.length, using a single arg (generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/arguments-object/gen-meth-args-trailing-comma-undefined.js
+++ b/test/language/arguments-object/gen-meth-args-trailing-comma-undefined.js
@@ -4,6 +4,7 @@
 /*---
 description: A trailing comma after undefined should not increase the arguments.length (generator method)
 esid: sec-arguments-exotic-objects
+features: [generators]
 flags: [generated]
 info: |
     9.4.4 Arguments Exotic Objects
@@ -11,6 +12,7 @@ info: |
     Most ECMAScript functions make an arguments object available to their code. Depending upon the
     characteristics of the function definition, its arguments object is either an ordinary object
     or an arguments exotic object.
+
 
     Trailing comma in the arguments list
 

--- a/test/language/eval-code/direct/non-definable-global-generator.js
+++ b/test/language/eval-code/direct/non-definable-global-generator.js
@@ -20,6 +20,7 @@ info: >
           c. If fnDefinable is false, throw TypeError exception.
         ...
 flags: [noStrict]
+features: [generators]
 ---*/
 
 var error;

--- a/test/language/expressions/await/await-in-generator.js
+++ b/test/language/expressions/await/await-in-generator.js
@@ -6,6 +6,7 @@ author: Brian Terlson <brian.terlson@microsoft.com>
 esid: pending
 description: >
   Await in a generator is an identifier
+features: [generators]
 ---*/
 
 function* foo(await) { yield await; };

--- a/test/language/expressions/await/await-in-nested-generator.js
+++ b/test/language/expressions/await/await-in-nested-generator.js
@@ -6,6 +6,7 @@ author: Brian Terlson <brian.terlson@microsoft.com>
 esid: pending
 description: >
   Await is allowed as an identifier in generator functions nested in async functions
+features: [generators]
 ---*/
 
 var await;

--- a/test/language/expressions/class/fields-after-same-line-gen-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-computed-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property names (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [computed-property-names, class-fields]
+features: [computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/fields-after-same-line-gen-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-computed-symbol-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property symbol names (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [Symbol, computed-property-names, class-fields]
+features: [Symbol, computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/fields-after-same-line-gen-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-literal-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Literal property names (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [class-fields]
+features: [generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/fields-after-same-line-gen-static-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-static-computed-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Static Computed property names (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [computed-property-names, class-fields]
+features: [computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/fields-after-same-line-gen-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-static-computed-symbol-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Static computed property symbol names (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [Symbol, computed-property-names, class-fields]
+features: [Symbol, computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/fields-after-same-line-gen-static-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-static-literal-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Static literal property names (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [class-fields]
+features: [generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/fields-after-same-line-gen-string-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-string-literal-names.js
@@ -4,7 +4,7 @@
 /*---
 description: String literal names (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [class-fields]
+features: [generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/fields-after-same-line-static-gen-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-computed-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property names (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [computed-property-names, class-fields]
+features: [computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/fields-after-same-line-static-gen-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-computed-symbol-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property symbol names (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [Symbol, computed-property-names, class-fields]
+features: [Symbol, computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/fields-after-same-line-static-gen-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-literal-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Literal property names (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [class-fields]
+features: [generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/fields-after-same-line-static-gen-static-computed-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-static-computed-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Static Computed property names (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [computed-property-names, class-fields]
+features: [computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/fields-after-same-line-static-gen-static-computed-symbol-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-static-computed-symbol-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Static computed property symbol names (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [Symbol, computed-property-names, class-fields]
+features: [Symbol, computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/fields-after-same-line-static-gen-static-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-static-literal-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Static literal property names (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [class-fields]
+features: [generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/fields-after-same-line-static-gen-string-literal-names.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-string-literal-names.js
@@ -4,7 +4,7 @@
 /*---
 description: String literal names (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [class-fields]
+features: [generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/gen-method-length-dflt.js
+++ b/test/language/expressions/class/gen-method-length-dflt.js
@@ -26,7 +26,7 @@ info: |
     2. If HasInitializer of FormalsList is true or HasInitializer of
     FormalParameter is true, return count.
     3. Return count+1.
-features: [default-parameters]
+features: [generators, default-parameters]
 includes: [propertyHelper.js]
 ---*/
 

--- a/test/language/expressions/class/params-dflt-gen-meth-args-unmapped.js
+++ b/test/language/expressions/class/params-dflt-gen-meth-args-unmapped.js
@@ -4,7 +4,7 @@
 description: Referencing the arguments object from a default parameter (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [default-parameters]
+features: [generators, default-parameters]
 info: |
     ClassExpression : class BindingIdentifieropt ClassTail
 

--- a/test/language/expressions/class/params-dflt-gen-meth-ref-arguments.js
+++ b/test/language/expressions/class/params-dflt-gen-meth-ref-arguments.js
@@ -4,7 +4,7 @@
 description: Referencing the arguments object from a default parameter (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [default-parameters]
+features: [generators, default-parameters]
 info: |
     ClassExpression : class BindingIdentifieropt ClassTail
 

--- a/test/language/expressions/class/params-dflt-gen-meth-static-args-unmapped.js
+++ b/test/language/expressions/class/params-dflt-gen-meth-static-args-unmapped.js
@@ -4,7 +4,7 @@
 description: Referencing the arguments object from a default parameter (static class expression generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [default-parameters]
+features: [generators, default-parameters]
 info: |
     ClassExpression : class BindingIdentifieropt ClassTail
 
@@ -67,7 +67,7 @@ info: |
        FormalsList using iteratorRecord and environment as the arguments.
     2. ReturnIfAbrupt(status).
     3. Return the result of performing IteratorBindingInitialization for
-       FormalParameter using iteratorRecord and environment as the arguments. 
+       FormalParameter using iteratorRecord and environment as the arguments.
 ---*/
 
 var callCount = 0;

--- a/test/language/expressions/class/params-dflt-gen-meth-static-ref-arguments.js
+++ b/test/language/expressions/class/params-dflt-gen-meth-static-ref-arguments.js
@@ -4,7 +4,7 @@
 description: Referencing the arguments object from a default parameter (static class expression generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [default-parameters]
+features: [generators, default-parameters]
 info: |
     ClassExpression : class BindingIdentifieropt ClassTail
 

--- a/test/language/expressions/class/scope-gen-meth-paramsbody-var-close.js
+++ b/test/language/expressions/class/scope-gen-meth-paramsbody-var-close.js
@@ -17,6 +17,7 @@ info: |
         d. Set the VariableEnvironment of calleeContext to varEnv.
         e. Let instantiatedVarNames be a new empty List.
         [...]
+features: [generators]
 ---*/
 
 var probe;

--- a/test/language/expressions/class/scope-gen-meth-paramsbody-var-open.js
+++ b/test/language/expressions/class/scope-gen-meth-paramsbody-var-open.js
@@ -18,6 +18,7 @@ info: |
         d. Set the VariableEnvironment of calleeContext to varEnv.
         e. Let instantiatedVarNames be a new empty List.
         [...]
+features: [generators]
 ---*/
 
 var x = 'outside';

--- a/test/language/expressions/class/scope-static-gen-meth-paramsbody-var-close.js
+++ b/test/language/expressions/class/scope-static-gen-meth-paramsbody-var-close.js
@@ -17,6 +17,7 @@ info: |
         d. Set the VariableEnvironment of calleeContext to varEnv.
         e. Let instantiatedVarNames be a new empty List.
         [...]
+features: [generators]
 ---*/
 
 var probe;

--- a/test/language/expressions/class/scope-static-gen-meth-paramsbody-var-open.js
+++ b/test/language/expressions/class/scope-static-gen-meth-paramsbody-var-open.js
@@ -18,6 +18,7 @@ info: |
         d. Set the VariableEnvironment of calleeContext to varEnv.
         e. Let instantiatedVarNames be a new empty List.
         [...]
+features: [generators]
 ---*/
 
 var x = 'outside';

--- a/test/language/expressions/object/concise-generator.js
+++ b/test/language/expressions/object/concise-generator.js
@@ -4,6 +4,7 @@
 es6id: 12.2.5
 description: >
     super method calls in object literal concise generator
+features: [generators]
 ---*/
 var proto = {
   method() {

--- a/test/language/expressions/object/method-definition/async-meth-dflt-params-duplicates.js
+++ b/test/language/expressions/object/method-definition/async-meth-dflt-params-duplicates.js
@@ -4,7 +4,7 @@
 /*---
 description: It is a Syntax Error if BoundNames of FormalParameters contains any duplicate elements. (async method)
 esid: sec-async-function-definitions
-features: [default-parameters]
+features: [default-parameters, async-iteration]
 flags: [generated]
 negative:
   phase: early
@@ -14,6 +14,7 @@ info: |
 
     AsyncMethod :
      async PropertyName ( UniqueFormalParameters ) { AsyncFunctionBody }
+
 
     14.1.2 Static Semantics: Early Errors
 

--- a/test/language/expressions/object/method-definition/async-meth-dflt-params-rest.js
+++ b/test/language/expressions/object/method-definition/async-meth-dflt-params-rest.js
@@ -4,7 +4,7 @@
 /*---
 description: RestParameter does not support an initializer (async method)
 esid: sec-async-function-definitions
-features: [default-parameters]
+features: [default-parameters, async-iteration]
 flags: [generated]
 negative:
   phase: early
@@ -14,6 +14,7 @@ info: |
 
     AsyncMethod :
      async PropertyName ( UniqueFormalParameters ) { AsyncFunctionBody }
+
 
     14.1 Function Definitions
 

--- a/test/language/expressions/object/method-definition/async-meth-rest-params-trailing-comma-early-error.js
+++ b/test/language/expressions/object/method-definition/async-meth-rest-params-trailing-comma-early-error.js
@@ -4,6 +4,7 @@
 /*---
 description: It's a syntax error if a FunctionRestParameter is followed by a trailing comma (async method)
 esid: sec-async-function-definitions
+features: [async-iteration]
 flags: [generated]
 negative:
   phase: early
@@ -13,6 +14,7 @@ info: |
 
     AsyncMethod :
      async PropertyName ( UniqueFormalParameters ) { AsyncFunctionBody }
+
 
     Trailing comma in the parameters list
 

--- a/test/language/expressions/object/method-definition/generator-length-dflt.js
+++ b/test/language/expressions/object/method-definition/generator-length-dflt.js
@@ -26,7 +26,7 @@ info: |
     2. If HasInitializer of FormalsList is true or HasInitializer of
     FormalParameter is true, return count.
     3. Return count+1.
-features: [default-parameters]
+features: [generators, default-parameters]
 includes: [propertyHelper.js]
 ---*/
 

--- a/test/language/expressions/object/method-definition/generator-use-strict-with-non-simple-param.js
+++ b/test/language/expressions/object/method-definition/generator-use-strict-with-non-simple-param.js
@@ -12,6 +12,7 @@ info: >
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/expressions/object/method-definition/params-dflt-gen-meth-args-unmapped.js
+++ b/test/language/expressions/object/method-definition/params-dflt-gen-meth-args-unmapped.js
@@ -4,7 +4,7 @@
 description: Referencing the arguments object from a default parameter (generator method)
 esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
 es6id: 14.4.13
-features: [default-parameters]
+features: [generators, default-parameters]
 info: |
     GeneratorMethod :
         * PropertyName ( StrictFormalParameters ) { GeneratorBody }
@@ -49,7 +49,7 @@ info: |
        FormalsList using iteratorRecord and environment as the arguments.
     2. ReturnIfAbrupt(status).
     3. Return the result of performing IteratorBindingInitialization for
-       FormalParameter using iteratorRecord and environment as the arguments. 
+       FormalParameter using iteratorRecord and environment as the arguments.
 ---*/
 
 var callCount = 0;

--- a/test/language/expressions/object/method-definition/params-dflt-gen-meth-ref-arguments.js
+++ b/test/language/expressions/object/method-definition/params-dflt-gen-meth-ref-arguments.js
@@ -4,7 +4,7 @@
 description: Referencing the arguments object from a default parameter (generator method)
 esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
 es6id: 14.4.13
-features: [default-parameters]
+features: [generators, default-parameters]
 info: |
     GeneratorMethod :
         * PropertyName ( StrictFormalParameters ) { GeneratorBody }

--- a/test/language/expressions/object/scope-gen-meth-body-lex-distinct.js
+++ b/test/language/expressions/object/scope-gen-meth-body-lex-distinct.js
@@ -40,7 +40,7 @@ info: |
                     like-named lexical declaration.
           iii. Let thisLex be thisLex's outer environment reference.
 flags: [noStrict]
-features: [let]
+features: [generators, let]
 ---*/
 
 var o = {

--- a/test/language/expressions/object/scope-gen-meth-param-elem-var-close.js
+++ b/test/language/expressions/object/scope-gen-meth-param-elem-var-close.js
@@ -15,6 +15,7 @@ info: |
     11. Set the LexicalEnvironment of currentContext to originalEnv.
     [...]
 flags: [noStrict]
+features: [generators]
 ---*/
 
 var x = 'outside';

--- a/test/language/expressions/object/scope-gen-meth-param-elem-var-open.js
+++ b/test/language/expressions/object/scope-gen-meth-param-elem-var-open.js
@@ -16,6 +16,7 @@ info: |
     11. Set the LexicalEnvironment of currentContext to originalEnv.
     [...]
 flags: [noStrict]
+features: [generators]
 ---*/
 
 var x = 'outside';

--- a/test/language/expressions/object/scope-gen-meth-param-rest-elem-var-close.js
+++ b/test/language/expressions/object/scope-gen-meth-param-rest-elem-var-close.js
@@ -21,6 +21,7 @@ info: |
     11. Set the LexicalEnvironment of currentContext to originalEnv.
     [...]
 flags: [noStrict]
+features: [generators]
 ---*/
 
 var x = 'outside';

--- a/test/language/expressions/object/scope-gen-meth-param-rest-elem-var-open.js
+++ b/test/language/expressions/object/scope-gen-meth-param-rest-elem-var-open.js
@@ -21,6 +21,7 @@ info: |
     11. Set the LexicalEnvironment of currentContext to originalEnv.
     [...]
 flags: [noStrict]
+features: [generators]
 ---*/
 
 var x = 'outside';

--- a/test/language/expressions/object/scope-gen-meth-paramsbody-var-close.js
+++ b/test/language/expressions/object/scope-gen-meth-paramsbody-var-close.js
@@ -17,6 +17,7 @@ info: |
         d. Set the VariableEnvironment of calleeContext to varEnv.
         e. Let instantiatedVarNames be a new empty List.
         [...]
+features: [generators]
 ---*/
 
 var probe;

--- a/test/language/expressions/object/scope-gen-meth-paramsbody-var-open.js
+++ b/test/language/expressions/object/scope-gen-meth-paramsbody-var-open.js
@@ -18,6 +18,7 @@ info: |
         d. Set the VariableEnvironment of calleeContext to varEnv.
         e. Let instantiatedVarNames be a new empty List.
         [...]
+features: [generators]
 ---*/
 
 var x = 'outside';

--- a/test/language/module-code/early-dup-export-decl.js
+++ b/test/language/module-code/early-dup-export-decl.js
@@ -9,6 +9,7 @@ flags: [module]
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/eval-export-dflt-expr-gen-anon.js
+++ b/test/language/module-code/eval-export-dflt-expr-gen-anon.js
@@ -23,6 +23,7 @@ info: |
     5. Perform ? InitializeBoundName("*default*", value, env).
     [...]
 flags: [module]
+features: [generators]
 ---*/
 
 export default (function* () { return 24601; });

--- a/test/language/module-code/eval-export-dflt-expr-gen-named.js
+++ b/test/language/module-code/eval-export-dflt-expr-gen-named.js
@@ -23,6 +23,7 @@ info: |
     5. Perform ? InitializeBoundName("*default*", value, env).
     [...]
 flags: [module]
+features: [generators]
 ---*/
 
 export default (function* gName() { return 88; });

--- a/test/language/module-code/eval-export-dflt-gen-anon-semi.js
+++ b/test/language/module-code/eval-export-dflt-gen-anon-semi.js
@@ -6,6 +6,7 @@ description: >
     need to be terminated with a semicolon or newline
 esid: sec-moduleevaluation
 flags: [module]
+features: [generators]
 ---*/
 
 var count = 0;

--- a/test/language/module-code/eval-export-dflt-gen-named-semi.js
+++ b/test/language/module-code/eval-export-dflt-gen-named-semi.js
@@ -6,6 +6,7 @@ description: >
     be terminated with a semicolon or newline
 esid: sec-moduleevaluation
 flags: [module]
+features: [generators]
 ---*/
 
 var count = 0;

--- a/test/language/module-code/eval-export-gen-semi.js
+++ b/test/language/module-code/eval-export-gen-semi.js
@@ -6,6 +6,7 @@ description: >
     with a semicolon or newline
 esid: sec-moduleevaluation
 flags: [module]
+features: [generators]
 ---*/
 
 var count = 0;

--- a/test/language/module-code/instn-iee-bndng-gen.js
+++ b/test/language/module-code/instn-iee-bndng-gen.js
@@ -38,6 +38,7 @@ info: |
        and N2 as its target binding and record that the binding is initialized.
     6. Return NormalCompletion(empty).
 flags: [module]
+features: [generators]
 ---*/
 
 assert.sameValue(

--- a/test/language/module-code/instn-named-bndng-dflt-gen-anon.js
+++ b/test/language/module-code/instn-named-bndng-dflt-gen-anon.js
@@ -43,6 +43,7 @@ info: |
          function * BindingIdentifier[?Yield] ( FormalParameters[Yield] ) { GeneratorBody }
          [+Default] function * ( FormalParameters[Yield] ) { GeneratorBody }
 flags: [module]
+features: [generators]
 ---*/
 
 assert.sameValue(g().next().value, 23, 'generator function value is hoisted');

--- a/test/language/module-code/instn-named-bndng-dflt-gen-named.js
+++ b/test/language/module-code/instn-named-bndng-dflt-gen-named.js
@@ -43,6 +43,7 @@ info: |
          function * BindingIdentifier[?Yield] ( FormalParameters[Yield] ) { GeneratorBody }
          [+Default] function * ( FormalParameters[Yield] ) { GeneratorBody }
 flags: [module]
+features: [generators]
 ---*/
 
 assert.sameValue(g().next().value, 23, 'generator function value is hoisted');

--- a/test/language/module-code/instn-named-bndng-gen.js
+++ b/test/language/module-code/instn-named-bndng-gen.js
@@ -40,6 +40,7 @@ info: |
        and N2 as its target binding and record that the binding is initialized.
     6. Return NormalCompletion(empty).
 flags: [module]
+features: [generators]
 ---*/
 
 assert.sameValue(

--- a/test/language/module-code/instn-uniq-env-rec.js
+++ b/test/language/module-code/instn-uniq-env-rec.js
@@ -14,6 +14,7 @@ info: |
     1. Let env be a new Lexical Environment.
     [...]
 flags: [module]
+features: [generators]
 ---*/
 
 import './instn-uniq-env-rec-other_FIXTURE.js'

--- a/test/language/module-code/parse-err-decl-pos-export-class-decl-method-gen-static.js
+++ b/test/language/module-code/parse-err-decl-pos-export-class-decl-method-gen-static.js
@@ -7,6 +7,7 @@ negative:
   phase: early
   type: SyntaxError
 flags: [module]
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-decl-pos-export-class-decl-method-gen.js
+++ b/test/language/module-code/parse-err-decl-pos-export-class-decl-method-gen.js
@@ -7,6 +7,7 @@ negative:
   phase: early
   type: SyntaxError
 flags: [module]
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-decl-pos-export-class-expr-meth-gen-static.js
+++ b/test/language/module-code/parse-err-decl-pos-export-class-expr-meth-gen-static.js
@@ -7,6 +7,7 @@ negative:
   phase: early
   type: SyntaxError
 flags: [module]
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-decl-pos-export-class-expr-meth-gen.js
+++ b/test/language/module-code/parse-err-decl-pos-export-class-expr-meth-gen.js
@@ -7,6 +7,7 @@ negative:
   phase: early
   type: SyntaxError
 flags: [module]
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-decl-pos-export-generator-decl.js
+++ b/test/language/module-code/parse-err-decl-pos-export-generator-decl.js
@@ -7,6 +7,7 @@ negative:
   phase: early
   type: SyntaxError
 flags: [module]
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-decl-pos-export-object-gen-method.js
+++ b/test/language/module-code/parse-err-decl-pos-export-object-gen-method.js
@@ -7,6 +7,7 @@ negative:
   phase: early
   type: SyntaxError
 flags: [module]
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-decl-pos-import-class-decl-method-gen-static.js
+++ b/test/language/module-code/parse-err-decl-pos-import-class-decl-method-gen-static.js
@@ -7,6 +7,7 @@ negative:
   phase: early
   type: SyntaxError
 flags: [module]
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-decl-pos-import-class-decl-method-gen.js
+++ b/test/language/module-code/parse-err-decl-pos-import-class-decl-method-gen.js
@@ -7,6 +7,7 @@ negative:
   phase: early
   type: SyntaxError
 flags: [module]
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-decl-pos-import-class-expr-meth-gen-static.js
+++ b/test/language/module-code/parse-err-decl-pos-import-class-expr-meth-gen-static.js
@@ -7,6 +7,7 @@ negative:
   phase: early
   type: SyntaxError
 flags: [module]
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-decl-pos-import-class-expr-meth-gen.js
+++ b/test/language/module-code/parse-err-decl-pos-import-class-expr-meth-gen.js
@@ -7,6 +7,7 @@ negative:
   phase: early
   type: SyntaxError
 flags: [module]
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-decl-pos-import-generator-decl.js
+++ b/test/language/module-code/parse-err-decl-pos-import-generator-decl.js
@@ -7,6 +7,7 @@ negative:
   phase: early
   type: SyntaxError
 flags: [module]
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-decl-pos-import-object-gen-method.js
+++ b/test/language/module-code/parse-err-decl-pos-import-object-gen-method.js
@@ -7,6 +7,7 @@ negative:
   phase: early
   type: SyntaxError
 flags: [module]
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-hoist-lex-gen.js
+++ b/test/language/module-code/parse-err-hoist-lex-gen.js
@@ -18,6 +18,7 @@ negative:
   phase: early
   type: SyntaxError
 flags: [module]
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-invoke-anon-gen-decl.js
+++ b/test/language/module-code/parse-err-invoke-anon-gen-decl.js
@@ -19,6 +19,7 @@ negative:
   phase: early
   type: SyntaxError
 flags: [module]
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/statements/class/definition/fn-name-static-precedence.js
+++ b/test/language/statements/class/definition/fn-name-static-precedence.js
@@ -14,6 +14,7 @@ info: >
     6. If hasNameProperty is false, then perform SetFunctionName(value,
        className).
 includes: [propertyHelper.js]
+features: [generators]
 ---*/
 
 class A {

--- a/test/language/statements/class/fields-after-same-line-gen-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-gen-computed-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property names (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [computed-property-names, class-fields]
+features: [computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/fields-after-same-line-gen-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-gen-computed-symbol-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property symbol names (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [Symbol, computed-property-names, class-fields]
+features: [Symbol, computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/fields-after-same-line-gen-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-gen-literal-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Literal property names (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [class-fields]
+features: [generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/fields-after-same-line-gen-static-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-gen-static-computed-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Static Computed property names (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [computed-property-names, class-fields]
+features: [computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/fields-after-same-line-gen-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-gen-static-computed-symbol-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Static computed property symbol names (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [Symbol, computed-property-names, class-fields]
+features: [Symbol, computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/fields-after-same-line-gen-static-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-gen-static-literal-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Static literal property names (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [class-fields]
+features: [generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/fields-after-same-line-gen-string-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-gen-string-literal-names.js
@@ -4,7 +4,7 @@
 /*---
 description: String literal names (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [class-fields]
+features: [generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/fields-after-same-line-static-gen-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-computed-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property names (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [computed-property-names, class-fields]
+features: [computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/fields-after-same-line-static-gen-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-computed-symbol-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property symbol names (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [Symbol, computed-property-names, class-fields]
+features: [Symbol, computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/fields-after-same-line-static-gen-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-literal-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Literal property names (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [class-fields]
+features: [generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/fields-after-same-line-static-gen-static-computed-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-static-computed-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Static Computed property names (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [computed-property-names, class-fields]
+features: [computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/fields-after-same-line-static-gen-static-computed-symbol-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-static-computed-symbol-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Static computed property symbol names (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [Symbol, computed-property-names, class-fields]
+features: [Symbol, computed-property-names, generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/fields-after-same-line-static-gen-static-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-static-literal-names.js
@@ -4,7 +4,7 @@
 /*---
 description: Static literal property names (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [class-fields]
+features: [generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/fields-after-same-line-static-gen-string-literal-names.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-string-literal-names.js
@@ -4,7 +4,7 @@
 /*---
 description: String literal names (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [class-fields]
+features: [generators, class-fields]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/gen-method-length-dflt.js
+++ b/test/language/statements/class/gen-method-length-dflt.js
@@ -26,7 +26,7 @@ info: |
     2. If HasInitializer of FormalsList is true or HasInitializer of
     FormalParameter is true, return count.
     3. Return count+1.
-features: [default-parameters]
+features: [generators, default-parameters]
 includes: [propertyHelper.js]
 ---*/
 

--- a/test/language/statements/class/params-dflt-gen-meth-args-unmapped.js
+++ b/test/language/statements/class/params-dflt-gen-meth-args-unmapped.js
@@ -4,7 +4,7 @@
 description: Referencing the arguments object from a default parameter (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [default-parameters]
+features: [generators, default-parameters]
 info: |
     ClassDeclaration : class BindingIdentifier ClassTail
 
@@ -65,7 +65,7 @@ info: |
        FormalsList using iteratorRecord and environment as the arguments.
     2. ReturnIfAbrupt(status).
     3. Return the result of performing IteratorBindingInitialization for
-       FormalParameter using iteratorRecord and environment as the arguments. 
+       FormalParameter using iteratorRecord and environment as the arguments.
 ---*/
 
 var callCount = 0;

--- a/test/language/statements/class/params-dflt-gen-meth-ref-arguments.js
+++ b/test/language/statements/class/params-dflt-gen-meth-ref-arguments.js
@@ -4,7 +4,7 @@
 description: Referencing the arguments object from a default parameter (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 es6id: 14.5.16
-features: [default-parameters]
+features: [generators, default-parameters]
 info: |
     ClassDeclaration : class BindingIdentifier ClassTail
 

--- a/test/language/statements/class/params-dflt-gen-meth-static-args-unmapped.js
+++ b/test/language/statements/class/params-dflt-gen-meth-static-args-unmapped.js
@@ -4,7 +4,7 @@
 description: Referencing the arguments object from a default parameter (static class expression generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [default-parameters]
+features: [generators, default-parameters]
 info: |
     ClassDeclaration : class BindingIdentifier ClassTail
 
@@ -65,7 +65,7 @@ info: |
        FormalsList using iteratorRecord and environment as the arguments.
     2. ReturnIfAbrupt(status).
     3. Return the result of performing IteratorBindingInitialization for
-       FormalParameter using iteratorRecord and environment as the arguments. 
+       FormalParameter using iteratorRecord and environment as the arguments.
 ---*/
 
 var callCount = 0;

--- a/test/language/statements/class/params-dflt-gen-meth-static-ref-arguments.js
+++ b/test/language/statements/class/params-dflt-gen-meth-static-ref-arguments.js
@@ -4,7 +4,7 @@
 description: Referencing the arguments object from a default parameter (static class expression generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 es6id: 14.5.15
-features: [default-parameters]
+features: [generators, default-parameters]
 info: |
     ClassDeclaration : class BindingIdentifier ClassTail
 

--- a/test/language/statements/class/scope-gen-meth-paramsbody-var-close.js
+++ b/test/language/statements/class/scope-gen-meth-paramsbody-var-close.js
@@ -17,6 +17,7 @@ info: |
         d. Set the VariableEnvironment of calleeContext to varEnv.
         e. Let instantiatedVarNames be a new empty List.
         [...]
+features: [generators]
 ---*/
 
 var probe;

--- a/test/language/statements/class/scope-gen-meth-paramsbody-var-open.js
+++ b/test/language/statements/class/scope-gen-meth-paramsbody-var-open.js
@@ -18,6 +18,7 @@ info: |
         d. Set the VariableEnvironment of calleeContext to varEnv.
         e. Let instantiatedVarNames be a new empty List.
         [...]
+features: [generators]
 ---*/
 
 var x = 'outside';

--- a/test/language/statements/class/scope-static-gen-meth-paramsbody-var-close.js
+++ b/test/language/statements/class/scope-static-gen-meth-paramsbody-var-close.js
@@ -17,6 +17,7 @@ info: |
         d. Set the VariableEnvironment of calleeContext to varEnv.
         e. Let instantiatedVarNames be a new empty List.
         [...]
+features: [generators]
 ---*/
 
 var probe;

--- a/test/language/statements/class/scope-static-gen-meth-paramsbody-var-open.js
+++ b/test/language/statements/class/scope-static-gen-meth-paramsbody-var-open.js
@@ -18,6 +18,7 @@ info: |
         d. Set the VariableEnvironment of calleeContext to varEnv.
         e. Let instantiatedVarNames be a new empty List.
         [...]
+features: [generators]
 ---*/
 
 var x = 'outside';

--- a/test/language/statements/class/subclass/class-definition-superclass-generator.js
+++ b/test/language/statements/class/subclass/class-definition-superclass-generator.js
@@ -6,6 +6,7 @@ description: >
     Runtime Semantics: ClassDefinitionEvaluation
 
     If superclass has a [[FunctionKind]] internal slot whose value is "generator", throw a TypeError exception.
+features: [generators]
 ---*/
 function * G() {}
 

--- a/test/language/statements/class/syntax/early-errors/class-body-special-method-generator-contains-direct-super.js
+++ b/test/language/statements/class/syntax/early-errors/class-body-special-method-generator-contains-direct-super.js
@@ -12,6 +12,7 @@ description: >
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/statements/class/syntax/early-errors/class-body-special-method-generator-propname-constructor.js
+++ b/test/language/statements/class/syntax/early-errors/class-body-special-method-generator-propname-constructor.js
@@ -12,6 +12,7 @@ description: >
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/statements/do-while/decl-gen.js
+++ b/test/language/statements/do-while/decl-gen.js
@@ -7,6 +7,7 @@ es6id: 13.7.2
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/statements/for-in/decl-gen.js
+++ b/test/language/statements/for-in/decl-gen.js
@@ -7,6 +7,7 @@ es6id: 13.7.5
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/statements/for-of/decl-gen.js
+++ b/test/language/statements/for-of/decl-gen.js
@@ -7,6 +7,7 @@ es6id: 13.7.5
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/statements/for-of/nested.js
+++ b/test/language/statements/for-of/nested.js
@@ -4,6 +4,7 @@
 es6id: 13.6.4.13
 description: >
     Nested statements should operate independently.
+features: [generators]
 ---*/
 
 function* values() {

--- a/test/language/statements/for/decl-gen.js
+++ b/test/language/statements/for/decl-gen.js
@@ -7,6 +7,7 @@ es6id: 13.7.4
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/statements/if/if-gen-else-gen.js
+++ b/test/language/statements/if/if-gen-else-gen.js
@@ -7,6 +7,7 @@ es6id: 13.6
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/statements/if/if-gen-else-stmt.js
+++ b/test/language/statements/if/if-gen-else-stmt.js
@@ -7,6 +7,7 @@ es6id: 13.6
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/statements/if/if-gen-no-else.js
+++ b/test/language/statements/if/if-gen-no-else.js
@@ -7,6 +7,7 @@ es6id: 13.6
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/statements/if/if-stmt-else-gen.js
+++ b/test/language/statements/if/if-stmt-else-gen.js
@@ -7,6 +7,7 @@ es6id: 13.6
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/statements/labeled/decl-gen.js
+++ b/test/language/statements/labeled/decl-gen.js
@@ -7,6 +7,7 @@ es6id: 13.13
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/statements/let/syntax/let-newline-yield-in-generator-function.js
+++ b/test/language/statements/let/syntax/let-newline-yield-in-generator-function.js
@@ -14,6 +14,7 @@ info: >
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/statements/while/decl-gen.js
+++ b/test/language/statements/while/decl-gen.js
@@ -7,6 +7,7 @@ es6id: 13.7.3
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/statements/with/decl-gen.js
+++ b/test/language/statements/with/decl-gen.js
@@ -8,6 +8,7 @@ flags: [noStrict]
 negative:
   phase: early
   type: SyntaxError
+features: [generators]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";


### PR DESCRIPTION
I've found more tests without the necessary generators flags.

This shouldn't affect any test functionality but tooling only.

out of curiosity:

```
git grep -Le "generators" --or -e "async-iteration" -- $(git grep -lE "\*\s?[a-zA-Z_]+\s?\(" test/)
```