### PR TITLE
Update 15.2.3.6-4-124.js

### DIFF
--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-124.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-124.js
@@ -18,7 +18,7 @@ Object.defineProperty(arrObj, "length", {
 });
 verifyEqualTo(arrObj, "length", 0);
 
-verifyNotWritable(arrObj, "length");
+verifyNotWritable(arrObj, "length", undefined, 0);
 
 verifyNotEnumerable(arrObj, "length");
 


### PR DESCRIPTION
VerifyNotWriteable calls isWritable which tries to assign the parameter "value" to obj[name], where 'name' is the property name.  In this case, since no value is supplied, the value assigned is the string "unlikelyValue".  So we have array["length"] = "unlikelyValue", which in Chrome & Firefox result in a RangeError and isWriteable expects a TypeError to be thrown.  So implementations that validate the validate the assigned value before the property's writability will always fail this test.