### PR TITLE
Assert that promise callbacks were actually called

### DIFF
--- a/test/built-ins/Promise/prototype/finally/rejected-observable-then-calls.js
+++ b/test/built-ins/Promise/prototype/finally/rejected-observable-then-calls.js
@@ -8,6 +8,7 @@ features: [Promise.prototype.finally]
 flags: [async]
 ---*/
 
+var callbackCount = 0;
 var initialThenCount = 0;
 var noReason = {};
 var no = Promise.reject(noReason);
@@ -28,15 +29,19 @@ var finallyCalled = false;
 var catchCalled = false;
 
 no.catch(function (e) {
+  callbackCount++;
   assert.sameValue(e, noReason);
   throw e;
 }).finally(function () {
+  callbackCount++;
   finallyCalled = true;
   return yes;
 }).catch(function (e) {
+  callbackCount++;
   catchCalled = true;
   assert.sameValue(e, noReason);
 }).then(function () {
+  assert.sameValue(callbackCount, 3, 'all three callbacks were called');
   assert.sameValue(finallyCalled, true, 'initial finally was called');
   assert.sameValue(initialThenCount, 1, 'initial finally invokes .then once');
 

--- a/test/built-ins/Promise/prototype/finally/rejection-reason-no-fulfill.js
+++ b/test/built-ins/Promise/prototype/finally/rejection-reason-no-fulfill.js
@@ -10,14 +10,20 @@ flags: [async]
 
 var original = {};
 var replacement = {};
+var callbackCount = 0;
 
 var p = Promise.reject(original);
 
 p.finally(function () {
+  callbackCount++;
   assert.sameValue(arguments.length, 0, 'onFinally receives zero args');
   return replacement;
 }).then(function () {
   $ERROR('promise is rejected pre-finally; onFulfill should not be called');
 }).catch(function (reason) {
+  callbackCount++;
   assert.sameValue(reason, original, 'onFinally can not override the rejection value by returning');
-}).then($DONE).catch($ERROR);
+}).then(function() {
+  assert.sameValue(callbackCount, 2, "both callbacks were called");
+  $DONE();
+}).catch($ERROR);

--- a/test/built-ins/Promise/prototype/finally/rejection-reason-override-with-throw.js
+++ b/test/built-ins/Promise/prototype/finally/rejection-reason-override-with-throw.js
@@ -8,16 +8,22 @@ features: [Promise.prototype.finally]
 flags: [async]
 ---*/
 
+var callbackCount = 0;
 var original = {};
 var thrown = {};
 
 var p = Promise.reject(original);
 
 p.finally(function () {
+  callbackCount++;
   assert.sameValue(arguments.length, 0, 'onFinally receives zero args');
   throw thrown;
 }).then(function () {
   $ERROR('promise is rejected; onFulfill should not be called');
 }).catch(function (reason) {
+  callbackCount++;
   assert.sameValue(reason, thrown, 'onFinally can override the rejection reason by throwing');
-}).then($DONE).catch($ERROR);
+}).then(function() {
+  assert.sameValue(callbackCount, 2, "both callbacks were called");
+  $DONE();
+}).catch($ERROR);

--- a/test/built-ins/Promise/prototype/finally/resolution-value-no-override.js
+++ b/test/built-ins/Promise/prototype/finally/resolution-value-no-override.js
@@ -8,13 +8,19 @@ features: [Promise.prototype.finally]
 flags: [async]
 ---*/
 
+var callbackCount = 0;
 var obj = {};
 
 var p = Promise.resolve(obj);
 
 p.finally(function () {
+  callbackCount++;
   assert.sameValue(arguments.length, 0, 'onFinally receives zero args');
   return {};
 }).then(function (x) {
+  callbackCount++;
   assert.sameValue(x, obj, 'onFinally can not override the resolution value');
-}).then($DONE).catch($ERROR);
+}).then(function() {
+  assert.sameValue(callbackCount, 2, "both callbacks were called");
+  $DONE();
+}).catch($ERROR);

--- a/test/built-ins/Promise/prototype/finally/resolved-observable-then-calls.js
+++ b/test/built-ins/Promise/prototype/finally/resolved-observable-then-calls.js
@@ -9,6 +9,7 @@ flags: [async]
 ---*/
 
 var initialThenCount = 0;
+var callbackCount = 0;
 var yesValue = {};
 var yes = Promise.resolve(yesValue);
 yes.then = function () {
@@ -28,15 +29,19 @@ var finallyCalled = false;
 var catchCalled = false;
 
 yes.then(function (x) {
+  callbackCount++;
   assert.sameValue(x, yesValue);
   return x;
 }).finally(function () {
+  callbackCount++;
   finallyCalled = true;
   return no;
 }).catch(function (e) {
+  callbackCount++;
   catchCalled = true;
   assert.sameValue(e, noReason);
 }).then(function () {
+  assert.sameValue(callbackCount, 3, "all three callbacks were called");
   assert.sameValue(finallyCalled, true, 'initial finally was called');
   assert.sameValue(initialThenCount, 1, 'initial finally invokes .then once');
 


### PR DESCRIPTION
Add a counter to keep count of callbacks and assert the count before
passing the test. This makes sure that skipping a callback would fail the test.

Some of the counters may not be required, but I've them in all cases just to be consistent.

A better, but bigger change would be to add an assert.plan(assertCount) API that checks that assertCount matches up as part of $DONE ..