### PR TITLE
Test setting/defining a typed array element to a value, when ToNumber(value) detaches the underlying ArrayBuffer

### DIFF
--- a/test/built-ins/TypedArrays/internals/DefineOwnProperty/tonumber-value-detached-buffer.js
+++ b/test/built-ins/TypedArrays/internals/DefineOwnProperty/tonumber-value-detached-buffer.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-integer-indexed-exotic-objects-defineownproperty-p-desc
+description: >
+    Defining a typed array element to a value that, when converted to the typed
+    array element type, detaches the typed array's underlying buffer, should
+    throw a TypeError and not modify the typed array.
+info: >
+  9.4.5.3 [[DefineOwnProperty]] ( P, Desc )
+
+  ...
+  3. If Type(P) is String, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      ...
+      x. If Desc has a [[Value]] field, then
+        1. Let value be Desc.[[Value]].
+        2. Return ? IntegerIndexedElementSet(O, numericIndex, value).
+  ...
+
+  9.4.5.9 IntegerIndexedElementSet ( O, index, value )
+
+  ...
+  15. Perform SetValueInBuffer(buffer, indexedPosition, elementType, numValue).
+  16. Return true.
+includes: [testTypedArray.js, detachArrayBuffer.js]
+features: [Reflect, TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var ta = new TA([17]);
+
+  var desc =
+    {
+      value: {
+        valueOf: function() {
+          $262.detachArrayBuffer(ta.buffer);
+          return 42;
+        }
+      }
+    };
+
+  assert.throws(TypeError, function() {
+    Reflect.defineProperty(ta, 0, desc);
+  },
+  "detaching a ArrayBuffer during defining an element of a typed array " +
+  "viewing it should throw");
+
+  assert.sameValue(ta[0], 17, "typed array element shouldn't be set");
+});
+

--- a/test/built-ins/TypedArrays/internals/Set/tonumber-value-detached-buffer.js
+++ b/test/built-ins/TypedArrays/internals/Set/tonumber-value-detached-buffer.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2017 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-integer-indexed-exotic-objects-set-p-v-receiver
+description: >
+    Setting a typed array element to a value that, when converted to the typed
+    array element type, detaches the typed array's underlying buffer, should
+    throw a TypeError and not modify the typed array.
+info: >
+  9.4.5.5 [[Set]] ( P, V, Receiver)
+
+  ...
+  2. If Type(P) is String, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      i. Return ? IntegerIndexedElementSet(O, numericIndex, V).
+  ...
+
+  9.4.5.9 IntegerIndexedElementSet ( O, index, value )
+
+  ...
+  15. Perform SetValueInBuffer(buffer, indexedPosition, elementType, numValue).
+  16. Return true.
+includes: [testTypedArray.js, detachArrayBuffer.js]
+features: [Reflect, TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var ta = new TA([17]);
+
+  assert.throws(TypeError, function() {
+    Reflect.set(ta, 0, {
+      valueOf: function() {
+        $262.detachArrayBuffer(ta.buffer);
+        return 42;
+      }
+    });
+  },
+  "detaching a ArrayBuffer during setting an element of a typed array " +
+  "viewing it should throw");
+
+  assert.sameValue(ta[0], 17, "typed array element shouldn't be set");
+});


### PR DESCRIPTION
The historical failure of implementations to throw when setting a typed array element backed by a detached buffer rears its ugly head when I try these tests in SpiderMonkey.  Other implementations probably suffer similarly, but I didn't test anyone else.  Probably good for someone else to verify correctness here by a separate inspection, or in an implementation that handles detached-sets correctly.