### PR TITLE
Let paramVarEnv be NewDeclarativeEnvironment(originalEnv).

### DIFF
--- a/test/language/function-code/each-param-has-own-non-shared-eval-scope.js
+++ b/test/language/function-code/each-param-has-own-non-shared-eval-scope.js
@@ -3,7 +3,9 @@
 
 /*---
 esid: sec-function-definitions-runtime-semantics-iteratorbindinginitialization
-description: A new declarative environment is created, from the originalEnv, for each parameter.
+description: >
+  A new declarative environment is created, from the originalEnv, for each
+  parameter, and paramVarEnv is not shared.
 info: |
   Runtime Semantics: IteratorBindingInitialization
 
@@ -17,7 +19,7 @@ features: [arrow-function, default-parameters]
 ---*/
 
 var y;
-function f(a = eval("var x = 1; y = 42; x"), b = x) {}
+function f(a = eval("var x = 1; y = 42; x"), b = eval("x")) {}
 
 assert.throws(ReferenceError, () => {
   f();

--- a/test/language/function-code/each-param-has-own-scope.js
+++ b/test/language/function-code/each-param-has-own-scope.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-function-definitions-runtime-semantics-iteratorbindinginitialization
+description: A new declarative environment is created, from the originalEnv, for each parameter.
+info: |
+  Runtime Semantics: IteratorBindingInitialization
+
+  FormalParameter : BindingElement
+
+  ...
+  6. Let paramVarEnv be NewDeclarativeEnvironment(originalEnv).
+  ...
+---*/
+
+function f(a = eval("var x = 1; x"), b = x) {}
+
+assert.throws(ReferenceError, () => {
+  f();
+});


### PR DESCRIPTION
Originally discovered by Cait Potter (@caitp), reported in irc.mozilla.org#jslang


@leobalter I need another critical look at this, I searched through _a lot_ of existing tests (thanks to detailed `info` frontmatter, I was able to search for tests with relevant spec prose!), but I'm afraid that I may have missed something—hopefully you can help me recheck. In the meantime, I will do another pass. It seems unlikely and would be very surprising that such a test doesn't already exist.