### PR TITLE
Added missing cases into BigIntConstructor with String parameters

### DIFF
--- a/test/built-ins/BigInt/constructor-empty-string.js
+++ b/test/built-ins/BigInt/constructor-empty-string.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Empty String should in BigInt should result into 0n
+esid: sec-string-to-bigint
+info: |
+  Apply the algorithm in 3.1.3.1 with the following changes:
+
+  EDITOR'S NOTE StringToBigInt("") is 0n according to the logic in 3.1.3.1.
+
+features: [BigInt]
+---*/
+
+assert.sameValue(BigInt(""), 0n);
+assert.sameValue(BigInt(" "), 0n);
+

--- a/test/built-ins/BigInt/constructor-from-binary-string.js
+++ b/test/built-ins/BigInt/constructor-from-binary-string.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: String should be parsed to BigInt according StringToBigInt
+esid: sec-string-to-bigint
+info: |
+  Apply the algorithm in 3.1.3.1 with the following changes:
+
+  - Replace the StrUnsignedDecimalLiteral production with DecimalDigits
+    to not allow decimal points or exponents.
+
+features: [BigInt]
+---*/
+
+assert.sameValue(BigInt("0b1111"), 15n);
+assert.sameValue(BigInt("0b10"), 2n);
+assert.sameValue(BigInt("0b0"), 0n);
+assert.sameValue(BigInt("0b1"), 0n);
+
+let binaryString = "0b1";
+for (let i = 0; i < 128; i++)
+    binaryString += "0";
+
+assert.sameValue(BigInt(binaryString), 340282366920938463463374607431768211456n);
+
+assert.sameValue(BigInt("0B1111"), 15n);
+assert.sameValue(BigInt("0B10"), 2n);
+assert.sameValue(BigInt("0B0"), 0n);
+assert.sameValue(BigInt("0B1"), 0n);
+
+binaryString = "0B1";
+for (let i = 0; i < 128; i++)
+    binaryString += "0";
+
+assert.sameValue(BigInt(binaryString), 340282366920938463463374607431768211456n);
+

--- a/test/built-ins/BigInt/constructor-from-decimal-string.js
+++ b/test/built-ins/BigInt/constructor-from-decimal-string.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: String should be parsed to BigInt according StringToBigInt
+esid: sec-string-to-bigint
+info: |
+  Apply the algorithm in 3.1.3.1 with the following changes:
+
+  - Replace the StrUnsignedDecimalLiteral production with DecimalDigits
+    to not allow decimal points or exponents.
+
+features: [BigInt]
+---*/
+
+assert.sameValue(BigInt("10"), 10n);
+assert.sameValue(BigInt("18446744073709551616"), 18446744073709551616n);
+assert.sameValue(BigInt("7"), 7n);
+assert.sameValue(BigInt("88"), 88n);
+assert.sameValue(BigInt("900"), 900n);
+
+assert.sameValue(BigInt("-10"), -10n);
+assert.sameValue(BigInt("-18446744073709551616"), -18446744073709551616n);
+assert.sameValue(BigInt("-7"), -7n);
+assert.sameValue(BigInt("-88"), -88n);
+assert.sameValue(BigInt("-900"), -900n);
+

--- a/test/built-ins/BigInt/constructor-from-hex-string.js
+++ b/test/built-ins/BigInt/constructor-from-hex-string.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Hexdecimal prefixed String should be parsed to BigInt according StringToBigInt
+esid: sec-string-to-bigint
+info: |
+  Apply the algorithm in 3.1.3.1 with the following changes:
+
+  - Replace the StrUnsignedDecimalLiteral production with DecimalDigits
+    to not allow decimal points or exponents.
+
+features: [BigInt]
+---*/
+
+assert.sameValue(BigInt("0xa"), 10n);
+assert.sameValue(BigInt("0xff"), 255n);
+assert.sameValue(BigInt("0xfabc"), 64188n);
+assert.sameValue(BigInt("0xfffffffffffffffffff"), 75557863725914323419135n);
+
+assert.sameValue(BigInt("0Xa"), 10n);
+assert.sameValue(BigInt("0Xff"), 255n);
+assert.sameValue(BigInt("0Xfabc"), 64188n);
+assert.sameValue(BigInt("0Xfffffffffffffffffff"), 75557863725914323419135n);
+

--- a/test/built-ins/BigInt/constructor-from-octal-string.js
+++ b/test/built-ins/BigInt/constructor-from-octal-string.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Octal prefixed String should be parsed to BigInt according StringToBigInt
+esid: sec-string-to-bigint
+info: |
+  Apply the algorithm in 3.1.3.1 with the following changes:
+
+  - Replace the StrUnsignedDecimalLiteral production with DecimalDigits
+    to not allow decimal points or exponents.
+
+features: [BigInt]
+---*/
+
+assert.sameValue(BigInt("0o7"), 7n);
+assert.sameValue(BigInt("0o10"), 8n);
+assert.sameValue(BigInt("0o20"), 16n);
+
+assert.sameValue(BigInt("0O7"), 7n);
+assert.sameValue(BigInt("0O10"), 8n);
+assert.sameValue(BigInt("0O20"), 16n);
+

--- a/test/built-ins/BigInt/constructor-from-string-syntax-errors.js
+++ b/test/built-ins/BigInt/constructor-from-string-syntax-errors.js
@@ -1,0 +1,71 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Invalid String into BigInt constructor should throw SyntaxError
+esid: sec-string-to-bigint
+info: |
+  Apply the algorithm in 3.1.3.1 with the following changes:
+
+  - Replace the StrUnsignedDecimalLiteral production with DecimalDigits
+    to not allow decimal points or exponents.
+
+features: [BigInt]
+---*/
+
+assert.throws(SyntaxError, function() {
+  BigInt("10n");
+}
+
+assert.throws(SyntaxError, function() {
+  BigInt("10x");
+}
+
+assert.throws(SyntaxError, function() {
+  BigInt("10b");
+}
+
+assert.throws(SyntaxError, function() {
+  BigInt("10.5");
+}
+
+assert.throws(SyntaxError, function() {
+  BigInt("0b");
+}
+
+assert.throws(SyntaxError, function() {
+  BigInt("-0x1");
+}
+
+assert.throws(SyntaxError, function() {
+  BigInt("-0XFFab");
+}
+
+assert.throws(SyntaxError, function() {
+  BigInt("0oa");
+}
+
+assert.throws(SyntaxError, function() {
+  BigInt("000 12");
+}
+
+assert.throws(SyntaxError, function() {
+  BigInt("0o");
+}
+
+assert.throws(SyntaxError, function() {
+  BigInt("0x");
+}
+
+assert.throws(SyntaxError, function() {
+  BigInt("00o");
+}
+
+assert.throws(SyntaxError, function() {
+  BigInt("00b");
+}
+
+assert.throws(SyntaxError, function() {
+  BigInt("00x");
+}
+

--- a/test/built-ins/BigInt/constructor-trailing-leading-spaces.js
+++ b/test/built-ins/BigInt/constructor-trailing-leading-spaces.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Tariling/Leading spaces should be ignored in BigInt constructor should
+esid: sec-string-to-bigint
+info: |
+  Apply the algorithm in 3.1.3.1 with the following changes:
+
+  - Replace the StrUnsignedDecimalLiteral production with DecimalDigits
+    to not allow decimal points or exponents.
+
+features: [BigInt]
+---*/
+
+assert.sameValue(BigInt("   0b1111"), 15n);
+assert.sameValue(BigInt("18446744073709551616   "), 18446744073709551616n);
+assert.sameValue(BigInt("   7   "), 7n);
+assert.sameValue(BigInt("   -197   "), -197n);
+assert.sameValue(BigInt("     "), 0n);
+

--- a/test/built-ins/BigInt/value-of-throws.js
+++ b/test/built-ins/BigInt/value-of-throws.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Throws exception in BigIntConstructor if valueOf/toString does that
+esid: sec-bigint-constructor-number-value
+info: |
+  1. If NewTarget is not undefined, throw a TypeError exception.
+  2. Let prim be ? ToPrimitive(value, hint Number).
+  3. If Type(prim) is Number, return ? NumberToBigInt(prim).
+  4. Otherwise, return ? ToBigInt(value).
+features: [BigInt]
+---*/
+
+assert.throws(Test262Error, function() {
+  BigInt({
+    valueOf: function() { throw new Test262Error("unreachable"); }
+  });
+}
+
+assert.throws(Test262Error, function() {
+  BigInt({
+    toString: function() { throw new Test262Error("unreachable"); }
+  });
+}
+


### PR DESCRIPTION
This are tests that I'm writing into JSC implementation. I'm not sure if they are really missing, but I would like to propose them.