### PR TITLE
Test change in PluralRules default options semantics

### DIFF
--- a/test/intl402/PluralRules/default-options-object-prototype.js
+++ b/test/intl402/PluralRules/default-options-object-prototype.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 Igalia, S. L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-initializepluralrules
+description: >
+  Monkey-patching Object.prototype does not change the default
+  options for PluralRules as a null prototype is used.
+info: >
+  InitializePluralRules ( collator, locales, options )
+
+    1. If _options_ is *undefined*, then
+      1. Let _options_ be ObjectCreate(*null*).
+---*/
+
+Object.prototype.type = "ordinal";
+let pluralRules = new Intl.PluralRules("en");
+assert.sameValue(pluralRules.resolvedOptions().type, "cardinal");


### PR DESCRIPTION
The change is done in the following patch, where default options
have a null prototype. This matches what other Intl objects have.
https://github.com/tc39/proposal-intl-plural-rules/commit/1abe8af440fb47d888ace701e8a46559bdbe7b06

Note that this change has already been committed to the proposal repository, and it matches existing implementations, so the patch should be land-able from a spec perspective.

I looked at adding a feature flag, but it seems like there's no feature flag for PluralRules yet.