### PR TITLE
Fix several Decode tests

### DIFF
--- a/test/built-ins/decodeURI/S15.1.3.1_A1.11_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.11_T2.js
@@ -20,7 +20,7 @@ var interval = [[0x00, 0x29], [0x40,0x40], [0x47, 0x60], [0x67, 0xFFFF]];
 for (var indexI = 0; indexI < interval.length; indexI++) {
   for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
     try {
-      decodeURI("%E0%" + "%A0" + String.fromCharCode(indexJ, indexJ));
+      decodeURI("%E0" + "%A0%" + String.fromCharCode(indexJ, indexJ));
       result = false;
     } catch (e) {
       if ((e instanceof URIError) !== true) {

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.12_T2.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.12_T2.js
@@ -21,7 +21,7 @@ var interval = [[0x00, 0x29], [0x40,0x40], [0x47, 0x60], [0x67, 0xFFFF]];
 for (var indexI = 0; indexI < interval.length; indexI++) {
   for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
     try {
-      decodeURI("%F0%" + "%A0" + String.fromCharCode(indexJ, indexJ) + "%A0");
+      decodeURI("%F0" + "%A0%" + String.fromCharCode(indexJ, indexJ) + "%A0");
       result = false;
     } catch (e) {
       if ((e instanceof URIError) !== true) {

--- a/test/built-ins/decodeURI/S15.1.3.1_A1.12_T3.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A1.12_T3.js
@@ -21,7 +21,7 @@ var interval = [[0x00, 0x29], [0x40,0x40], [0x47, 0x60], [0x67, 0xFFFF]];
 for (var indexI = 0; indexI < interval.length; indexI++) {
   for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
     try {
-      decodeURI("%F0%" + "%A0%A0" + String.fromCharCode(indexJ, indexJ));
+      decodeURI("%F0" + "%A0%A0%" + String.fromCharCode(indexJ, indexJ));
       result = false;
     } catch (e) {
       if ((e instanceof URIError) !== true) {

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.11_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.11_T2.js
@@ -20,7 +20,7 @@ var interval = [[0x00, 0x29], [0x40,0x40], [0x47, 0x60], [0x67, 0xFFFF]];
 for (var indexI = 0; indexI < interval.length; indexI++) {
   for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
     try {
-      decodeURIComponent("%E0%" + "%A0" + String.fromCharCode(indexJ, indexJ));
+      decodeURIComponent("%E0" + "%A0%" + String.fromCharCode(indexJ, indexJ));
       result = false;
     } catch (e) {
       if ((e instanceof URIError) !== true) {

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.12_T2.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.12_T2.js
@@ -21,7 +21,7 @@ var interval = [[0x00, 0x29], [0x40,0x40], [0x47, 0x60], [0x67, 0xFFFF]];
 for (var indexI = 0; indexI < interval.length; indexI++) {
   for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
     try {
-      decodeURIComponent("%F0%" + "%A0" + String.fromCharCode(indexJ, indexJ) + "%A0");
+      decodeURIComponent("%F0" + "%A0%" + String.fromCharCode(indexJ, indexJ) + "%A0");
       result = false;
     } catch (e) {
       if ((e instanceof URIError) !== true) {

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A1.12_T3.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A1.12_T3.js
@@ -21,7 +21,7 @@ var interval = [[0x00, 0x29], [0x40,0x40], [0x47, 0x60], [0x67, 0xFFFF]];
 for (var indexI = 0; indexI < interval.length; indexI++) {
   for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
     try {
-      decodeURIComponent("%F0%" + "%A0%A0" + String.fromCharCode(indexJ, indexJ));
+      decodeURIComponent("%F0" + "%A0%A0%" + String.fromCharCode(indexJ, indexJ));
       result = false;
     } catch (e) {
       if ((e instanceof URIError) !== true) {


### PR DESCRIPTION
The tests are explicitly for bad hex chars at certain indexes, and that
rogue `%` was giving false positives.

I'm not super in favor of the string concats, but it's not affecting anything...