### PR TITLE
Remove unnecessary uses of let in harness.

### DIFF
--- a/harness/assert.js
+++ b/harness/assert.js
@@ -88,8 +88,8 @@ assert.throws = function (expectedErrorConstructor, func, message) {
 };
 
 assert.throws.early = function(err, code) {
-  let wrappedCode = 'function wrapperFn() { ' + code + ' }';
-  let ieval = eval;
+  var wrappedCode = 'function wrapperFn() { ' + code + ' }';
+  var ieval = eval;
 
   assert.throws(err, function() { Function(wrappedCode); }, 'Function: ' + code);
 };


### PR DESCRIPTION
The use of `let` is unnecessary here, particularly in a
file that is needed to run any of the tests, even the ES5 tests.
Removing it allows older engines to run older tests.