### PR TITLE
Remove some spurious blank lines

### DIFF
--- a/test/language/expressions/bitwise-and/bigint-non-primitive.js
+++ b/test/language/expressions/bitwise-and/bigint-non-primitive.js
@@ -5,7 +5,6 @@
 description: Bitwise AND for BigInt non-primitive values
 esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
 info: |
-
   5. Let lnum be ? ToNumeric(lval).
   6. Let rnum be ? ToNumeric(rval).
   ...

--- a/test/language/expressions/bitwise-or/bigint-non-primitive.js
+++ b/test/language/expressions/bitwise-or/bigint-non-primitive.js
@@ -5,7 +5,6 @@
 description: Bitwise OR for BigInt non-primitive values
 esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
 info: |
-
   5. Let lnum be ? ToNumeric(lval).
   6. Let rnum be ? ToNumeric(rval).
   ...

--- a/test/language/expressions/bitwise-xor/bigint-non-primitive.js
+++ b/test/language/expressions/bitwise-xor/bigint-non-primitive.js
@@ -5,7 +5,6 @@
 description: Bitwise XOR for BigInt non-primitive values
 esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
 info: |
-
   5. Let lnum be ? ToNumeric(lval).
   6. Let rnum be ? ToNumeric(rval).
   ...


### PR DESCRIPTION
A few BigInt tests had a blank line in an inconvenient place which
breaks an old, possibly incorrect YAML parser used by V8's test262
test automation. The best fix is to deploy a new YAML parser, but
in the short term, this patch deletes the blank lines and lets
V8 understand the feature flags below. Related: #1370