### PR TITLE
Various tests to increase coverage

### DIFF
--- a/test/annexB/built-ins/Function/createdynfn-html-close-comment-body.js
+++ b/test/annexB/built-ins/Function/createdynfn-html-close-comment-body.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-createdynamicfunction
+description: >
+  Create a Function with the function body being a html close comment.
+info: |
+  19.2.1.1.1 Runtime Semantics: CreateDynamicFunction(constructor, newTarget, kind, args)
+    ...
+    7. If kind is "normal", then
+      a. Let goal be the grammar symbol FunctionBody[~Yield, ~Await].
+    ...
+    11. Let body be the result of parsing bodyText, interpreted as UTF-16 encoded Unicode text
+        as described in 6.1.4, using goal as the goal symbol. Throw a SyntaxError exception if
+        the parse fails.
+    ...
+---*/
+
+Function("-->");

--- a/test/annexB/built-ins/Function/createdynfn-html-close-comment-params.js
+++ b/test/annexB/built-ins/Function/createdynfn-html-close-comment-params.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-createdynamicfunction
+description: >
+  Create a Function with the function parameters being a html close comment.
+info: |
+  19.2.1.1.1 Runtime Semantics: CreateDynamicFunction(constructor, newTarget, kind, args)
+    ...
+    7. If kind is "normal", then
+      ...
+      b. Let parameterGoal be the grammar symbol FormalParameters[~Yield, ~Await].
+    ...
+    10. Let parameters be the result of parsing P, interpreted as UTF-16 encoded Unicode text
+        as described in 6.1.4, using parameterGoal as the goal symbol. Throw a SyntaxError
+        exception if the parse fails.
+    ...
+---*/
+
+Function("-->", "");

--- a/test/annexB/built-ins/Function/createdynfn-html-open-comment-body.js
+++ b/test/annexB/built-ins/Function/createdynfn-html-open-comment-body.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-createdynamicfunction
+description: >
+  Create a Function with the function body being a html open comment.
+info: |
+  19.2.1.1.1 Runtime Semantics: CreateDynamicFunction(constructor, newTarget, kind, args)
+    ...
+    7. If kind is "normal", then
+      a. Let goal be the grammar symbol FunctionBody[~Yield, ~Await].
+    ...
+    11. Let body be the result of parsing bodyText, interpreted as UTF-16 encoded Unicode text
+        as described in 6.1.4, using goal as the goal symbol. Throw a SyntaxError exception if
+        the parse fails.
+    ...
+---*/
+
+Function("<!--");

--- a/test/annexB/built-ins/Function/createdynfn-html-open-comment-params.js
+++ b/test/annexB/built-ins/Function/createdynfn-html-open-comment-params.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-createdynamicfunction
+description: >
+  Create a Function with the function parameters being a html open comment.
+info: |
+  19.2.1.1.1 Runtime Semantics: CreateDynamicFunction(constructor, newTarget, kind, args)
+    ...
+    7. If kind is "normal", then
+      ...
+      b. Let parameterGoal be the grammar symbol FormalParameters[~Yield, ~Await].
+    ...
+    10. Let parameters be the result of parsing P, interpreted as UTF-16 encoded Unicode text
+        as described in 6.1.4, using parameterGoal as the goal symbol. Throw a SyntaxError
+        exception if the parse fails.
+    ...
+---*/
+
+Function("<!--", "");

--- a/test/annexB/built-ins/RegExp/prototype/Symbol.split/Symbol.match-getter-recompiles-source.js
+++ b/test/annexB/built-ins/RegExp/prototype/Symbol.split/Symbol.match-getter-recompiles-source.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-regexp.prototype-@@split
+description: >
+  Side-effects in IsRegExp may recompile the regular expression.
+info: |
+  21.2.5.11 RegExp.prototype [ @@split ] ( string, limit )
+    ...
+    4. Let C be ? SpeciesConstructor(rx, %RegExp%).
+    ...
+    10. Let splitter be ? Construct(C, « rx, newFlags »).
+    ...
+
+  21.2.3.1 RegExp ( pattern, flags )
+    1. Let patternIsRegExp be ? IsRegExp(pattern).
+    ...
+
+features: [Symbol.match, Symbol.split]
+---*/
+
+var regExp = /a/;
+Object.defineProperty(regExp, Symbol.match, {
+  get: function() {
+    regExp.compile("b");
+  }
+});
+
+var result = regExp[Symbol.split]("abba");
+
+assert.sameValue(result.length, 3);
+assert.sameValue(result[0], "a");
+assert.sameValue(result[1], "");
+assert.sameValue(result[2], "a");

--- a/test/annexB/built-ins/RegExp/prototype/Symbol.split/toint32-limit-recompiles-source.js
+++ b/test/annexB/built-ins/RegExp/prototype/Symbol.split/toint32-limit-recompiles-source.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-regexp.prototype-@@split
+description: >
+  Side-effects in ToUint32 may recompile the regular expression.
+info: |
+  21.2.5.11 RegExp.prototype [ @@split ] ( string, limit )
+    ...
+    10. Let splitter be ? Construct(C, « rx, newFlags »).
+    ...
+    13. If limit is undefined, let lim be 2^32-1; else let lim be ? ToUint32(limit).
+    ...
+
+features: [Symbol.split]
+---*/
+
+var regExp = /a/;
+var limit = {
+  valueOf: function() {
+    regExp.compile("b");
+    return -1;
+  }
+};
+
+var result = regExp[Symbol.split]("abba", limit);
+
+assert.sameValue(result.length, 3);
+assert.sameValue(result[0], "");
+assert.sameValue(result[1], "bb");
+assert.sameValue(result[2], "");

--- a/test/built-ins/TypedArrays/internals/Get/infinity-detached-buffer.js
+++ b/test/built-ins/TypedArrays/internals/Get/infinity-detached-buffer.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-integerindexedelementget
+info: >
+  "Infinity" is a canonical numeric string, test with access on detached buffer.
+description: |
+  9.4.5.4 [[Get]] ( P, Receiver )
+  ...
+  2. If Type(P) is String, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      i. Return ? IntegerIndexedElementGet(O, numericIndex).
+  ...
+
+  7.1.16 CanonicalNumericIndexString ( argument )
+    ...
+    3. Let n be ! ToNumber(argument).
+    4. If SameValue(! ToString(n), argument) is false, return undefined.
+    5. Return n.
+
+  9.4.5.8 IntegerIndexedElementGet ( O, index )
+    ...
+    3. Let buffer be O.[[ViewedArrayBuffer]].
+    4. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+    ...
+
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(0);
+  $DETACHBUFFER(sample.buffer);
+
+  assert.throws(TypeError, function() {
+    sample.Infinity;
+  });
+});

--- a/test/built-ins/TypedArrays/internals/GetOwnProperty/enumerate-detached-buffer.js
+++ b/test/built-ins/TypedArrays/internals/GetOwnProperty/enumerate-detached-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-integer-indexed-exotic-objects-getownproperty-p
+info: Test for-in enumeration with detached buffer.
+description: |
+  9.4.5.1 [[GetOwnProperty]] ( P )
+    ...
+    3. If Type(P) is String, then
+      a. Let numericIndex be ! CanonicalNumericIndexString(P).
+      b. If numericIndex is not undefined, then
+        i. Let value be ? IntegerIndexedElementGet(O, numericIndex).
+    ...
+
+  9.4.5.8 IntegerIndexedElementGet ( O, index )
+    ...
+    3. Let buffer be O.[[ViewedArrayBuffer]].
+    4. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+    ...
+
+  13.7.5.15 EnumerateObjectProperties (O)
+    ...
+    EnumerateObjectProperties must obtain the own property keys of the
+    target object by calling its [[OwnPropertyKeys]] internal method.
+    Property attributes of the target object must be obtained by
+    calling its [[GetOwnProperty]] internal method.
+
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(42);
+  $DETACHBUFFER(sample.buffer);
+
+  assert.throws(TypeError, function() {
+    for (var key in sample) {
+      throw new Test262Error();
+    }
+  });
+});

--- a/test/built-ins/TypedArrays/internals/HasProperty/infinity-with-detached-buffer.js
+++ b/test/built-ins/TypedArrays/internals/HasProperty/infinity-with-detached-buffer.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-integer-indexed-exotic-objects-hasproperty-p
+info: >
+  "Infinity" is a canonical numeric string, test with access on detached buffer.
+description: |
+  9.4.5.2 [[HasProperty]]( P )
+  ...
+  3. If Type(P) is String, then
+    a. Let numericIndex be ! CanonicalNumericIndexString(P).
+    b. If numericIndex is not undefined, then
+      i. Let buffer be O.[[ViewedArrayBuffer]].
+      ii. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+      ...
+
+  7.1.16 CanonicalNumericIndexString ( argument )
+    ...
+    3. Let n be ! ToNumber(argument).
+    4. If SameValue(! ToString(n), argument) is false, return undefined.
+    5. Return n.
+
+flags: [noStrict]
+includes: [testTypedArray.js, detachArrayBuffer.js]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(0);
+  $DETACHBUFFER(sample.buffer);
+
+  assert.throws(TypeError, function() {
+    with (sample) Infinity;
+  });
+});

--- a/test/intl402/Collator/unicode-ext-seq-in-private-tag.js
+++ b/test/intl402/Collator/unicode-ext-seq-in-private-tag.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-initializecollator
+description: >
+  Unicode extension sequence-like parts are ignored in private-use tags.
+info: |
+  10.1.1 InitializeCollator ( collator, locales, options )
+    ...
+    15. For each element key of relevantExtensionKeys in List order, do
+      a. If key is "co", then
+          i. Let value be r.[[co]].
+         ii. If value is null, let value be "default".
+        iii. Set collator.[[Collation]] to value.
+    ...
+
+  10.3.5 Intl.Collator.prototype.resolvedOptions ()
+    The function returns a new object whose properties and attributes are set as if constructed
+    by an object literal assigning to each of the following properties the value of the
+    corresponding internal slot of this Collator object (see 10.4): ...
+---*/
+
+var c = new Intl.Collator("de-x-u-co-phonebk");
+var resolved = c.resolvedOptions();
+
+assert.sameValue(resolved.collation, "default");

--- a/test/intl402/Collator/unicode-ext-seq-with-attribute.js
+++ b/test/intl402/Collator/unicode-ext-seq-with-attribute.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-initializecollator
+description: >
+  Attributes in Unicode extension subtags should be ignored.
+info: |
+  10.1.1 InitializeCollator ( collator, locales, options )
+    ...
+    15. For each element key of relevantExtensionKeys in List order, do
+      a. If key is "co", then
+          i. Let value be r.[[co]].
+         ii. If value is null, let value be "default".
+        iii. Set collator.[[Collation]] to value.
+    ...
+
+  10.3.5 Intl.Collator.prototype.resolvedOptions ()
+    The function returns a new object whose properties and attributes are set as if constructed
+    by an object literal assigning to each of the following properties the value of the
+    corresponding internal slot of this Collator object (see 10.4): ...
+---*/
+
+var colExpected = new Intl.Collator("de-u-attrval-co-phonebk");
+var colActual = new Intl.Collator("de-u-co-phonebk");
+
+var resolvedExpected = colExpected.resolvedOptions();
+var resolvedActual = colActual.resolvedOptions();
+
+assert.sameValue(resolvedActual.locale, resolvedExpected.locale);
+assert.sameValue(resolvedActual.collation, resolvedExpected.collation);

--- a/test/intl402/Intl/getCanonicalLocales/canonicalized-tags.js
+++ b/test/intl402/Intl/getCanonicalLocales/canonicalized-tags.js
@@ -1,0 +1,69 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Call Intl.getCanonicalLocales function with valid language tags.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      a. Let Pk be ToString(k).
+      b. Let kPresent be ? HasProperty(O, Pk).
+      c. If kPresent is true, then
+        i. Let kValue be ? Get(O, Pk).
+        ...
+        iii. Let tag be ? ToString(kValue).
+        ...
+        v. Let canonicalizedTag be CanonicalizeLanguageTag(tag).
+        vi. If canonicalizedTag is not an element of seen, append canonicalizedTag as the last element of seen.
+      ...
+includes: [testIntl.js]
+---*/
+
+var canonicalizedTags = {
+  "de": "de",
+  "DE-de": "de-DE",
+  "de-DE": "de-DE",
+  "cmn": "cmn",
+  "CMN-hANS": "cmn-Hans",
+  "cmn-hans-cn": "cmn-Hans-CN",
+  "es-419": "es-419",
+  "es-419-u-nu-latn": "es-419-u-nu-latn",
+  "cmn-hans-cn-u-ca-t-ca-x-t-u": "cmn-Hans-CN-t-ca-u-ca-x-t-u",
+  "de-gregory-u-ca-gregory": "de-gregory-u-ca-gregory",
+  "no-nyn": "nn",
+  "i-klingon": "tlh",
+  "sgn-GR": "gss",
+  "ji": "yi",
+  "de-DD": "de-DE",
+  "zh-hak-CN": "hak-CN",
+  "sgn-ils": "ils",
+  "in": "id",
+  "x-foo": "x-foo",
+  "sr-cyrl-ekavsk": "sr-Cyrl-ekavsk",
+  "en-ca-newfound": "en-CA-newfound",
+  "sl-rozaj-biske-1994": "sl-rozaj-biske-1994",
+  "da-u-attr": "da-u-attr",
+  "da-u-attr-co-search": "da-u-attr-co-search",
+};
+
+// make sure the data above is correct
+Object.getOwnPropertyNames(canonicalizedTags).forEach(function (tag) {
+  var canonicalizedTag = canonicalizedTags[tag];
+  assert(
+    isCanonicalizedStructurallyValidLanguageTag(canonicalizedTag),
+    "Test data \"" + canonicalizedTag + "\" is not canonicalized and structurally valid language tag."
+  );
+});
+
+Object.getOwnPropertyNames(canonicalizedTags).forEach(function (tag) {
+  var canonicalLocales = Intl.getCanonicalLocales(tag);
+  assert.sameValue(canonicalLocales.length, 1);
+  assert.sameValue(canonicalLocales[0], canonicalizedTags[tag]);
+});

--- a/test/intl402/Intl/getCanonicalLocales/canonicalized-unicode-ext-seq.js
+++ b/test/intl402/Intl/getCanonicalLocales/canonicalized-unicode-ext-seq.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Implementations are allowed to canonicalize extension subtag sequences.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        v. Let canonicalizedTag be CanonicalizeLanguageTag(tag).
+        ...
+
+  6.2.3 CanonicalizeLanguageTag (locale)
+    The specifications for extensions to BCP 47 language tags, such as
+    RFC 6067, may include canonicalization rules for the extension subtag
+    sequences they define that go beyond the canonicalization rules of
+    RFC 5646 section 4.5. Implementations are allowed, but not required,
+    to apply these additional rules.
+---*/
+
+var locale = "it-u-nu-latn-ca-gregory";
+
+// RFC 6067: The canonical order of keywords is in US-ASCII order by key.
+var sorted = "it-u-ca-gregory-nu-latn";
+
+var canonicalLocales = Intl.getCanonicalLocales(locale);
+assert.sameValue(canonicalLocales.length, 1);
+
+var canonicalLocale = canonicalLocales[0];
+assert((canonicalLocale === locale) || (canonicalLocale === sorted));

--- a/test/intl402/Intl/getCanonicalLocales/descriptor.js
+++ b/test/intl402/Intl/getCanonicalLocales/descriptor.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Intl.getCanonicalLocales property attributes.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+
+  17 ECMAScript Standard Built-in Objects:
+    Every other data property described in clauses 18 through 26 and in
+    Annex B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyNotEnumerable(Intl, "getCanonicalLocales");
+verifyWritable(Intl, "getCanonicalLocales");
+verifyConfigurable(Intl, "getCanonicalLocales");

--- a/test/intl402/Intl/getCanonicalLocales/elements-not-reordered.js
+++ b/test/intl402/Intl/getCanonicalLocales/elements-not-reordered.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Language tags are not reordered.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        vi. If canonicalizedTag is not an element of seen, append canonicalizedTag as the last element of seen.
+        ...
+---*/
+
+var canonicalLocales = Intl.getCanonicalLocales(["zu", "af"]);
+
+assert.sameValue(canonicalLocales.length, 2);
+assert.sameValue(canonicalLocales[0], "zu");
+assert.sameValue(canonicalLocales[1], "af");

--- a/test/intl402/Intl/getCanonicalLocales/error-cases.js
+++ b/test/intl402/Intl/getCanonicalLocales/error-cases.js
@@ -33,6 +33,7 @@ var typeErrorCases =
   [
     null,
     [null],
+    [undefined],
     [true],
     [NaN],
     [2],

--- a/test/intl402/Intl/getCanonicalLocales/invalid-tags.js
+++ b/test/intl402/Intl/getCanonicalLocales/invalid-tags.js
@@ -1,0 +1,81 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Throws a RangeError if the language tag is invalid.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    ...
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        iv. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+        ...
+includes: [testIntl.js]
+---*/
+
+var invalidLanguageTags = [
+  "", // empty tag
+  "i", // singleton alone
+  "x", // private use without subtag
+  "u", // extension singleton in first place
+  "419", // region code in first place
+  "u-nu-latn-cu-bob", // extension sequence without language
+  "hans-cmn-cn", // "hans" could theoretically be a 4-letter language code,
+                 // but those can't be followed by extlang codes.
+  "cmn-hans-cn-u-u", // duplicate singleton
+  "cmn-hans-cn-t-u-ca-u", // duplicate singleton
+  "de-gregory-gregory", // duplicate variant
+  "*", // language range
+  "de-*", // language range
+  "中文", // non-ASCII letters
+  "en-ß", // non-ASCII letters
+  "ıd", // non-ASCII letters
+
+  // underscores in different parts of the language tag
+  "de_DE",
+  "DE_de",
+  "cmn_Hans",
+  "cmn-hans_cn",
+  "es_419",
+  "es-419-u-nu-latn-cu_bob",
+  "i_klingon",
+  "cmn-hans-cn-t-ca-u-ca-x_t-u",
+  "enochian_enochian",
+  "de-gregory_u-ca-gregory",
+
+  "en\u0000", // null-terminator sequence
+  " en", // leading whitespace
+  "en ", // trailing whitespace
+  "it-IT-Latn", // country before script tag
+  "de-u", // incomplete Unicode extension sequences
+  "de-u-",
+  "de-u-ca-",
+  "de-u-ca-gregory-",
+  "si-x", // incomplete private-use tags
+  "x-",
+  "x-y-",
+];
+
+// make sure the data above is correct
+for (var i = 0; i < invalidLanguageTags.length; ++i) {
+  var invalidTag = invalidLanguageTags[i];
+  assert(
+    !isCanonicalizedStructurallyValidLanguageTag(invalidTag),
+    "Test data \"" + invalidTag + "\" is a canonicalized and structurally valid language tag."
+  );
+}
+
+for (var i = 0; i < invalidLanguageTags.length; ++i) {
+  var invalidTag = invalidLanguageTags[i];
+  assert.throws(RangeError, function() {
+    Intl.getCanonicalLocales(invalidTag)
+  }, "Language tag: " + invalidTag);
+}

--- a/test/intl402/Intl/getCanonicalLocales/locales-is-not-a-string.js
+++ b/test/intl402/Intl/getCanonicalLocales/locales-is-not-a-string.js
@@ -19,6 +19,7 @@ function assertArray(l, r) {
 }
 
 assertArray(gCL(), []);
+assertArray(gCL(undefined), []);
 assertArray(gCL(false), []);
 assertArray(gCL(true), []);
 assertArray(gCL(Symbol("foo")), []);

--- a/test/intl402/Intl/getCanonicalLocales/preferred-grandfathered.js
+++ b/test/intl402/Intl/getCanonicalLocales/preferred-grandfathered.js
@@ -1,0 +1,86 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Call Intl.getCanonicalLocales function with grandfathered language tags.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        v. Let canonicalizedTag be CanonicalizeLanguageTag(tag).
+      ...
+
+  6.2.3 CanonicalizeLanguageTag ( locale )
+    The CanonicalizeLanguageTag abstract operation returns the canonical and case-regularized
+    form of the locale argument (which must be a String value that is a structurally valid
+    BCP 47 language tag as verified by the IsStructurallyValidLanguageTag abstract operation).
+    A conforming implementation shall take the steps specified in RFC 5646 section 4.5, or
+    successor, to bring the language tag into canonical form, and to regularize the case of
+    the subtags. Furthermore, a conforming implementation shall not take the steps to bring
+    a language tag into "extlang form", nor shall it reorder variant subtags.
+
+    The specifications for extensions to BCP 47 language tags, such as RFC 6067, may include
+    canonicalization rules for the extension subtag sequences they define that go beyond the
+    canonicalization rules of RFC 5646 section 4.5. Implementations are allowed, but not
+    required, to apply these additional rules.
+
+includes: [testIntl.js]
+---*/
+
+// Generated from http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+// File-Date: 2017-08-15
+var canonicalizedTags = {
+  // Irregular tags.
+  "en-gb-oed": "en-GB-oxendict",
+  "i-ami": "ami",
+  "i-bnn": "bnn",
+  "i-default": "i-default",
+  "i-enochian": "i-enochian",
+  "i-hak": "hak",
+  "i-klingon": "tlh",
+  "i-lux": "lb",
+  "i-mingo": "i-mingo",
+  "i-navajo": "nv",
+  "i-pwn": "pwn",
+  "i-tao": "tao",
+  "i-tay": "tay",
+  "i-tsu": "tsu",
+  "sgn-be-fr": "sfb",
+  "sgn-be-nl": "vgt",
+  "sgn-ch-de": "sgg",
+
+  // Regular tags.
+  "art-lojban": "jbo",
+  "cel-gaulish": "cel-gaulish",
+  "no-bok": "nb",
+  "no-nyn": "nn",
+  "zh-guoyu": "cmn",
+  "zh-hakka": "hak",
+  "zh-min": "zh-min",
+  "zh-min-nan": "nan",
+  "zh-xiang": "hsn",
+};
+
+// make sure the data above is correct
+Object.getOwnPropertyNames(canonicalizedTags).forEach(function (tag) {
+  var canonicalizedTag = canonicalizedTags[tag];
+  assert(
+    isCanonicalizedStructurallyValidLanguageTag(canonicalizedTag),
+    "Test data \"" + canonicalizedTag + "\" is not canonicalized and structurally valid language tag."
+  );
+});
+
+Object.getOwnPropertyNames(canonicalizedTags).forEach(function (tag) {
+  var canonicalLocales = Intl.getCanonicalLocales(tag);
+  assert.sameValue(canonicalLocales.length, 1);
+  assert.sameValue(canonicalLocales[0], canonicalizedTags[tag]);
+});

--- a/test/intl402/Intl/getCanonicalLocales/preferred-variant.js
+++ b/test/intl402/Intl/getCanonicalLocales/preferred-variant.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Call Intl.getCanonicalLocales function with grandfathered language tags.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        v. Let canonicalizedTag be CanonicalizeLanguageTag(tag).
+      ...
+
+  6.2.3 CanonicalizeLanguageTag ( locale )
+    The CanonicalizeLanguageTag abstract operation returns the canonical and case-regularized
+    form of the locale argument (which must be a String value that is a structurally valid
+    BCP 47 language tag as verified by the IsStructurallyValidLanguageTag abstract operation).
+    A conforming implementation shall take the steps specified in RFC 5646 section 4.5, or
+    successor, to bring the language tag into canonical form, and to regularize the case of
+    the subtags. Furthermore, a conforming implementation shall not take the steps to bring
+    a language tag into "extlang form", nor shall it reorder variant subtags.
+
+    The specifications for extensions to BCP 47 language tags, such as RFC 6067, may include
+    canonicalization rules for the extension subtag sequences they define that go beyond the
+    canonicalization rules of RFC 5646 section 4.5. Implementations are allowed, but not
+    required, to apply these additional rules.
+
+includes: [testIntl.js]
+---*/
+
+// Generated from http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+// File-Date: 2017-08-15
+var canonicalizedTags = {
+  "ja-latn-hepburn-heploc": "ja-Latn-alalc97",
+};
+
+// make sure the data above is correct
+Object.getOwnPropertyNames(canonicalizedTags).forEach(function (tag) {
+  var canonicalizedTag = canonicalizedTags[tag];
+  assert(
+    isCanonicalizedStructurallyValidLanguageTag(canonicalizedTag),
+    "Test data \"" + canonicalizedTag + "\" is not canonicalized and structurally valid language tag."
+  );
+});
+
+Object.getOwnPropertyNames(canonicalizedTags).forEach(function (tag) {
+  var canonicalLocales = Intl.getCanonicalLocales(tag);
+  assert.sameValue(canonicalLocales.length, 1);
+  assert.sameValue(canonicalLocales[0], canonicalizedTags[tag]);
+});

--- a/test/language/expressions/call/eval-spread-empty-leading.js
+++ b/test/language/expressions/call/eval-spread-empty-leading.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-function-calls-runtime-semantics-evaluation
+info: >
+  Direct eval call with empty leading spread.
+description: |
+  12.3.4.1 Runtime Semantics: Evaluation
+    ...
+    3. If Type(ref) is Reference and IsPropertyReference(ref) is false and GetReferencedName(ref) is "eval", then
+      a. If SameValue(func, %eval%) is true, then
+        i. Let argList be ? ArgumentListEvaluation(Arguments).
+        ii. If argList has no elements, return undefined.
+        iii. Let evalText be the first element of argList.
+        ...
+
+features: [Symbol.iterator]
+---*/
+
+var nextCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      var i = nextCount++;
+      return {done: true, value: undefined};
+    }
+  };
+};
+
+var x = "global";
+
+(function() {
+  var x = "local";
+  eval(...iter, "x = 0;");
+  assert.sameValue(x, 0);
+})();
+
+assert.sameValue(x, "global");
+assert.sameValue(nextCount, 1);

--- a/test/language/expressions/call/eval-spread-empty-trailing.js
+++ b/test/language/expressions/call/eval-spread-empty-trailing.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-function-calls-runtime-semantics-evaluation
+info: >
+  Direct eval call with empty trailing spread.
+description: |
+  12.3.4.1 Runtime Semantics: Evaluation
+    ...
+    3. If Type(ref) is Reference and IsPropertyReference(ref) is false and GetReferencedName(ref) is "eval", then
+      a. If SameValue(func, %eval%) is true, then
+        i. Let argList be ? ArgumentListEvaluation(Arguments).
+        ii. If argList has no elements, return undefined.
+        iii. Let evalText be the first element of argList.
+        ...
+
+features: [Symbol.iterator]
+---*/
+
+var nextCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      var i = nextCount++;
+      return {done: true, value: undefined};
+    }
+  };
+};
+
+var x = "global";
+
+(function() {
+  var x = "local";
+  eval("x = 0;", ...iter);
+  assert.sameValue(x, 0);
+})();
+
+assert.sameValue(x, "global");
+assert.sameValue(nextCount, 1);

--- a/test/language/expressions/call/eval-spread-empty.js
+++ b/test/language/expressions/call/eval-spread-empty.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-function-calls-runtime-semantics-evaluation
+info: >
+  Direct eval call with empty spread.
+description: |
+  12.3.4.1 Runtime Semantics: Evaluation
+    ...
+    3. If Type(ref) is Reference and IsPropertyReference(ref) is false and GetReferencedName(ref) is "eval", then
+      a. If SameValue(func, %eval%) is true, then
+        i. Let argList be ? ArgumentListEvaluation(Arguments).
+        ii. If argList has no elements, return undefined.
+        ...
+
+features: [Symbol.iterator]
+---*/
+
+var nextCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      var i = nextCount++;
+      return {done: true, value: undefined};
+    }
+  };
+};
+
+var result = eval(...iter);
+
+assert.sameValue(result, undefined);
+assert.sameValue(nextCount, 1);

--- a/test/language/expressions/call/eval-spread.js
+++ b/test/language/expressions/call/eval-spread.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-function-calls-runtime-semantics-evaluation
+info: >
+  Direct eval call with spread.
+description: |
+  12.3.4.1 Runtime Semantics: Evaluation
+    ...
+    3. If Type(ref) is Reference and IsPropertyReference(ref) is false and GetReferencedName(ref) is "eval", then
+      a. If SameValue(func, %eval%) is true, then
+        i. Let argList be ? ArgumentListEvaluation(Arguments).
+        ii. If argList has no elements, return undefined.
+        iii. Let evalText be the first element of argList.
+        ...
+
+features: [Symbol.iterator]
+---*/
+
+var elements = [
+  "x = 1;",
+  "x = 2;",
+];
+
+var nextCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      var i = nextCount++;
+      if (i < elements.length) {
+        return {done: false, value: elements[i]};
+      }
+      return {done: true, value: undefined};
+    }
+  };
+};
+
+var x = "global";
+
+(function() {
+  var x = "local";
+  eval(...iter);
+  assert.sameValue(x, 1);
+})();
+
+assert.sameValue(x, "global");
+assert.sameValue(nextCount, 3);

--- a/test/language/expressions/call/tco-cross-realm-class-construct.js
+++ b/test/language/expressions/call/tco-cross-realm-class-construct.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-function-calls-runtime-semantics-evaluation
+info: >
+  Check TypeError is thrown from correct realm with tco-call to class constructor from derived
+  class [[Construct]] invocation.
+description: |
+  12.3.4.3 Runtime Semantics: EvaluateDirectCall( func, thisValue, arguments, tailPosition )
+    ...
+    4. If tailPosition is true, perform PrepareForTailCall().
+    5. Let result be Call(func, thisValue, argList).
+    6. Assert: If tailPosition is true, the above call will not return here, but instead evaluation will continue as if the following return has already occurred.
+    7. Assert: If result is not an abrupt completion, then Type(result) is an ECMAScript language type.
+    8. Return result.
+
+  9.2.1 [[Call]] ( thisArgument, argumentsList)
+    ...
+    2. If F.[[FunctionKind]] is "classConstructor", throw a TypeError exception.
+    3. Let callerContext be the running execution context.
+    4. Let calleeContext be PrepareForOrdinaryCall(F, undefined).
+    5. Assert: calleeContext is now the running execution context.
+    ...
+
+features: [tail-call-optimization, class]
+---*/
+
+// - The class constructor call is in a valid tail-call position, which means PrepareForTailCall is performed.
+// - The function call returns from `otherRealm` and proceeds the tail-call in this realm.
+// - Calling the class constructor throws a TypeError from the current realm, that means this realm and not `otherRealm`.
+var code = "(class { constructor() { return (class {})(); } });";
+
+var otherRealm = $262.createRealm();
+var tco = otherRealm.evalScript(code);
+
+assert.throws(TypeError, function() {
+  new tco();
+});

--- a/test/language/expressions/call/tco-cross-realm-class-derived-construct.js
+++ b/test/language/expressions/call/tco-cross-realm-class-derived-construct.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-function-calls-runtime-semantics-evaluation
+info: >
+  Check TypeError is thrown from correct realm with tco-call to class constructor from
+  class [[Construct]] invocation.
+description: |
+  12.3.4.3 Runtime Semantics: EvaluateDirectCall( func, thisValue, arguments, tailPosition )
+    ...
+    4. If tailPosition is true, perform PrepareForTailCall().
+    5. Let result be Call(func, thisValue, argList).
+    6. Assert: If tailPosition is true, the above call will not return here, but instead evaluation will continue as if the following return has already occurred.
+    7. Assert: If result is not an abrupt completion, then Type(result) is an ECMAScript language type.
+    8. Return result.
+
+  9.2.1 [[Call]] ( thisArgument, argumentsList)
+    ...
+    2. If F.[[FunctionKind]] is "classConstructor", throw a TypeError exception.
+    3. Let callerContext be the running execution context.
+    4. Let calleeContext be PrepareForOrdinaryCall(F, undefined).
+    5. Assert: calleeContext is now the running execution context.
+    ...
+
+features: [tail-call-optimization, class]
+---*/
+
+// - The class constructor call is in a valid tail-call position, which means PrepareForTailCall is performed.
+// - The function call returns from `otherRealm` and proceeds the tail-call in this realm.
+// - Calling the class constructor throws a TypeError from the current realm, that means this realm and not `otherRealm`.
+var code = "(class extends Object { constructor() { return (class {})(); } });";
+
+var otherRealm = $262.createRealm();
+var tco = otherRealm.evalScript(code);
+
+assert.throws(TypeError, function() {
+  new tco();
+});

--- a/test/language/expressions/call/tco-cross-realm-fun-call.js
+++ b/test/language/expressions/call/tco-cross-realm-fun-call.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-function-calls-runtime-semantics-evaluation
+info: >
+  Check TypeError is thrown from correct realm with tco-call to class constructor from [[Call]] invocation.
+description: |
+  12.3.4.3 Runtime Semantics: EvaluateDirectCall( func, thisValue, arguments, tailPosition )
+    ...
+    4. If tailPosition is true, perform PrepareForTailCall().
+    5. Let result be Call(func, thisValue, argList).
+    6. Assert: If tailPosition is true, the above call will not return here, but instead evaluation will continue as if the following return has already occurred.
+    7. Assert: If result is not an abrupt completion, then Type(result) is an ECMAScript language type.
+    8. Return result.
+
+  9.2.1 [[Call]] ( thisArgument, argumentsList)
+    ...
+    2. If F.[[FunctionKind]] is "classConstructor", throw a TypeError exception.
+    3. Let callerContext be the running execution context.
+    4. Let calleeContext be PrepareForOrdinaryCall(F, undefined).
+    5. Assert: calleeContext is now the running execution context.
+    ...
+
+features: [tail-call-optimization, class]
+---*/
+
+// - The class constructor call is in a valid tail-call position, which means PrepareForTailCall is performed.
+// - The function call returns from `otherRealm` and proceeds the tail-call in this realm.
+// - Calling the class constructor throws a TypeError from the current realm, that means this realm and not `otherRealm`.
+var code = "'use strict'; (function() { return (class {})(); });";
+
+var otherRealm = $262.createRealm();
+var tco = otherRealm.evalScript(code);
+
+assert.throws(TypeError, function() {
+  tco();
+});

--- a/test/language/expressions/call/tco-cross-realm-fun-construct.js
+++ b/test/language/expressions/call/tco-cross-realm-fun-construct.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-function-calls-runtime-semantics-evaluation
+info: >
+  Check TypeError is thrown from correct realm with tco-call to class constructor from [[Construct]] invocation.
+description: |
+  12.3.4.3 Runtime Semantics: EvaluateDirectCall( func, thisValue, arguments, tailPosition )
+    ...
+    4. If tailPosition is true, perform PrepareForTailCall().
+    5. Let result be Call(func, thisValue, argList).
+    6. Assert: If tailPosition is true, the above call will not return here, but instead evaluation will continue as if the following return has already occurred.
+    7. Assert: If result is not an abrupt completion, then Type(result) is an ECMAScript language type.
+    8. Return result.
+
+  9.2.1 [[Call]] ( thisArgument, argumentsList)
+    ...
+    2. If F.[[FunctionKind]] is "classConstructor", throw a TypeError exception.
+    3. Let callerContext be the running execution context.
+    4. Let calleeContext be PrepareForOrdinaryCall(F, undefined).
+    5. Assert: calleeContext is now the running execution context.
+    ...
+
+features: [tail-call-optimization, class]
+---*/
+
+// - The class constructor call is in a valid tail-call position, which means PrepareForTailCall is performed.
+// - The function call returns from `otherRealm` and proceeds the tail-call in this realm.
+// - Calling the class constructor throws a TypeError from the current realm, that means this realm and not `otherRealm`.
+var code = "'use strict'; (function() { return (class {})(); });";
+
+var otherRealm = $262.createRealm();
+var tco = otherRealm.evalScript(code);
+
+assert.throws(TypeError, function() {
+  new tco();
+});

--- a/test/language/expressions/call/tco-non-eval-function-dynamic.js
+++ b/test/language/expressions/call/tco-non-eval-function-dynamic.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-function-calls-runtime-semantics-evaluation
+info: >
+  Tail-call with identifier named "eval" in function environment, local "eval" binding dynamically added.
+description: |
+  12.3.4.1 Runtime Semantics: Evaluation
+    ...
+    6. If Type(ref) is Reference and IsPropertyReference(ref) is false and
+       GetReferencedName(ref) is "eval", then
+      a. If SameValue(func, %eval%) is true, then
+        ...
+    ...
+    9. Return ? EvaluateCall(func, ref, arguments, tailCall).
+
+  12.3.4.2 Runtime Semantics: EvaluateCall( func, ref, arguments, tailPosition )
+    ...
+    7. If tailPosition is true, perform PrepareForTailCall().
+    8. Let result be Call(func, thisValue, argList).
+    ...
+
+flags: [noStrict]
+features: [tail-call-optimization]
+includes: [tcoHelper.js]
+---*/
+
+var callCount = 0;
+
+(function() {
+  function f(n) {
+    "use strict";
+    if (n === 0) {
+      callCount += 1
+      return;
+    }
+    return eval(n - 1);
+  }
+  eval("var eval = f;");
+  f($MAX_ITERATIONS);
+})();
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/call/tco-non-eval-function.js
+++ b/test/language/expressions/call/tco-non-eval-function.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-function-calls-runtime-semantics-evaluation
+info: >
+  Tail-call with identifier named "eval" in function environment.
+description: |
+  12.3.4.1 Runtime Semantics: Evaluation
+    ...
+    6. If Type(ref) is Reference and IsPropertyReference(ref) is false and
+       GetReferencedName(ref) is "eval", then
+      a. If SameValue(func, %eval%) is true, then
+        ...
+    ...
+    9. Return ? EvaluateCall(func, ref, arguments, tailCall).
+
+  12.3.4.2 Runtime Semantics: EvaluateCall( func, ref, arguments, tailPosition )
+    ...
+    7. If tailPosition is true, perform PrepareForTailCall().
+    8. Let result be Call(func, thisValue, argList).
+    ...
+
+flags: [noStrict]
+features: [tail-call-optimization]
+includes: [tcoHelper.js]
+---*/
+
+var callCount = 0;
+
+(function() {
+  function f(n) {
+    "use strict";
+    if (n === 0) {
+      callCount += 1
+      return;
+    }
+    return eval(n - 1);
+  }
+  var eval = f;
+  f($MAX_ITERATIONS);
+})();
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/call/tco-non-eval-global.js
+++ b/test/language/expressions/call/tco-non-eval-global.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-function-calls-runtime-semantics-evaluation
+info: >
+  Tail-call with identifier named "eval" in global environment.
+description: |
+  12.3.4.1 Runtime Semantics: Evaluation
+    ...
+    6. If Type(ref) is Reference and IsPropertyReference(ref) is false and
+       GetReferencedName(ref) is "eval", then
+      a. If SameValue(func, %eval%) is true, then
+        ...
+    ...
+    9. Return ? EvaluateCall(func, ref, arguments, tailCall).
+
+  12.3.4.2 Runtime Semantics: EvaluateCall( func, ref, arguments, tailPosition )
+    ...
+    7. If tailPosition is true, perform PrepareForTailCall().
+    8. Let result be Call(func, thisValue, argList).
+    ...
+
+flags: [noStrict]
+features: [tail-call-optimization]
+includes: [tcoHelper.js]
+---*/
+
+var callCount = 0;
+
+function f(n) {
+  "use strict";
+  if (n === 0) {
+    callCount += 1
+    return;
+  }
+  return eval(n - 1);
+}
+eval = f;
+
+f($MAX_ITERATIONS);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/call/tco-non-eval-with.js
+++ b/test/language/expressions/call/tco-non-eval-with.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-function-calls-runtime-semantics-evaluation
+info: >
+  Tail-call with identifier named "eval" in object environment.
+description: |
+  12.3.4.1 Runtime Semantics: Evaluation
+    ...
+    6. If Type(ref) is Reference and IsPropertyReference(ref) is false and
+       GetReferencedName(ref) is "eval", then
+      a. If SameValue(func, %eval%) is true, then
+        ...
+    ...
+    9. Return ? EvaluateCall(func, ref, arguments, tailCall).
+
+  12.3.4.2 Runtime Semantics: EvaluateCall( func, ref, arguments, tailPosition )
+    ...
+    7. If tailPosition is true, perform PrepareForTailCall().
+    8. Let result be Call(func, thisValue, argList).
+    ...
+
+flags: [noStrict]
+features: [tail-call-optimization]
+includes: [tcoHelper.js]
+---*/
+
+var callCount = 0;
+
+var f, scope = {};
+with (scope) {
+  f = function (n) {
+    "use strict";
+    if (n === 0) {
+      callCount += 1
+      return;
+    }
+    return eval(n - 1);
+  }
+}
+scope.eval = f;
+
+f($MAX_ITERATIONS);
+
+assert.sameValue(callCount, 1);

--- a/test/language/expressions/property-accessors/non-identifier-name.js
+++ b/test/language/expressions/property-accessors/non-identifier-name.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-left-hand-side-expressions
+info: >
+  Token following DOT must be a valid identifier-name, test with string literal.
+description: |
+  12.3 Left-Hand-Side Expressions
+    MemberExpression[Yield, Await]:
+      MemberExpression[?Yield, ?Await] . IdentifierName
+
+negative:
+  type: SyntaxError
+  phase: early
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+unresolvableReference."";

--- a/test/language/identifiers/other_id_continue-escaped.js
+++ b/test/language/identifiers/other_id_continue-escaped.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-names-and-keywords
+info: Test grandfathered characters of ID_Continue.
+description: >
+  Grandfathered characters (Other_ID_Start + Other_ID_Continue)
+---*/
+
+// Other_ID_Start (Unicode 4.0)
+var a\u2118;
+var a\u212E;
+var a\u309B;
+var a\u309C;
+
+// Other_ID_Start (Unicode 9.0)
+var a\u1885;
+var a\u1886;
+
+// Other_ID_Continue (Unicode 4.1)
+var a\u1369;
+var a\u136A;
+var a\u136B;
+var a\u136C;
+var a\u136D;
+var a\u136E;
+var a\u136F;
+var a\u1370;
+var a\u1371;
+
+// Other_ID_Continue (Unicode 5.1)
+var a\u00B7;
+var a\u0387;
+
+// Other_ID_Continue (Unicode 6.0)
+var a\u19DA;

--- a/test/language/identifiers/other_id_continue.js
+++ b/test/language/identifiers/other_id_continue.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-names-and-keywords
+info: Test grandfathered characters of ID_Continue.
+description: >
+  Grandfathered characters (Other_ID_Start + Other_ID_Continue)
+---*/
+
+// Other_ID_Start (Unicode 4.0)
+var a℘; // U+2118
+var a℮; // U+212E
+var a゛; // U+309B
+var a゜; // U+309C
+
+// Other_ID_Start (Unicode 9.0)
+var aᢅ; // U+1885
+var aᢆ; // U+1886
+
+// Other_ID_Continue (Unicode 4.1)
+var a፩; // U+1369
+var a፪; // U+136A
+var a፫; // U+136B
+var a፬; // U+136C
+var a፭; // U+136D
+var a፮; // U+136E
+var a፯; // U+136F
+var a፰; // U+1370
+var a፱; // U+1371
+
+// Other_ID_Continue (Unicode 5.1)
+var a·; // U+00B7
+var a·; // U+0387
+
+// Other_ID_Continue (Unicode 6.0)
+var a᧚; // U+19DA

--- a/test/language/identifiers/other_id_start-escaped.js
+++ b/test/language/identifiers/other_id_start-escaped.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-names-and-keywords
+info: Test grandfathered characters of ID_Start.
+description: >
+  Grandfathered characters (Other_ID_Start)
+---*/
+
+// Other_ID_Start (Unicode 4.0)
+var \u2118;
+var \u212E;
+var \u309B;
+var \u309C;
+
+// Other_ID_Start (Unicode 9.0)
+var \u1885;
+var \u1886;

--- a/test/language/identifiers/other_id_start.js
+++ b/test/language/identifiers/other_id_start.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-names-and-keywords
+info: Test grandfathered characters of ID_Start.
+description: >
+  Grandfathered characters (Other_ID_Start)
+---*/
+
+// Other_ID_Start (Unicode 4.0)
+var ℘; // U+2118
+var ℮; // U+212E
+var ゛; // U+309B
+var ゜; // U+309C
+
+// Other_ID_Start (Unicode 9.0)
+var ᢅ; // U+1885
+var ᢆ; // U+1886

--- a/test/language/identifiers/vertical-tilde-continue-escaped.js
+++ b/test/language/identifiers/vertical-tilde-continue-escaped.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-names-and-keywords
+info: Test VERTICAL TILDE (U+2E2F) is not recognized as ID_Continue character.
+description: >
+  VERTICAL TILDE is in General Category 'Lm' and [:Pattern_Syntax:].
+negative:
+  type: SyntaxError
+  phase: early
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+var a\u2E2F;

--- a/test/language/identifiers/vertical-tilde-continue.js
+++ b/test/language/identifiers/vertical-tilde-continue.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-names-and-keywords
+info: Test VERTICAL TILDE (U+2E2F) is not recognized as ID_Continue character.
+description: >
+  VERTICAL TILDE is in General Category 'Lm' and [:Pattern_Syntax:].
+negative:
+  type: SyntaxError
+  phase: early
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+var aⸯ; // U+2E2F

--- a/test/language/identifiers/vertical-tilde-start-escaped.js
+++ b/test/language/identifiers/vertical-tilde-start-escaped.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-names-and-keywords
+info: Test VERTICAL TILDE (U+2E2F) is not recognized as ID_Start character.
+description: >
+  VERTICAL TILDE is in General Category 'Lm' and [:Pattern_Syntax:].
+negative:
+  type: SyntaxError
+  phase: early
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+var \u2E2F;

--- a/test/language/identifiers/vertical-tilde-start.js
+++ b/test/language/identifiers/vertical-tilde-start.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-names-and-keywords
+info: Test VERTICAL TILDE (U+2E2F) is not recognized as ID_Start character.
+description: >
+  VERTICAL TILDE is in General Category 'Lm' and [:Pattern_Syntax:].
+negative:
+  type: SyntaxError
+  phase: early
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+var ⸯ; // U+2E2F

--- a/test/language/module-code/namespace/internals/enumerate-binding-uninit.js
+++ b/test/language/module-code/namespace/internals/enumerate-binding-uninit.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-enumerate-object-properties
+info: >
+  Test for-in enumeration with uninitialized binding.
+description: |
+  13.7.5.15 EnumerateObjectProperties (O)
+    ...
+    EnumerateObjectProperties must obtain the own property keys of the
+    target object by calling its [[OwnPropertyKeys]] internal method.
+    Property attributes of the target object must be obtained by
+    calling its [[GetOwnProperty]] internal method.
+
+  9.4.6.4 [[GetOwnProperty]] (P)
+    ...
+    4. Let value be ? O.[[Get]](P, O).
+    ...
+
+  9.4.6.7 [[Get]] (P, Receiver)
+    ...
+    12. Let targetEnvRec be targetEnv's EnvironmentRecord.
+    13. Return ? targetEnvRec.GetBindingValue(binding.[[BindingName]], true).
+
+  8.1.1.1.6 GetBindingValue ( N, S )
+    ...
+    If the binding for N in envRec is an uninitialized binding, throw a ReferenceError exception.
+    ...
+
+flags: [module]
+---*/
+
+import* as self from "./enumerate-binding-uninit.js";
+
+assert.throws(ReferenceError, function() {
+  for (var key in self) {
+    throw new Test262Error();
+  }
+});
+
+export default 0;

--- a/test/language/module-code/namespace/internals/object-hasOwnProperty-binding-uninit.js
+++ b/test/language/module-code/namespace/internals/object-hasOwnProperty-binding-uninit.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-object.prototype.hasownproperty
+info: >
+  Test Object.prototype.hasOwnProperty() with uninitialized binding.
+description: |
+  19.1.3.2 Object.prototype.hasOwnProperty ( V )
+    ...
+    3. Return ? HasOwnProperty(O, P).
+
+  7.3.11 HasOwnProperty ( O, P )
+    ...
+    3. Let desc be ? O.[[GetOwnProperty]](P).
+    ...
+
+  9.4.6.4 [[GetOwnProperty]] (P)
+    ...
+    4. Let value be ? O.[[Get]](P, O).
+    ...
+
+  9.4.6.7 [[Get]] (P, Receiver)
+    ...
+    12. Let targetEnvRec be targetEnv's EnvironmentRecord.
+    13. Return ? targetEnvRec.GetBindingValue(binding.[[BindingName]], true).
+
+  8.1.1.1.6 GetBindingValue ( N, S )
+    ...
+    If the binding for N in envRec is an uninitialized binding, throw a ReferenceError exception.
+    ...
+
+flags: [module]
+---*/
+
+import* as self from "./object-hasOwnProperty-binding-uninit.js";
+
+assert.throws(ReferenceError, function() {
+  Object.prototype.hasOwnProperty.call(self, "default");
+});
+
+export default 0;

--- a/test/language/module-code/namespace/internals/object-keys-binding-uninit.js
+++ b/test/language/module-code/namespace/internals/object-keys-binding-uninit.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-object.keys
+info: >
+  Test Object.keys() with uninitialized binding.
+description: |
+  19.1.2.16 Object.keys ( O )
+    ...
+    2. Let nameList be ? EnumerableOwnProperties(obj, "key").
+    ...
+
+  7.3.21 EnumerableOwnProperties ( O, kind )
+    ...
+    4. For each element key of ownKeys in List order, do
+      a. If Type(key) is String, then
+        i. Let desc be ? O.[[GetOwnProperty]](key).
+        ...
+
+  9.4.6.4 [[GetOwnProperty]] (P)
+    ...
+    4. Let value be ? O.[[Get]](P, O).
+    ...
+
+  9.4.6.7 [[Get]] (P, Receiver)
+    ...
+    12. Let targetEnvRec be targetEnv's EnvironmentRecord.
+    13. Return ? targetEnvRec.GetBindingValue(binding.[[BindingName]], true).
+
+  8.1.1.1.6 GetBindingValue ( N, S )
+    ...
+    If the binding for N in envRec is an uninitialized binding, throw a ReferenceError exception.
+    ...
+
+flags: [module]
+---*/
+
+import* as self from "./object-keys-binding-uninit.js";
+
+assert.throws(ReferenceError, function() {
+  Object.keys(self);
+});
+
+export default 0;

--- a/test/language/module-code/namespace/internals/object-propertyIsEnumerable-binding-uninit.js
+++ b/test/language/module-code/namespace/internals/object-propertyIsEnumerable-binding-uninit.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-object.prototype.propertyisenumerable
+info: >
+  Test Object.prototype.propertyIsEnumerable() with uninitialized binding.
+description: |
+  19.1.3.4 Object.prototype.propertyIsEnumerable ( V )
+    ...
+    3. Let desc be ? O.[[GetOwnProperty]](P).
+    ...
+
+  9.4.6.4 [[GetOwnProperty]] (P)
+    ...
+    4. Let value be ? O.[[Get]](P, O).
+    ...
+
+  9.4.6.7 [[Get]] (P, Receiver)
+    ...
+    12. Let targetEnvRec be targetEnv's EnvironmentRecord.
+    13. Return ? targetEnvRec.GetBindingValue(binding.[[BindingName]], true).
+
+  8.1.1.1.6 GetBindingValue ( N, S )
+    ...
+    If the binding for N in envRec is an uninitialized binding, throw a ReferenceError exception.
+    ...
+
+flags: [module]
+---*/
+
+import* as self from "./object-propertyIsEnumerable-binding-uninit.js";
+
+assert.throws(ReferenceError, function() {
+  Object.prototype.propertyIsEnumerable.call(self, "default");
+});
+
+export default 0;

--- a/test/language/statements/for-of/generator-close-via-continue.js
+++ b/test/language/statements/for-of/generator-close-via-continue.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset
+description: >
+  Generators should be closed via their `return` method when iteration is
+  interrupted via a `continue` statement.
+info: |
+  13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation ( lhs, stmt, iteratorRecord, iterationKind, lhsKind, labelSet )
+    ...
+    5. Repeat,
+      ...
+      i. Let result be the result of evaluating stmt.
+      ...
+      k. If LoopContinues(result, labelSet) is false, then
+        i. If iterationKind is enumerate, then
+          ...
+        ii. Else,
+          1. Assert: iterationKind is iterate.
+          2. Return ? IteratorClose(iteratorRecord, UpdateEmpty(result, V)).
+      ...
+
+features: [generators]
+---*/
+
+var startedCount = 0;
+var finallyCount = 0;
+var iterationCount = 0;
+function* values() {
+  startedCount += 1;
+  try {
+    yield;
+    $ERROR('This code is unreachable (within `try` block)');
+  } finally {
+    finallyCount += 1;
+  }
+  $ERROR('This code is unreachable (following `try` statement)');
+}
+var iterable = values();
+
+assert.sameValue(
+  startedCount, 0, 'Generator is initialized in suspended state'
+);
+
+L: do {
+  for (var x of iterable) {
+    assert.sameValue(
+      startedCount, 1, 'Generator executes prior to first iteration'
+    );
+    assert.sameValue(
+      finallyCount, 0, 'Generator is paused during first iteration'
+    );
+    iterationCount += 1;
+    continue L;
+  }
+} while (false);
+
+assert.sameValue(
+  startedCount, 1, 'Generator does not restart following interruption'
+);
+assert.sameValue(iterationCount, 1, 'A single iteration occurs');
+assert.sameValue(
+  finallyCount, 1, 'Generator is closed after `continue` statement'
+);

--- a/test/language/statements/for-of/iterator-close-via-continue.js
+++ b/test/language/statements/for-of/iterator-close-via-continue.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+id: sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset
+description: >
+  Iterators should be closed via their `return` method when iteration is
+  interrupted via a `continue` statement.
+info: |
+  13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation ( lhs, stmt, iteratorRecord, iterationKind, lhsKind, labelSet )
+    ...
+    5. Repeat,
+      ...
+      i. Let result be the result of evaluating stmt.
+      ...
+      k. If LoopContinues(result, labelSet) is false, then
+        i. If iterationKind is enumerate, then
+          ...
+        ii. Else,
+          1. Assert: iterationKind is iterate.
+          2. Return ? IteratorClose(iteratorRecord, UpdateEmpty(result, V)).
+      ...
+
+features: [Symbol.iterator]
+---*/
+
+var startedCount = 0;
+var returnCount = 0;
+var iterationCount = 0;
+var iterable = {};
+
+iterable[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      startedCount += 1;
+      return { done: false, value: null };
+    },
+    return: function() {
+      returnCount += 1;
+      return {};
+    }
+  };
+};
+
+L: do {
+  for (var x of iterable) {
+    assert.sameValue(
+      startedCount, 1, 'Value is retrieved'
+    );
+    assert.sameValue(
+      returnCount, 0, 'Iterator is not closed'
+    );
+    iterationCount += 1;
+    continue L;
+  }
+} while (false);
+
+assert.sameValue(
+  startedCount, 1, 'Iterator does not restart following interruption'
+);
+assert.sameValue(iterationCount, 1, 'A single iteration occurs');
+assert.sameValue(
+  returnCount, 1, 'Iterator is closed after `continue` statement'
+);

--- a/test/language/statements/try/cptn-catch-empty-break.js
+++ b/test/language/statements/try/cptn-catch-empty-break.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-try-statement-runtime-semantics-evaluation
+description: Abrupt completion from catch block calls UpdatEmpty()
+info: |
+  13.15.8 Runtime Semantics: Evaluation
+  TryStatement : try Block Catch
+    ...
+    2. If B.[[Type]] is throw, let C be CatchClauseEvaluation of Catch with parameter B.[[Value]].
+    ...
+    4. Return Completion(UpdateEmpty(C, undefined)).
+---*/
+
+// Ensure the completion value from the first iteration ('bad completion') is not returned.
+var completion = eval("for (var i = 0; i < 2; ++i) { if (i) { try { throw null; } catch (e) { break; } } 'bad completion'; }");
+assert.sameValue(completion, undefined);

--- a/test/language/statements/try/cptn-catch-empty-continue.js
+++ b/test/language/statements/try/cptn-catch-empty-continue.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-try-statement-runtime-semantics-evaluation
+description: Abrupt completion from catch block calls UpdatEmpty()
+info: |
+  13.15.8 Runtime Semantics: Evaluation
+  TryStatement : try Block Catch
+    ...
+    2. If B.[[Type]] is throw, let C be CatchClauseEvaluation of Catch with parameter B.[[Value]].
+    ...
+    4. Return Completion(UpdateEmpty(C, undefined)).
+---*/
+
+// Ensure the completion value from the first iteration ('bad completion') is not returned.
+var completion = eval("for (var i = 0; i < 2; ++i) { if (i) { try { throw null; } catch (e) { continue; } } 'bad completion'; }");
+assert.sameValue(completion, undefined);

--- a/test/language/statements/try/cptn-catch-finally-empty-break.js
+++ b/test/language/statements/try/cptn-catch-finally-empty-break.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-try-statement-runtime-semantics-evaluation
+description: Abrupt completion from finally block calls UpdatEmpty()
+info: |
+  13.15.8 Runtime Semantics: Evaluation
+   TryStatement : try Block Catch Finally
+    ...
+    4. Let F be the result of evaluating Finally.
+    ...
+    6. Return Completion(UpdateEmpty(F, undefined)).
+---*/
+
+// Ensure the completion value from the first iteration ('bad completion') is not returned.
+var completion = eval("for (var i = 0; i < 2; ++i) { if (i) { try { throw null; } catch (e) {} finally { break; } } 'bad completion'; }");
+assert.sameValue(completion, undefined);

--- a/test/language/statements/try/cptn-catch-finally-empty-continue.js
+++ b/test/language/statements/try/cptn-catch-finally-empty-continue.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-try-statement-runtime-semantics-evaluation
+description: Abrupt completion from finally block calls UpdatEmpty()
+info: |
+  13.15.8 Runtime Semantics: Evaluation
+   TryStatement : try Block Catch Finally
+    ...
+    4. Let F be the result of evaluating Finally.
+    ...
+    6. Return Completion(UpdateEmpty(F, undefined)).
+---*/
+
+// Ensure the completion value from the first iteration ('bad completion') is not returned.
+var completion = eval("for (var i = 0; i < 2; ++i) { if (i) { try { throw null; } catch (e) {} finally { continue; } } 'bad completion'; }");
+assert.sameValue(completion, undefined);

--- a/test/language/statements/try/cptn-finally-empty-break.js
+++ b/test/language/statements/try/cptn-finally-empty-break.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-try-statement-runtime-semantics-evaluation
+description: Abrupt completion from finally block calls UpdatEmpty()
+info: |
+  13.15.8 Runtime Semantics: Evaluation
+  TryStatement : try Block Finally
+    ...
+    2. Let F be the result of evaluating Finally.
+    ...
+    4. Return Completion(UpdateEmpty(F, undefined)).
+---*/
+
+// Ensure the completion value from the first iteration ('bad completion') is not returned.
+var completion = eval("for (var i = 0; i < 2; ++i) { if (i) { try {} finally { break; } } 'bad completion'; }");
+assert.sameValue(completion, undefined);

--- a/test/language/statements/try/cptn-finally-empty-continue.js
+++ b/test/language/statements/try/cptn-finally-empty-continue.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-try-statement-runtime-semantics-evaluation
+description: Abrupt completion from finally block calls UpdatEmpty()
+info: |
+  13.15.8 Runtime Semantics: Evaluation
+  TryStatement : try Block Finally
+    ...
+    2. Let F be the result of evaluating Finally.
+    ...
+    4. Return Completion(UpdateEmpty(F, undefined)).
+---*/
+
+// Ensure the completion value from the first iteration ('bad completion') is not returned.
+var completion = eval("for (var i = 0; i < 2; ++i) { if (i) { try {} finally { continue; } } 'bad completion'; }");
+assert.sameValue(completion, undefined);


### PR DESCRIPTION
Just a couple of tests I've written some time ago. They cover a wide range of topics from known implementation bugs, missing coverage (per JaCoCo when running on es6draft), and some err...  *cracktastic* spec stuff for TCO in [[Construct]] calls (relevant #jsapi thread from last year: https://mozilla.logbot.info/jsapi/20161031#c806458 :stuck_out_tongue_closed_eyes: ). 