### PR TITLE
Correct path to helper files directory in "contributing" docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ When writing a new test for a Stage 3+ spec not yet published on the draft, the 
 
 This tag names a list of helper files that will be included in the test environment prior to running the test.  Filenames **must** include the `.js` extension.
 
-The helper files are found in the `test/harness/` directory. When some code is used repeatedly across a group of tests, a new helper function (or group of helpers) can be defined. Helpers increase test complexity, so they should be created and used sparingly.
+The helper files are found in the `harness/` directory. When some code is used repeatedly across a group of tests, a new helper function (or group of helpers) can be defined. Helpers increase test complexity, so they should be created and used sparingly.
 
 #### timeout
 **timeout**: [integer]


### PR DESCRIPTION
Fix a small but rather confusing typo in the CONTRIBUTING.md file.

(I didn't find any commit message rules, so just followed the style of the most recent commit. I hope it's ok.)