### PR TITLE
Inline typeCoercion.js for some tests

### DIFF
--- a/test/built-ins/BigInt/asIntN/bigint-tobigint-errors.js
+++ b/test/built-ins/BigInt/asIntN/bigint-tobigint-errors.js
@@ -1,0 +1,162 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: BigInt.asIntN type coercion for bigint parameter
+esid: pending
+info: |
+  BigInt.asIntN ( bits, bigint )
+
+  2. Let bigint ? ToBigInt(bigint).
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, undefined);
+}, "ToBigInt: undefined => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    [Symbol.toPrimitive]: function() {
+      return undefined;
+    }
+  });
+}, "ToBigInt: @@toPrimitive => undefined => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    valueOf: function() {
+      return undefined;
+    }
+  });
+}, "ToBigInt: valueOf => undefined => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    toString: function() {
+      return undefined;
+    }
+  });
+}, "ToBigInt: toString => undefined => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, null);
+}, "ToBigInt: null => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    [Symbol.toPrimitive]: function() {
+      return null;
+    }
+  });
+}, "ToBigInt: @@toPrimitive => null => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    valueOf: function() {
+      return null;
+    }
+  });
+}, "ToBigInt: valueOf => null => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    toString: function() {
+      return null;
+    }
+  });
+}, "ToBigInt: toString => null => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, 0);
+}, "ToBigInt: Number => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, Object(0));
+}, "ToBigInt: unbox object with internal slot => Number => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    [Symbol.toPrimitive]: function() {
+      return 0;
+    }
+  });
+}, "ToBigInt: @@toPrimitive => Number => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    valueOf: function() {
+      return 0;
+    }
+  });
+}, "ToBigInt: valueOf => Number => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    toString: function() {
+      return 0;
+    }
+  });
+}, "ToBigInt: toString => Number => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, NaN);
+}, "ToBigInt: Number => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, Infinity);
+}, "ToBigInt: Number => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, Symbol("1"));
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, Object(Symbol("1")));
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    toString: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToBigInt: toString => Symbol => TypeError");
+assert.throws(SyntaxError, function() {
+  BigInt.asIntN(0, "a");
+}, "ToBigInt: unparseable BigInt");
+assert.throws(SyntaxError, function() {
+  BigInt.asIntN(0, "0b2");
+}, "ToBigInt: unparseable BigInt binary");
+assert.throws(SyntaxError, function() {
+  BigInt.asIntN(0, Object("0b2"));
+}, "ToBigInt: unbox object with internal slot => unparseable BigInt binary");
+assert.throws(SyntaxError, function() {
+  BigInt.asIntN(0, {
+    [Symbol.toPrimitive]: function() {
+      return "0b2";
+    }
+  });
+}, "ToBigInt: @@toPrimitive => unparseable BigInt binary");
+assert.throws(SyntaxError, function() {
+  BigInt.asIntN(0, {
+    valueOf: function() {
+      return "0b2";
+    }
+  });
+}, "ToBigInt: valueOf => unparseable BigInt binary");
+assert.throws(SyntaxError, function() {
+  BigInt.asIntN(0, {
+    toString: function() {
+      return "0b2";
+    }
+  });
+}, "ToBigInt: toString => unparseable BigInt binary");
+assert.throws(SyntaxError, function() {
+  BigInt.asIntN(0, "   0b2   ");
+}, "ToBigInt: unparseable BigInt with leading/trailing whitespace");
+assert.throws(SyntaxError, function() {
+  BigInt.asIntN(0, "0o8");
+}, "ToBigInt: unparseable BigInt octal");
+assert.throws(SyntaxError, function() {
+  BigInt.asIntN(0, "0xg");
+}, "ToBigInt: unparseable BigInt hex");
+assert.throws(SyntaxError, function() {
+  BigInt.asIntN(0, "1n");
+}, "ToBigInt: unparseable BigInt due to literal suffix");

--- a/test/built-ins/BigInt/asIntN/bigint-tobigint-toprimitive.js
+++ b/test/built-ins/BigInt/asIntN/bigint-tobigint-toprimitive.js
@@ -1,0 +1,165 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: BigInt.asIntN type coercion for bigint parameter
+esid: pending
+info: |
+  BigInt.asIntN ( bits, bigint )
+
+  2. Let bigint ? ToBigInt(bigint).
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(BigInt.asIntN(2, {
+  [Symbol.toPrimitive]: function() {
+    return "1";
+  },
+  valueOf: err,
+  toString: err
+}), 1n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(BigInt.asIntN(2, {
+  valueOf: function() {
+    return "1";
+  },
+  toString: err
+}), 1n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(BigInt.asIntN(2, {
+  toString: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(BigInt.asIntN(2, {
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(BigInt.asIntN(2, {
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(BigInt.asIntN(2, {
+  valueOf: null,
+  toString: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(BigInt.asIntN(2, {
+  valueOf: 1,
+  toString: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(BigInt.asIntN(2, {
+  valueOf: {},
+  toString: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(BigInt.asIntN(2, {
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(BigInt.asIntN(2, {
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    [Symbol.toPrimitive]: 1
+  });
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    [Symbol.toPrimitive]: {}
+  });
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  });
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  });
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  BigInt.asIntN(0, {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  BigInt.asIntN(0, {
+    valueOf: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  BigInt.asIntN(0, {
+    toString: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    valueOf: null,
+    toString: null
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    valueOf: 1,
+    toString: 1
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    valueOf: {},
+    toString: {}
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0, {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/built-ins/BigInt/asIntN/bigint-tobigint-wrapped-values.js
+++ b/test/built-ins/BigInt/asIntN/bigint-tobigint-wrapped-values.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: BigInt.asIntN type coercion for bigint parameter
+esid: pending
+info: |
+  BigInt.asIntN ( bits, bigint )
+
+  2. Let bigint ? ToBigInt(bigint).
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(BigInt.asIntN(2, Object(0n)), 0n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(BigInt.asIntN(2, {
+  [Symbol.toPrimitive]: function() {
+    return 0n;
+  }
+}), 0n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(BigInt.asIntN(2, {
+  valueOf: function() {
+    return 0n;
+  }
+}), 0n, "ToPrimitive: valueOf");
+assert.sameValue(BigInt.asIntN(2, {
+  toString: function() {
+    return 0n;
+  }
+}), 0n, "ToPrimitive: toString");
+assert.sameValue(BigInt.asIntN(2, Object(true)), 1n,
+  "ToBigInt: unbox object with internal slot => true => 1n");
+assert.sameValue(BigInt.asIntN(2, {
+  [Symbol.toPrimitive]: function() {
+    return true;
+  }
+}), 1n, "ToBigInt: @@toPrimitive => true => 1n");
+assert.sameValue(BigInt.asIntN(2, {
+  valueOf: function() {
+    return true;
+  }
+}), 1n, "ToBigInt: valueOf => true => 1n");
+assert.sameValue(BigInt.asIntN(2, {
+  toString: function() {
+    return true;
+  }
+}), 1n, "ToBigInt: toString => true => 1n");
+assert.sameValue(BigInt.asIntN(2, Object("1")), 1n,
+  "ToBigInt: unbox object with internal slot => parse BigInt");
+assert.sameValue(BigInt.asIntN(2, {
+  [Symbol.toPrimitive]: function() {
+    return "1";
+  }
+}), 1n, "ToBigInt: @@toPrimitive => parse BigInt");
+assert.sameValue(BigInt.asIntN(2, {
+  valueOf: function() {
+    return "1";
+  }
+}), 1n, "ToBigInt: valueOf => parse BigInt");
+assert.sameValue(BigInt.asIntN(2, {
+  toString: function() {
+    return "1";
+  }
+}), 1n, "ToBigInt: toString => parse BigInt");

--- a/test/built-ins/BigInt/asIntN/bigint-tobigint.js
+++ b/test/built-ins/BigInt/asIntN/bigint-tobigint.js
@@ -1,33 +1,49 @@
 // Copyright (C) 2017 Josh Wolfe. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: pending
 description: BigInt.asIntN type coercion for bigint parameter
-info: >
+esid: pending
+info: |
   BigInt.asIntN ( bits, bigint )
 
   2. Let bigint ? ToBigInt(bigint).
-
-features: [BigInt, Symbol, Symbol.toPrimitive]
-includes: [typeCoercion.js]
+features: [BigInt]
 ---*/
 
-testCoercibleToBigIntZero(function(zero) {
-  assert.sameValue(BigInt.asIntN(2, zero), 0n);
-});
-
-testCoercibleToBigIntOne(function(one) {
-  assert.sameValue(BigInt.asIntN(2, one), 1n);
-});
-
-testCoercibleToBigIntFromBigInt(10n, function(ten) {
-  assert.sameValue(BigInt.asIntN(3, ten), 2n);
-});
-
-testCoercibleToBigIntFromBigInt(12345678901234567890003n, function(value) {
-  assert.sameValue(BigInt.asIntN(4, value), 3n);
-});
-
-testNotCoercibleToBigInt(function(error, value) {
-  assert.throws(error, function() { BigInt.asIntN(0, value); });
-});
+assert.sameValue(BigInt.asIntN(2, 0n), 0n);
+assert.sameValue(BigInt.asIntN(2, -0n), 0n);
+assert.sameValue(BigInt.asIntN(2, false), 0n, "ToBigInt: false => 0n");
+assert.sameValue(BigInt.asIntN(2, true), 1n, "ToBigInt: true => 1n");
+assert.sameValue(BigInt.asIntN(2, "1"), 1n, "ToBigInt: parse BigInt");
+assert.sameValue(BigInt.asIntN(2, "-0"), 0n, "ToBigInt: parse BigInt");
+assert.sameValue(BigInt.asIntN(2, ""), 0n, "ToBigInt: empty String => 0n");
+assert.sameValue(BigInt.asIntN(2, "     "), 0n, "ToBigInt: String with only whitespace => 0n");
+assert.sameValue(BigInt.asIntN(2, []), 0n, "ToBigInt: .toString() => empty String => 0n");
+assert.sameValue(BigInt.asIntN(2, [1]), 1n, "ToBigInt: .toString() => parse BigInt");
+assert.sameValue(BigInt.asIntN(3, 10n), 2n);
+assert.sameValue(BigInt.asIntN(3, "10"), 2n, "ToBigInt: parse BigInt");
+assert.sameValue(BigInt.asIntN(3, "0b1010"), 2n, "ToBigInt: parse BigInt binary");
+assert.sameValue(BigInt.asIntN(3, "0o12"), 2n, "ToBigInt: parse BigInt octal");
+assert.sameValue(BigInt.asIntN(3, "0xa"), 2n, "ToBigInt: parse BigInt hex");
+assert.sameValue(BigInt.asIntN(3, "    0xa    "), 2n,
+  "ToBigInt: parse BigInt ignore leading/trailing whitespace");
+assert.sameValue(BigInt.asIntN(3, "     10     "), 2n,
+  "ToBigInt: parse BigInt ignore leading/trailing whitespace");
+assert.sameValue(BigInt.asIntN(3, [10n]), 2n, "ToBigInt: .toString() => parse BigInt");
+assert.sameValue(BigInt.asIntN(3, ["10"]), 2n, "ToBigInt: .toString() => parse BigInt");
+assert.sameValue(BigInt.asIntN(4, 12345678901234567890003n), 3n);
+assert.sameValue(BigInt.asIntN(4, "12345678901234567890003"), 3n, "ToBigInt: parse BigInt");
+assert.sameValue(BigInt.asIntN(4,
+    "0b10100111010100001010110110010011100111011001110001010000100100010001010011"), 3n,
+  "ToBigInt: parse BigInt binary");
+assert.sameValue(BigInt.asIntN(4, "0o2472412662347316120442123"), 3n,
+  "ToBigInt: parse BigInt octal");
+assert.sameValue(BigInt.asIntN(4, "0x29d42b64e7671424453"), 3n, "ToBigInt: parse BigInt hex");
+assert.sameValue(BigInt.asIntN(4, "    0x29d42b64e7671424453    "), 3n,
+  "ToBigInt: parse BigInt ignore leading/trailing whitespace");
+assert.sameValue(BigInt.asIntN(4, "     12345678901234567890003     "), 3n,
+  "ToBigInt: parse BigInt ignore leading/trailing whitespace");
+assert.sameValue(BigInt.asIntN(4, [12345678901234567890003n]), 3n,
+  "ToBigInt: .toString() => parse BigInt");
+assert.sameValue(BigInt.asIntN(4, ["12345678901234567890003"]), 3n,
+  "ToBigInt: .toString() => parse BigInt");

--- a/test/built-ins/BigInt/asIntN/bits-toindex-errors.js
+++ b/test/built-ins/BigInt/asIntN/bits-toindex-errors.js
@@ -1,0 +1,84 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: BigInt.asIntN type coercion for bits parameter
+esid: pending
+info: |
+  BigInt.asIntN ( bits, bigint )
+
+  1. Let bits be ? ToIndex(bits).
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(RangeError, function() {
+  BigInt.asIntN(-1, 0n);
+}, "ToIndex: throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  BigInt.asIntN(-2.5, 0n);
+}, "ToIndex: throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  BigInt.asIntN("-2.5", 0n);
+}, "ToIndex: parse Number => throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  BigInt.asIntN(-Infinity, 0n);
+}, "ToIndex: throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  BigInt.asIntN(9007199254740992, 0n);
+}, "ToIndex: throw when integerIndex > 2**53-1");
+assert.throws(RangeError, function() {
+  BigInt.asIntN(Infinity, 0n);
+}, "ToIndex: throw when integerIndex > 2**53-1");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(0n, 0n);
+}, "ToIndex: BigInt => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(Object(0n), 0n);
+}, "ToIndex: unbox object with internal slot => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    [Symbol.toPrimitive]: function() {
+      return 0n;
+    }
+  }, 0n);
+}, "ToIndex: @@toPrimitive => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    valueOf: function() {
+      return 0n;
+    }
+  }, 0n);
+}, "ToIndex: valueOf => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    toString: function() {
+      return 0n;
+    }
+  }, 0n);
+}, "ToIndex: toString => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(Symbol("1"), 0n);
+}, "ToIndex: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN(Object(Symbol("1")), 0n);
+}, "ToIndex: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  }, 0n);
+}, "ToIndex: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  }, 0n);
+}, "ToIndex: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    toString: function() {
+      return Symbol("1");
+    }
+  }, 0n);
+}, "ToIndex: toString => Symbol => TypeError");

--- a/test/built-ins/BigInt/asIntN/bits-toindex-toprimitive.js
+++ b/test/built-ins/BigInt/asIntN/bits-toindex-toprimitive.js
@@ -1,0 +1,165 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: BigInt.asIntN type coercion for bits parameter
+esid: pending
+info: |
+  BigInt.asIntN ( bits, bigint )
+
+  1. Let bits be ? ToIndex(bits).
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(BigInt.asIntN({
+  [Symbol.toPrimitive]: function() {
+    return 1;
+  },
+  valueOf: err,
+  toString: err
+}, 1n), -1n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(BigInt.asIntN({
+  valueOf: function() {
+    return 1;
+  },
+  toString: err
+}, 1n), -1n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(BigInt.asIntN({
+  toString: function() {
+    return 1;
+  }
+}, 1n), -1n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(BigInt.asIntN({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 1;
+  }
+}, 1n), -1n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(BigInt.asIntN({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 1;
+  }
+}, 1n), -1n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(BigInt.asIntN({
+  valueOf: null,
+  toString: function() {
+    return 1;
+  }
+}, 1n), -1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(BigInt.asIntN({
+  valueOf: 1,
+  toString: function() {
+    return 1;
+  }
+}, 1n), -1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(BigInt.asIntN({
+  valueOf: {},
+  toString: function() {
+    return 1;
+  }
+}, 1n), -1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(BigInt.asIntN({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 1;
+  }
+}, 1n), -1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(BigInt.asIntN({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 1;
+  }
+}, 1n), -1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    [Symbol.toPrimitive]: 1
+  }, 0n);
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    [Symbol.toPrimitive]: {}
+  }, 0n);
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  }, 0n);
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  }, 0n);
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  BigInt.asIntN({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  }, 0n);
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  BigInt.asIntN({
+    valueOf: function() {
+      throw new MyError();
+    }
+  }, 0n);
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  BigInt.asIntN({
+    toString: function() {
+      throw new MyError();
+    }
+  }, 0n);
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    valueOf: null,
+    toString: null
+  }, 0n);
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    valueOf: 1,
+    toString: 1
+  }, 0n);
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    valueOf: {},
+    toString: {}
+  }, 0n);
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  }, 0n);
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asIntN({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  }, 0n);
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/built-ins/BigInt/asIntN/bits-toindex-wrapped-values.js
+++ b/test/built-ins/BigInt/asIntN/bits-toindex-wrapped-values.js
@@ -1,0 +1,109 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: BigInt.asIntN type coercion for bits parameter
+esid: pending
+info: |
+  BigInt.asIntN ( bits, bigint )
+
+  1. Let bits be ? ToIndex(bits).
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(BigInt.asIntN(Object(0), 1n), 0n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(BigInt.asIntN({
+  [Symbol.toPrimitive]: function() {
+    return 0;
+  }
+}, 1n), 0n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(BigInt.asIntN({
+  valueOf: function() {
+    return 0;
+  }
+}, 1n), 0n, "ToPrimitive: valueOf");
+assert.sameValue(BigInt.asIntN({
+  toString: function() {
+    return 0;
+  }
+}, 1n), 0n, "ToPrimitive: toString");
+assert.sameValue(BigInt.asIntN(Object(NaN), 1n), 0n,
+  "ToIndex: unbox object with internal slot => NaN => 0");
+assert.sameValue(BigInt.asIntN({
+  [Symbol.toPrimitive]: function() {
+    return NaN;
+  }
+}, 1n), 0n, "ToIndex: @@toPrimitive => NaN => 0");
+assert.sameValue(BigInt.asIntN({
+  valueOf: function() {
+    return NaN;
+  }
+}, 1n), 0n, "ToIndex: valueOf => NaN => 0");
+assert.sameValue(BigInt.asIntN({
+  toString: function() {
+    return NaN;
+  }
+}, 1n), 0n, "ToIndex: toString => NaN => 0");
+assert.sameValue(BigInt.asIntN({
+  [Symbol.toPrimitive]: function() {
+    return undefined;
+  }
+}, 1n), 0n, "ToIndex: @@toPrimitive => undefined => NaN => 0");
+assert.sameValue(BigInt.asIntN({
+  valueOf: function() {
+    return undefined;
+  }
+}, 1n), 0n, "ToIndex: valueOf => undefined => NaN => 0");
+assert.sameValue(BigInt.asIntN({
+  toString: function() {
+    return undefined;
+  }
+}, 1n), 0n, "ToIndex: toString => undefined => NaN => 0");
+assert.sameValue(BigInt.asIntN({
+  [Symbol.toPrimitive]: function() {
+    return null;
+  }
+}, 1n), 0n, "ToIndex: @@toPrimitive => null => 0");
+assert.sameValue(BigInt.asIntN({
+  valueOf: function() {
+    return null;
+  }
+}, 1n), 0n, "ToIndex: valueOf => null => 0");
+assert.sameValue(BigInt.asIntN({
+  toString: function() {
+    return null;
+  }
+}, 1n), 0n, "ToIndex: toString => null => 0");
+assert.sameValue(BigInt.asIntN(Object(true), 1n), -1n,
+  "ToIndex: unbox object with internal slot => true => 1");
+assert.sameValue(BigInt.asIntN({
+  [Symbol.toPrimitive]: function() {
+    return true;
+  }
+}, 1n), -1n, "ToIndex: @@toPrimitive => true => 1");
+assert.sameValue(BigInt.asIntN({
+  valueOf: function() {
+    return true;
+  }
+}, 1n), -1n, "ToIndex: valueOf => true => 1");
+assert.sameValue(BigInt.asIntN({
+  toString: function() {
+    return true;
+  }
+}, 1n), -1n, "ToIndex: toString => true => 1");
+assert.sameValue(BigInt.asIntN(Object("1"), 1n), -1n,
+  "ToIndex: unbox object with internal slot => parse Number");
+assert.sameValue(BigInt.asIntN({
+  [Symbol.toPrimitive]: function() {
+    return "1";
+  }
+}, 1n), -1n, "ToIndex: @@toPrimitive => parse Number");
+assert.sameValue(BigInt.asIntN({
+  valueOf: function() {
+    return "1";
+  }
+}, 1n), -1n, "ToIndex: valueOf => parse Number");
+assert.sameValue(BigInt.asIntN({
+  toString: function() {
+    return "1";
+  }
+}, 1n), -1n, "ToIndex: toString => parse Number");

--- a/test/built-ins/BigInt/asIntN/bits-toindex.js
+++ b/test/built-ins/BigInt/asIntN/bits-toindex.js
@@ -1,29 +1,35 @@
 // Copyright (C) 2017 Josh Wolfe. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: pending
 description: BigInt.asIntN type coercion for bits parameter
-info: >
+esid: pending
+info: |
   BigInt.asIntN ( bits, bigint )
 
   1. Let bits be ? ToIndex(bits).
-
-features: [BigInt, Symbol, Symbol.toPrimitive]
-includes: [typeCoercion.js]
+features: [BigInt]
 ---*/
 
-testCoercibleToIndexZero(function(zero) {
-  assert.sameValue(BigInt.asIntN(zero, 1n), 0n);
-});
-
-testCoercibleToIndexOne(function(one) {
-  assert.sameValue(BigInt.asIntN(one, 1n), -1n);
-});
-
-testCoercibleToIndexFromIndex(3, function(three) {
-  assert.sameValue(BigInt.asIntN(three, 10n), 2n);
-});
-
-testNotCoercibleToIndex(function(error, value) {
-  assert.throws(error, function() { BigInt.asIntN(value, 0n); });
-});
+assert.sameValue(BigInt.asIntN(0, 1n), 0n);
+assert.sameValue(BigInt.asIntN(1, 1n), -1n);
+assert.sameValue(BigInt.asIntN(-0.9, 1n), 0n, "ToIndex: truncate towards 0");
+assert.sameValue(BigInt.asIntN(0.9, 1n), 0n, "ToIndex: truncate towards 0");
+assert.sameValue(BigInt.asIntN(NaN, 1n), 0n, "ToIndex: NaN => 0");
+assert.sameValue(BigInt.asIntN(undefined, 1n), 0n, "ToIndex: undefined => NaN => 0");
+assert.sameValue(BigInt.asIntN(null, 1n), 0n, "ToIndex: null => 0");
+assert.sameValue(BigInt.asIntN(false, 1n), 0n, "ToIndex: false => 0");
+assert.sameValue(BigInt.asIntN(true, 1n), -1n, "ToIndex: true => 1");
+assert.sameValue(BigInt.asIntN("0", 1n), 0n, "ToIndex: parse Number");
+assert.sameValue(BigInt.asIntN("1", 1n), -1n, "ToIndex: parse Number");
+assert.sameValue(BigInt.asIntN("", 1n), 0n, "ToIndex: parse Number => NaN => 0");
+assert.sameValue(BigInt.asIntN("foo", 1n), 0n, "ToIndex: parse Number => NaN => 0");
+assert.sameValue(BigInt.asIntN("true", 1n), 0n, "ToIndex: parse Number => NaN => 0");
+assert.sameValue(BigInt.asIntN(3, 10n), 2n);
+assert.sameValue(BigInt.asIntN("3", 10n), 2n, "toIndex: parse Number");
+assert.sameValue(BigInt.asIntN(3.9, 10n), 2n, "toIndex: truncate towards 0");
+assert.sameValue(BigInt.asIntN("3.9", 10n), 2n, "toIndex: parse Number => truncate towards 0");
+assert.sameValue(BigInt.asIntN([0], 1n), 0n, 'ToIndex: [0].toString() => "0" => 0');
+assert.sameValue(BigInt.asIntN(["1"], 1n), -1n, 'ToIndex: ["1"].toString() => "1" => 1');
+assert.sameValue(BigInt.asIntN({}, 1n), 0n,
+  'ToIndex: ({}).toString() => "[object Object]" => NaN => 0');
+assert.sameValue(BigInt.asIntN([], 1n), 0n, 'ToIndex: [].toString() => "" => NaN => 0');

--- a/test/built-ins/BigInt/asUintN/bigint-tobigint-errors.js
+++ b/test/built-ins/BigInt/asUintN/bigint-tobigint-errors.js
@@ -1,0 +1,162 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: BigInt.asUintN type coercion for bigint parameter
+esid: pending
+info: |
+  BigInt.asUintN ( bits, bigint )
+
+  2. Let bigint ? ToBigInt(bigint).
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, undefined);
+}, "ToBigInt: undefined => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    [Symbol.toPrimitive]: function() {
+      return undefined;
+    }
+  });
+}, "ToBigInt: @@toPrimitive => undefined => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    valueOf: function() {
+      return undefined;
+    }
+  });
+}, "ToBigInt: valueOf => undefined => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    toString: function() {
+      return undefined;
+    }
+  });
+}, "ToBigInt: toString => undefined => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, null);
+}, "ToBigInt: null => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    [Symbol.toPrimitive]: function() {
+      return null;
+    }
+  });
+}, "ToBigInt: @@toPrimitive => null => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    valueOf: function() {
+      return null;
+    }
+  });
+}, "ToBigInt: valueOf => null => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    toString: function() {
+      return null;
+    }
+  });
+}, "ToBigInt: toString => null => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, 0);
+}, "ToBigInt: Number => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, Object(0));
+}, "ToBigInt: unbox object with internal slot => Number => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    [Symbol.toPrimitive]: function() {
+      return 0;
+    }
+  });
+}, "ToBigInt: @@toPrimitive => Number => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    valueOf: function() {
+      return 0;
+    }
+  });
+}, "ToBigInt: valueOf => Number => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    toString: function() {
+      return 0;
+    }
+  });
+}, "ToBigInt: toString => Number => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, NaN);
+}, "ToBigInt: Number => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, Infinity);
+}, "ToBigInt: Number => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, Symbol("1"));
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, Object(Symbol("1")));
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    toString: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToBigInt: toString => Symbol => TypeError");
+assert.throws(SyntaxError, function() {
+  BigInt.asUintN(0, "a");
+}, "ToBigInt: unparseable BigInt");
+assert.throws(SyntaxError, function() {
+  BigInt.asUintN(0, "0b2");
+}, "ToBigInt: unparseable BigInt binary");
+assert.throws(SyntaxError, function() {
+  BigInt.asUintN(0, Object("0b2"));
+}, "ToBigInt: unbox object with internal slot => unparseable BigInt binary");
+assert.throws(SyntaxError, function() {
+  BigInt.asUintN(0, {
+    [Symbol.toPrimitive]: function() {
+      return "0b2";
+    }
+  });
+}, "ToBigInt: @@toPrimitive => unparseable BigInt binary");
+assert.throws(SyntaxError, function() {
+  BigInt.asUintN(0, {
+    valueOf: function() {
+      return "0b2";
+    }
+  });
+}, "ToBigInt: valueOf => unparseable BigInt binary");
+assert.throws(SyntaxError, function() {
+  BigInt.asUintN(0, {
+    toString: function() {
+      return "0b2";
+    }
+  });
+}, "ToBigInt: toString => unparseable BigInt binary");
+assert.throws(SyntaxError, function() {
+  BigInt.asUintN(0, "   0b2   ");
+}, "ToBigInt: unparseable BigInt with leading/trailing whitespace");
+assert.throws(SyntaxError, function() {
+  BigInt.asUintN(0, "0o8");
+}, "ToBigInt: unparseable BigInt octal");
+assert.throws(SyntaxError, function() {
+  BigInt.asUintN(0, "0xg");
+}, "ToBigInt: unparseable BigInt hex");
+assert.throws(SyntaxError, function() {
+  BigInt.asUintN(0, "1n");
+}, "ToBigInt: unparseable BigInt due to literal suffix");

--- a/test/built-ins/BigInt/asUintN/bigint-tobigint-toprimitive.js
+++ b/test/built-ins/BigInt/asUintN/bigint-tobigint-toprimitive.js
@@ -1,0 +1,165 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: BigInt.asUintN type coercion for bigint parameter
+esid: pending
+info: |
+  BigInt.asUintN ( bits, bigint )
+
+  2. Let bigint ? ToBigInt(bigint).
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(BigInt.asUintN(2, {
+  [Symbol.toPrimitive]: function() {
+    return "1";
+  },
+  valueOf: err,
+  toString: err
+}), 1n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(BigInt.asUintN(2, {
+  valueOf: function() {
+    return "1";
+  },
+  toString: err
+}), 1n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(BigInt.asUintN(2, {
+  toString: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(BigInt.asUintN(2, {
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(BigInt.asUintN(2, {
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(BigInt.asUintN(2, {
+  valueOf: null,
+  toString: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(BigInt.asUintN(2, {
+  valueOf: 1,
+  toString: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(BigInt.asUintN(2, {
+  valueOf: {},
+  toString: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(BigInt.asUintN(2, {
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(BigInt.asUintN(2, {
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return "1";
+  }
+}), 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    [Symbol.toPrimitive]: 1
+  });
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    [Symbol.toPrimitive]: {}
+  });
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  });
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  });
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  BigInt.asUintN(0, {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  BigInt.asUintN(0, {
+    valueOf: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  BigInt.asUintN(0, {
+    toString: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    valueOf: null,
+    toString: null
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    valueOf: 1,
+    toString: 1
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    valueOf: {},
+    toString: {}
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0, {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/built-ins/BigInt/asUintN/bigint-tobigint-wrapped-values.js
+++ b/test/built-ins/BigInt/asUintN/bigint-tobigint-wrapped-values.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: BigInt.asUintN type coercion for bigint parameter
+esid: pending
+info: |
+  BigInt.asUintN ( bits, bigint )
+
+  2. Let bigint ? ToBigInt(bigint).
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(BigInt.asUintN(2, Object(0n)), 0n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(BigInt.asUintN(2, {
+  [Symbol.toPrimitive]: function() {
+    return 0n;
+  }
+}), 0n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(BigInt.asUintN(2, {
+  valueOf: function() {
+    return 0n;
+  }
+}), 0n, "ToPrimitive: valueOf");
+assert.sameValue(BigInt.asUintN(2, {
+  toString: function() {
+    return 0n;
+  }
+}), 0n, "ToPrimitive: toString");
+assert.sameValue(BigInt.asUintN(2, Object(true)), 1n,
+  "ToBigInt: unbox object with internal slot => true => 1n");
+assert.sameValue(BigInt.asUintN(2, {
+  [Symbol.toPrimitive]: function() {
+    return true;
+  }
+}), 1n, "ToBigInt: @@toPrimitive => true => 1n");
+assert.sameValue(BigInt.asUintN(2, {
+  valueOf: function() {
+    return true;
+  }
+}), 1n, "ToBigInt: valueOf => true => 1n");
+assert.sameValue(BigInt.asUintN(2, {
+  toString: function() {
+    return true;
+  }
+}), 1n, "ToBigInt: toString => true => 1n");
+assert.sameValue(BigInt.asUintN(2, Object("1")), 1n,
+  "ToBigInt: unbox object with internal slot => parse BigInt");
+assert.sameValue(BigInt.asUintN(2, {
+  [Symbol.toPrimitive]: function() {
+    return "1";
+  }
+}), 1n, "ToBigInt: @@toPrimitive => parse BigInt");
+assert.sameValue(BigInt.asUintN(2, {
+  valueOf: function() {
+    return "1";
+  }
+}), 1n, "ToBigInt: valueOf => parse BigInt");
+assert.sameValue(BigInt.asUintN(2, {
+  toString: function() {
+    return "1";
+  }
+}), 1n, "ToBigInt: toString => parse BigInt");

--- a/test/built-ins/BigInt/asUintN/bigint-tobigint.js
+++ b/test/built-ins/BigInt/asUintN/bigint-tobigint.js
@@ -1,33 +1,49 @@
 // Copyright (C) 2017 Josh Wolfe. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: pending
 description: BigInt.asUintN type coercion for bigint parameter
-info: >
+esid: pending
+info: |
   BigInt.asUintN ( bits, bigint )
 
   2. Let bigint ? ToBigInt(bigint).
-
-features: [BigInt, Symbol, Symbol.toPrimitive]
-includes: [typeCoercion.js]
+features: [BigInt]
 ---*/
 
-testCoercibleToBigIntZero(function(zero) {
-  assert.sameValue(BigInt.asUintN(2, zero), 0n);
-});
-
-testCoercibleToBigIntOne(function(one) {
-  assert.sameValue(BigInt.asUintN(2, one), 1n);
-});
-
-testCoercibleToBigIntFromBigInt(10n, function(ten) {
-  assert.sameValue(BigInt.asUintN(3, ten), 2n);
-});
-
-testCoercibleToBigIntFromBigInt(12345678901234567890003n, function(value) {
-  assert.sameValue(BigInt.asUintN(4, value), 3n);
-});
-
-testNotCoercibleToBigInt(function(error, value) {
-  assert.throws(error, function() { BigInt.asUintN(0, value); });
-});
+assert.sameValue(BigInt.asUintN(2, 0n), 0n);
+assert.sameValue(BigInt.asUintN(2, -0n), 0n);
+assert.sameValue(BigInt.asUintN(2, false), 0n, "ToBigInt: false => 0n");
+assert.sameValue(BigInt.asUintN(2, true), 1n, "ToBigInt: true => 1n");
+assert.sameValue(BigInt.asUintN(2, "1"), 1n, "ToBigInt: parse BigInt");
+assert.sameValue(BigInt.asUintN(2, "-0"), 0n, "ToBigInt: parse BigInt");
+assert.sameValue(BigInt.asUintN(2, ""), 0n, "ToBigInt: empty String => 0n");
+assert.sameValue(BigInt.asUintN(2, "     "), 0n, "ToBigInt: String with only whitespace => 0n");
+assert.sameValue(BigInt.asUintN(2, []), 0n, "ToBigInt: .toString() => empty String => 0n");
+assert.sameValue(BigInt.asUintN(2, [1]), 1n, "ToBigInt: .toString() => parse BigInt");
+assert.sameValue(BigInt.asUintN(3, 10n), 2n);
+assert.sameValue(BigInt.asUintN(3, "10"), 2n, "ToBigInt: parse BigInt");
+assert.sameValue(BigInt.asUintN(3, "0b1010"), 2n, "ToBigInt: parse BigInt binary");
+assert.sameValue(BigInt.asUintN(3, "0o12"), 2n, "ToBigInt: parse BigInt octal");
+assert.sameValue(BigInt.asUintN(3, "0xa"), 2n, "ToBigInt: parse BigInt hex");
+assert.sameValue(BigInt.asUintN(3, "    0xa    "), 2n,
+  "ToBigInt: parse BigInt ignore leading/trailing whitespace");
+assert.sameValue(BigInt.asUintN(3, "     10     "), 2n,
+  "ToBigInt: parse BigInt ignore leading/trailing whitespace");
+assert.sameValue(BigInt.asUintN(3, [10n]), 2n, "ToBigInt: .toString() => parse BigInt");
+assert.sameValue(BigInt.asUintN(3, ["10"]), 2n, "ToBigInt: .toString() => parse BigInt");
+assert.sameValue(BigInt.asUintN(4, 12345678901234567890003n), 3n);
+assert.sameValue(BigInt.asUintN(4, "12345678901234567890003"), 3n, "ToBigInt: parse BigInt");
+assert.sameValue(BigInt.asUintN(4,
+    "0b10100111010100001010110110010011100111011001110001010000100100010001010011"), 3n,
+  "ToBigInt: parse BigInt binary");
+assert.sameValue(BigInt.asUintN(4, "0o2472412662347316120442123"), 3n,
+  "ToBigInt: parse BigInt octal");
+assert.sameValue(BigInt.asUintN(4, "0x29d42b64e7671424453"), 3n, "ToBigInt: parse BigInt hex");
+assert.sameValue(BigInt.asUintN(4, "    0x29d42b64e7671424453    "), 3n,
+  "ToBigInt: parse BigInt ignore leading/trailing whitespace");
+assert.sameValue(BigInt.asUintN(4, "     12345678901234567890003     "), 3n,
+  "ToBigInt: parse BigInt ignore leading/trailing whitespace");
+assert.sameValue(BigInt.asUintN(4, [12345678901234567890003n]), 3n,
+  "ToBigInt: .toString() => parse BigInt");
+assert.sameValue(BigInt.asUintN(4, ["12345678901234567890003"]), 3n,
+  "ToBigInt: .toString() => parse BigInt");

--- a/test/built-ins/BigInt/asUintN/bits-toindex-errors.js
+++ b/test/built-ins/BigInt/asUintN/bits-toindex-errors.js
@@ -1,0 +1,84 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: BigInt.asUintN type coercion for bits parameter
+esid: pending
+info: |
+  BigInt.asUintN ( bits, bigint )
+
+  1. Let bits be ? ToIndex(bits).
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(RangeError, function() {
+  BigInt.asUintN(-1, 0n);
+}, "ToIndex: throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  BigInt.asUintN(-2.5, 0n);
+}, "ToIndex: throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  BigInt.asUintN("-2.5", 0n);
+}, "ToIndex: parse Number => throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  BigInt.asUintN(-Infinity, 0n);
+}, "ToIndex: throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  BigInt.asUintN(9007199254740992, 0n);
+}, "ToIndex: throw when integerIndex > 2**53-1");
+assert.throws(RangeError, function() {
+  BigInt.asUintN(Infinity, 0n);
+}, "ToIndex: throw when integerIndex > 2**53-1");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(0n, 0n);
+}, "ToIndex: BigInt => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(Object(0n), 0n);
+}, "ToIndex: unbox object with internal slot => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    [Symbol.toPrimitive]: function() {
+      return 0n;
+    }
+  }, 0n);
+}, "ToIndex: @@toPrimitive => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    valueOf: function() {
+      return 0n;
+    }
+  }, 0n);
+}, "ToIndex: valueOf => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    toString: function() {
+      return 0n;
+    }
+  }, 0n);
+}, "ToIndex: toString => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(Symbol("1"), 0n);
+}, "ToIndex: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN(Object(Symbol("1")), 0n);
+}, "ToIndex: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  }, 0n);
+}, "ToIndex: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  }, 0n);
+}, "ToIndex: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    toString: function() {
+      return Symbol("1");
+    }
+  }, 0n);
+}, "ToIndex: toString => Symbol => TypeError");

--- a/test/built-ins/BigInt/asUintN/bits-toindex-toprimitive.js
+++ b/test/built-ins/BigInt/asUintN/bits-toindex-toprimitive.js
@@ -1,0 +1,165 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: BigInt.asUintN type coercion for bits parameter
+esid: pending
+info: |
+  BigInt.asUintN ( bits, bigint )
+
+  1. Let bits be ? ToIndex(bits).
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(BigInt.asUintN({
+  [Symbol.toPrimitive]: function() {
+    return 1;
+  },
+  valueOf: err,
+  toString: err
+}, 1n), 1n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(BigInt.asUintN({
+  valueOf: function() {
+    return 1;
+  },
+  toString: err
+}, 1n), 1n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(BigInt.asUintN({
+  toString: function() {
+    return 1;
+  }
+}, 1n), 1n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(BigInt.asUintN({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 1;
+  }
+}, 1n), 1n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(BigInt.asUintN({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 1;
+  }
+}, 1n), 1n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(BigInt.asUintN({
+  valueOf: null,
+  toString: function() {
+    return 1;
+  }
+}, 1n), 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(BigInt.asUintN({
+  valueOf: 1,
+  toString: function() {
+    return 1;
+  }
+}, 1n), 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(BigInt.asUintN({
+  valueOf: {},
+  toString: function() {
+    return 1;
+  }
+}, 1n), 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(BigInt.asUintN({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 1;
+  }
+}, 1n), 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(BigInt.asUintN({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 1;
+  }
+}, 1n), 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    [Symbol.toPrimitive]: 1
+  }, 0n);
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    [Symbol.toPrimitive]: {}
+  }, 0n);
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  }, 0n);
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  }, 0n);
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  BigInt.asUintN({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  }, 0n);
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  BigInt.asUintN({
+    valueOf: function() {
+      throw new MyError();
+    }
+  }, 0n);
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  BigInt.asUintN({
+    toString: function() {
+      throw new MyError();
+    }
+  }, 0n);
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    valueOf: null,
+    toString: null
+  }, 0n);
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    valueOf: 1,
+    toString: 1
+  }, 0n);
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    valueOf: {},
+    toString: {}
+  }, 0n);
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  }, 0n);
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  BigInt.asUintN({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  }, 0n);
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/built-ins/BigInt/asUintN/bits-toindex-wrapped-values.js
+++ b/test/built-ins/BigInt/asUintN/bits-toindex-wrapped-values.js
@@ -1,0 +1,109 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: BigInt.asUintN type coercion for bits parameter
+esid: pending
+info: |
+  BigInt.asUintN ( bits, bigint )
+
+  1. Let bits be ? ToIndex(bits).
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(BigInt.asUintN(Object(0), 1n), 0n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(BigInt.asUintN({
+  [Symbol.toPrimitive]: function() {
+    return 0;
+  }
+}, 1n), 0n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(BigInt.asUintN({
+  valueOf: function() {
+    return 0;
+  }
+}, 1n), 0n, "ToPrimitive: valueOf");
+assert.sameValue(BigInt.asUintN({
+  toString: function() {
+    return 0;
+  }
+}, 1n), 0n, "ToPrimitive: toString");
+assert.sameValue(BigInt.asUintN(Object(NaN), 1n), 0n,
+  "ToIndex: unbox object with internal slot => NaN => 0");
+assert.sameValue(BigInt.asUintN({
+  [Symbol.toPrimitive]: function() {
+    return NaN;
+  }
+}, 1n), 0n, "ToIndex: @@toPrimitive => NaN => 0");
+assert.sameValue(BigInt.asUintN({
+  valueOf: function() {
+    return NaN;
+  }
+}, 1n), 0n, "ToIndex: valueOf => NaN => 0");
+assert.sameValue(BigInt.asUintN({
+  toString: function() {
+    return NaN;
+  }
+}, 1n), 0n, "ToIndex: toString => NaN => 0");
+assert.sameValue(BigInt.asUintN({
+  [Symbol.toPrimitive]: function() {
+    return undefined;
+  }
+}, 1n), 0n, "ToIndex: @@toPrimitive => undefined => NaN => 0");
+assert.sameValue(BigInt.asUintN({
+  valueOf: function() {
+    return undefined;
+  }
+}, 1n), 0n, "ToIndex: valueOf => undefined => NaN => 0");
+assert.sameValue(BigInt.asUintN({
+  toString: function() {
+    return undefined;
+  }
+}, 1n), 0n, "ToIndex: toString => undefined => NaN => 0");
+assert.sameValue(BigInt.asUintN({
+  [Symbol.toPrimitive]: function() {
+    return null;
+  }
+}, 1n), 0n, "ToIndex: @@toPrimitive => null => 0");
+assert.sameValue(BigInt.asUintN({
+  valueOf: function() {
+    return null;
+  }
+}, 1n), 0n, "ToIndex: valueOf => null => 0");
+assert.sameValue(BigInt.asUintN({
+  toString: function() {
+    return null;
+  }
+}, 1n), 0n, "ToIndex: toString => null => 0");
+assert.sameValue(BigInt.asUintN(Object(true), 1n), 1n,
+  "ToIndex: unbox object with internal slot => true => 1");
+assert.sameValue(BigInt.asUintN({
+  [Symbol.toPrimitive]: function() {
+    return true;
+  }
+}, 1n), 1n, "ToIndex: @@toPrimitive => true => 1");
+assert.sameValue(BigInt.asUintN({
+  valueOf: function() {
+    return true;
+  }
+}, 1n), 1n, "ToIndex: valueOf => true => 1");
+assert.sameValue(BigInt.asUintN({
+  toString: function() {
+    return true;
+  }
+}, 1n), 1n, "ToIndex: toString => true => 1");
+assert.sameValue(BigInt.asUintN(Object("1"), 1n), 1n,
+  "ToIndex: unbox object with internal slot => parse Number");
+assert.sameValue(BigInt.asUintN({
+  [Symbol.toPrimitive]: function() {
+    return "1";
+  }
+}, 1n), 1n, "ToIndex: @@toPrimitive => parse Number");
+assert.sameValue(BigInt.asUintN({
+  valueOf: function() {
+    return "1";
+  }
+}, 1n), 1n, "ToIndex: valueOf => parse Number");
+assert.sameValue(BigInt.asUintN({
+  toString: function() {
+    return "1";
+  }
+}, 1n), 1n, "ToIndex: toString => parse Number");

--- a/test/built-ins/BigInt/asUintN/bits-toindex.js
+++ b/test/built-ins/BigInt/asUintN/bits-toindex.js
@@ -1,29 +1,35 @@
 // Copyright (C) 2017 Josh Wolfe. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: pending
 description: BigInt.asUintN type coercion for bits parameter
-info: >
+esid: pending
+info: |
   BigInt.asUintN ( bits, bigint )
 
   1. Let bits be ? ToIndex(bits).
-
-features: [BigInt, Symbol, Symbol.toPrimitive]
-includes: [typeCoercion.js]
+features: [BigInt]
 ---*/
 
-testCoercibleToIndexZero(function(zero) {
-  assert.sameValue(BigInt.asUintN(zero, 1n), 0n);
-});
-
-testCoercibleToIndexOne(function(one) {
-  assert.sameValue(BigInt.asUintN(one, 1n), 1n);
-});
-
-testCoercibleToIndexFromIndex(3, function(three) {
-  assert.sameValue(BigInt.asUintN(three, 10n), 2n);
-});
-
-testNotCoercibleToIndex(function(error, value) {
-  assert.throws(error, function() { BigInt.asUintN(value, 0n); });
-});
+assert.sameValue(BigInt.asUintN(0, 1n), 0n);
+assert.sameValue(BigInt.asUintN(1, 1n), 1n);
+assert.sameValue(BigInt.asUintN(-0.9, 1n), 0n, "ToIndex: truncate towards 0");
+assert.sameValue(BigInt.asUintN(0.9, 1n), 0n, "ToIndex: truncate towards 0");
+assert.sameValue(BigInt.asUintN(NaN, 1n), 0n, "ToIndex: NaN => 0");
+assert.sameValue(BigInt.asUintN(undefined, 1n), 0n, "ToIndex: undefined => NaN => 0");
+assert.sameValue(BigInt.asUintN(null, 1n), 0n, "ToIndex: null => 0");
+assert.sameValue(BigInt.asUintN(false, 1n), 0n, "ToIndex: false => 0");
+assert.sameValue(BigInt.asUintN(true, 1n), 1n, "ToIndex: true => 1");
+assert.sameValue(BigInt.asUintN("0", 1n), 0n, "ToIndex: parse Number");
+assert.sameValue(BigInt.asUintN("1", 1n), 1n, "ToIndex: parse Number");
+assert.sameValue(BigInt.asUintN("", 1n), 0n, "ToIndex: parse Number => NaN => 0");
+assert.sameValue(BigInt.asUintN("foo", 1n), 0n, "ToIndex: parse Number => NaN => 0");
+assert.sameValue(BigInt.asUintN("true", 1n), 0n, "ToIndex: parse Number => NaN => 0");
+assert.sameValue(BigInt.asUintN(3, 10n), 2n);
+assert.sameValue(BigInt.asUintN("3", 10n), 2n, "toIndex: parse Number");
+assert.sameValue(BigInt.asUintN(3.9, 10n), 2n, "toIndex: truncate towards 0");
+assert.sameValue(BigInt.asUintN("3.9", 10n), 2n, "toIndex: parse Number => truncate towards 0");
+assert.sameValue(BigInt.asUintN([0], 1n), 0n, 'ToIndex: [0].toString() => "0" => 0');
+assert.sameValue(BigInt.asUintN(["1"], 1n), 1n, 'ToIndex: ["1"].toString() => "1" => 1');
+assert.sameValue(BigInt.asUintN({}, 1n), 0n,
+  'ToIndex: ({}).toString() => "[object Object]" => NaN => 0');
+assert.sameValue(BigInt.asUintN([], 1n), 0n, 'ToIndex: [].toString() => "" => NaN => 0');

--- a/test/built-ins/String/prototype/indexOf/position-tointeger-bigint.js
+++ b/test/built-ins/String/prototype/indexOf/position-tointeger-bigint.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: String.prototype.indexOf type coercion for position parameter
+esid: sec-string.prototype.indexof
+info: |
+  String.prototype.indexOf ( searchString [ , position ] )
+
+  4. Let pos be ? ToInteger(position).
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  "".indexOf("", 0n);
+}, "ToInteger: BigInt => TypeError");
+assert.throws(TypeError, function() {
+  "".indexOf("", Object(0n));
+}, "ToInteger: unbox object with internal slot => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    [Symbol.toPrimitive]: function() {
+      return 0n;
+    }
+  });
+}, "ToInteger: @@toPrimitive => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    valueOf: function() {
+      return 0n;
+    }
+  });
+}, "ToInteger: valueOf => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    toString: function() {
+      return 0n;
+    }
+  });
+}, "ToInteger: toString => BigInt => TypeError");

--- a/test/built-ins/String/prototype/indexOf/position-tointeger-errors.js
+++ b/test/built-ins/String/prototype/indexOf/position-tointeger-errors.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: String.prototype.indexOf type coercion for position parameter
+esid: sec-string.prototype.indexof
+info: |
+  String.prototype.indexOf ( searchString [ , position ] )
+
+  4. Let pos be ? ToInteger(position).
+features: [Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  "".indexOf("", Symbol("1"));
+}, "ToInteger: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  "".indexOf("", Object(Symbol("1")));
+}, "ToInteger: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToInteger: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToInteger: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    toString: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToInteger: toString => Symbol => TypeError");

--- a/test/built-ins/String/prototype/indexOf/position-tointeger-toprimitive.js
+++ b/test/built-ins/String/prototype/indexOf/position-tointeger-toprimitive.js
@@ -1,0 +1,165 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: String.prototype.indexOf type coercion for position parameter
+esid: sec-string.prototype.indexof
+info: |
+  String.prototype.indexOf ( searchString [ , position ] )
+
+  4. Let pos be ? ToInteger(position).
+features: [Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue("aaaa".indexOf("aa", {
+  [Symbol.toPrimitive]: function() {
+    return 1;
+  },
+  valueOf: err,
+  toString: err
+}), 1, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue("aaaa".indexOf("aa", {
+  valueOf: function() {
+    return 1;
+  },
+  toString: err
+}), 1, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue("aaaa".indexOf("aa", {
+  toString: function() {
+    return 1;
+  }
+}), 1, "ToPrimitive: toString with no valueOf");
+assert.sameValue("aaaa".indexOf("aa", {
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 1;
+  }
+}), 1, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue("aaaa".indexOf("aa", {
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 1;
+  }
+}), 1, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue("aaaa".indexOf("aa", {
+  valueOf: null,
+  toString: function() {
+    return 1;
+  }
+}), 1, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue("aaaa".indexOf("aa", {
+  valueOf: 1,
+  toString: function() {
+    return 1;
+  }
+}), 1, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue("aaaa".indexOf("aa", {
+  valueOf: {},
+  toString: function() {
+    return 1;
+  }
+}), 1, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue("aaaa".indexOf("aa", {
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 1;
+  }
+}), 1, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue("aaaa".indexOf("aa", {
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 1;
+  }
+}), 1, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    [Symbol.toPrimitive]: 1
+  });
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    [Symbol.toPrimitive]: {}
+  });
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  });
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  });
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  "".indexOf("", {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  "".indexOf("", {
+    valueOf: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  "".indexOf("", {
+    toString: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    valueOf: null,
+    toString: null
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    valueOf: 1,
+    toString: 1
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    valueOf: {},
+    toString: {}
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  "".indexOf("", {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/built-ins/String/prototype/indexOf/position-tointeger-wrapped-values.js
+++ b/test/built-ins/String/prototype/indexOf/position-tointeger-wrapped-values.js
@@ -1,0 +1,109 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: String.prototype.indexOf type coercion for position parameter
+esid: sec-string.prototype.indexof
+info: |
+  String.prototype.indexOf ( searchString [ , position ] )
+
+  4. Let pos be ? ToInteger(position).
+features: [Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue("aaaa".indexOf("aa", Object(0)), 0, "ToPrimitive: unbox object with internal slot");
+assert.sameValue("aaaa".indexOf("aa", {
+  [Symbol.toPrimitive]: function() {
+    return 0;
+  }
+}), 0, "ToPrimitive: @@toPrimitive");
+assert.sameValue("aaaa".indexOf("aa", {
+  valueOf: function() {
+    return 0;
+  }
+}), 0, "ToPrimitive: valueOf");
+assert.sameValue("aaaa".indexOf("aa", {
+  toString: function() {
+    return 0;
+  }
+}), 0, "ToPrimitive: toString");
+assert.sameValue("aaaa".indexOf("aa", Object(NaN)), 0,
+  "ToInteger: unbox object with internal slot => NaN => 0");
+assert.sameValue("aaaa".indexOf("aa", {
+  [Symbol.toPrimitive]: function() {
+    return NaN;
+  }
+}), 0, "ToInteger: @@toPrimitive => NaN => 0");
+assert.sameValue("aaaa".indexOf("aa", {
+  valueOf: function() {
+    return NaN;
+  }
+}), 0, "ToInteger: valueOf => NaN => 0");
+assert.sameValue("aaaa".indexOf("aa", {
+  toString: function() {
+    return NaN;
+  }
+}), 0, "ToInteger: toString => NaN => 0");
+assert.sameValue("aaaa".indexOf("aa", {
+  [Symbol.toPrimitive]: function() {
+    return undefined;
+  }
+}), 0, "ToInteger: @@toPrimitive => undefined => NaN => 0");
+assert.sameValue("aaaa".indexOf("aa", {
+  valueOf: function() {
+    return undefined;
+  }
+}), 0, "ToInteger: valueOf => undefined => NaN => 0");
+assert.sameValue("aaaa".indexOf("aa", {
+  toString: function() {
+    return undefined;
+  }
+}), 0, "ToInteger: toString => undefined => NaN => 0");
+assert.sameValue("aaaa".indexOf("aa", {
+  [Symbol.toPrimitive]: function() {
+    return null;
+  }
+}), 0, "ToInteger: @@toPrimitive => null => 0");
+assert.sameValue("aaaa".indexOf("aa", {
+  valueOf: function() {
+    return null;
+  }
+}), 0, "ToInteger: valueOf => null => 0");
+assert.sameValue("aaaa".indexOf("aa", {
+  toString: function() {
+    return null;
+  }
+}), 0, "ToInteger: toString => null => 0");
+assert.sameValue("aaaa".indexOf("aa", Object(true)), 1,
+  "ToInteger: unbox object with internal slot => true => 1");
+assert.sameValue("aaaa".indexOf("aa", {
+  [Symbol.toPrimitive]: function() {
+    return true;
+  }
+}), 1, "ToInteger: @@toPrimitive => true => 1");
+assert.sameValue("aaaa".indexOf("aa", {
+  valueOf: function() {
+    return true;
+  }
+}), 1, "ToInteger: valueOf => true => 1");
+assert.sameValue("aaaa".indexOf("aa", {
+  toString: function() {
+    return true;
+  }
+}), 1, "ToInteger: toString => true => 1");
+assert.sameValue("aaaa".indexOf("aa", Object("1.9")), 1,
+  "ToInteger: unbox object with internal slot => parse Number => 1.9 => 1");
+assert.sameValue("aaaa".indexOf("aa", {
+  [Symbol.toPrimitive]: function() {
+    return "1.9";
+  }
+}), 1, "ToInteger: @@toPrimitive => parse Number => 1.9 => 1");
+assert.sameValue("aaaa".indexOf("aa", {
+  valueOf: function() {
+    return "1.9";
+  }
+}), 1, "ToInteger: valueOf => parse Number => 1.9 => 1");
+assert.sameValue("aaaa".indexOf("aa", {
+  toString: function() {
+    return "1.9";
+  }
+}), 1, "ToInteger: toString => parse Number => 1.9 => 1");

--- a/test/built-ins/String/prototype/indexOf/position-tointeger.js
+++ b/test/built-ins/String/prototype/indexOf/position-tointeger.js
@@ -1,29 +1,37 @@
 // Copyright (C) 2017 Josh Wolfe. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-string.prototype.indexof
 description: String.prototype.indexOf type coercion for position parameter
-info: >
+esid: sec-string.prototype.indexof
+info: |
   String.prototype.indexOf ( searchString [ , position ] )
 
   4. Let pos be ? ToInteger(position).
-
-includes: [typeCoercion.js]
-features: [BigInt, Symbol.toPrimitive]
 ---*/
 
-testCoercibleToIntegerZero(function(zero) {
-  assert.sameValue("aaaa".indexOf("aa", zero), 0);
-});
-
-testCoercibleToIntegerOne(function(one) {
-  assert.sameValue("aaaa".indexOf("aa", one), 1);
-});
-
-testCoercibleToIntegerFromInteger(2, function(two) {
-  assert.sameValue("aaaa".indexOf("aa", two), 2);
-});
-
-testNotCoercibleToInteger(function(error, value) {
-  assert.throws(error, function() { "".indexOf("", value); });
-});
+assert.sameValue("aaaa".indexOf("aa", 0), 0);
+assert.sameValue("aaaa".indexOf("aa", 1), 1);
+assert.sameValue("aaaa".indexOf("aa", -0.9), 0, "ToInteger: truncate towards 0");
+assert.sameValue("aaaa".indexOf("aa", 0.9), 0, "ToInteger: truncate towards 0");
+assert.sameValue("aaaa".indexOf("aa", 1.9), 1, "ToInteger: truncate towards 0");
+assert.sameValue("aaaa".indexOf("aa", NaN), 0, "ToInteger: NaN => 0");
+assert.sameValue("aaaa".indexOf("aa", Infinity), -1);
+assert.sameValue("aaaa".indexOf("aa", undefined), 0, "ToInteger: undefined => NaN => 0");
+assert.sameValue("aaaa".indexOf("aa", null), 0, "ToInteger: null => 0");
+assert.sameValue("aaaa".indexOf("aa", false), 0, "ToInteger: false => 0");
+assert.sameValue("aaaa".indexOf("aa", true), 1, "ToInteger: true => 1");
+assert.sameValue("aaaa".indexOf("aa", "0"), 0, "ToInteger: parse Number");
+assert.sameValue("aaaa".indexOf("aa", "1.9"), 1, "ToInteger: parse Number => 1.9 => 1");
+assert.sameValue("aaaa".indexOf("aa", "Infinity"), -1, "ToInteger: parse Number");
+assert.sameValue("aaaa".indexOf("aa", ""), 0, "ToInteger: unparseable string => NaN => 0");
+assert.sameValue("aaaa".indexOf("aa", "foo"), 0, "ToInteger: unparseable string => NaN => 0");
+assert.sameValue("aaaa".indexOf("aa", "true"), 0, "ToInteger: unparseable string => NaN => 0");
+assert.sameValue("aaaa".indexOf("aa", 2), 2);
+assert.sameValue("aaaa".indexOf("aa", "2"), 2, "ToInteger: parse Number");
+assert.sameValue("aaaa".indexOf("aa", 2.9), 2, "ToInteger: truncate towards 0");
+assert.sameValue("aaaa".indexOf("aa", "2.9"), 2, "ToInteger: parse Number => truncate towards 0");
+assert.sameValue("aaaa".indexOf("aa", [0]), 0, 'ToInteger: [0].toString() => "0" => 0');
+assert.sameValue("aaaa".indexOf("aa", ["1"]), 1, 'ToInteger: ["1"].toString() => "1" => 1');
+assert.sameValue("aaaa".indexOf("aa", {}), 0,
+  'ToInteger: ({}).toString() => "[object Object]" => NaN => 0');
+assert.sameValue("aaaa".indexOf("aa", []), 0, 'ToInteger: [].toString() => "" => NaN => 0');

--- a/test/built-ins/String/prototype/indexOf/searchstring-tostring-bigint.js
+++ b/test/built-ins/String/prototype/indexOf/searchstring-tostring-bigint.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: String.prototype.indexOf type coercion for searchString parameter
+esid: sec-string.prototype.indexof
+info: |
+  String.prototype.indexOf ( searchString [ , position ] )
+
+  3. Let searchStr be ? ToString(searchString).
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue("__0__".indexOf(0n), 2, "ToString: BigInt to String");
+assert.sameValue("__0__".indexOf(Object(0n)), 2,
+  "ToString: unbox object with internal slot => BigInt to String");
+assert.sameValue("__0__".indexOf({
+  [Symbol.toPrimitive]: function() {
+    return 0n;
+  }
+}), 2, "ToString: @@toPrimitive => BigInt to String");
+assert.sameValue("__0__".indexOf({
+  valueOf: function() {
+    return 0n;
+  },
+  toString: null
+}), 2, "ToString: valueOf => BigInt to String");
+assert.sameValue("__0__".indexOf({
+  toString: function() {
+    return 0n;
+  }
+}), 2, "ToString: toString => BigInt to String");

--- a/test/built-ins/String/prototype/indexOf/searchstring-tostring-errors.js
+++ b/test/built-ins/String/prototype/indexOf/searchstring-tostring-errors.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: String.prototype.indexOf type coercion for searchString parameter
+esid: sec-string.prototype.indexof
+info: |
+  String.prototype.indexOf ( searchString [ , position ] )
+
+  3. Let searchStr be ? ToString(searchString).
+features: [Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  "".indexOf(Symbol("1"));
+}, "ToString: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  "".indexOf(Object(Symbol("1")));
+}, "ToString: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  "".indexOf({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToString: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  "".indexOf({
+    valueOf: function() {
+      return Symbol("1");
+    },
+    toString: null
+  });
+}, "ToString: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  "".indexOf({
+    toString: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToString: toString => Symbol => TypeError");

--- a/test/built-ins/String/prototype/indexOf/searchstring-tostring-toprimitive.js
+++ b/test/built-ins/String/prototype/indexOf/searchstring-tostring-toprimitive.js
@@ -1,0 +1,161 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: String.prototype.indexOf type coercion for searchString parameter
+esid: sec-string.prototype.indexof
+info: |
+  String.prototype.indexOf ( searchString [ , position ] )
+
+  3. Let searchStr be ? ToString(searchString).
+features: [Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue("__foo__".indexOf({
+  [Symbol.toPrimitive]: function() {
+    return "foo";
+  },
+  toString: err,
+  valueOf: err
+}), 2, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue("__foo__".indexOf({
+  toString: function() {
+    return "foo";
+  },
+  valueOf: err
+}), 2, "ToPrimitive: toString takes precedence over valueOf");
+assert.sameValue("__foo__".indexOf({
+  [Symbol.toPrimitive]: undefined,
+  toString: function() {
+    return "foo";
+  }
+}), 2, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue("__foo__".indexOf({
+  [Symbol.toPrimitive]: null,
+  toString: function() {
+    return "foo";
+  }
+}), 2, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue("__foo__".indexOf({
+  toString: null,
+  valueOf: function() {
+    return "foo";
+  }
+}), 2, "ToPrimitive: skip toString when it's not callable");
+assert.sameValue("__foo__".indexOf({
+  toString: 1,
+  valueOf: function() {
+    return "foo";
+  }
+}), 2, "ToPrimitive: skip toString when it's not callable");
+assert.sameValue("__foo__".indexOf({
+  toString: {},
+  valueOf: function() {
+    return "foo";
+  }
+}), 2, "ToPrimitive: skip toString when it's not callable");
+assert.sameValue("__foo__".indexOf({
+  toString: function() {
+    return {};
+  },
+  valueOf: function() {
+    return "foo";
+  }
+}), 2, "ToPrimitive: skip toString when it returns an object");
+assert.sameValue("__foo__".indexOf({
+  toString: function() {
+    return Object(12345);
+  },
+  valueOf: function() {
+    return "foo";
+  }
+}), 2, "ToPrimitive: skip toString when it returns an object");
+assert.throws(TypeError, function() {
+  "".indexOf({
+    [Symbol.toPrimitive]: 1
+  });
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  "".indexOf({
+    [Symbol.toPrimitive]: {}
+  });
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  "".indexOf({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  });
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  "".indexOf({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  });
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  "".indexOf({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  "".indexOf({
+    valueOf: function() {
+      throw new MyError();
+    },
+    toString: null
+  });
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  "".indexOf({
+    toString: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  "".indexOf({
+    valueOf: null,
+    toString: null
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  "".indexOf({
+    valueOf: 1,
+    toString: 1
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  "".indexOf({
+    valueOf: {},
+    toString: {}
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  "".indexOf({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  "".indexOf({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/built-ins/String/prototype/indexOf/searchstring-tostring-wrapped-values.js
+++ b/test/built-ins/String/prototype/indexOf/searchstring-tostring-wrapped-values.js
@@ -1,0 +1,98 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: String.prototype.indexOf type coercion for searchString parameter
+esid: sec-string.prototype.indexof
+info: |
+  String.prototype.indexOf ( searchString [ , position ] )
+
+  3. Let searchStr be ? ToString(searchString).
+features: [Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue("__foo__".indexOf(Object("foo")), 2,
+  "ToPrimitive: unbox object with internal slot");
+assert.sameValue("__foo__".indexOf({
+  [Symbol.toPrimitive]: function() {
+    return "foo";
+  }
+}), 2, "ToPrimitive: @@toPrimitive");
+assert.sameValue("__foo__".indexOf({
+  valueOf: function() {
+    return "foo";
+  },
+  toString: null
+}), 2, "ToPrimitive: valueOf");
+assert.sameValue("__foo__".indexOf({
+  toString: function() {
+    return "foo";
+  }
+}), 2, "ToPrimitive: toString");
+assert.sameValue("__undefined__".indexOf({
+  [Symbol.toPrimitive]: function() {
+    return undefined;
+  }
+}), 2, 'ToString: @@toPrimitive => undefined => "undefined"');
+assert.sameValue("__undefined__".indexOf({
+  valueOf: function() {
+    return undefined;
+  },
+  toString: null
+}), 2, 'ToString: valueOf => undefined => "undefined"');
+assert.sameValue("__undefined__".indexOf({
+  toString: function() {
+    return undefined;
+  }
+}), 2, 'ToString: toString => undefined => "undefined"');
+assert.sameValue("__null__".indexOf({
+  [Symbol.toPrimitive]: function() {
+    return null;
+  }
+}), 2, 'ToString: @@toPrimitive => null => "null"');
+assert.sameValue("__null__".indexOf({
+  valueOf: function() {
+    return null;
+  },
+  toString: null
+}), 2, 'ToString: valueOf => null => "null"');
+assert.sameValue("__null__".indexOf({
+  toString: function() {
+    return null;
+  }
+}), 2, 'ToString: toString => null => "null"');
+assert.sameValue("__false__".indexOf(Object(false)), 2,
+  'ToString: unbox object with internal slot => false => "false"');
+assert.sameValue("__false__".indexOf({
+  [Symbol.toPrimitive]: function() {
+    return false;
+  }
+}), 2, 'ToString: @@toPrimitive => false => "false"');
+assert.sameValue("__false__".indexOf({
+  valueOf: function() {
+    return false;
+  },
+  toString: null
+}), 2, 'ToString: valueOf => false => "false"');
+assert.sameValue("__false__".indexOf({
+  toString: function() {
+    return false;
+  }
+}), 2, 'ToString: toString => false => "false"');
+assert.sameValue("__0__".indexOf(Object(0)), 2,
+  "ToString: unbox object with internal slot => Number to String");
+assert.sameValue("__0__".indexOf({
+  [Symbol.toPrimitive]: function() {
+    return 0;
+  }
+}), 2, "ToString: @@toPrimitive => Number to String");
+assert.sameValue("__0__".indexOf({
+  valueOf: function() {
+    return 0;
+  },
+  toString: null
+}), 2, "ToString: valueOf => Number to String");
+assert.sameValue("__0__".indexOf({
+  toString: function() {
+    return 0;
+  }
+}), 2, "ToString: toString => Number to String");

--- a/test/built-ins/String/prototype/indexOf/searchstring-tostring.js
+++ b/test/built-ins/String/prototype/indexOf/searchstring-tostring.js
@@ -1,26 +1,27 @@
 // Copyright (C) 2017 Josh Wolfe. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-string.prototype.indexof
 description: String.prototype.indexOf type coercion for searchString parameter
-info: >
+esid: sec-string.prototype.indexof
+info: |
   String.prototype.indexOf ( searchString [ , position ] )
 
   3. Let searchStr be ? ToString(searchString).
-
-includes: [typeCoercion.js]
-features: [Symbol.toPrimitive, BigInt]
 ---*/
 
-testCoercibleToString(function(value, expectedString) {
-  if (expectedString.length === 0) {
-    assert.sameValue(("x_x_x").indexOf(value), 0);
-  } else {
-    assert.sameValue(expectedString.indexOf("\x00"), -1, "sanity check");
-    assert.sameValue(("\x00\x00" + expectedString + "\x00\x00").indexOf(value), 2);
-  }
-});
-
-testNotCoercibleToString(function(error, value) {
-  assert.throws(error, function() { "".indexOf(value); });
-});
+assert.sameValue("foo".indexOf(""), 0);
+assert.sameValue("__foo__".indexOf("foo"), 2);
+assert.sameValue("__undefined__".indexOf(undefined), 2, 'ToString: undefined => "undefined"');
+assert.sameValue("__null__".indexOf(null), 2, 'ToString: null => "null"');
+assert.sameValue("__true__".indexOf(true), 2, 'ToString: true => "true"');
+assert.sameValue("__false__".indexOf(false), 2, 'ToString: false => "false"');
+assert.sameValue("__0__".indexOf(0), 2, "ToString: Number to String");
+assert.sameValue("__0__".indexOf(-0), 2, 'ToString: -0 => "0"');
+assert.sameValue("__Infinity__".indexOf(Infinity), 2, 'ToString: Infinity => "Infinity"');
+assert.sameValue("__-Infinity__".indexOf(-Infinity), 2, 'ToString: -Infinity => "-Infinity"');
+assert.sameValue("__NaN__".indexOf(NaN), 2, 'ToString: NaN => "NaN"');
+assert.sameValue("__123.456__".indexOf(123.456), 2, "ToString: Number to String");
+assert.sameValue("__-123.456__".indexOf(-123.456), 2, "ToString: Number to String");
+assert.sameValue("foo".indexOf([]), 0, "ToString: .toString()");
+assert.sameValue("__foo,bar__".indexOf(["foo", "bar"]), 2, "ToString: .toString()");
+assert.sameValue("__[object Object]__".indexOf({}), 2, "ToString: .toString()");


### PR DESCRIPTION
This removes some of the dependencies on `harness/typeCoercion.js`.

This is an iteration on the proposal in #1341 which does not include the generator code. For that, see https://github.com/thejoshwolfe/test262-generators .

I didn't touch the DataView tests yet. That will come in a follow up PR.

This code was formatted with `js-beautify -n -w 100 -s 2` (after [patching](https://github.com/beautify-web/js-beautify/pull/1303) it to support BigInt literal notation).