### PR TITLE
Generate type coercion tests for DataView tests

### DIFF
--- a/test/built-ins/DataView/prototype/getBigInt64/to-boolean-littleendian.js
+++ b/test/built-ins/DataView/prototype/getBigInt64/to-boolean-littleendian.js
@@ -1,10 +1,8 @@
 // Copyright (C) 2017 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
+description: Boolean littleEndian argument coerced in ToBoolean
 esid: sec-dataview.prototype.getbigint64
-description: >
-  Boolean littleEndian argument coerced in ToBoolean
 info: |
   DataView.prototype.getBigInt64 ( byteOffset [ , littleEndian ] )
 
@@ -32,22 +30,38 @@ info: |
   ...
   2. If isLittleEndian is false, reverse the order of the elements of rawBytes.
   ...
-includes: [typeCoercion.js]
-features: [DataView, ArrayBuffer, DataView.prototype.setUint8, BigInt, Symbol, Symbol.toPrimitive]
+features: [ArrayBuffer, BigInt, DataView, DataView.prototype.setUint8, Symbol]
 ---*/
 
 var buffer = new ArrayBuffer(8);
 var sample = new DataView(buffer, 0);
-
 sample.setUint8(7, 0xff);
-
-// False
 assert.sameValue(sample.getBigInt64(0), 0xffn, "no argument");
-testCoercibleToBooleanFalse(function (x) {
-  assert.sameValue(sample.getBigInt64(0, x), 0xffn);
-});
 
-// True
-testCoercibleToBooleanTrue(function (x) {
-  assert.sameValue(sample.getBigInt64(0, x), -0x100000000000000n);
-});
+assert.sameValue(sample.getBigInt64(0, false), 0xffn);
+assert.sameValue(sample.getBigInt64(0, true), -0x100000000000000n);
+assert.sameValue(sample.getBigInt64(0, 0), 0xffn, "ToBoolean: 0 => false");
+assert.sameValue(sample.getBigInt64(0, -0), 0xffn, "ToBoolean: -0 => false");
+assert.sameValue(sample.getBigInt64(0, 1), -0x100000000000000n, "ToBoolean: Number != 0 => true");
+assert.sameValue(sample.getBigInt64(0, -1), -0x100000000000000n, "ToBoolean: Number != 0 => true");
+assert.sameValue(sample.getBigInt64(0, 0.1), -0x100000000000000n, "ToBoolean: Number != 0 => true");
+assert.sameValue(sample.getBigInt64(0, Infinity), -0x100000000000000n,
+  "ToBoolean: Number != 0 => true");
+assert.sameValue(sample.getBigInt64(0, NaN), 0xffn, "ToBoolean: NaN => false");
+assert.sameValue(sample.getBigInt64(0, undefined), 0xffn, "ToBoolean: undefined => false");
+assert.sameValue(sample.getBigInt64(0, null), 0xffn, "ToBoolean: null => false");
+assert.sameValue(sample.getBigInt64(0, ""), 0xffn, "ToBoolean: String .length == 0 => false");
+assert.sameValue(sample.getBigInt64(0, "string"), -0x100000000000000n,
+  "ToBoolean: String .length > 0 => true");
+assert.sameValue(sample.getBigInt64(0, "false"), -0x100000000000000n,
+  "ToBoolean: String .length > 0 => true");
+assert.sameValue(sample.getBigInt64(0, " "), -0x100000000000000n,
+  "ToBoolean: String .length > 0 => true");
+assert.sameValue(sample.getBigInt64(0, Symbol("1")), -0x100000000000000n,
+  "ToBoolean: Symbol => true");
+assert.sameValue(sample.getBigInt64(0, 0n), 0xffn, "ToBoolean: 0n => false");
+assert.sameValue(sample.getBigInt64(0, 1n), -0x100000000000000n, "ToBoolean: BigInt != 0n => true");
+assert.sameValue(sample.getBigInt64(0, []), -0x100000000000000n, "ToBoolean: any object => true");
+assert.sameValue(sample.getBigInt64(0, {}), -0x100000000000000n, "ToBoolean: any object => true");
+assert.sameValue(sample.getBigInt64(0, Object(false)), -0x100000000000000n,
+  "ToBoolean: any object => true; no ToPrimitive");

--- a/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset-errors.js
+++ b/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset-errors.js
@@ -1,0 +1,107 @@
+// Copyright (C) 2017 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: ToIndex conversions on byteOffset
+esid: sec-dataview.prototype.getbigint64
+info: |
+  DataView.prototype.getBigInt64 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be undefined.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Int64").
+
+  24.3.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  4. Let getIndex be ? ToIndex(requestIndex).
+  ...
+features: [ArrayBuffer, BigInt, DataView, DataView.prototype.setUint8, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+var buffer = new ArrayBuffer(12);
+var sample = new DataView(buffer, 0);
+sample.setUint8(0, 0x27);
+sample.setUint8(1, 0x02);
+sample.setUint8(2, 0x06);
+sample.setUint8(3, 0x02);
+sample.setUint8(4, 0x80);
+sample.setUint8(5, 0x00);
+sample.setUint8(6, 0x80);
+sample.setUint8(7, 0x01);
+sample.setUint8(8, 0x7f);
+sample.setUint8(9, 0x00);
+sample.setUint8(10, 0x01);
+sample.setUint8(11, 0x02);
+
+assert.throws(RangeError, function() {
+  sample.getBigInt64(-1);
+}, "ToIndex: throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  sample.getBigInt64(-2.5);
+}, "ToIndex: throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  sample.getBigInt64("-2.5");
+}, "ToIndex: parse Number => throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  sample.getBigInt64(-Infinity);
+}, "ToIndex: throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  sample.getBigInt64(9007199254740992);
+}, "ToIndex: throw when integerIndex > 2**53-1");
+assert.throws(RangeError, function() {
+  sample.getBigInt64(Infinity);
+}, "ToIndex: throw when integerIndex > 2**53-1");
+assert.throws(TypeError, function() {
+  sample.getBigInt64(0n);
+}, "ToIndex: BigInt => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigInt64(Object(0n));
+}, "ToIndex: unbox object with internal slot => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    [Symbol.toPrimitive]: function() {
+      return 0n;
+    }
+  });
+}, "ToIndex: @@toPrimitive => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    valueOf: function() {
+      return 0n;
+    }
+  });
+}, "ToIndex: valueOf => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    toString: function() {
+      return 0n;
+    }
+  });
+}, "ToIndex: toString => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigInt64(Symbol("1"));
+}, "ToIndex: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigInt64(Object(Symbol("1")));
+}, "ToIndex: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToIndex: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToIndex: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    toString: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToIndex: toString => Symbol => TypeError");

--- a/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset-toprimitive.js
+++ b/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset-toprimitive.js
@@ -1,0 +1,188 @@
+// Copyright (C) 2017 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: ToIndex conversions on byteOffset
+esid: sec-dataview.prototype.getbigint64
+info: |
+  DataView.prototype.getBigInt64 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be undefined.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Int64").
+
+  24.3.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  4. Let getIndex be ? ToIndex(requestIndex).
+  ...
+features: [ArrayBuffer, BigInt, DataView, DataView.prototype.setUint8, Symbol.toPrimitive, computed-property-names]
+---*/
+
+var buffer = new ArrayBuffer(12);
+var sample = new DataView(buffer, 0);
+sample.setUint8(0, 0x27);
+sample.setUint8(1, 0x02);
+sample.setUint8(2, 0x06);
+sample.setUint8(3, 0x02);
+sample.setUint8(4, 0x80);
+sample.setUint8(5, 0x00);
+sample.setUint8(6, 0x80);
+sample.setUint8(7, 0x01);
+sample.setUint8(8, 0x7f);
+sample.setUint8(9, 0x00);
+sample.setUint8(10, 0x01);
+sample.setUint8(11, 0x02);
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(sample.getBigInt64({
+  [Symbol.toPrimitive]: function() {
+    return 1;
+  },
+  valueOf: err,
+  toString: err
+}), 0x20602800080017fn, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(sample.getBigInt64({
+  valueOf: function() {
+    return 1;
+  },
+  toString: err
+}), 0x20602800080017fn, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(sample.getBigInt64({
+  toString: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: toString with no valueOf");
+assert.sameValue(sample.getBigInt64({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(sample.getBigInt64({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(sample.getBigInt64({
+  valueOf: null,
+  toString: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(sample.getBigInt64({
+  valueOf: 1,
+  toString: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(sample.getBigInt64({
+  valueOf: {},
+  toString: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(sample.getBigInt64({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(sample.getBigInt64({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    [Symbol.toPrimitive]: 1
+  });
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    [Symbol.toPrimitive]: {}
+  });
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  });
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  });
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  sample.getBigInt64({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  sample.getBigInt64({
+    valueOf: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  sample.getBigInt64({
+    toString: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    valueOf: null,
+    toString: null
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    valueOf: 1,
+    toString: 1
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    valueOf: {},
+    toString: {}
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  sample.getBigInt64({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset-wrapped-values.js
+++ b/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset-wrapped-values.js
@@ -1,0 +1,133 @@
+// Copyright (C) 2017 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: ToIndex conversions on byteOffset
+esid: sec-dataview.prototype.getbigint64
+info: |
+  DataView.prototype.getBigInt64 ( byteOffset [ , littleEndian ] )
+
+  1. Let v be the this value.
+  2. If littleEndian is not present, let littleEndian be undefined.
+  3. Return ? GetViewValue(v, byteOffset, littleEndian, "Int64").
+
+  24.3.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type )
+
+  ...
+  4. Let getIndex be ? ToIndex(requestIndex).
+  ...
+features: [ArrayBuffer, BigInt, DataView, DataView.prototype.setUint8, Symbol.toPrimitive, computed-property-names]
+---*/
+
+var buffer = new ArrayBuffer(12);
+var sample = new DataView(buffer, 0);
+sample.setUint8(0, 0x27);
+sample.setUint8(1, 0x02);
+sample.setUint8(2, 0x06);
+sample.setUint8(3, 0x02);
+sample.setUint8(4, 0x80);
+sample.setUint8(5, 0x00);
+sample.setUint8(6, 0x80);
+sample.setUint8(7, 0x01);
+sample.setUint8(8, 0x7f);
+sample.setUint8(9, 0x00);
+sample.setUint8(10, 0x01);
+sample.setUint8(11, 0x02);
+
+assert.sameValue(sample.getBigInt64(Object(0)), 0x2702060280008001n,
+  "ToPrimitive: unbox object with internal slot");
+assert.sameValue(sample.getBigInt64({
+  [Symbol.toPrimitive]: function() {
+    return 0;
+  }
+}), 0x2702060280008001n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(sample.getBigInt64({
+  valueOf: function() {
+    return 0;
+  }
+}), 0x2702060280008001n, "ToPrimitive: valueOf");
+assert.sameValue(sample.getBigInt64({
+  toString: function() {
+    return 0;
+  }
+}), 0x2702060280008001n, "ToPrimitive: toString");
+assert.sameValue(sample.getBigInt64(Object(NaN)), 0x2702060280008001n,
+  "ToIndex: unbox object with internal slot => NaN => 0");
+assert.sameValue(sample.getBigInt64({
+  [Symbol.toPrimitive]: function() {
+    return NaN;
+  }
+}), 0x2702060280008001n, "ToIndex: @@toPrimitive => NaN => 0");
+assert.sameValue(sample.getBigInt64({
+  valueOf: function() {
+    return NaN;
+  }
+}), 0x2702060280008001n, "ToIndex: valueOf => NaN => 0");
+assert.sameValue(sample.getBigInt64({
+  toString: function() {
+    return NaN;
+  }
+}), 0x2702060280008001n, "ToIndex: toString => NaN => 0");
+assert.sameValue(sample.getBigInt64({
+  [Symbol.toPrimitive]: function() {
+    return undefined;
+  }
+}), 0x2702060280008001n, "ToIndex: @@toPrimitive => undefined => NaN => 0");
+assert.sameValue(sample.getBigInt64({
+  valueOf: function() {
+    return undefined;
+  }
+}), 0x2702060280008001n, "ToIndex: valueOf => undefined => NaN => 0");
+assert.sameValue(sample.getBigInt64({
+  toString: function() {
+    return undefined;
+  }
+}), 0x2702060280008001n, "ToIndex: toString => undefined => NaN => 0");
+assert.sameValue(sample.getBigInt64({
+  [Symbol.toPrimitive]: function() {
+    return null;
+  }
+}), 0x2702060280008001n, "ToIndex: @@toPrimitive => null => 0");
+assert.sameValue(sample.getBigInt64({
+  valueOf: function() {
+    return null;
+  }
+}), 0x2702060280008001n, "ToIndex: valueOf => null => 0");
+assert.sameValue(sample.getBigInt64({
+  toString: function() {
+    return null;
+  }
+}), 0x2702060280008001n, "ToIndex: toString => null => 0");
+assert.sameValue(sample.getBigInt64(Object(true)), 0x20602800080017fn,
+  "ToIndex: unbox object with internal slot => true => 1");
+assert.sameValue(sample.getBigInt64({
+  [Symbol.toPrimitive]: function() {
+    return true;
+  }
+}), 0x20602800080017fn, "ToIndex: @@toPrimitive => true => 1");
+assert.sameValue(sample.getBigInt64({
+  valueOf: function() {
+    return true;
+  }
+}), 0x20602800080017fn, "ToIndex: valueOf => true => 1");
+assert.sameValue(sample.getBigInt64({
+  toString: function() {
+    return true;
+  }
+}), 0x20602800080017fn, "ToIndex: toString => true => 1");
+assert.sameValue(sample.getBigInt64(Object("1")), 0x20602800080017fn,
+  "ToIndex: unbox object with internal slot => parse Number");
+assert.sameValue(sample.getBigInt64({
+  [Symbol.toPrimitive]: function() {
+    return "1";
+  }
+}), 0x20602800080017fn, "ToIndex: @@toPrimitive => parse Number");
+assert.sameValue(sample.getBigInt64({
+  valueOf: function() {
+    return "1";
+  }
+}), 0x20602800080017fn, "ToIndex: valueOf => parse Number");
+assert.sameValue(sample.getBigInt64({
+  toString: function() {
+    return "1";
+  }
+}), 0x20602800080017fn, "ToIndex: toString => parse Number");

--- a/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset.js
+++ b/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset.js
@@ -1,10 +1,8 @@
 // Copyright (C) 2017 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
+description: ToIndex conversions on byteOffset
 esid: sec-dataview.prototype.getbigint64
-description: >
-  ToIndex conversions on byteOffset
 info: |
   DataView.prototype.getBigInt64 ( byteOffset [ , littleEndian ] )
 
@@ -17,13 +15,11 @@ info: |
   ...
   4. Let getIndex be ? ToIndex(requestIndex).
   ...
-includes: [typeCoercion.js]
-features: [DataView, ArrayBuffer, DataView.prototype.setUint8, BigInt, Symbol, Symbol.toPrimitive]
+features: [ArrayBuffer, BigInt, DataView, DataView.prototype.setUint8]
 ---*/
 
 var buffer = new ArrayBuffer(12);
 var sample = new DataView(buffer, 0);
-
 sample.setUint8(0, 0x27);
 sample.setUint8(1, 0x02);
 sample.setUint8(2, 0x06);
@@ -37,18 +33,38 @@ sample.setUint8(9, 0x00);
 sample.setUint8(10, 0x01);
 sample.setUint8(11, 0x02);
 
-testCoercibleToIndexZero(function (x) {
-  assert.sameValue(sample.getBigInt64(x), 0x2702060280008001n);
-});
-
-testCoercibleToIndexOne(function (x) {
-  assert.sameValue(sample.getBigInt64(x), 0x20602800080017fn);
-});
-
-testCoercibleToIndexFromIndex(2, function (x) {
-  assert.sameValue(sample.getBigInt64(x), 0x602800080017F00n);
-});
-
-testCoercibleToIndexFromIndex(3, function (x) {
-  assert.sameValue(sample.getBigInt64(x), 0x2800080017F0001n);
-});
+assert.sameValue(sample.getBigInt64(0), 0x2702060280008001n);
+assert.sameValue(sample.getBigInt64(1), 0x20602800080017fn);
+assert.sameValue(sample.getBigInt64(-0.9), 0x2702060280008001n, "ToIndex: truncate towards 0");
+assert.sameValue(sample.getBigInt64(0.9), 0x2702060280008001n, "ToIndex: truncate towards 0");
+assert.sameValue(sample.getBigInt64(NaN), 0x2702060280008001n, "ToIndex: NaN => 0");
+assert.sameValue(sample.getBigInt64(undefined), 0x2702060280008001n,
+  "ToIndex: undefined => NaN => 0");
+assert.sameValue(sample.getBigInt64(null), 0x2702060280008001n, "ToIndex: null => 0");
+assert.sameValue(sample.getBigInt64(false), 0x2702060280008001n, "ToIndex: false => 0");
+assert.sameValue(sample.getBigInt64(true), 0x20602800080017fn, "ToIndex: true => 1");
+assert.sameValue(sample.getBigInt64("0"), 0x2702060280008001n, "ToIndex: parse Number");
+assert.sameValue(sample.getBigInt64("1"), 0x20602800080017fn, "ToIndex: parse Number");
+assert.sameValue(sample.getBigInt64(""), 0x2702060280008001n, "ToIndex: parse Number => NaN => 0");
+assert.sameValue(sample.getBigInt64("foo"), 0x2702060280008001n,
+  "ToIndex: parse Number => NaN => 0");
+assert.sameValue(sample.getBigInt64("true"), 0x2702060280008001n,
+  "ToIndex: parse Number => NaN => 0");
+assert.sameValue(sample.getBigInt64(2), 0x602800080017F00n);
+assert.sameValue(sample.getBigInt64("2"), 0x602800080017F00n, "toIndex: parse Number");
+assert.sameValue(sample.getBigInt64(2.9), 0x602800080017F00n, "toIndex: truncate towards 0");
+assert.sameValue(sample.getBigInt64("2.9"), 0x602800080017F00n,
+  "toIndex: parse Number => truncate towards 0");
+assert.sameValue(sample.getBigInt64(3), 0x2800080017F0001n);
+assert.sameValue(sample.getBigInt64("3"), 0x2800080017F0001n, "toIndex: parse Number");
+assert.sameValue(sample.getBigInt64(3.9), 0x2800080017F0001n, "toIndex: truncate towards 0");
+assert.sameValue(sample.getBigInt64("3.9"), 0x2800080017F0001n,
+  "toIndex: parse Number => truncate towards 0");
+assert.sameValue(sample.getBigInt64([0]), 0x2702060280008001n,
+  'ToIndex: [0].toString() => "0" => 0');
+assert.sameValue(sample.getBigInt64(["1"]), 0x20602800080017fn,
+  'ToIndex: ["1"].toString() => "1" => 1');
+assert.sameValue(sample.getBigInt64({}), 0x2702060280008001n,
+  'ToIndex: ({}).toString() => "[object Object]" => NaN => 0');
+assert.sameValue(sample.getBigInt64([]), 0x2702060280008001n,
+  'ToIndex: [].toString() => "" => NaN => 0');

--- a/test/built-ins/DataView/prototype/getBigUint64/to-boolean-littleendian.js
+++ b/test/built-ins/DataView/prototype/getBigUint64/to-boolean-littleendian.js
@@ -1,26 +1,40 @@
 // Copyright (C) 2017 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
+description: Boolean littleEndian argument coerced in ToBoolean
 esid: sec-dataview.prototype.getbiguint64
-description: >
-  Boolean littleEndian argument coerced in ToBoolean
-includes: [typeCoercion.js]
-features: [DataView, ArrayBuffer, DataView.prototype.setUint8, BigInt, Symbol, Symbol.toPrimitive]
+features: [ArrayBuffer, BigInt, DataView, DataView.prototype.setUint8, Symbol]
 ---*/
 
 var buffer = new ArrayBuffer(8);
 var sample = new DataView(buffer, 0);
-
 sample.setUint8(7, 0xff);
-
-// False
 assert.sameValue(sample.getBigUint64(0), 0xffn, "no argument");
-testCoercibleToBooleanFalse(function (x) {
-  assert.sameValue(sample.getBigUint64(0, x), 0xffn);
-});
 
-// True
-testCoercibleToBooleanTrue(function (x) {
-  assert.sameValue(sample.getBigUint64(0, x), 0xff00000000000000n);
-});
+assert.sameValue(sample.getBigUint64(0, false), 0xffn);
+assert.sameValue(sample.getBigUint64(0, true), 0xff00000000000000n);
+assert.sameValue(sample.getBigUint64(0, 0), 0xffn, "ToBoolean: 0 => false");
+assert.sameValue(sample.getBigUint64(0, -0), 0xffn, "ToBoolean: -0 => false");
+assert.sameValue(sample.getBigUint64(0, 1), 0xff00000000000000n, "ToBoolean: Number != 0 => true");
+assert.sameValue(sample.getBigUint64(0, -1), 0xff00000000000000n, "ToBoolean: Number != 0 => true");
+assert.sameValue(sample.getBigUint64(0, 0.1), 0xff00000000000000n, "ToBoolean: Number != 0 => true");
+assert.sameValue(sample.getBigUint64(0, Infinity), 0xff00000000000000n,
+  "ToBoolean: Number != 0 => true");
+assert.sameValue(sample.getBigUint64(0, NaN), 0xffn, "ToBoolean: NaN => false");
+assert.sameValue(sample.getBigUint64(0, undefined), 0xffn, "ToBoolean: undefined => false");
+assert.sameValue(sample.getBigUint64(0, null), 0xffn, "ToBoolean: null => false");
+assert.sameValue(sample.getBigUint64(0, ""), 0xffn, "ToBoolean: String .length == 0 => false");
+assert.sameValue(sample.getBigUint64(0, "string"), 0xff00000000000000n,
+  "ToBoolean: String .length > 0 => true");
+assert.sameValue(sample.getBigUint64(0, "false"), 0xff00000000000000n,
+  "ToBoolean: String .length > 0 => true");
+assert.sameValue(sample.getBigUint64(0, " "), 0xff00000000000000n,
+  "ToBoolean: String .length > 0 => true");
+assert.sameValue(sample.getBigUint64(0, Symbol("1")), 0xff00000000000000n,
+  "ToBoolean: Symbol => true");
+assert.sameValue(sample.getBigUint64(0, 0n), 0xffn, "ToBoolean: 0n => false");
+assert.sameValue(sample.getBigUint64(0, 1n), 0xff00000000000000n, "ToBoolean: BigInt != 0n => true");
+assert.sameValue(sample.getBigUint64(0, []), 0xff00000000000000n, "ToBoolean: any object => true");
+assert.sameValue(sample.getBigUint64(0, {}), 0xff00000000000000n, "ToBoolean: any object => true");
+assert.sameValue(sample.getBigUint64(0, Object(false)), 0xff00000000000000n,
+  "ToBoolean: any object => true; no ToPrimitive");

--- a/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset-errors.js
+++ b/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset-errors.js
@@ -1,0 +1,95 @@
+// Copyright (C) 2017 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: ToIndex conversions on byteOffset
+esid: sec-dataview.prototype.getbiguint64
+features: [ArrayBuffer, BigInt, DataView, DataView.prototype.setUint8, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+var buffer = new ArrayBuffer(12);
+var sample = new DataView(buffer, 0);
+sample.setUint8(0, 0x27);
+sample.setUint8(1, 0x02);
+sample.setUint8(2, 0x06);
+sample.setUint8(3, 0x02);
+sample.setUint8(4, 0x80);
+sample.setUint8(5, 0x00);
+sample.setUint8(6, 0x80);
+sample.setUint8(7, 0x01);
+sample.setUint8(8, 0x7f);
+sample.setUint8(9, 0x00);
+sample.setUint8(10, 0x01);
+sample.setUint8(11, 0x02);
+
+assert.throws(RangeError, function() {
+  sample.getBigUint64(-1);
+}, "ToIndex: throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  sample.getBigUint64(-2.5);
+}, "ToIndex: throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  sample.getBigUint64("-2.5");
+}, "ToIndex: parse Number => throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  sample.getBigUint64(-Infinity);
+}, "ToIndex: throw when integerIndex < 0");
+assert.throws(RangeError, function() {
+  sample.getBigUint64(9007199254740992);
+}, "ToIndex: throw when integerIndex > 2**53-1");
+assert.throws(RangeError, function() {
+  sample.getBigUint64(Infinity);
+}, "ToIndex: throw when integerIndex > 2**53-1");
+assert.throws(TypeError, function() {
+  sample.getBigUint64(0n);
+}, "ToIndex: BigInt => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigUint64(Object(0n));
+}, "ToIndex: unbox object with internal slot => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    [Symbol.toPrimitive]: function() {
+      return 0n;
+    }
+  });
+}, "ToIndex: @@toPrimitive => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    valueOf: function() {
+      return 0n;
+    }
+  });
+}, "ToIndex: valueOf => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    toString: function() {
+      return 0n;
+    }
+  });
+}, "ToIndex: toString => BigInt => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigUint64(Symbol("1"));
+}, "ToIndex: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigUint64(Object(Symbol("1")));
+}, "ToIndex: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToIndex: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToIndex: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    toString: function() {
+      return Symbol("1");
+    }
+  });
+}, "ToIndex: toString => Symbol => TypeError");

--- a/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset-toprimitive.js
+++ b/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset-toprimitive.js
@@ -1,0 +1,176 @@
+// Copyright (C) 2017 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: ToIndex conversions on byteOffset
+esid: sec-dataview.prototype.getbiguint64
+features: [ArrayBuffer, BigInt, DataView, DataView.prototype.setUint8, Symbol.toPrimitive, computed-property-names]
+---*/
+
+var buffer = new ArrayBuffer(12);
+var sample = new DataView(buffer, 0);
+sample.setUint8(0, 0x27);
+sample.setUint8(1, 0x02);
+sample.setUint8(2, 0x06);
+sample.setUint8(3, 0x02);
+sample.setUint8(4, 0x80);
+sample.setUint8(5, 0x00);
+sample.setUint8(6, 0x80);
+sample.setUint8(7, 0x01);
+sample.setUint8(8, 0x7f);
+sample.setUint8(9, 0x00);
+sample.setUint8(10, 0x01);
+sample.setUint8(11, 0x02);
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(sample.getBigUint64({
+  [Symbol.toPrimitive]: function() {
+    return 1;
+  },
+  valueOf: err,
+  toString: err
+}), 0x20602800080017fn, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(sample.getBigUint64({
+  valueOf: function() {
+    return 1;
+  },
+  toString: err
+}), 0x20602800080017fn, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(sample.getBigUint64({
+  toString: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: toString with no valueOf");
+assert.sameValue(sample.getBigUint64({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(sample.getBigUint64({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(sample.getBigUint64({
+  valueOf: null,
+  toString: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(sample.getBigUint64({
+  valueOf: 1,
+  toString: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(sample.getBigUint64({
+  valueOf: {},
+  toString: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(sample.getBigUint64({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(sample.getBigUint64({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 1;
+  }
+}), 0x20602800080017fn, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    [Symbol.toPrimitive]: 1
+  });
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    [Symbol.toPrimitive]: {}
+  });
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  });
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  });
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  sample.getBigUint64({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  sample.getBigUint64({
+    valueOf: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  sample.getBigUint64({
+    toString: function() {
+      throw new MyError();
+    }
+  });
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    valueOf: null,
+    toString: null
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    valueOf: 1,
+    toString: 1
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    valueOf: {},
+    toString: {}
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  sample.getBigUint64({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  });
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset-wrapped-values.js
+++ b/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset-wrapped-values.js
@@ -1,0 +1,121 @@
+// Copyright (C) 2017 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: ToIndex conversions on byteOffset
+esid: sec-dataview.prototype.getbiguint64
+features: [ArrayBuffer, BigInt, DataView, DataView.prototype.setUint8, Symbol.toPrimitive, computed-property-names]
+---*/
+
+var buffer = new ArrayBuffer(12);
+var sample = new DataView(buffer, 0);
+sample.setUint8(0, 0x27);
+sample.setUint8(1, 0x02);
+sample.setUint8(2, 0x06);
+sample.setUint8(3, 0x02);
+sample.setUint8(4, 0x80);
+sample.setUint8(5, 0x00);
+sample.setUint8(6, 0x80);
+sample.setUint8(7, 0x01);
+sample.setUint8(8, 0x7f);
+sample.setUint8(9, 0x00);
+sample.setUint8(10, 0x01);
+sample.setUint8(11, 0x02);
+
+assert.sameValue(sample.getBigUint64(Object(0)), 0x2702060280008001n,
+  "ToPrimitive: unbox object with internal slot");
+assert.sameValue(sample.getBigUint64({
+  [Symbol.toPrimitive]: function() {
+    return 0;
+  }
+}), 0x2702060280008001n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(sample.getBigUint64({
+  valueOf: function() {
+    return 0;
+  }
+}), 0x2702060280008001n, "ToPrimitive: valueOf");
+assert.sameValue(sample.getBigUint64({
+  toString: function() {
+    return 0;
+  }
+}), 0x2702060280008001n, "ToPrimitive: toString");
+assert.sameValue(sample.getBigUint64(Object(NaN)), 0x2702060280008001n,
+  "ToIndex: unbox object with internal slot => NaN => 0");
+assert.sameValue(sample.getBigUint64({
+  [Symbol.toPrimitive]: function() {
+    return NaN;
+  }
+}), 0x2702060280008001n, "ToIndex: @@toPrimitive => NaN => 0");
+assert.sameValue(sample.getBigUint64({
+  valueOf: function() {
+    return NaN;
+  }
+}), 0x2702060280008001n, "ToIndex: valueOf => NaN => 0");
+assert.sameValue(sample.getBigUint64({
+  toString: function() {
+    return NaN;
+  }
+}), 0x2702060280008001n, "ToIndex: toString => NaN => 0");
+assert.sameValue(sample.getBigUint64({
+  [Symbol.toPrimitive]: function() {
+    return undefined;
+  }
+}), 0x2702060280008001n, "ToIndex: @@toPrimitive => undefined => NaN => 0");
+assert.sameValue(sample.getBigUint64({
+  valueOf: function() {
+    return undefined;
+  }
+}), 0x2702060280008001n, "ToIndex: valueOf => undefined => NaN => 0");
+assert.sameValue(sample.getBigUint64({
+  toString: function() {
+    return undefined;
+  }
+}), 0x2702060280008001n, "ToIndex: toString => undefined => NaN => 0");
+assert.sameValue(sample.getBigUint64({
+  [Symbol.toPrimitive]: function() {
+    return null;
+  }
+}), 0x2702060280008001n, "ToIndex: @@toPrimitive => null => 0");
+assert.sameValue(sample.getBigUint64({
+  valueOf: function() {
+    return null;
+  }
+}), 0x2702060280008001n, "ToIndex: valueOf => null => 0");
+assert.sameValue(sample.getBigUint64({
+  toString: function() {
+    return null;
+  }
+}), 0x2702060280008001n, "ToIndex: toString => null => 0");
+assert.sameValue(sample.getBigUint64(Object(true)), 0x20602800080017fn,
+  "ToIndex: unbox object with internal slot => true => 1");
+assert.sameValue(sample.getBigUint64({
+  [Symbol.toPrimitive]: function() {
+    return true;
+  }
+}), 0x20602800080017fn, "ToIndex: @@toPrimitive => true => 1");
+assert.sameValue(sample.getBigUint64({
+  valueOf: function() {
+    return true;
+  }
+}), 0x20602800080017fn, "ToIndex: valueOf => true => 1");
+assert.sameValue(sample.getBigUint64({
+  toString: function() {
+    return true;
+  }
+}), 0x20602800080017fn, "ToIndex: toString => true => 1");
+assert.sameValue(sample.getBigUint64(Object("1")), 0x20602800080017fn,
+  "ToIndex: unbox object with internal slot => parse Number");
+assert.sameValue(sample.getBigUint64({
+  [Symbol.toPrimitive]: function() {
+    return "1";
+  }
+}), 0x20602800080017fn, "ToIndex: @@toPrimitive => parse Number");
+assert.sameValue(sample.getBigUint64({
+  valueOf: function() {
+    return "1";
+  }
+}), 0x20602800080017fn, "ToIndex: valueOf => parse Number");
+assert.sameValue(sample.getBigUint64({
+  toString: function() {
+    return "1";
+  }
+}), 0x20602800080017fn, "ToIndex: toString => parse Number");

--- a/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset.js
+++ b/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset.js
@@ -1,17 +1,13 @@
 // Copyright (C) 2017 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
+description: ToIndex conversions on byteOffset
 esid: sec-dataview.prototype.getbiguint64
-description: >
-  ToIndex conversions on byteOffset
-includes: [typeCoercion.js]
-features: [DataView, ArrayBuffer, DataView.prototype.setUint8, BigInt, Symbol, Symbol.toPrimitive]
+features: [ArrayBuffer, BigInt, DataView, DataView.prototype.setUint8]
 ---*/
 
 var buffer = new ArrayBuffer(12);
 var sample = new DataView(buffer, 0);
-
 sample.setUint8(0, 0x27);
 sample.setUint8(1, 0x02);
 sample.setUint8(2, 0x06);
@@ -25,18 +21,38 @@ sample.setUint8(9, 0x00);
 sample.setUint8(10, 0x01);
 sample.setUint8(11, 0x02);
 
-testCoercibleToIndexZero(function (x) {
-  assert.sameValue(sample.getBigUint64(x), 0x2702060280008001n);
-});
-
-testCoercibleToIndexOne(function (x) {
-  assert.sameValue(sample.getBigUint64(x), 0x20602800080017fn);
-});
-
-testCoercibleToIndexFromIndex(2, function (x) {
-  assert.sameValue(sample.getBigUint64(x), 0x602800080017F00n);
-});
-
-testCoercibleToIndexFromIndex(3, function (x) {
-  assert.sameValue(sample.getBigUint64(x), 0x2800080017F0001n);
-});
+assert.sameValue(sample.getBigUint64(0), 0x2702060280008001n);
+assert.sameValue(sample.getBigUint64(1), 0x20602800080017fn);
+assert.sameValue(sample.getBigUint64(-0.9), 0x2702060280008001n, "ToIndex: truncate towards 0");
+assert.sameValue(sample.getBigUint64(0.9), 0x2702060280008001n, "ToIndex: truncate towards 0");
+assert.sameValue(sample.getBigUint64(NaN), 0x2702060280008001n, "ToIndex: NaN => 0");
+assert.sameValue(sample.getBigUint64(undefined), 0x2702060280008001n,
+  "ToIndex: undefined => NaN => 0");
+assert.sameValue(sample.getBigUint64(null), 0x2702060280008001n, "ToIndex: null => 0");
+assert.sameValue(sample.getBigUint64(false), 0x2702060280008001n, "ToIndex: false => 0");
+assert.sameValue(sample.getBigUint64(true), 0x20602800080017fn, "ToIndex: true => 1");
+assert.sameValue(sample.getBigUint64("0"), 0x2702060280008001n, "ToIndex: parse Number");
+assert.sameValue(sample.getBigUint64("1"), 0x20602800080017fn, "ToIndex: parse Number");
+assert.sameValue(sample.getBigUint64(""), 0x2702060280008001n, "ToIndex: parse Number => NaN => 0");
+assert.sameValue(sample.getBigUint64("foo"), 0x2702060280008001n,
+  "ToIndex: parse Number => NaN => 0");
+assert.sameValue(sample.getBigUint64("true"), 0x2702060280008001n,
+  "ToIndex: parse Number => NaN => 0");
+assert.sameValue(sample.getBigUint64(2), 0x602800080017F00n);
+assert.sameValue(sample.getBigUint64("2"), 0x602800080017F00n, "toIndex: parse Number");
+assert.sameValue(sample.getBigUint64(2.9), 0x602800080017F00n, "toIndex: truncate towards 0");
+assert.sameValue(sample.getBigUint64("2.9"), 0x602800080017F00n,
+  "toIndex: parse Number => truncate towards 0");
+assert.sameValue(sample.getBigUint64(3), 0x2800080017F0001n);
+assert.sameValue(sample.getBigUint64("3"), 0x2800080017F0001n, "toIndex: parse Number");
+assert.sameValue(sample.getBigUint64(3.9), 0x2800080017F0001n, "toIndex: truncate towards 0");
+assert.sameValue(sample.getBigUint64("3.9"), 0x2800080017F0001n,
+  "toIndex: parse Number => truncate towards 0");
+assert.sameValue(sample.getBigUint64([0]), 0x2702060280008001n,
+  'ToIndex: [0].toString() => "0" => 0');
+assert.sameValue(sample.getBigUint64(["1"]), 0x20602800080017fn,
+  'ToIndex: ["1"].toString() => "1" => 1');
+assert.sameValue(sample.getBigUint64({}), 0x2702060280008001n,
+  'ToIndex: ({}).toString() => "[object Object]" => NaN => 0');
+assert.sameValue(sample.getBigUint64([]), 0x2702060280008001n,
+  'ToIndex: [].toString() => "" => NaN => 0');


### PR DESCRIPTION
This is the remainder of the uses of `harness/typeCoercion.js`. That file can be removed in a follow up PR.

(This is an iteration on the proposal in #1341 which does not include the generator code. For that, see https://github.com/thejoshwolfe/test262-generators .)

*I do not have access to an implementation of the apis that are being tested in this PR. I would appreciate if someone could run these to make sure I didn't make any typos.*

(This code was formatted with `js-beautify -n -w 100 -s 2` (after [patching](https://github.com/beautify-web/js-beautify/pull/1303) it to support BigInt literal notation).)