### PR TITLE
Add more tests for ToNumber conversion of invalid StringNumericLiterals

### DIFF
--- a/test/built-ins/Number/string-binary-literal-invalid.js
+++ b/test/built-ins/Number/string-binary-literal-invalid.js
@@ -18,3 +18,9 @@ info: >
 assert.sameValue(Number('0b2'), NaN, 'invalid digit');
 assert.sameValue(Number('00b0'), NaN, 'leading zero');
 assert.sameValue(Number('0b'), NaN, 'omitted digits');
+assert.sameValue(Number('+0b1'), NaN, 'plus sign');
+assert.sameValue(Number('-0b1'), NaN, 'minus sign');
+assert.sameValue(Number('0b1.01'), NaN, 'fractional part');
+assert.sameValue(Number('0b1e10'), NaN, 'exponent part');
+assert.sameValue(Number('0b1e-10'), NaN, 'exponent part with a minus sign');
+assert.sameValue(Number('0b1e+10'), NaN, 'exponent part with a plus sign');

--- a/test/built-ins/Number/string-hex-literal-invalid.js
+++ b/test/built-ins/Number/string-hex-literal-invalid.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2017 Ivan Vyshnevskyi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-number-constructor-number-value
+description: Invalid hex literals yield NaN
+info: >
+    HexIntegerLiteral ::
+      0x HexDigits
+      0X HexDigits
+    HexDigits ::
+      HexDigit
+      HexDigits HexDigit
+    HexDigit :: one of
+      0 1 2 3 4 5 6 7 8 9 a b c d e f A B C D E F
+---*/
+
+assert.sameValue(Number('0xG'), NaN, 'invalid digit');
+assert.sameValue(Number('00x0'), NaN, 'leading zero');
+assert.sameValue(Number('0x'), NaN, 'omitted digits');
+assert.sameValue(Number('+0x10'), NaN, 'plus sign');
+assert.sameValue(Number('-0x10'), NaN, 'minus sign');
+assert.sameValue(Number('0x10.01'), NaN, 'fractional part');
+assert.sameValue(Number('0x1e-10'), NaN, 'exponent part with a minus sign');
+assert.sameValue(Number('0x1e+10'), NaN, 'exponent part with a plus sign');

--- a/test/built-ins/Number/string-octal-literal-invald.js
+++ b/test/built-ins/Number/string-octal-literal-invald.js
@@ -18,3 +18,9 @@ info: >
 assert.sameValue(Number('0o8'), NaN, 'invalid digit');
 assert.sameValue(Number('00o0'), NaN, 'leading zero');
 assert.sameValue(Number('0o'), NaN, 'omitted digits');
+assert.sameValue(Number('+0o10'), NaN, 'plus sign');
+assert.sameValue(Number('-0o10'), NaN, 'minus sign');
+assert.sameValue(Number('0o10.01'), NaN, 'fractional part');
+assert.sameValue(Number('0o1e10'), NaN, 'exponent part');
+assert.sameValue(Number('0o1e-10'), NaN, 'exponent part with a minus sign');
+assert.sameValue(Number('0o1e+10'), NaN, 'exponent part with a plus sign');


### PR DESCRIPTION
As far as I understand grammar in the [“ToNumber Applied to the String Type,”](https://tc39.github.io/ecma262/#sec-tonumber-applied-to-the-string-type) only StrDecimalLiteral may have a sign, fractional or exponent parts. Yet I couldn't find tests for BinaryIntegerLiteral, OctalIntegerLiteral, and HexIntegerLiteral that are invalid in this way, so decided to add them.

These checks apply (more or less) to anything that uses ToNumber, but it seems that the Number constructor is a place for most ToNumber tests, so I simply followed that. Also, for the same reason, I've used `esid` of [`Number(value)`](https://tc39.github.io/ecma262/#sec-number-constructor-number-value).

Note that because `0x1e10` is a valid HexIntegerLiteral there's no test for the unsigned exponent in hex literals.

I don't know if it's ok to put my name in the license of the new file, since it's basically an edited copy of `string-binary-literal-invalid.js`, but leaving "V8 project authors” there felt a bit weird. I'd be happy to replace it back if this decision was wrong/unfair.