### PR TITLE
Add es[56]?id checks

### DIFF
--- a/tools/lint/lib/checks/esid.py
+++ b/tools/lint/lib/checks/esid.py
@@ -1,0 +1,31 @@
+from ..check import Check
+import re
+
+class CheckEsid(Check):
+    '''Ensure tests specify only valid `es6id's'''
+    ID = 'ESID'
+
+    def __init__(self):
+        #self.es5idRegex = re.compile(r"^S?(B|\d+)(\.\d+)+(-(\d+|[a-z]|i+))*(_A\d(\.\d+)?(_T\d(\.\d+)?)?)?$")
+        self.es6idRegex = re.compile(r"^(S?(B|\d+)(\.\d+)+(((_A\d\.\d)?_T?\d)|[ _]S\d+(\.[a-z])*)?(, |$))+")
+        self.esidRegex = re.compile(r"^(pending|(prod|sec)-[-_A-Za-z0-9.%@]+)$")
+
+    def run(self, name, meta, source):
+        if not meta:
+            return
+
+        # es5ids are a mess
+        #if 'es5id' in meta:
+        #  es5id = str(meta['es5id'])
+        #  if self.es5idRegex.match(es5id) == None:
+        #      return 'The `es5id` tag has the wrong format: %s' % es5id
+
+        if 'es6id' in meta:
+          es6id = str(meta['es6id'])
+          if self.es6idRegex.match(es6id) == None:
+              return 'The `es6id` tag has the wrong format: %s' % es6id
+
+        if 'esid' in meta:
+          esid = str(meta['esid'])
+          if self.esidRegex.match(esid) == None:
+              return 'The `esid` tag has the wrong format: %s' % esid

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -23,6 +23,7 @@ except ImportError:
 
 
 from lib.collect_files import collect_files
+from lib.checks.esid import CheckEsid
 from lib.checks.features import CheckFeatures
 from lib.checks.frontmatter import CheckFrontmatter
 from lib.checks.harnessfeatures import CheckHarnessFeatures
@@ -41,6 +42,7 @@ parser.add_argument('path',
         help='file name or directory of files to lint')
 
 checks = [
+        CheckEsid(),
         CheckFrontmatter(),
         CheckFeatures('features.txt'),
         CheckHarnessFeatures(),


### PR DESCRIPTION
I can try to fix the malformed ids if these regular expressions seem agreeable. `es5id` is more complicated.