### PR TITLE
Infix operator ToNumeric coercion tests for BigInt operands

### DIFF
--- a/test/language/expressions/addition/bigint-errors.js
+++ b/test/language/expressions/addition/bigint-errors.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: addition operator ToNumeric with BigInt operands
+esid: sec-addition-operator-plus-runtime-semantics-evaluation
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  Symbol("1") + 0n;
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n + Symbol("1");
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  Object(Symbol("1")) + 0n;
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n + Object(Symbol("1"));
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  }) + 0n;
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n + {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  }) + 0n;
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n + {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    toString: function() {
+      return Symbol("1");
+    }
+  }) + 0n;
+}, "ToBigInt: toString => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n + {
+    toString: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: toString => Symbol => TypeError");

--- a/test/language/expressions/addition/bigint-toprimitive.js
+++ b/test/language/expressions/addition/bigint-toprimitive.js
@@ -1,0 +1,308 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: addition operator ToNumeric with BigInt operands
+esid: sec-addition-operator-plus-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}) + 1n, 3n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(1n + {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}, 3n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}) + 1n, 3n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(1n + {
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}, 3n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) + 1n, 3n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(1n + {
+  toString: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}) + 1n, 3n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(1n + {
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}) + 1n, 3n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(1n + {
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(({
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}) + 1n, 3n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(1n + {
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}) + 1n, 3n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(1n + {
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}) + 1n, 3n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(1n + {
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}) + 1n, 3n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(1n + {
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}) + 1n, 3n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(1n + {
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: 1
+  }) + 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n + {
+    [Symbol.toPrimitive]: 1
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: {}
+  }) + 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n + {
+    [Symbol.toPrimitive]: {}
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  }) + 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n + {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  }) + 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n + {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  }) + 0n;
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  0n + {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  ({
+    valueOf: function() {
+      throw new MyError();
+    }
+  }) + 0n;
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  0n + {
+    valueOf: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  ({
+    toString: function() {
+      throw new MyError();
+    }
+  }) + 0n;
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(MyError, function() {
+  0n + {
+    toString: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: null,
+    toString: null
+  }) + 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n + {
+    valueOf: null,
+    toString: null
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: 1,
+    toString: 1
+  }) + 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n + {
+    valueOf: 1,
+    toString: 1
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: {},
+    toString: {}
+  }) + 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n + {
+    valueOf: {},
+    toString: {}
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  }) + 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n + {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  }) + 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n + {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/language/expressions/addition/bigint-wrapped-values.js
+++ b/test/language/expressions/addition/bigint-wrapped-values.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: addition operator ToNumeric with BigInt operands
+esid: sec-addition-operator-plus-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(Object(2n) + 1n, 3n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(1n + Object(2n), 3n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}) + 1n, 3n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(1n + {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  }
+}) + 1n, 3n, "ToPrimitive: valueOf");
+assert.sameValue(1n + {
+  valueOf: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: valueOf");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) + 1n, 3n, "ToPrimitive: toString");
+assert.sameValue(1n + {
+  toString: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: toString");

--- a/test/language/expressions/bitwise-and/bigint-errors.js
+++ b/test/language/expressions/bitwise-and/bigint-errors.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: bitwise-and operator ToNumeric with BigInt operands
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  Symbol("1") & 0n;
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n & Symbol("1");
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  Object(Symbol("1")) & 0n;
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n & Object(Symbol("1"));
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  }) & 0n;
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n & {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  }) & 0n;
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n & {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    toString: function() {
+      return Symbol("1");
+    }
+  }) & 0n;
+}, "ToBigInt: toString => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n & {
+    toString: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: toString => Symbol => TypeError");

--- a/test/language/expressions/bitwise-and/bigint-toprimitive.js
+++ b/test/language/expressions/bitwise-and/bigint-toprimitive.js
@@ -1,0 +1,308 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: bitwise-and operator ToNumeric with BigInt operands
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}) & 3n, 2n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(3n & {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}, 2n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}) & 3n, 2n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(3n & {
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}, 2n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) & 3n, 2n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(3n & {
+  toString: function() {
+    return 2n;
+  }
+}, 2n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}) & 3n, 2n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(3n & {
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}, 2n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}) & 3n, 2n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(3n & {
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}, 2n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(({
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}) & 3n, 2n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(3n & {
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}, 2n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}) & 3n, 2n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(3n & {
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}, 2n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}) & 3n, 2n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(3n & {
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}, 2n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}) & 3n, 2n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(3n & {
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 2n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}) & 3n, 2n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(3n & {
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 2n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: 1
+  }) & 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n & {
+    [Symbol.toPrimitive]: 1
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: {}
+  }) & 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n & {
+    [Symbol.toPrimitive]: {}
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  }) & 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n & {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  }) & 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n & {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  }) & 0n;
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  0n & {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  ({
+    valueOf: function() {
+      throw new MyError();
+    }
+  }) & 0n;
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  0n & {
+    valueOf: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  ({
+    toString: function() {
+      throw new MyError();
+    }
+  }) & 0n;
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(MyError, function() {
+  0n & {
+    toString: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: null,
+    toString: null
+  }) & 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n & {
+    valueOf: null,
+    toString: null
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: 1,
+    toString: 1
+  }) & 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n & {
+    valueOf: 1,
+    toString: 1
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: {},
+    toString: {}
+  }) & 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n & {
+    valueOf: {},
+    toString: {}
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  }) & 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n & {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  }) & 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n & {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/language/expressions/bitwise-and/bigint-wrapped-values.js
+++ b/test/language/expressions/bitwise-and/bigint-wrapped-values.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: bitwise-and operator ToNumeric with BigInt operands
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(Object(2n) & 3n, 2n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(3n & Object(2n), 2n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}) & 3n, 2n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(3n & {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}, 2n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  }
+}) & 3n, 2n, "ToPrimitive: valueOf");
+assert.sameValue(3n & {
+  valueOf: function() {
+    return 2n;
+  }
+}, 2n, "ToPrimitive: valueOf");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) & 3n, 2n, "ToPrimitive: toString");
+assert.sameValue(3n & {
+  toString: function() {
+    return 2n;
+  }
+}, 2n, "ToPrimitive: toString");

--- a/test/language/expressions/bitwise-or/bigint-errors.js
+++ b/test/language/expressions/bitwise-or/bigint-errors.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: bitwise-or operator ToNumeric with BigInt operands
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  Symbol("1") | 0n;
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n | Symbol("1");
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  Object(Symbol("1")) | 0n;
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n | Object(Symbol("1"));
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  }) | 0n;
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n | {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  }) | 0n;
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n | {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    toString: function() {
+      return Symbol("1");
+    }
+  }) | 0n;
+}, "ToBigInt: toString => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n | {
+    toString: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: toString => Symbol => TypeError");

--- a/test/language/expressions/bitwise-or/bigint-toprimitive.js
+++ b/test/language/expressions/bitwise-or/bigint-toprimitive.js
@@ -1,0 +1,308 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: bitwise-or operator ToNumeric with BigInt operands
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}) | 1n, 3n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(1n | {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}, 3n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}) | 1n, 3n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(1n | {
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}, 3n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) | 1n, 3n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(1n | {
+  toString: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}) | 1n, 3n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(1n | {
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}) | 1n, 3n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(1n | {
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(({
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}) | 1n, 3n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(1n | {
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}) | 1n, 3n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(1n | {
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}) | 1n, 3n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(1n | {
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}) | 1n, 3n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(1n | {
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}) | 1n, 3n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(1n | {
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: 1
+  }) | 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n | {
+    [Symbol.toPrimitive]: 1
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: {}
+  }) | 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n | {
+    [Symbol.toPrimitive]: {}
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  }) | 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n | {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  }) | 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n | {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  }) | 0n;
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  0n | {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  ({
+    valueOf: function() {
+      throw new MyError();
+    }
+  }) | 0n;
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  0n | {
+    valueOf: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  ({
+    toString: function() {
+      throw new MyError();
+    }
+  }) | 0n;
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(MyError, function() {
+  0n | {
+    toString: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: null,
+    toString: null
+  }) | 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n | {
+    valueOf: null,
+    toString: null
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: 1,
+    toString: 1
+  }) | 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n | {
+    valueOf: 1,
+    toString: 1
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: {},
+    toString: {}
+  }) | 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n | {
+    valueOf: {},
+    toString: {}
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  }) | 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n | {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  }) | 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n | {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/language/expressions/bitwise-or/bigint-wrapped-values.js
+++ b/test/language/expressions/bitwise-or/bigint-wrapped-values.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: bitwise-or operator ToNumeric with BigInt operands
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(Object(2n) | 1n, 3n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(1n | Object(2n), 3n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}) | 1n, 3n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(1n | {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  }
+}) | 1n, 3n, "ToPrimitive: valueOf");
+assert.sameValue(1n | {
+  valueOf: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: valueOf");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) | 1n, 3n, "ToPrimitive: toString");
+assert.sameValue(1n | {
+  toString: function() {
+    return 2n;
+  }
+}, 3n, "ToPrimitive: toString");

--- a/test/language/expressions/bitwise-xor/bigint-errors.js
+++ b/test/language/expressions/bitwise-xor/bigint-errors.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: bitwise-xor operator ToNumeric with BigInt operands
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  Symbol("1") ^ 0n;
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n ^ Symbol("1");
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  Object(Symbol("1")) ^ 0n;
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n ^ Object(Symbol("1"));
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  }) ^ 0n;
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n ^ {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  }) ^ 0n;
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n ^ {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    toString: function() {
+      return Symbol("1");
+    }
+  }) ^ 0n;
+}, "ToBigInt: toString => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n ^ {
+    toString: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: toString => Symbol => TypeError");

--- a/test/language/expressions/bitwise-xor/bigint-toprimitive.js
+++ b/test/language/expressions/bitwise-xor/bigint-toprimitive.js
@@ -1,0 +1,308 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: bitwise-xor operator ToNumeric with BigInt operands
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}) ^ 3n, 1n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(3n ^ {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}, 1n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}) ^ 3n, 1n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(3n ^ {
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}, 1n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) ^ 3n, 1n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(3n ^ {
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}) ^ 3n, 1n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(3n ^ {
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}) ^ 3n, 1n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(3n ^ {
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(({
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}) ^ 3n, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(3n ^ {
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}) ^ 3n, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(3n ^ {
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}) ^ 3n, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(3n ^ {
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}) ^ 3n, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(3n ^ {
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}) ^ 3n, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(3n ^ {
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: 1
+  }) ^ 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n ^ {
+    [Symbol.toPrimitive]: 1
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: {}
+  }) ^ 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n ^ {
+    [Symbol.toPrimitive]: {}
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  }) ^ 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n ^ {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  }) ^ 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n ^ {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  }) ^ 0n;
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  0n ^ {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  ({
+    valueOf: function() {
+      throw new MyError();
+    }
+  }) ^ 0n;
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  0n ^ {
+    valueOf: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  ({
+    toString: function() {
+      throw new MyError();
+    }
+  }) ^ 0n;
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(MyError, function() {
+  0n ^ {
+    toString: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: null,
+    toString: null
+  }) ^ 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n ^ {
+    valueOf: null,
+    toString: null
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: 1,
+    toString: 1
+  }) ^ 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n ^ {
+    valueOf: 1,
+    toString: 1
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: {},
+    toString: {}
+  }) ^ 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n ^ {
+    valueOf: {},
+    toString: {}
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  }) ^ 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n ^ {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  }) ^ 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n ^ {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/language/expressions/bitwise-xor/bigint-wrapped-values.js
+++ b/test/language/expressions/bitwise-xor/bigint-wrapped-values.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: bitwise-xor operator ToNumeric with BigInt operands
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(Object(2n) ^ 3n, 1n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(3n ^ Object(2n), 1n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}) ^ 3n, 1n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(3n ^ {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  }
+}) ^ 3n, 1n, "ToPrimitive: valueOf");
+assert.sameValue(3n ^ {
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: valueOf");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) ^ 3n, 1n, "ToPrimitive: toString");
+assert.sameValue(3n ^ {
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: toString");

--- a/test/language/expressions/division/bigint-errors.js
+++ b/test/language/expressions/division/bigint-errors.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: division operator ToNumeric with BigInt operands
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  Symbol("1") / 1n;
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n / Symbol("1");
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  Object(Symbol("1")) / 1n;
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n / Object(Symbol("1"));
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  }) / 1n;
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n / {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  }) / 1n;
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n / {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    toString: function() {
+      return Symbol("1");
+    }
+  }) / 1n;
+}, "ToBigInt: toString => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n / {
+    toString: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: toString => Symbol => TypeError");

--- a/test/language/expressions/division/bigint-toprimitive.js
+++ b/test/language/expressions/division/bigint-toprimitive.js
@@ -1,0 +1,308 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: division operator ToNumeric with BigInt operands
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}) / 2n, 1n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(2n / {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}, 1n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}) / 2n, 1n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(2n / {
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}, 1n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) / 2n, 1n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(2n / {
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}) / 2n, 1n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(2n / {
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}) / 2n, 1n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(2n / {
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(({
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}) / 2n, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(2n / {
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}) / 2n, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(2n / {
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}) / 2n, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(2n / {
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}) / 2n, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(2n / {
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}) / 2n, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(2n / {
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: 1
+  }) / 1n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n / {
+    [Symbol.toPrimitive]: 1
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: {}
+  }) / 1n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n / {
+    [Symbol.toPrimitive]: {}
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  }) / 1n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n / {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  }) / 1n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n / {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  }) / 1n;
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  0n / {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  ({
+    valueOf: function() {
+      throw new MyError();
+    }
+  }) / 1n;
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  0n / {
+    valueOf: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  ({
+    toString: function() {
+      throw new MyError();
+    }
+  }) / 1n;
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(MyError, function() {
+  0n / {
+    toString: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: null,
+    toString: null
+  }) / 1n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n / {
+    valueOf: null,
+    toString: null
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: 1,
+    toString: 1
+  }) / 1n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n / {
+    valueOf: 1,
+    toString: 1
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: {},
+    toString: {}
+  }) / 1n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n / {
+    valueOf: {},
+    toString: {}
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  }) / 1n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n / {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  }) / 1n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n / {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/language/expressions/division/bigint-wrapped-values.js
+++ b/test/language/expressions/division/bigint-wrapped-values.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: division operator ToNumeric with BigInt operands
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(Object(2n) / 2n, 1n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(2n / Object(2n), 1n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}) / 2n, 1n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(2n / {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  }
+}) / 2n, 1n, "ToPrimitive: valueOf");
+assert.sameValue(2n / {
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: valueOf");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) / 2n, 1n, "ToPrimitive: toString");
+assert.sameValue(2n / {
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: toString");

--- a/test/language/expressions/exponentiation/bigint-errors.js
+++ b/test/language/expressions/exponentiation/bigint-errors.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: exponentiation operator ToNumeric with BigInt operands
+esid: sec-exp-operator-runtime-semantics-evaluation
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  Symbol("1") ** 0n;
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n ** Symbol("1");
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  Object(Symbol("1")) ** 0n;
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n ** Object(Symbol("1"));
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  }) ** 0n;
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n ** {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  }) ** 0n;
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n ** {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    toString: function() {
+      return Symbol("1");
+    }
+  }) ** 0n;
+}, "ToBigInt: toString => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n ** {
+    toString: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: toString => Symbol => TypeError");

--- a/test/language/expressions/exponentiation/bigint-toprimitive.js
+++ b/test/language/expressions/exponentiation/bigint-toprimitive.js
@@ -1,0 +1,308 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: exponentiation operator ToNumeric with BigInt operands
+esid: sec-exp-operator-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}) ** 1n, 2n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(1n ** {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}, 1n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}) ** 1n, 2n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(1n ** {
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}, 1n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) ** 1n, 2n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(1n ** {
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}) ** 1n, 2n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(1n ** {
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}) ** 1n, 2n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(1n ** {
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(({
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}) ** 1n, 2n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(1n ** {
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}) ** 1n, 2n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(1n ** {
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}) ** 1n, 2n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(1n ** {
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}) ** 1n, 2n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(1n ** {
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}) ** 1n, 2n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(1n ** {
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: 1
+  }) ** 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n ** {
+    [Symbol.toPrimitive]: 1
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: {}
+  }) ** 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n ** {
+    [Symbol.toPrimitive]: {}
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  }) ** 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n ** {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  }) ** 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n ** {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  }) ** 0n;
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  0n ** {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  ({
+    valueOf: function() {
+      throw new MyError();
+    }
+  }) ** 0n;
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  0n ** {
+    valueOf: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  ({
+    toString: function() {
+      throw new MyError();
+    }
+  }) ** 0n;
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(MyError, function() {
+  0n ** {
+    toString: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: null,
+    toString: null
+  }) ** 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n ** {
+    valueOf: null,
+    toString: null
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: 1,
+    toString: 1
+  }) ** 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n ** {
+    valueOf: 1,
+    toString: 1
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: {},
+    toString: {}
+  }) ** 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n ** {
+    valueOf: {},
+    toString: {}
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  }) ** 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n ** {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  }) ** 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n ** {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/language/expressions/exponentiation/bigint-wrapped-values.js
+++ b/test/language/expressions/exponentiation/bigint-wrapped-values.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: exponentiation operator ToNumeric with BigInt operands
+esid: sec-exp-operator-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(Object(2n) ** 1n, 2n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(1n ** Object(2n), 1n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}) ** 1n, 2n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(1n ** {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  }
+}) ** 1n, 2n, "ToPrimitive: valueOf");
+assert.sameValue(1n ** {
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: valueOf");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) ** 1n, 2n, "ToPrimitive: toString");
+assert.sameValue(1n ** {
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: toString");

--- a/test/language/expressions/left-shift/bigint-errors.js
+++ b/test/language/expressions/left-shift/bigint-errors.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: left-shift operator ToNumeric with BigInt operands
+esid: sec-left-shift-operator-runtime-semantics-evaluation
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  Symbol("1") << 0n;
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n << Symbol("1");
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  Object(Symbol("1")) << 0n;
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n << Object(Symbol("1"));
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  }) << 0n;
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n << {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  }) << 0n;
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n << {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    toString: function() {
+      return Symbol("1");
+    }
+  }) << 0n;
+}, "ToBigInt: toString => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n << {
+    toString: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: toString => Symbol => TypeError");

--- a/test/language/expressions/left-shift/bigint-toprimitive.js
+++ b/test/language/expressions/left-shift/bigint-toprimitive.js
@@ -1,0 +1,308 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: left-shift operator ToNumeric with BigInt operands
+esid: sec-left-shift-operator-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}) << 1n, 4n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(1n << {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}, 4n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}) << 1n, 4n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(1n << {
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}, 4n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) << 1n, 4n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(1n << {
+  toString: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}) << 1n, 4n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(1n << {
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}) << 1n, 4n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(1n << {
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(({
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}) << 1n, 4n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(1n << {
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}) << 1n, 4n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(1n << {
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}) << 1n, 4n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(1n << {
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}) << 1n, 4n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(1n << {
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}) << 1n, 4n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(1n << {
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: 1
+  }) << 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n << {
+    [Symbol.toPrimitive]: 1
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: {}
+  }) << 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n << {
+    [Symbol.toPrimitive]: {}
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  }) << 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n << {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  }) << 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n << {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  }) << 0n;
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  0n << {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  ({
+    valueOf: function() {
+      throw new MyError();
+    }
+  }) << 0n;
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  0n << {
+    valueOf: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  ({
+    toString: function() {
+      throw new MyError();
+    }
+  }) << 0n;
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(MyError, function() {
+  0n << {
+    toString: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: null,
+    toString: null
+  }) << 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n << {
+    valueOf: null,
+    toString: null
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: 1,
+    toString: 1
+  }) << 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n << {
+    valueOf: 1,
+    toString: 1
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: {},
+    toString: {}
+  }) << 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n << {
+    valueOf: {},
+    toString: {}
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  }) << 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n << {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  }) << 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n << {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/language/expressions/left-shift/bigint-wrapped-values.js
+++ b/test/language/expressions/left-shift/bigint-wrapped-values.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: left-shift operator ToNumeric with BigInt operands
+esid: sec-left-shift-operator-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(Object(2n) << 1n, 4n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(1n << Object(2n), 4n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}) << 1n, 4n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(1n << {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  }
+}) << 1n, 4n, "ToPrimitive: valueOf");
+assert.sameValue(1n << {
+  valueOf: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: valueOf");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) << 1n, 4n, "ToPrimitive: toString");
+assert.sameValue(1n << {
+  toString: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: toString");

--- a/test/language/expressions/modulus/bigint-errors.js
+++ b/test/language/expressions/modulus/bigint-errors.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: modulus operator ToNumeric with BigInt operands
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  Symbol("1") % 1n;
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n % Symbol("1");
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  Object(Symbol("1")) % 1n;
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n % Object(Symbol("1"));
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  }) % 1n;
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n % {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  }) % 1n;
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n % {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    toString: function() {
+      return Symbol("1");
+    }
+  }) % 1n;
+}, "ToBigInt: toString => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n % {
+    toString: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: toString => Symbol => TypeError");

--- a/test/language/expressions/modulus/bigint-toprimitive.js
+++ b/test/language/expressions/modulus/bigint-toprimitive.js
@@ -1,0 +1,308 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: modulus operator ToNumeric with BigInt operands
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}) % 2n, 0n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(2n % {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}, 0n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}) % 2n, 0n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(2n % {
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}, 0n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) % 2n, 0n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(2n % {
+  toString: function() {
+    return 2n;
+  }
+}, 0n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}) % 2n, 0n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(2n % {
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}, 0n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}) % 2n, 0n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(2n % {
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}, 0n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(({
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}) % 2n, 0n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(2n % {
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}, 0n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}) % 2n, 0n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(2n % {
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}, 0n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}) % 2n, 0n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(2n % {
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}, 0n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}) % 2n, 0n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(2n % {
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 0n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}) % 2n, 0n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(2n % {
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 0n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: 1
+  }) % 1n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n % {
+    [Symbol.toPrimitive]: 1
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: {}
+  }) % 1n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n % {
+    [Symbol.toPrimitive]: {}
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  }) % 1n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n % {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  }) % 1n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n % {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  }) % 1n;
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  0n % {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  ({
+    valueOf: function() {
+      throw new MyError();
+    }
+  }) % 1n;
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  0n % {
+    valueOf: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  ({
+    toString: function() {
+      throw new MyError();
+    }
+  }) % 1n;
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(MyError, function() {
+  0n % {
+    toString: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: null,
+    toString: null
+  }) % 1n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n % {
+    valueOf: null,
+    toString: null
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: 1,
+    toString: 1
+  }) % 1n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n % {
+    valueOf: 1,
+    toString: 1
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: {},
+    toString: {}
+  }) % 1n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n % {
+    valueOf: {},
+    toString: {}
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  }) % 1n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n % {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  }) % 1n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n % {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/language/expressions/modulus/bigint-wrapped-values.js
+++ b/test/language/expressions/modulus/bigint-wrapped-values.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: modulus operator ToNumeric with BigInt operands
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(Object(2n) % 2n, 0n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(2n % Object(2n), 0n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}) % 2n, 0n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(2n % {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}, 0n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  }
+}) % 2n, 0n, "ToPrimitive: valueOf");
+assert.sameValue(2n % {
+  valueOf: function() {
+    return 2n;
+  }
+}, 0n, "ToPrimitive: valueOf");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) % 2n, 0n, "ToPrimitive: toString");
+assert.sameValue(2n % {
+  toString: function() {
+    return 2n;
+  }
+}, 0n, "ToPrimitive: toString");

--- a/test/language/expressions/multiplication/bigint-errors.js
+++ b/test/language/expressions/multiplication/bigint-errors.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: multiplication operator ToNumeric with BigInt operands
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  Symbol("1") * 0n;
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n * Symbol("1");
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  Object(Symbol("1")) * 0n;
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n * Object(Symbol("1"));
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  }) * 0n;
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n * {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  }) * 0n;
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n * {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    toString: function() {
+      return Symbol("1");
+    }
+  }) * 0n;
+}, "ToBigInt: toString => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n * {
+    toString: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: toString => Symbol => TypeError");

--- a/test/language/expressions/multiplication/bigint-toprimitive.js
+++ b/test/language/expressions/multiplication/bigint-toprimitive.js
@@ -1,0 +1,308 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: multiplication operator ToNumeric with BigInt operands
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}) * 2n, 4n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(2n * {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}, 4n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}) * 2n, 4n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(2n * {
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}, 4n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) * 2n, 4n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(2n * {
+  toString: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}) * 2n, 4n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(2n * {
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}) * 2n, 4n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(2n * {
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(({
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}) * 2n, 4n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(2n * {
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}) * 2n, 4n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(2n * {
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}) * 2n, 4n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(2n * {
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}) * 2n, 4n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(2n * {
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}) * 2n, 4n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(2n * {
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: 1
+  }) * 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n * {
+    [Symbol.toPrimitive]: 1
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: {}
+  }) * 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n * {
+    [Symbol.toPrimitive]: {}
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  }) * 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n * {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  }) * 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n * {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  }) * 0n;
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  0n * {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  ({
+    valueOf: function() {
+      throw new MyError();
+    }
+  }) * 0n;
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  0n * {
+    valueOf: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  ({
+    toString: function() {
+      throw new MyError();
+    }
+  }) * 0n;
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(MyError, function() {
+  0n * {
+    toString: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: null,
+    toString: null
+  }) * 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n * {
+    valueOf: null,
+    toString: null
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: 1,
+    toString: 1
+  }) * 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n * {
+    valueOf: 1,
+    toString: 1
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: {},
+    toString: {}
+  }) * 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n * {
+    valueOf: {},
+    toString: {}
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  }) * 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n * {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  }) * 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n * {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/language/expressions/multiplication/bigint-wrapped-values.js
+++ b/test/language/expressions/multiplication/bigint-wrapped-values.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: multiplication operator ToNumeric with BigInt operands
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(Object(2n) * 2n, 4n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(2n * Object(2n), 4n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}) * 2n, 4n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(2n * {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  }
+}) * 2n, 4n, "ToPrimitive: valueOf");
+assert.sameValue(2n * {
+  valueOf: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: valueOf");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) * 2n, 4n, "ToPrimitive: toString");
+assert.sameValue(2n * {
+  toString: function() {
+    return 2n;
+  }
+}, 4n, "ToPrimitive: toString");

--- a/test/language/expressions/right-shift/bigint-errors.js
+++ b/test/language/expressions/right-shift/bigint-errors.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: right-shift operator ToNumeric with BigInt operands
+esid: sec-signed-right-shift-operator-runtime-semantics-evaluation
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  Symbol("1") >> 0n;
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n >> Symbol("1");
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  Object(Symbol("1")) >> 0n;
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n >> Object(Symbol("1"));
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  }) >> 0n;
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n >> {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  }) >> 0n;
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n >> {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    toString: function() {
+      return Symbol("1");
+    }
+  }) >> 0n;
+}, "ToBigInt: toString => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n >> {
+    toString: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: toString => Symbol => TypeError");

--- a/test/language/expressions/right-shift/bigint-toprimitive.js
+++ b/test/language/expressions/right-shift/bigint-toprimitive.js
@@ -1,0 +1,308 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: right-shift operator ToNumeric with BigInt operands
+esid: sec-signed-right-shift-operator-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}) >> 1n, 1n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(4n >> {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}, 1n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}) >> 1n, 1n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(4n >> {
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}, 1n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) >> 1n, 1n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(4n >> {
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}) >> 1n, 1n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(4n >> {
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}) >> 1n, 1n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(4n >> {
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(({
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}) >> 1n, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(4n >> {
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}) >> 1n, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(4n >> {
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}) >> 1n, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(4n >> {
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}) >> 1n, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(4n >> {
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}) >> 1n, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(4n >> {
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: 1
+  }) >> 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n >> {
+    [Symbol.toPrimitive]: 1
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: {}
+  }) >> 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n >> {
+    [Symbol.toPrimitive]: {}
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  }) >> 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n >> {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  }) >> 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n >> {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  }) >> 0n;
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  0n >> {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  ({
+    valueOf: function() {
+      throw new MyError();
+    }
+  }) >> 0n;
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  0n >> {
+    valueOf: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  ({
+    toString: function() {
+      throw new MyError();
+    }
+  }) >> 0n;
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(MyError, function() {
+  0n >> {
+    toString: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: null,
+    toString: null
+  }) >> 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n >> {
+    valueOf: null,
+    toString: null
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: 1,
+    toString: 1
+  }) >> 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n >> {
+    valueOf: 1,
+    toString: 1
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: {},
+    toString: {}
+  }) >> 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n >> {
+    valueOf: {},
+    toString: {}
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  }) >> 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n >> {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  }) >> 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n >> {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/language/expressions/right-shift/bigint-wrapped-values.js
+++ b/test/language/expressions/right-shift/bigint-wrapped-values.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: right-shift operator ToNumeric with BigInt operands
+esid: sec-signed-right-shift-operator-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(Object(2n) >> 1n, 1n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(4n >> Object(2n), 1n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}) >> 1n, 1n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(4n >> {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  }
+}) >> 1n, 1n, "ToPrimitive: valueOf");
+assert.sameValue(4n >> {
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: valueOf");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) >> 1n, 1n, "ToPrimitive: toString");
+assert.sameValue(4n >> {
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: toString");

--- a/test/language/expressions/subtraction/bigint-errors.js
+++ b/test/language/expressions/subtraction/bigint-errors.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: subtraction operator ToNumeric with BigInt operands
+esid: sec-subtraction-operator-minus-runtime-semantics-evaluation
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  Symbol("1") - 0n;
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n - Symbol("1");
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  Object(Symbol("1")) - 0n;
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n - Object(Symbol("1"));
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  }) - 0n;
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n - {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  }) - 0n;
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n - {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    toString: function() {
+      return Symbol("1");
+    }
+  }) - 0n;
+}, "ToBigInt: toString => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n - {
+    toString: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: toString => Symbol => TypeError");

--- a/test/language/expressions/subtraction/bigint-toprimitive.js
+++ b/test/language/expressions/subtraction/bigint-toprimitive.js
@@ -1,0 +1,308 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: subtraction operator ToNumeric with BigInt operands
+esid: sec-subtraction-operator-minus-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}) - 1n, 1n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(3n - {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  },
+  valueOf: err,
+  toString: err
+}, 1n, "ToPrimitive: @@toPrimitive takes precedence");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}) - 1n, 1n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(3n - {
+  valueOf: function() {
+    return 2n;
+  },
+  toString: err
+}, 1n, "ToPrimitive: valueOf takes precedence over toString");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) - 1n, 1n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(3n - {
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: toString with no valueOf");
+assert.sameValue(({
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}) - 1n, 1n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(3n - {
+  [Symbol.toPrimitive]: undefined,
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.sameValue(({
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}) - 1n, 1n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(3n - {
+  [Symbol.toPrimitive]: null,
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.sameValue(({
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}) - 1n, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(3n - {
+  valueOf: null,
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}) - 1n, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(3n - {
+  valueOf: 1,
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}) - 1n, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(3n - {
+  valueOf: {},
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it's not callable");
+assert.sameValue(({
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}) - 1n, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(3n - {
+  valueOf: function() {
+    return {};
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(({
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}) - 1n, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.sameValue(3n - {
+  valueOf: function() {
+    return Object(12345);
+  },
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: 1
+  }) - 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n - {
+    [Symbol.toPrimitive]: 1
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: {}
+  }) - 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n - {
+    [Symbol.toPrimitive]: {}
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  }) - 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n - {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  }) - 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n - {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  }) - 0n;
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  0n - {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  ({
+    valueOf: function() {
+      throw new MyError();
+    }
+  }) - 0n;
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  0n - {
+    valueOf: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  ({
+    toString: function() {
+      throw new MyError();
+    }
+  }) - 0n;
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(MyError, function() {
+  0n - {
+    toString: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: null,
+    toString: null
+  }) - 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n - {
+    valueOf: null,
+    toString: null
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: 1,
+    toString: 1
+  }) - 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n - {
+    valueOf: 1,
+    toString: 1
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: {},
+    toString: {}
+  }) - 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n - {
+    valueOf: {},
+    toString: {}
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  }) - 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n - {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  }) - 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n - {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/language/expressions/subtraction/bigint-wrapped-values.js
+++ b/test/language/expressions/subtraction/bigint-wrapped-values.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: subtraction operator ToNumeric with BigInt operands
+esid: sec-subtraction-operator-minus-runtime-semantics-evaluation
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.sameValue(Object(2n) - 1n, 1n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(3n - Object(2n), 1n, "ToPrimitive: unbox object with internal slot");
+assert.sameValue(({
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}) - 1n, 1n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(3n - {
+  [Symbol.toPrimitive]: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: @@toPrimitive");
+assert.sameValue(({
+  valueOf: function() {
+    return 2n;
+  }
+}) - 1n, 1n, "ToPrimitive: valueOf");
+assert.sameValue(3n - {
+  valueOf: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: valueOf");
+assert.sameValue(({
+  toString: function() {
+    return 2n;
+  }
+}) - 1n, 1n, "ToPrimitive: toString");
+assert.sameValue(3n - {
+  toString: function() {
+    return 2n;
+  }
+}, 1n, "ToPrimitive: toString");

--- a/test/language/expressions/unsigned-right-shift/bigint-errors.js
+++ b/test/language/expressions/unsigned-right-shift/bigint-errors.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: unsigned-right-shift operator ToNumeric with BigInt operands
+esid: sec-unsigned-right-shift-operator-runtime-semantics-evaluation
+info: After ToNumeric type coercion, unsigned-right-shift always throws for BigInt operands
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  Symbol("1") >>> 0n;
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n >>> Symbol("1");
+}, "ToBigInt: Symbol => TypeError");
+assert.throws(TypeError, function() {
+  Object(Symbol("1")) >>> 0n;
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n >>> Object(Symbol("1"));
+}, "ToBigInt: unbox object with internal slot => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  }) >>> 0n;
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n >>> {
+    [Symbol.toPrimitive]: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: @@toPrimitive => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Symbol("1");
+    }
+  }) >>> 0n;
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n >>> {
+    valueOf: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: valueOf => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  ({
+    toString: function() {
+      return Symbol("1");
+    }
+  }) >>> 0n;
+}, "ToBigInt: toString => Symbol => TypeError");
+assert.throws(TypeError, function() {
+  0n >>> {
+    toString: function() {
+      return Symbol("1");
+    }
+  };
+}, "ToBigInt: toString => Symbol => TypeError");

--- a/test/language/expressions/unsigned-right-shift/bigint-toprimitive.js
+++ b/test/language/expressions/unsigned-right-shift/bigint-toprimitive.js
@@ -1,0 +1,349 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: unsigned-right-shift operator ToNumeric with BigInt operands
+esid: sec-unsigned-right-shift-operator-runtime-semantics-evaluation
+info: After ToNumeric type coercion, unsigned-right-shift always throws for BigInt operands
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+function err() {
+  throw new Test262Error();
+}
+
+function MyError() {}
+
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return 2n;
+    },
+    valueOf: err,
+    toString: err
+  }) >>> 0n;
+}, "ToPrimitive: @@toPrimitive takes precedence");
+assert.throws(TypeError, function() {
+  0n >>> {
+    [Symbol.toPrimitive]: function() {
+      return 2n;
+    },
+    valueOf: err,
+    toString: err
+  };
+}, "ToPrimitive: @@toPrimitive takes precedence");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return 2n;
+    },
+    toString: err
+  }) >>> 0n;
+}, "ToPrimitive: valueOf takes precedence over toString");
+assert.throws(TypeError, function() {
+  0n >>> {
+    valueOf: function() {
+      return 2n;
+    },
+    toString: err
+  };
+}, "ToPrimitive: valueOf takes precedence over toString");
+assert.throws(TypeError, function() {
+  ({
+    toString: function() {
+      return 2n;
+    }
+  }) >>> 0n;
+}, "ToPrimitive: toString with no valueOf");
+assert.throws(TypeError, function() {
+  0n >>> {
+    toString: function() {
+      return 2n;
+    }
+  };
+}, "ToPrimitive: toString with no valueOf");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: undefined,
+    valueOf: function() {
+      return 2n;
+    }
+  }) >>> 0n;
+}, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.throws(TypeError, function() {
+  0n >>> {
+    [Symbol.toPrimitive]: undefined,
+    valueOf: function() {
+      return 2n;
+    }
+  };
+}, "ToPrimitive: skip @@toPrimitive when it's undefined");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: null,
+    valueOf: function() {
+      return 2n;
+    }
+  }) >>> 0n;
+}, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.throws(TypeError, function() {
+  0n >>> {
+    [Symbol.toPrimitive]: null,
+    valueOf: function() {
+      return 2n;
+    }
+  };
+}, "ToPrimitive: skip @@toPrimitive when it's null");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: null,
+    toString: function() {
+      return 2n;
+    }
+  }) >>> 0n;
+}, "ToPrimitive: skip valueOf when it's not callable");
+assert.throws(TypeError, function() {
+  0n >>> {
+    valueOf: null,
+    toString: function() {
+      return 2n;
+    }
+  };
+}, "ToPrimitive: skip valueOf when it's not callable");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: 1,
+    toString: function() {
+      return 2n;
+    }
+  }) >>> 0n;
+}, "ToPrimitive: skip valueOf when it's not callable");
+assert.throws(TypeError, function() {
+  0n >>> {
+    valueOf: 1,
+    toString: function() {
+      return 2n;
+    }
+  };
+}, "ToPrimitive: skip valueOf when it's not callable");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: {},
+    toString: function() {
+      return 2n;
+    }
+  }) >>> 0n;
+}, "ToPrimitive: skip valueOf when it's not callable");
+assert.throws(TypeError, function() {
+  0n >>> {
+    valueOf: {},
+    toString: function() {
+      return 2n;
+    }
+  };
+}, "ToPrimitive: skip valueOf when it's not callable");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return 2n;
+    }
+  }) >>> 0n;
+}, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  0n >>> {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return 2n;
+    }
+  };
+}, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Object(12345);
+    },
+    toString: function() {
+      return 2n;
+    }
+  }) >>> 0n;
+}, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  0n >>> {
+    valueOf: function() {
+      return Object(12345);
+    },
+    toString: function() {
+      return 2n;
+    }
+  };
+}, "ToPrimitive: skip valueOf when it returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: 1
+  }) >>> 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n >>> {
+    [Symbol.toPrimitive]: 1
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: {}
+  }) >>> 0n;
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  0n >>> {
+    [Symbol.toPrimitive]: {}
+  };
+}, "ToPrimitive: throw when @@toPrimitive is not callable");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  }) >>> 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n >>> {
+    [Symbol.toPrimitive]: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  }) >>> 0n;
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(TypeError, function() {
+  0n >>> {
+    [Symbol.toPrimitive]: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when @@toPrimitive returns an object");
+assert.throws(MyError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  }) >>> 0n;
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  0n >>> {
+    [Symbol.toPrimitive]: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from @@toPrimitive");
+assert.throws(MyError, function() {
+  ({
+    valueOf: function() {
+      throw new MyError();
+    }
+  }) >>> 0n;
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  0n >>> {
+    valueOf: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from valueOf");
+assert.throws(MyError, function() {
+  ({
+    toString: function() {
+      throw new MyError();
+    }
+  }) >>> 0n;
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(MyError, function() {
+  0n >>> {
+    toString: function() {
+      throw new MyError();
+    }
+  };
+}, "ToPrimitive: propagate errors from toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: null,
+    toString: null
+  }) >>> 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n >>> {
+    valueOf: null,
+    toString: null
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: 1,
+    toString: 1
+  }) >>> 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n >>> {
+    valueOf: 1,
+    toString: 1
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: {},
+    toString: {}
+  }) >>> 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n >>> {
+    valueOf: {},
+    toString: {}
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  }) >>> 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n >>> {
+    valueOf: function() {
+      return Object(1);
+    },
+    toString: function() {
+      return Object(1);
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  }) >>> 0n;
+}, "ToPrimitive: throw when skipping both valueOf and toString");
+assert.throws(TypeError, function() {
+  0n >>> {
+    valueOf: function() {
+      return {};
+    },
+    toString: function() {
+      return {};
+    }
+  };
+}, "ToPrimitive: throw when skipping both valueOf and toString");

--- a/test/language/expressions/unsigned-right-shift/bigint-wrapped-values.js
+++ b/test/language/expressions/unsigned-right-shift/bigint-wrapped-values.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: unsigned-right-shift operator ToNumeric with BigInt operands
+esid: sec-unsigned-right-shift-operator-runtime-semantics-evaluation
+info: After ToNumeric type coercion, unsigned-right-shift always throws for BigInt operands
+features: [BigInt, Symbol.toPrimitive, computed-property-names]
+---*/
+
+assert.throws(TypeError, function() {
+  Object(2n) >>> 0n;
+}, "ToPrimitive: unbox object with internal slot");
+assert.throws(TypeError, function() {
+  0n >>> Object(2n);
+}, "ToPrimitive: unbox object with internal slot");
+assert.throws(TypeError, function() {
+  ({
+    [Symbol.toPrimitive]: function() {
+      return 2n;
+    }
+  }) >>> 0n;
+}, "ToPrimitive: @@toPrimitive");
+assert.throws(TypeError, function() {
+  0n >>> {
+    [Symbol.toPrimitive]: function() {
+      return 2n;
+    }
+  };
+}, "ToPrimitive: @@toPrimitive");
+assert.throws(TypeError, function() {
+  ({
+    valueOf: function() {
+      return 2n;
+    }
+  }) >>> 0n;
+}, "ToPrimitive: valueOf");
+assert.throws(TypeError, function() {
+  0n >>> {
+    valueOf: function() {
+      return 2n;
+    }
+  };
+}, "ToPrimitive: valueOf");
+assert.throws(TypeError, function() {
+  ({
+    toString: function() {
+      return 2n;
+    }
+  }) >>> 0n;
+}, "ToPrimitive: toString");
+assert.throws(TypeError, function() {
+  0n >>> {
+    toString: function() {
+      return 2n;
+    }
+  };
+}, "ToPrimitive: toString");


### PR DESCRIPTION
This code was generated with https://github.com/thejoshwolfe/test262-generators and formatted with `js-beautify -n -w 100 -s 2` (after [patching](https://github.com/beautify-web/js-beautify/pull/1303) it to support BigInt literal notation).