### PR TITLE
Order of evaluation tests for infix numeric operators

### DIFF
--- a/test/language/expressions/addition/order-of-evaluation.js
+++ b/test/language/expressions/addition/order-of-evaluation.js
@@ -1,0 +1,140 @@
+// Copyright (C) 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-addition-operator-plus-runtime-semantics-evaluation
+description: Type coercion order of operations for addition operator
+features: [Symbol]
+info: |
+  Evaluate lhs
+  Evaluate rhs
+  ToPrimitive(lhs)
+  ToPrimitive(rhs)
+  ToNumeric(lhs)
+  ToNumeric(rhs)
+---*/
+
+function MyError() {}
+var trace;
+
+// ?GetValue(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    throw new MyError();
+  })() + (function() {
+    trace += "2";
+    throw new Test262Error("should not be evaluated");
+  })();
+}, "?GetValue(lhs) throws.");
+assert.sameValue(trace, "1", "?GetValue(lhs) throws.");
+
+// ?GetValue(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })() + (function() {
+    trace += "2";
+    throw new MyError();
+  })();
+}, "?GetValue(rhs) throws.");
+assert.sameValue(trace, "12", "?GetValue(rhs) throws.");
+
+// ?ToPrimive(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new MyError();
+      }
+    };
+  })() + (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToPrimive(lhs) throws.");
+assert.sameValue(trace, "123", "?ToPrimive(lhs) throws.");
+
+// ?ToPrimive(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() + (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new MyError();
+      }
+    };
+  })();
+}, "?ToPrimive(rhs) throws.");
+assert.sameValue(trace, "1234", "?ToPrimive(rhs) throws.");
+
+// ?ToPrimive(rhs) is called before ?ToNumeric(lhs).
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return Symbol("1");
+      }
+    };
+  })() + (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new MyError();
+      }
+    };
+  })();
+}, "?ToPrimive(rhs) is called before ?ToNumeric(lhs).");
+assert.sameValue(trace, "1234", "?ToPrimive(rhs) is called before ?ToNumeric(lhs).");
+
+// GetValue(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() + (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        return Symbol("1");
+      }
+    };
+  })();
+}, "GetValue(lhs) throws.");
+assert.sameValue(trace, "1234", "GetValue(lhs) throws.");

--- a/test/language/expressions/addition/order-of-evaluation.js
+++ b/test/language/expressions/addition/order-of-evaluation.js
@@ -35,7 +35,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new Test262Error("should not be evaluated");
       }
@@ -53,7 +53,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new MyError();
       }
@@ -61,7 +61,7 @@ assert.throws(MyError, function() {
   })() + (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -76,7 +76,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -84,7 +84,7 @@ assert.throws(MyError, function() {
   })() + (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new MyError();
       }
@@ -99,7 +99,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return Symbol("1");
       }
@@ -107,7 +107,7 @@ assert.throws(MyError, function() {
   })() + (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new MyError();
       }
@@ -122,7 +122,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -130,7 +130,7 @@ assert.throws(TypeError, function() {
   })() + (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         return Symbol("1");
       }

--- a/test/language/expressions/bitwise-and/order-of-evaluation.js
+++ b/test/language/expressions/bitwise-and/order-of-evaluation.js
@@ -1,0 +1,138 @@
+// Copyright (C) 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+description: Type coercion order of operations for bitwise-and operator
+features: [Symbol]
+info: |
+  Evaluate lhs
+  Evaluate rhs
+  ToNumeric(lhs)
+  ToNumeric(rhs)
+---*/
+
+function MyError() {}
+var trace;
+
+// ?GetValue(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    throw new MyError();
+  })() & (function() {
+    trace += "2";
+    throw new Test262Error("should not be evaluated");
+  })();
+}, "?GetValue(lhs) throws.");
+assert.sameValue(trace, "1", "?GetValue(lhs) throws.");
+
+// ?GetValue(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })() & (function() {
+    trace += "2";
+    throw new MyError();
+  })();
+}, "?GetValue(rhs) throws.");
+assert.sameValue(trace, "12", "?GetValue(rhs) throws.");
+
+// ?ToPrimive(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new MyError();
+      }
+    };
+  })() & (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToPrimive(lhs) throws.");
+assert.sameValue(trace, "123", "?ToPrimive(lhs) throws.");
+
+// ?ToPrimive(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() & (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new MyError();
+      }
+    };
+  })();
+}, "?ToPrimive(rhs) throws.");
+assert.sameValue(trace, "1234", "?ToPrimive(rhs) throws.");
+
+// ?ToNumeric(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return Symbol("1");
+      }
+    };
+  })() & (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToNumeric(lhs) throws.");
+assert.sameValue(trace, "123", "?ToNumeric(lhs) throws.");
+
+// GetValue(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() & (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        return Symbol("1");
+      }
+    };
+  })();
+}, "GetValue(lhs) throws.");
+assert.sameValue(trace, "1234", "GetValue(lhs) throws.");

--- a/test/language/expressions/bitwise-and/order-of-evaluation.js
+++ b/test/language/expressions/bitwise-and/order-of-evaluation.js
@@ -33,7 +33,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new Test262Error("should not be evaluated");
       }
@@ -51,7 +51,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new MyError();
       }
@@ -59,7 +59,7 @@ assert.throws(MyError, function() {
   })() & (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -74,7 +74,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -82,7 +82,7 @@ assert.throws(MyError, function() {
   })() & (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new MyError();
       }
@@ -97,7 +97,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return Symbol("1");
       }
@@ -105,7 +105,7 @@ assert.throws(TypeError, function() {
   })() & (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -120,7 +120,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -128,7 +128,7 @@ assert.throws(TypeError, function() {
   })() & (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         return Symbol("1");
       }

--- a/test/language/expressions/bitwise-or/order-of-evaluation.js
+++ b/test/language/expressions/bitwise-or/order-of-evaluation.js
@@ -33,7 +33,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new Test262Error("should not be evaluated");
       }
@@ -51,7 +51,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new MyError();
       }
@@ -59,7 +59,7 @@ assert.throws(MyError, function() {
   })() | (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -74,7 +74,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -82,7 +82,7 @@ assert.throws(MyError, function() {
   })() | (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new MyError();
       }
@@ -97,7 +97,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return Symbol("1");
       }
@@ -105,7 +105,7 @@ assert.throws(TypeError, function() {
   })() | (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -120,7 +120,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -128,7 +128,7 @@ assert.throws(TypeError, function() {
   })() | (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         return Symbol("1");
       }

--- a/test/language/expressions/bitwise-or/order-of-evaluation.js
+++ b/test/language/expressions/bitwise-or/order-of-evaluation.js
@@ -1,0 +1,138 @@
+// Copyright (C) 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+description: Type coercion order of operations for bitwise-or operator
+features: [Symbol]
+info: |
+  Evaluate lhs
+  Evaluate rhs
+  ToNumeric(lhs)
+  ToNumeric(rhs)
+---*/
+
+function MyError() {}
+var trace;
+
+// ?GetValue(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    throw new MyError();
+  })() | (function() {
+    trace += "2";
+    throw new Test262Error("should not be evaluated");
+  })();
+}, "?GetValue(lhs) throws.");
+assert.sameValue(trace, "1", "?GetValue(lhs) throws.");
+
+// ?GetValue(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })() | (function() {
+    trace += "2";
+    throw new MyError();
+  })();
+}, "?GetValue(rhs) throws.");
+assert.sameValue(trace, "12", "?GetValue(rhs) throws.");
+
+// ?ToPrimive(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new MyError();
+      }
+    };
+  })() | (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToPrimive(lhs) throws.");
+assert.sameValue(trace, "123", "?ToPrimive(lhs) throws.");
+
+// ?ToPrimive(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() | (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new MyError();
+      }
+    };
+  })();
+}, "?ToPrimive(rhs) throws.");
+assert.sameValue(trace, "1234", "?ToPrimive(rhs) throws.");
+
+// ?ToNumeric(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return Symbol("1");
+      }
+    };
+  })() | (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToNumeric(lhs) throws.");
+assert.sameValue(trace, "123", "?ToNumeric(lhs) throws.");
+
+// GetValue(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() | (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        return Symbol("1");
+      }
+    };
+  })();
+}, "GetValue(lhs) throws.");
+assert.sameValue(trace, "1234", "GetValue(lhs) throws.");

--- a/test/language/expressions/bitwise-xor/order-of-evaluation.js
+++ b/test/language/expressions/bitwise-xor/order-of-evaluation.js
@@ -1,0 +1,138 @@
+// Copyright (C) 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-binary-bitwise-operators-runtime-semantics-evaluation
+description: Type coercion order of operations for bitwise-xor operator
+features: [Symbol]
+info: |
+  Evaluate lhs
+  Evaluate rhs
+  ToNumeric(lhs)
+  ToNumeric(rhs)
+---*/
+
+function MyError() {}
+var trace;
+
+// ?GetValue(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    throw new MyError();
+  })() ^ (function() {
+    trace += "2";
+    throw new Test262Error("should not be evaluated");
+  })();
+}, "?GetValue(lhs) throws.");
+assert.sameValue(trace, "1", "?GetValue(lhs) throws.");
+
+// ?GetValue(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })() ^ (function() {
+    trace += "2";
+    throw new MyError();
+  })();
+}, "?GetValue(rhs) throws.");
+assert.sameValue(trace, "12", "?GetValue(rhs) throws.");
+
+// ?ToPrimive(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new MyError();
+      }
+    };
+  })() ^ (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToPrimive(lhs) throws.");
+assert.sameValue(trace, "123", "?ToPrimive(lhs) throws.");
+
+// ?ToPrimive(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() ^ (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new MyError();
+      }
+    };
+  })();
+}, "?ToPrimive(rhs) throws.");
+assert.sameValue(trace, "1234", "?ToPrimive(rhs) throws.");
+
+// ?ToNumeric(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return Symbol("1");
+      }
+    };
+  })() ^ (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToNumeric(lhs) throws.");
+assert.sameValue(trace, "123", "?ToNumeric(lhs) throws.");
+
+// GetValue(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() ^ (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        return Symbol("1");
+      }
+    };
+  })();
+}, "GetValue(lhs) throws.");
+assert.sameValue(trace, "1234", "GetValue(lhs) throws.");

--- a/test/language/expressions/bitwise-xor/order-of-evaluation.js
+++ b/test/language/expressions/bitwise-xor/order-of-evaluation.js
@@ -33,7 +33,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new Test262Error("should not be evaluated");
       }
@@ -51,7 +51,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new MyError();
       }
@@ -59,7 +59,7 @@ assert.throws(MyError, function() {
   })() ^ (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -74,7 +74,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -82,7 +82,7 @@ assert.throws(MyError, function() {
   })() ^ (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new MyError();
       }
@@ -97,7 +97,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return Symbol("1");
       }
@@ -105,7 +105,7 @@ assert.throws(TypeError, function() {
   })() ^ (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -120,7 +120,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -128,7 +128,7 @@ assert.throws(TypeError, function() {
   })() ^ (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         return Symbol("1");
       }

--- a/test/language/expressions/division/order-of-evaluation.js
+++ b/test/language/expressions/division/order-of-evaluation.js
@@ -1,0 +1,138 @@
+// Copyright (C) 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+description: Type coercion order of operations for division operator
+features: [Symbol]
+info: |
+  Evaluate lhs
+  Evaluate rhs
+  ToNumeric(lhs)
+  ToNumeric(rhs)
+---*/
+
+function MyError() {}
+var trace;
+
+// ?GetValue(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    throw new MyError();
+  })() / (function() {
+    trace += "2";
+    throw new Test262Error("should not be evaluated");
+  })();
+}, "?GetValue(lhs) throws.");
+assert.sameValue(trace, "1", "?GetValue(lhs) throws.");
+
+// ?GetValue(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })() / (function() {
+    trace += "2";
+    throw new MyError();
+  })();
+}, "?GetValue(rhs) throws.");
+assert.sameValue(trace, "12", "?GetValue(rhs) throws.");
+
+// ?ToPrimive(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new MyError();
+      }
+    };
+  })() / (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToPrimive(lhs) throws.");
+assert.sameValue(trace, "123", "?ToPrimive(lhs) throws.");
+
+// ?ToPrimive(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() / (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new MyError();
+      }
+    };
+  })();
+}, "?ToPrimive(rhs) throws.");
+assert.sameValue(trace, "1234", "?ToPrimive(rhs) throws.");
+
+// ?ToNumeric(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return Symbol("1");
+      }
+    };
+  })() / (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToNumeric(lhs) throws.");
+assert.sameValue(trace, "123", "?ToNumeric(lhs) throws.");
+
+// GetValue(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() / (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        return Symbol("1");
+      }
+    };
+  })();
+}, "GetValue(lhs) throws.");
+assert.sameValue(trace, "1234", "GetValue(lhs) throws.");

--- a/test/language/expressions/division/order-of-evaluation.js
+++ b/test/language/expressions/division/order-of-evaluation.js
@@ -33,7 +33,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new Test262Error("should not be evaluated");
       }
@@ -51,7 +51,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new MyError();
       }
@@ -59,7 +59,7 @@ assert.throws(MyError, function() {
   })() / (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -74,7 +74,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -82,7 +82,7 @@ assert.throws(MyError, function() {
   })() / (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new MyError();
       }
@@ -97,7 +97,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return Symbol("1");
       }
@@ -105,7 +105,7 @@ assert.throws(TypeError, function() {
   })() / (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -120,7 +120,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -128,7 +128,7 @@ assert.throws(TypeError, function() {
   })() / (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         return Symbol("1");
       }

--- a/test/language/expressions/exponentiation/order-of-evaluation.js
+++ b/test/language/expressions/exponentiation/order-of-evaluation.js
@@ -1,0 +1,138 @@
+// Copyright (C) 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-exp-operator-runtime-semantics-evaluation
+description: Type coercion order of operations for exponentiation operator
+features: [Symbol]
+info: |
+  Evaluate lhs
+  Evaluate rhs
+  ToNumeric(lhs)
+  ToNumeric(rhs)
+---*/
+
+function MyError() {}
+var trace;
+
+// ?GetValue(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    throw new MyError();
+  })() ** (function() {
+    trace += "2";
+    throw new Test262Error("should not be evaluated");
+  })();
+}, "?GetValue(lhs) throws.");
+assert.sameValue(trace, "1", "?GetValue(lhs) throws.");
+
+// ?GetValue(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })() ** (function() {
+    trace += "2";
+    throw new MyError();
+  })();
+}, "?GetValue(rhs) throws.");
+assert.sameValue(trace, "12", "?GetValue(rhs) throws.");
+
+// ?ToPrimive(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new MyError();
+      }
+    };
+  })() ** (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToPrimive(lhs) throws.");
+assert.sameValue(trace, "123", "?ToPrimive(lhs) throws.");
+
+// ?ToPrimive(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() ** (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new MyError();
+      }
+    };
+  })();
+}, "?ToPrimive(rhs) throws.");
+assert.sameValue(trace, "1234", "?ToPrimive(rhs) throws.");
+
+// ?ToNumeric(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return Symbol("1");
+      }
+    };
+  })() ** (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToNumeric(lhs) throws.");
+assert.sameValue(trace, "123", "?ToNumeric(lhs) throws.");
+
+// GetValue(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() ** (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        return Symbol("1");
+      }
+    };
+  })();
+}, "GetValue(lhs) throws.");
+assert.sameValue(trace, "1234", "GetValue(lhs) throws.");

--- a/test/language/expressions/exponentiation/order-of-evaluation.js
+++ b/test/language/expressions/exponentiation/order-of-evaluation.js
@@ -33,7 +33,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new Test262Error("should not be evaluated");
       }
@@ -51,7 +51,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new MyError();
       }
@@ -59,7 +59,7 @@ assert.throws(MyError, function() {
   })() ** (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -74,7 +74,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -82,7 +82,7 @@ assert.throws(MyError, function() {
   })() ** (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new MyError();
       }
@@ -97,7 +97,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return Symbol("1");
       }
@@ -105,7 +105,7 @@ assert.throws(TypeError, function() {
   })() ** (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -120,7 +120,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -128,7 +128,7 @@ assert.throws(TypeError, function() {
   })() ** (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         return Symbol("1");
       }

--- a/test/language/expressions/left-shift/order-of-evaluation.js
+++ b/test/language/expressions/left-shift/order-of-evaluation.js
@@ -33,7 +33,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new Test262Error("should not be evaluated");
       }
@@ -51,7 +51,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new MyError();
       }
@@ -59,7 +59,7 @@ assert.throws(MyError, function() {
   })() << (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -74,7 +74,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -82,7 +82,7 @@ assert.throws(MyError, function() {
   })() << (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new MyError();
       }
@@ -97,7 +97,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return Symbol("1");
       }
@@ -105,7 +105,7 @@ assert.throws(TypeError, function() {
   })() << (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -120,7 +120,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -128,7 +128,7 @@ assert.throws(TypeError, function() {
   })() << (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         return Symbol("1");
       }

--- a/test/language/expressions/left-shift/order-of-evaluation.js
+++ b/test/language/expressions/left-shift/order-of-evaluation.js
@@ -1,0 +1,138 @@
+// Copyright (C) 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-left-shift-operator-runtime-semantics-evaluation
+description: Type coercion order of operations for left-shift operator
+features: [Symbol]
+info: |
+  Evaluate lhs
+  Evaluate rhs
+  ToNumeric(lhs)
+  ToNumeric(rhs)
+---*/
+
+function MyError() {}
+var trace;
+
+// ?GetValue(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    throw new MyError();
+  })() << (function() {
+    trace += "2";
+    throw new Test262Error("should not be evaluated");
+  })();
+}, "?GetValue(lhs) throws.");
+assert.sameValue(trace, "1", "?GetValue(lhs) throws.");
+
+// ?GetValue(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })() << (function() {
+    trace += "2";
+    throw new MyError();
+  })();
+}, "?GetValue(rhs) throws.");
+assert.sameValue(trace, "12", "?GetValue(rhs) throws.");
+
+// ?ToPrimive(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new MyError();
+      }
+    };
+  })() << (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToPrimive(lhs) throws.");
+assert.sameValue(trace, "123", "?ToPrimive(lhs) throws.");
+
+// ?ToPrimive(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() << (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new MyError();
+      }
+    };
+  })();
+}, "?ToPrimive(rhs) throws.");
+assert.sameValue(trace, "1234", "?ToPrimive(rhs) throws.");
+
+// ?ToNumeric(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return Symbol("1");
+      }
+    };
+  })() << (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToNumeric(lhs) throws.");
+assert.sameValue(trace, "123", "?ToNumeric(lhs) throws.");
+
+// GetValue(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() << (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        return Symbol("1");
+      }
+    };
+  })();
+}, "GetValue(lhs) throws.");
+assert.sameValue(trace, "1234", "GetValue(lhs) throws.");

--- a/test/language/expressions/modulus/order-of-evaluation.js
+++ b/test/language/expressions/modulus/order-of-evaluation.js
@@ -1,0 +1,138 @@
+// Copyright (C) 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+description: Type coercion order of operations for modulus operator
+features: [Symbol]
+info: |
+  Evaluate lhs
+  Evaluate rhs
+  ToNumeric(lhs)
+  ToNumeric(rhs)
+---*/
+
+function MyError() {}
+var trace;
+
+// ?GetValue(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    throw new MyError();
+  })() % (function() {
+    trace += "2";
+    throw new Test262Error("should not be evaluated");
+  })();
+}, "?GetValue(lhs) throws.");
+assert.sameValue(trace, "1", "?GetValue(lhs) throws.");
+
+// ?GetValue(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })() % (function() {
+    trace += "2";
+    throw new MyError();
+  })();
+}, "?GetValue(rhs) throws.");
+assert.sameValue(trace, "12", "?GetValue(rhs) throws.");
+
+// ?ToPrimive(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new MyError();
+      }
+    };
+  })() % (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToPrimive(lhs) throws.");
+assert.sameValue(trace, "123", "?ToPrimive(lhs) throws.");
+
+// ?ToPrimive(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() % (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new MyError();
+      }
+    };
+  })();
+}, "?ToPrimive(rhs) throws.");
+assert.sameValue(trace, "1234", "?ToPrimive(rhs) throws.");
+
+// ?ToNumeric(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return Symbol("1");
+      }
+    };
+  })() % (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToNumeric(lhs) throws.");
+assert.sameValue(trace, "123", "?ToNumeric(lhs) throws.");
+
+// GetValue(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() % (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        return Symbol("1");
+      }
+    };
+  })();
+}, "GetValue(lhs) throws.");
+assert.sameValue(trace, "1234", "GetValue(lhs) throws.");

--- a/test/language/expressions/modulus/order-of-evaluation.js
+++ b/test/language/expressions/modulus/order-of-evaluation.js
@@ -33,7 +33,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new Test262Error("should not be evaluated");
       }
@@ -51,7 +51,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new MyError();
       }
@@ -59,7 +59,7 @@ assert.throws(MyError, function() {
   })() % (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -74,7 +74,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -82,7 +82,7 @@ assert.throws(MyError, function() {
   })() % (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new MyError();
       }
@@ -97,7 +97,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return Symbol("1");
       }
@@ -105,7 +105,7 @@ assert.throws(TypeError, function() {
   })() % (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -120,7 +120,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -128,7 +128,7 @@ assert.throws(TypeError, function() {
   })() % (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         return Symbol("1");
       }

--- a/test/language/expressions/multiplication/order-of-evaluation.js
+++ b/test/language/expressions/multiplication/order-of-evaluation.js
@@ -33,7 +33,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new Test262Error("should not be evaluated");
       }
@@ -51,7 +51,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new MyError();
       }
@@ -59,7 +59,7 @@ assert.throws(MyError, function() {
   })() * (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -74,7 +74,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -82,7 +82,7 @@ assert.throws(MyError, function() {
   })() * (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new MyError();
       }
@@ -97,7 +97,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return Symbol("1");
       }
@@ -105,7 +105,7 @@ assert.throws(TypeError, function() {
   })() * (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -120,7 +120,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -128,7 +128,7 @@ assert.throws(TypeError, function() {
   })() * (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         return Symbol("1");
       }

--- a/test/language/expressions/multiplication/order-of-evaluation.js
+++ b/test/language/expressions/multiplication/order-of-evaluation.js
@@ -1,0 +1,138 @@
+// Copyright (C) 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-multiplicative-operators-runtime-semantics-evaluation
+description: Type coercion order of operations for multiplication operator
+features: [Symbol]
+info: |
+  Evaluate lhs
+  Evaluate rhs
+  ToNumeric(lhs)
+  ToNumeric(rhs)
+---*/
+
+function MyError() {}
+var trace;
+
+// ?GetValue(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    throw new MyError();
+  })() * (function() {
+    trace += "2";
+    throw new Test262Error("should not be evaluated");
+  })();
+}, "?GetValue(lhs) throws.");
+assert.sameValue(trace, "1", "?GetValue(lhs) throws.");
+
+// ?GetValue(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })() * (function() {
+    trace += "2";
+    throw new MyError();
+  })();
+}, "?GetValue(rhs) throws.");
+assert.sameValue(trace, "12", "?GetValue(rhs) throws.");
+
+// ?ToPrimive(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new MyError();
+      }
+    };
+  })() * (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToPrimive(lhs) throws.");
+assert.sameValue(trace, "123", "?ToPrimive(lhs) throws.");
+
+// ?ToPrimive(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() * (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new MyError();
+      }
+    };
+  })();
+}, "?ToPrimive(rhs) throws.");
+assert.sameValue(trace, "1234", "?ToPrimive(rhs) throws.");
+
+// ?ToNumeric(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return Symbol("1");
+      }
+    };
+  })() * (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToNumeric(lhs) throws.");
+assert.sameValue(trace, "123", "?ToNumeric(lhs) throws.");
+
+// GetValue(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() * (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        return Symbol("1");
+      }
+    };
+  })();
+}, "GetValue(lhs) throws.");
+assert.sameValue(trace, "1234", "GetValue(lhs) throws.");

--- a/test/language/expressions/right-shift/order-of-evaluation.js
+++ b/test/language/expressions/right-shift/order-of-evaluation.js
@@ -1,0 +1,138 @@
+// Copyright (C) 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-signed-right-shift-operator-runtime-semantics-evaluation
+description: Type coercion order of operations for right-shift operator
+features: [Symbol]
+info: |
+  Evaluate lhs
+  Evaluate rhs
+  ToNumeric(lhs)
+  ToNumeric(rhs)
+---*/
+
+function MyError() {}
+var trace;
+
+// ?GetValue(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    throw new MyError();
+  })() >> (function() {
+    trace += "2";
+    throw new Test262Error("should not be evaluated");
+  })();
+}, "?GetValue(lhs) throws.");
+assert.sameValue(trace, "1", "?GetValue(lhs) throws.");
+
+// ?GetValue(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })() >> (function() {
+    trace += "2";
+    throw new MyError();
+  })();
+}, "?GetValue(rhs) throws.");
+assert.sameValue(trace, "12", "?GetValue(rhs) throws.");
+
+// ?ToPrimive(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new MyError();
+      }
+    };
+  })() >> (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToPrimive(lhs) throws.");
+assert.sameValue(trace, "123", "?ToPrimive(lhs) throws.");
+
+// ?ToPrimive(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() >> (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new MyError();
+      }
+    };
+  })();
+}, "?ToPrimive(rhs) throws.");
+assert.sameValue(trace, "1234", "?ToPrimive(rhs) throws.");
+
+// ?ToNumeric(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return Symbol("1");
+      }
+    };
+  })() >> (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToNumeric(lhs) throws.");
+assert.sameValue(trace, "123", "?ToNumeric(lhs) throws.");
+
+// GetValue(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() >> (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        return Symbol("1");
+      }
+    };
+  })();
+}, "GetValue(lhs) throws.");
+assert.sameValue(trace, "1234", "GetValue(lhs) throws.");

--- a/test/language/expressions/right-shift/order-of-evaluation.js
+++ b/test/language/expressions/right-shift/order-of-evaluation.js
@@ -33,7 +33,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new Test262Error("should not be evaluated");
       }
@@ -51,7 +51,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new MyError();
       }
@@ -59,7 +59,7 @@ assert.throws(MyError, function() {
   })() >> (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -74,7 +74,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -82,7 +82,7 @@ assert.throws(MyError, function() {
   })() >> (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new MyError();
       }
@@ -97,7 +97,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return Symbol("1");
       }
@@ -105,7 +105,7 @@ assert.throws(TypeError, function() {
   })() >> (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -120,7 +120,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -128,7 +128,7 @@ assert.throws(TypeError, function() {
   })() >> (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         return Symbol("1");
       }

--- a/test/language/expressions/subtraction/order-of-evaluation.js
+++ b/test/language/expressions/subtraction/order-of-evaluation.js
@@ -33,7 +33,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new Test262Error("should not be evaluated");
       }
@@ -51,7 +51,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new MyError();
       }
@@ -59,7 +59,7 @@ assert.throws(MyError, function() {
   })() - (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -74,7 +74,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -82,7 +82,7 @@ assert.throws(MyError, function() {
   })() - (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new MyError();
       }
@@ -97,7 +97,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return Symbol("1");
       }
@@ -105,7 +105,7 @@ assert.throws(TypeError, function() {
   })() - (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -120,7 +120,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -128,7 +128,7 @@ assert.throws(TypeError, function() {
   })() - (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         return Symbol("1");
       }

--- a/test/language/expressions/subtraction/order-of-evaluation.js
+++ b/test/language/expressions/subtraction/order-of-evaluation.js
@@ -1,0 +1,138 @@
+// Copyright (C) 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-subtraction-operator-minus-runtime-semantics-evaluation
+description: Type coercion order of operations for subtraction operator
+features: [Symbol]
+info: |
+  Evaluate lhs
+  Evaluate rhs
+  ToNumeric(lhs)
+  ToNumeric(rhs)
+---*/
+
+function MyError() {}
+var trace;
+
+// ?GetValue(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    throw new MyError();
+  })() - (function() {
+    trace += "2";
+    throw new Test262Error("should not be evaluated");
+  })();
+}, "?GetValue(lhs) throws.");
+assert.sameValue(trace, "1", "?GetValue(lhs) throws.");
+
+// ?GetValue(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })() - (function() {
+    trace += "2";
+    throw new MyError();
+  })();
+}, "?GetValue(rhs) throws.");
+assert.sameValue(trace, "12", "?GetValue(rhs) throws.");
+
+// ?ToPrimive(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new MyError();
+      }
+    };
+  })() - (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToPrimive(lhs) throws.");
+assert.sameValue(trace, "123", "?ToPrimive(lhs) throws.");
+
+// ?ToPrimive(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() - (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new MyError();
+      }
+    };
+  })();
+}, "?ToPrimive(rhs) throws.");
+assert.sameValue(trace, "1234", "?ToPrimive(rhs) throws.");
+
+// ?ToNumeric(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return Symbol("1");
+      }
+    };
+  })() - (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToNumeric(lhs) throws.");
+assert.sameValue(trace, "123", "?ToNumeric(lhs) throws.");
+
+// GetValue(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() - (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        return Symbol("1");
+      }
+    };
+  })();
+}, "GetValue(lhs) throws.");
+assert.sameValue(trace, "1234", "GetValue(lhs) throws.");

--- a/test/language/expressions/unsigned-right-shift/order-of-evaluation.js
+++ b/test/language/expressions/unsigned-right-shift/order-of-evaluation.js
@@ -1,0 +1,138 @@
+// Copyright (C) 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-unsigned-right-shift-operator-runtime-semantics-evaluation
+description: Type coercion order of operations for unsigned-right-shift operator
+features: [Symbol]
+info: |
+  Evaluate lhs
+  Evaluate rhs
+  ToNumeric(lhs)
+  ToNumeric(rhs)
+---*/
+
+function MyError() {}
+var trace;
+
+// ?GetValue(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    throw new MyError();
+  })() >>> (function() {
+    trace += "2";
+    throw new Test262Error("should not be evaluated");
+  })();
+}, "?GetValue(lhs) throws.");
+assert.sameValue(trace, "1", "?GetValue(lhs) throws.");
+
+// ?GetValue(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })() >>> (function() {
+    trace += "2";
+    throw new MyError();
+  })();
+}, "?GetValue(rhs) throws.");
+assert.sameValue(trace, "12", "?GetValue(rhs) throws.");
+
+// ?ToPrimive(lhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        throw new MyError();
+      }
+    };
+  })() >>> (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToPrimive(lhs) throws.");
+assert.sameValue(trace, "123", "?ToPrimive(lhs) throws.");
+
+// ?ToPrimive(rhs) throws.
+trace = "";
+assert.throws(MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() >>> (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new MyError();
+      }
+    };
+  })();
+}, "?ToPrimive(rhs) throws.");
+assert.sameValue(trace, "1234", "?ToPrimive(rhs) throws.");
+
+// ?ToNumeric(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return Symbol("1");
+      }
+    };
+  })() >>> (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        throw new Test262Error("should not be evaluated");
+      }
+    };
+  })();
+}, "?ToNumeric(lhs) throws.");
+assert.sameValue(trace, "123", "?ToNumeric(lhs) throws.");
+
+// GetValue(lhs) throws.
+trace = "";
+assert.throws(TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() >>> (function() {
+    trace += "2";
+    return {
+      valueOf() {
+        trace += "4";
+        return Symbol("1");
+      }
+    };
+  })();
+}, "GetValue(lhs) throws.");
+assert.sameValue(trace, "1234", "GetValue(lhs) throws.");

--- a/test/language/expressions/unsigned-right-shift/order-of-evaluation.js
+++ b/test/language/expressions/unsigned-right-shift/order-of-evaluation.js
@@ -33,7 +33,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new Test262Error("should not be evaluated");
       }
@@ -51,7 +51,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         throw new MyError();
       }
@@ -59,7 +59,7 @@ assert.throws(MyError, function() {
   })() >>> (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -74,7 +74,7 @@ assert.throws(MyError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -82,7 +82,7 @@ assert.throws(MyError, function() {
   })() >>> (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new MyError();
       }
@@ -97,7 +97,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return Symbol("1");
       }
@@ -105,7 +105,7 @@ assert.throws(TypeError, function() {
   })() >>> (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         throw new Test262Error("should not be evaluated");
       }
@@ -120,7 +120,7 @@ assert.throws(TypeError, function() {
   (function() {
     trace += "1";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "3";
         return 1;
       }
@@ -128,7 +128,7 @@ assert.throws(TypeError, function() {
   })() >>> (function() {
     trace += "2";
     return {
-      valueOf() {
+      valueOf: function() {
         trace += "4";
         return Symbol("1");
       }


### PR DESCRIPTION
These tests use terminology from the BigInt proposal, such as ToNumeric, but do not functionally depend on anything from the BigInt proposal. The semantics tested in this PR are preserved by the BigInt proposal.

There is some overlap between these tests and existing tests such as:

* `language/expressions/unsigned-right-shift/S11.7.3_A2.3_T1.js`
* `language/expressions/unsigned-right-shift/S11.7.3_A2.4_T2.js`

I think the tests in this PR make sense as is, but they are quite long compared to other test262 tests. I would be happy to cut these tests up into smaller pieces, and/or cut out the parts that are already covered by other tests, such as the ones mentioned above. I'm using python to generate these, so it wouldn't be too much work to make changes like this.

I used shorthand in the frontmatter info to try to emphasize exactly what was being tested here. I can quote the spec verbatim instead of that would be preferable.

Note that the `addition` test has different semantics from all the others when comparing the second-to-last case in each test.