### PR TITLE
Refactor object initializer tests for parsers

### DIFF
--- a/test/language/expressions/object/11.1.5_4-4-d-1.js
+++ b/test/language/expressions/object/11.1.5_4-4-d-1.js
@@ -1,9 +1,0 @@
-// Copyright (c) 2012 Ecma International.  All rights reserved.
-// This code is governed by the BSD license found in the LICENSE file.
-
-/*---
-es5id: 11.1.5_4-4-d-1
-description: Object literal - No SyntaxError for duplicate property name (get,get)
----*/
-
-  eval("({get foo(){}, get foo(){}});");

--- a/test/language/expressions/object/getter-body-strict-inside.js
+++ b/test/language/expressions/object/getter-body-strict-inside.js
@@ -1,23 +1,22 @@
 // Copyright (c) 2012 Ecma International.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
 es5id: 11.1.5_6-2-2-s
 description: >
     Strict Mode - SyntaxError is thrown when an assignment to a
     reserved word or a future reserved word is made inside a strict
     mode FunctionBody of a PropertyAssignment
+negative:
+  type: SyntaxError
+  phase: parse
 flags: [noStrict]
 ---*/
 
+throw "Test262: This statement should not be evaluated.";
 
-assert.throws(SyntaxError, function() {
-            eval("var obj = {\
-                get _11_1_5_6_2_2() {\
-                   \"use strict\";\
-                   public = 42;\
-                   return public;\
-                }\
-            };\
-            var _11_1_5_6_2_2 = obj._11_1_5_6_2_2;");
-});
+void {
+  get x() {
+    "use strict";
+    public = 42;
+  }
+};

--- a/test/language/expressions/object/getter-body-strict-outside.js
+++ b/test/language/expressions/object/getter-body-strict-outside.js
@@ -1,22 +1,20 @@
 // Copyright (c) 2012 Ecma International.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
 es5id: 11.1.5_6-2-1-s
 description: >
     Strict Mode - SyntaxError is thrown when an assignment to a
     reserved word or a future reserved word is contained in strict code
+negative:
+  type: SyntaxError
+  phase: parse
 flags: [onlyStrict]
 ---*/
 
+throw "Test262: This statement should not be evaluated.";
 
-assert.throws(SyntaxError, function() {
-            eval("var obj = {\
-                get _11_1_5_6_2_1() {\
-                   public = 42;\
-                   return public;\
-                }\
-            };");
-
-            var _11_1_5_6_2_1 = obj._11_1_5_6_2_1;
-});
+void {
+  get x() {
+    public = 42;
+  }
+};

--- a/test/language/expressions/object/prop-dup-data-data.js
+++ b/test/language/expressions/object/prop-dup-data-data.js
@@ -14,4 +14,7 @@ description: >
     strict mode
 ---*/
 
-  eval("({foo:0,foo:1});");
+void {
+  foo: 0,
+  foo: 1
+};

--- a/test/language/expressions/object/prop-dup-data-set.js
+++ b/test/language/expressions/object/prop-dup-data-set.js
@@ -8,4 +8,7 @@ description: >
     followed by set accessor definition with the same name
 ---*/
 
-  eval("({foo : 1, set foo(x){}});");
+void {
+  foo: 1,
+  set foo(x) {}
+};

--- a/test/language/expressions/object/prop-dup-get-data.js
+++ b/test/language/expressions/object/prop-dup-get-data.js
@@ -2,10 +2,13 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.1.5_4-4-c-2
+es5id: 11.1.5_4-4-c-1
 description: >
-    Object literal - No SyntaxError if a set accessor property definition
+    Object literal - No SyntaxError if a get accessor property definition
     is followed by a data property definition with the same name
 ---*/
 
-  eval("({set foo(x){}, foo : 1});");
+void {
+  get foo() {},
+  foo: 1
+};

--- a/test/language/expressions/object/prop-dup-get-get.js
+++ b/test/language/expressions/object/prop-dup-get-get.js
@@ -2,9 +2,11 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.1.5-4-4-a-1-s
-description: >
-    Object literal - No SyntaxError for duplicate data property names
+es5id: 11.1.5_4-4-d-1
+description: Object literal - No SyntaxError for duplicate property name (get,get)
 ---*/
 
-  eval("({foo:0,foo:1});");
+void {
+  get foo() {},
+  get foo() {}
+};

--- a/test/language/expressions/object/prop-dup-get-set-get.js
+++ b/test/language/expressions/object/prop-dup-get-set-get.js
@@ -8,4 +8,8 @@ description: >
     (get,set,get)
 ---*/
 
-  eval("({get foo(){}, set foo(arg){}, get foo(){}});");
+void {
+  get foo() {},
+  set foo(arg) {},
+  get foo() {}
+};

--- a/test/language/expressions/object/prop-dup-set-data.js
+++ b/test/language/expressions/object/prop-dup-set-data.js
@@ -2,10 +2,13 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.1.5_4-4-c-1
+es5id: 11.1.5_4-4-c-2
 description: >
-    Object literal - No SyntaxError if a get accessor property definition
+    Object literal - No SyntaxError if a set accessor property definition
     is followed by a data property definition with the same name
 ---*/
 
-  eval("({get foo(){}, foo : 1});");
+void {
+  set foo(x) {},
+  foo: 1
+};

--- a/test/language/expressions/object/prop-dup-set-get-set.js
+++ b/test/language/expressions/object/prop-dup-set-get-set.js
@@ -8,4 +8,8 @@ description: >
     (set,get,set)
 ---*/
 
-  eval("({set foo(arg){}, get foo(){}, set foo(arg1){}});");
+void {
+  set foo(arg) {},
+  get foo() {},
+  set foo(arg1) {}
+};

--- a/test/language/expressions/object/prop-dup-set-set.js
+++ b/test/language/expressions/object/prop-dup-set-set.js
@@ -6,4 +6,7 @@ es5id: 11.1.5_4-4-d-2
 description: Object literal - No SyntaxError for duplicate property name (set,set)
 ---*/
 
-  eval("({set foo(arg){}, set foo(arg1){}});");
+void {
+  set foo(arg) {},
+  set foo(arg1) {}
+};

--- a/test/language/expressions/object/setter-body-strict-inside.js
+++ b/test/language/expressions/object/setter-body-strict-inside.js
@@ -1,23 +1,22 @@
 // Copyright (c) 2012 Ecma International.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
 es5id: 11.1.5_7-2-2-s
 description: >
     Strict Mode - SyntaxError is thrown when an assignment to a
     reserved word is made in  a strict FunctionBody of a
     PropertyAssignment
-flags: [onlyStrict]
+negative:
+  type: SyntaxError
+  phase: parse
+flags: [noStrict]
 ---*/
 
+throw "Test262: This statement should not be evaluated.";
 
-assert.throws(SyntaxError, function() {
-            eval("var data = \"data\";\
-            var obj = {\
-                set _11_1_5_7_2_2(value) {\
-                    public = 42;\
-                    data = value;\
-                }\
-            };\
-            obj._11_1_5_7_2_2 = 1;");
-});
+void {
+  set x(value) {
+    "use strict";
+    public = 42;
+  }
+};

--- a/test/language/expressions/object/setter-body-strict-outside.js
+++ b/test/language/expressions/object/setter-body-strict-outside.js
@@ -1,22 +1,20 @@
 // Copyright (c) 2012 Ecma International.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
 es5id: 11.1.5_7-2-1-s
 description: >
     Strict Mode - SyntaxError is thrown when an assignment to a
     reserved word is contained in strict code
+negative:
+  type: SyntaxError
+  phase: parse
 flags: [onlyStrict]
 ---*/
 
+throw "Test262: This statement should not be evaluated.";
 
-assert.throws(SyntaxError, function() {
-            eval("var data = \"data\";\
-            var obj = {\
-                set _11_1_5_7_2_1(value) {\
-                    public = 42;\
-                    data = value;\
-                }\
-            };\
-            obj._11_1_5_7_2_1 = 1;");
-});
+void {
+  set x(value) {
+    public = 42;
+  }
+};

--- a/test/language/expressions/object/setter-param-arguments-strict-inside.js
+++ b/test/language/expressions/object/setter-param-arguments-strict-inside.js
@@ -1,16 +1,21 @@
 // Copyright (c) 2012 Ecma International.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
 es5id: 11.1.5-4-s
 description: >
     Strict Mode - SyntaxError is thrown when 'arguments'  occurs as
     the Identifier in a PropertySetParameterList of a
     PropertyAssignment  if its FunctionBody is strict code
+negative:
+  type: SyntaxError
+  phase: parse
 flags: [noStrict]
 ---*/
 
+throw "Test262: This statement should not be evaluated.";
 
-assert.throws(SyntaxError, function() {
-            eval("var obj = {set _11_1_5_4_fun(arguments) {\"use strict\";}};");
-});
+void {
+  set x(arguments) {
+    "use strict";
+  }
+};

--- a/test/language/expressions/object/setter-param-arguments-strict-outside.js
+++ b/test/language/expressions/object/setter-param-arguments-strict-outside.js
@@ -1,16 +1,19 @@
 // Copyright (c) 2012 Ecma International.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
 es5id: 11.1.5-2-s
 description: >
     Strict Mode - SyntaxError is thrown when 'arguments' occurs as the
     Identifier in a PropertySetParameterList of a PropertyAssignment
     that is contained in strict code
+negative:
+  type: SyntaxError
+  phase: parse
 flags: [onlyStrict]
 ---*/
 
+throw "Test262: This statement should not be evaluated.";
 
-assert.throws(SyntaxError, function() {
-            eval("var obj = {set _11_1_5_2_fun(arguments) {} };");
-});
+void {
+  set x(arguments) {}
+};

--- a/test/language/expressions/object/setter-param-eval-strict-inside.js
+++ b/test/language/expressions/object/setter-param-eval-strict-inside.js
@@ -1,16 +1,21 @@
 // Copyright (c) 2012 Ecma International.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
 es5id: 11.1.5-3-s
 description: >
     Strict Mode - SyntaxError is thrown when  'evals'  occurs as the
     Identifier in a PropertySetParameterList of a PropertyAssignment
     if its FunctionBody is strict code
+negative:
+  type: SyntaxError
+  phase: parse
 flags: [noStrict]
 ---*/
 
+throw "Test262: This statement should not be evaluated.";
 
-assert.throws(SyntaxError, function() {
-            eval("var obj = {set _11_1_5_3_fun(eval) { \"use strict\"; }};");
-});
+void {
+  set x(eval) {
+    "use strict";
+  }
+};

--- a/test/language/expressions/object/setter-param-eval-strict-outside.js
+++ b/test/language/expressions/object/setter-param-eval-strict-outside.js
@@ -1,16 +1,19 @@
 // Copyright (c) 2012 Ecma International.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
 es5id: 11.1.5-1-s
 description: >
     Strict Mode - SyntaxError is thrown when 'eval' occurs as the
     Identifier in a PropertySetParameterList of a PropertyAssignment
     that is contained in strict code
+negative:
+  type: SyntaxError
+  phase: parse
 flags: [onlyStrict]
 ---*/
 
+throw "Test262: This statement should not be evaluated.";
 
-assert.throws(SyntaxError, function() {
-            eval("var obj = {set _11_1_5_1_fun(eval) {}};");
-});
+void {
+  set x(eval) {}
+};


### PR DESCRIPTION
A number of tests for the parsing of object initializers were expressed
using `eval`. This made the tests more complex than necessary and also
prevented the tests from providing value to ECMAScript parsers.

Remove the use of `eval` in the relevant tests and instead express the
expectations with literal source text.

---

This is in service of gh-1356