### PR TITLE
initial Atomics tests for BigInt

### DIFF
--- a/test/built-ins/Atomics/add/bad-range.js
+++ b/test/built-ins/Atomics/add/bad-range.js
@@ -9,8 +9,13 @@ includes: [testAtomics.js, testTypedArray.js]
 features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, let, TypedArray, for-of]
 ---*/
 
-var sab = new SharedArrayBuffer(4);
+var sab = new SharedArrayBuffer(8);
 var views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
+
+if (typeof BigInt !== "undefined") {
+  views.push(BigInt64Array);
+  views.push(BigUint64Array);
+}
 
 testWithTypedArrayConstructors(function(View) {
     let view = new View(sab);

--- a/test/built-ins/Atomics/add/nonshared-int-views.js
+++ b/test/built-ins/Atomics/add/nonshared-int-views.js
@@ -13,6 +13,11 @@ var ab = new ArrayBuffer(16);
 
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
+if (typeof BigInt !== "undefined") {
+  int_views.push(BigInt64Array);
+  int_views.push(BigUint64Array);
+}
+
 testWithTypedArrayConstructors(function(View) {
     var view = new View(ab);
 

--- a/test/built-ins/Atomics/and/bad-range.js
+++ b/test/built-ins/Atomics/and/bad-range.js
@@ -9,8 +9,13 @@ includes: [testAtomics.js, testTypedArray.js]
 features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, let, TypedArray, for-of]
 ---*/
 
-var sab = new SharedArrayBuffer(4);
+var sab = new SharedArrayBuffer(8);
 var views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
+
+if (typeof BigInt !== "undefined") {
+  views.push(BigInt64Array);
+  views.push(BigUint64Array);
+}
 
 testWithTypedArrayConstructors(function(View) {
     let view = new View(sab);

--- a/test/built-ins/Atomics/and/nonshared-int-views.js
+++ b/test/built-ins/Atomics/and/nonshared-int-views.js
@@ -13,6 +13,11 @@ var ab = new ArrayBuffer(16);
 
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
+if (typeof BigInt !== "undefined") {
+  int_views.push(BigInt64Array);
+  int_views.push(BigUint64Array);
+}
+
 testWithTypedArrayConstructors(function(View) {
     var view = new View(ab);
 

--- a/test/built-ins/Atomics/compareExchange/bad-range.js
+++ b/test/built-ins/Atomics/compareExchange/bad-range.js
@@ -9,8 +9,13 @@ includes: [testAtomics.js, testTypedArray.js]
 features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, let, TypedArray, for-of]
 ---*/
 
-var sab = new SharedArrayBuffer(4);
+var sab = new SharedArrayBuffer(8);
 var views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
+
+if (typeof BigInt !== "undefined") {
+  views.push(BigInt64Array);
+  views.push(BigUint64Array);
+}
 
 testWithTypedArrayConstructors(function(View) {
     let view = new View(sab);

--- a/test/built-ins/Atomics/compareExchange/nonshared-int-views.js
+++ b/test/built-ins/Atomics/compareExchange/nonshared-int-views.js
@@ -13,6 +13,11 @@ var ab = new ArrayBuffer(16);
 
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
+if (typeof BigInt !== "undefined") {
+  int_views.push(BigInt64Array);
+  int_views.push(BigUint64Array);
+}
+
 testWithTypedArrayConstructors(function(View) {
     var view = new View(ab);
 

--- a/test/built-ins/Atomics/exchange/bad-range.js
+++ b/test/built-ins/Atomics/exchange/bad-range.js
@@ -9,8 +9,13 @@ includes: [testAtomics.js, testTypedArray.js]
 features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, let, TypedArray, for-of]
 ---*/
 
-var sab = new SharedArrayBuffer(4);
+var sab = new SharedArrayBuffer(8);
 var views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
+
+if (typeof BigInt !== "undefined") {
+  views.push(BigInt64Array);
+  views.push(BigUint64Array);
+}
 
 testWithTypedArrayConstructors(function(View) {
     let view = new View(sab);

--- a/test/built-ins/Atomics/exchange/nonshared-int-views.js
+++ b/test/built-ins/Atomics/exchange/nonshared-int-views.js
@@ -13,6 +13,11 @@ var ab = new ArrayBuffer(16);
 
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
+if (typeof BigInt !== "undefined") {
+  int_views.push(BigInt64Array);
+  int_views.push(BigUint64Array);
+}
+
 testWithTypedArrayConstructors(function(View) {
     var view = new View(ab);
 

--- a/test/built-ins/Atomics/load/bad-range.js
+++ b/test/built-ins/Atomics/load/bad-range.js
@@ -9,8 +9,13 @@ includes: [testAtomics.js, testTypedArray.js]
 features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, let, TypedArray, for-of]
 ---*/
 
-var sab = new SharedArrayBuffer(4);
+var sab = new SharedArrayBuffer(8);
 var views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
+
+if (typeof BigInt !== "undefined") {
+  views.push(BigInt64Array);
+  views.push(BigUint64Array);
+}
 
 testWithTypedArrayConstructors(function(View) {
     let view = new View(sab);

--- a/test/built-ins/Atomics/load/nonshared-int-views.js
+++ b/test/built-ins/Atomics/load/nonshared-int-views.js
@@ -13,6 +13,11 @@ var ab = new ArrayBuffer(16);
 
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
+if (typeof BigInt !== "undefined") {
+  int_views.push(BigInt64Array);
+  int_views.push(BigUint64Array);
+}
+
 testWithTypedArrayConstructors(function(View) {
     var view = new View(ab);
 

--- a/test/built-ins/Atomics/or/bad-range.js
+++ b/test/built-ins/Atomics/or/bad-range.js
@@ -9,8 +9,13 @@ includes: [testAtomics.js, testTypedArray.js]
 features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, let, TypedArray, for-of]
 ---*/
 
-var sab = new SharedArrayBuffer(4);
+var sab = new SharedArrayBuffer(8);
 var views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
+
+if (typeof BigInt !== "undefined") {
+  views.push(BigInt64Array);
+  views.push(BigUint64Array);
+}
 
 testWithTypedArrayConstructors(function(View) {
     let view = new View(sab);

--- a/test/built-ins/Atomics/or/nonshared-int-views.js
+++ b/test/built-ins/Atomics/or/nonshared-int-views.js
@@ -13,6 +13,11 @@ var ab = new ArrayBuffer(16);
 
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
+if (typeof BigInt !== "undefined") {
+  int_views.push(BigInt64Array);
+  int_views.push(BigUint64Array);
+}
+
 testWithTypedArrayConstructors(function(View) {
     var view = new View(ab);
 

--- a/test/built-ins/Atomics/store/bad-range.js
+++ b/test/built-ins/Atomics/store/bad-range.js
@@ -9,8 +9,13 @@ includes: [testAtomics.js, testTypedArray.js]
 features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, let, TypedArray, for-of]
 ---*/
 
-var sab = new SharedArrayBuffer(4);
+var sab = new SharedArrayBuffer(8);
 var views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
+
+if (typeof BigInt !== "undefined") {
+  views.push(BigInt64Array);
+  views.push(BigUint64Array);
+}
 
 testWithTypedArrayConstructors(function(View) {
     let view = new View(sab);

--- a/test/built-ins/Atomics/store/nonshared-int-views.js
+++ b/test/built-ins/Atomics/store/nonshared-int-views.js
@@ -13,6 +13,11 @@ var ab = new ArrayBuffer(16);
 
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
+if (typeof BigInt !== "undefined") {
+  int_views.push(BigInt64Array);
+  int_views.push(BigUint64Array);
+}
+
 testWithTypedArrayConstructors(function(View) {
     var view = new View(ab);
 

--- a/test/built-ins/Atomics/sub/bad-range.js
+++ b/test/built-ins/Atomics/sub/bad-range.js
@@ -9,8 +9,13 @@ includes: [testAtomics.js, testTypedArray.js]
 features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, let, TypedArray, for-of]
 ---*/
 
-var sab = new SharedArrayBuffer(4);
+var sab = new SharedArrayBuffer(8);
 var views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
+
+if (typeof BigInt !== "undefined") {
+  views.push(BigInt64Array);
+  views.push(BigUint64Array);
+}
 
 testWithTypedArrayConstructors(function(View) {
     let view = new View(sab);

--- a/test/built-ins/Atomics/sub/nonshared-int-views.js
+++ b/test/built-ins/Atomics/sub/nonshared-int-views.js
@@ -13,6 +13,11 @@ var ab = new ArrayBuffer(16);
 
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
+if (typeof BigInt !== "undefined") {
+  int_views.push(BigInt64Array);
+  int_views.push(BigUint64Array);
+}
+
 testWithTypedArrayConstructors(function(View) {
     var view = new View(ab);
 

--- a/test/built-ins/Atomics/wait/bad-range.js
+++ b/test/built-ins/Atomics/wait/bad-range.js
@@ -5,14 +5,21 @@
 esid: sec-atomics.wait
 description: >
   Test range checking of Atomics.wait on arrays that allow atomic operations
-includes: [testAtomics.js]
-features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, let, for-of]
+includes: [testAtomics.js, testTypedArray.js]
+features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, TypedArray, arrow-function, let, for-of]
 ---*/
 
-var sab = new SharedArrayBuffer(4);
-var view = new Int32Array(sab);
+var sab = new SharedArrayBuffer(8);
+var views = [Int32Array];
 
-testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
+if (typeof BigInt !== "undefined") {
+  views.push(BigInt64Array);
+}
+
+testWithTypedArrayConstructors(function(View) {
+  let view = new View(sab);
+  testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     let Idx = IdxGen(view);
     assert.throws(RangeError, () => Atomics.wait(view, Idx, 10, 0)); // Even with zero timeout
-});
+  });
+}, views);

--- a/test/built-ins/Atomics/wait/nonshared-int-views.js
+++ b/test/built-ins/Atomics/wait/nonshared-int-views.js
@@ -13,6 +13,11 @@ var ab = new ArrayBuffer(16);
 
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
+if (typeof BigInt !== "undefined") {
+  int_views.push(BigInt64Array);
+  int_views.push(BigUint64Array);
+}
+
 testWithTypedArrayConstructors(function(View) {
     var view = new View(ab);
 

--- a/test/built-ins/Atomics/wake/bad-range.js
+++ b/test/built-ins/Atomics/wake/bad-range.js
@@ -5,14 +5,21 @@
 esid: sec-atomics.wake
 description: >
   Test range checking of Atomics.wake on arrays that allow atomic operations
-includes: [testAtomics.js]
-features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, let, for-of]
+includes: [testAtomics.js, testTypedArray.js]
+features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, TypedArray, arrow-function, let, for-of]
 ---*/
 
-var sab = new SharedArrayBuffer(4);
-var view = new Int32Array(sab);
+var sab = new SharedArrayBuffer(8);
+var views = [Int32Array];
 
-testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
+if (typeof BigInt !== "undefined") {
+  views.push(BigInt64Array);
+}
+
+testWithTypedArrayConstructors(function(View) {
+  let view = new View(sab);
+  testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
     let Idx = IdxGen(view);
     assert.throws(RangeError, () => Atomics.wake(view, Idx, 0)); // Even with waking zero
-});
+  });
+}, views);

--- a/test/built-ins/Atomics/wake/nonshared-int-views.js
+++ b/test/built-ins/Atomics/wake/nonshared-int-views.js
@@ -13,6 +13,11 @@ var ab = new ArrayBuffer(16);
 
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
+if (typeof BigInt !== "undefined") {
+  int_views.push(BigInt64Array);
+  int_views.push(BigUint64Array);
+}
+
 testWithTypedArrayConstructors(function(View) {
     var view = new View(ab);
 

--- a/test/built-ins/Atomics/xor/bad-range.js
+++ b/test/built-ins/Atomics/xor/bad-range.js
@@ -9,8 +9,13 @@ includes: [testAtomics.js, testTypedArray.js]
 features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, let, TypedArray, for-of]
 ---*/
 
-var sab = new SharedArrayBuffer(4);
+var sab = new SharedArrayBuffer(8);
 var views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
+
+if (typeof BigInt !== "undefined") {
+  views.push(BigInt64Array);
+  views.push(BigUint64Array);
+}
 
 testWithTypedArrayConstructors(function(View) {
     let view = new View(sab);

--- a/test/built-ins/Atomics/xor/nonshared-int-views.js
+++ b/test/built-ins/Atomics/xor/nonshared-int-views.js
@@ -13,6 +13,11 @@ var ab = new ArrayBuffer(16);
 
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
+if (typeof BigInt !== "undefined") {
+  int_views.push(BigInt64Array);
+  int_views.push(BigUint64Array);
+}
+
 testWithTypedArrayConstructors(function(View) {
     var view = new View(ab);
 


### PR DESCRIPTION
This patch updates the Atomics "bad-range" and "nonshared-int-views" test cases to test BigInt atomic operations when the feature is available.