### PR TITLE
[string-trimming] Fix whitespace tests

### DIFF
--- a/test/built-ins/String/prototype/trimEnd/this-value-whitespace.js
+++ b/test/built-ins/String/prototype/trimEnd/this-value-whitespace.js
@@ -22,7 +22,7 @@ features: [string-trimming, String.prototype.trimEnd]
 var trimEnd = String.prototype.trimEnd;
 
 // A string of all valid WhiteSpace Unicode code points
-var wspc = '\u0009\u000B\u000C\u0020\u00A0\FEFF\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000';
+var wspc = '\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF';
 
 var str = wspc + 'a' + wspc + 'b' + wspc;
 var expected = wspc + 'a' + wspc + 'b';

--- a/test/built-ins/String/prototype/trimStart/this-value-whitespace.js
+++ b/test/built-ins/String/prototype/trimStart/this-value-whitespace.js
@@ -22,7 +22,7 @@ features: [string-trimming, String.prototype.trimStart]
 var trimStart = String.prototype.trimStart;
 
 // A string of all valid WhiteSpace Unicode code points
-var wspc = '\u0009\u000B\u000C\u0020\u00A0\FEFF\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000';
+var wspc = '\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF';
 
 var str = wspc + 'a' + wspc + 'b' + wspc;
 var expected = 'a' + wspc + 'b' + wspc;


### PR DESCRIPTION
This patch fixes a typo (`\FEFF` → `\uFEFF`) and adds some missing whitespace symbols as a follow-up to https://github.com/tc39/test262/pull/1246.