### PR TITLE
Add missing closing parenthesis and remove invalid async flag

### DIFF
--- a/test/built-ins/Array/prototype/flatMap/depth-always-one.js
+++ b/test/built-ins/Array/prototype/flatMap/depth-always-one.js
@@ -14,7 +14,7 @@ assert.compareArray([1, 2].flatMap(function(e) {
 
 var result = [1, 2, 3].flatMap(function(ele) {
   return [[ele * 2]];
-};
+});
 assert.sameValue(result.length, 3, 'array depth is more than 1 - length');
 assert.compareArray(result[0], [2], 'array depth is more than 1 - 1st element');
 assert.compareArray(result[1], [4], 'array depth is more than 1 - 2nd element');

--- a/test/built-ins/Promise/prototype/finally/subclass-species-constructor-resolve-count.js
+++ b/test/built-ins/Promise/prototype/finally/subclass-species-constructor-resolve-count.js
@@ -5,7 +5,6 @@ author: Jordan Harband
 description: finally on resolved Promise calls the SpeciesConstructor
 esid: sec-promise.prototype.finally
 features: [Promise.prototype.finally]
-flags: [async]
 ---*/
 
 class FooPromise extends Promise {


### PR DESCRIPTION
Array/prototype/flatMap/depth-always-one.js
- Someone forgot a closing parenthesis... 😇 

Promise/prototype/finally/subclass-species-constructor-resolve-count.js
- Was incorrectly marked as async.