### PR TITLE
Prefer spaces to tabs if it is not syntax related tests

### DIFF
--- a/test/built-ins/Atomics/wake/wake-all-on-loc.js
+++ b/test/built-ins/Atomics/wake/wake-all-on-loc.js
@@ -70,8 +70,8 @@ function getReport() {
 function waitUntil(ia, k, value) {
     var i = 0;
     while (Atomics.load(ia, k) !== value && i < 15) {
-	$262.agent.sleep(100);
-	i++;
+        $262.agent.sleep(100);
+        i++;
     }
     assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
 }

--- a/test/built-ins/Atomics/wake/wake-all.js
+++ b/test/built-ins/Atomics/wake/wake-all.js
@@ -69,8 +69,8 @@ function getReport() {
 function waitUntil(ia, k, value) {
     var i = 0;
     while (Atomics.load(ia, k) !== value && i < 15) {
-	$262.agent.sleep(100);
-	i++;
+        $262.agent.sleep(100);
+        i++;
     }
     assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
 }

--- a/test/language/module-code/privatename-valid-no-earlyerr.js
+++ b/test/language/module-code/privatename-valid-no-earlyerr.js
@@ -35,7 +35,7 @@ class outer {
     var self = this;
     return class inner {
       g() {
-	return self.#x;
+        return self.#x;
       }
     }
   }

--- a/test/language/statements/class/privatefieldget-typeerror-2.js
+++ b/test/language/statements/class/privatefieldget-typeerror-2.js
@@ -40,7 +40,7 @@ class Outer {
     // private field `#x` is resolvable.
     return class {
       f() {
-	return this.#x;
+        return this.#x;
       }
     }
   }

--- a/test/language/statements/class/privatefieldget-typeerror-5.js
+++ b/test/language/statements/class/privatefieldget-typeerror-5.js
@@ -40,7 +40,7 @@ class Outer {
     return class extends Outer {
       #x = 'not42';
       f() {
-	return self.#x;
+        return self.#x;
       }
     }
   }

--- a/test/language/statements/class/privatefieldset-typeerror-2.js
+++ b/test/language/statements/class/privatefieldset-typeerror-2.js
@@ -40,7 +40,7 @@ class Outer {
     // private field `#x` is resolvable.
     return class {
       f() {
-	this.#x = 1;
+        this.#x = 1;
       }
     }
   }

--- a/test/language/statements/class/privatefieldset-typeerror-5.js
+++ b/test/language/statements/class/privatefieldset-typeerror-5.js
@@ -41,7 +41,7 @@ class Outer {
     return class extends Outer {
       #x = 'not42';
       f() {
-	self.#x = 1;
+        self.#x = 1;
       }
     }
   }

--- a/test/language/statements/class/privatename-valid-no-earlyerr.js
+++ b/test/language/statements/class/privatename-valid-no-earlyerr.js
@@ -37,7 +37,7 @@ class outer {
     var self = this;
     return class inner {
       g() {
-	return self.#x;
+        return self.#x;
       }
     }
   }

--- a/test/language/statements/function/name-unicode.js
+++ b/test/language/statements/function/name-unicode.js
@@ -12,7 +12,7 @@ var funcA = eval("function __func\u0041(__arg){return __arg;}; __funcA");
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
 if (typeof funcA !== "function") {
-	$ERROR('#1: unicode symbols in function name are allowed');
+    $ERROR('#1: unicode symbols in function name are allowed');
 }
 //
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch changes tabs to spaces for newly added tests.
The motivation is that SVN of WebKit tree rejects files including tabs.
If we annotate files with `allow-tabs` SVN property, we can land it.
But unless tabs are intentionally used for parser tests, using spaces is a safer choice.
It removes additional steps when updating test262 in WebKit tree, and WebKit tree can quickly update test262.