### PR TITLE
built-ins/Atomics/*: make all indentation consistent (depth & character)

### DIFF
--- a/test/built-ins/Atomics/add/bad-range.js
+++ b/test/built-ins/Atomics/add/bad-range.js
@@ -18,9 +18,9 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    let view = new View(sab);
-    testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        assert.throws(RangeError, () => Atomics.add(view, Idx, 10));
-    });
+  let view = new View(sab);
+  testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    assert.throws(RangeError, () => Atomics.add(view, Idx, 10));
+  });
 }, views);

--- a/test/built-ins/Atomics/add/good-views.js
+++ b/test/built-ins/Atomics/add/good-views.js
@@ -14,42 +14,42 @@ var ab = new ArrayBuffer(16);
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
 testWithTypedArrayConstructors(function(View) {
-    // Make it interesting - use non-zero byteOffsets and non-zero indexes.
+  // Make it interesting - use non-zero byteOffsets and non-zero indexes.
 
-    var view = new View(sab, 32, 20);
-    var control = new View(ab, 0, 2);
+  var view = new View(sab, 32, 20);
+  var control = new View(ab, 0, 2);
 
-    // Add positive number
-    view[8] = 0;
-    assert.sameValue(Atomics.add(view, 8, 10), 0);
-    assert.sameValue(view[8], 10);
+  // Add positive number
+  view[8] = 0;
+  assert.sameValue(Atomics.add(view, 8, 10), 0);
+  assert.sameValue(view[8], 10);
 
-    // Add negative number
-    assert.sameValue(Atomics.add(view, 8, -5), 10);
-    assert.sameValue(view[8], 5);
+  // Add negative number
+  assert.sameValue(Atomics.add(view, 8, -5), 10);
+  assert.sameValue(view[8], 5);
 
-    view[3] = -5;
-    control[0] = -5;
-    assert.sameValue(Atomics.add(view, 3, 0), control[0],
-                     "Result is negative and subject to coercion");
+  view[3] = -5;
+  control[0] = -5;
+  assert.sameValue(Atomics.add(view, 3, 0), control[0],
+    "Result is negative and subject to coercion");
 
-    control[0] = 12345;
-    view[3] = 12345;
-    assert.sameValue(Atomics.add(view, 3, 0), control[0],
-                     "Result is subject to chopping");
+  control[0] = 12345;
+  view[3] = 12345;
+  assert.sameValue(Atomics.add(view, 3, 0), control[0],
+    "Result is subject to chopping");
 
-    control[0] = 123456789;
-    view[3] = 123456789;
-    assert.sameValue(Atomics.add(view, 3, 0), control[0],
-                     "Result is subject to chopping");
+  control[0] = 123456789;
+  view[3] = 123456789;
+  assert.sameValue(Atomics.add(view, 3, 0), control[0],
+    "Result is subject to chopping");
 
-    // In-bounds boundary cases for indexing
-    testWithAtomicsInBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        view.fill(0);
-        // Atomics.store() computes an index from Idx in the same way as other
-        // Atomics operations, not quite like view[Idx].
-        Atomics.store(view, Idx, 37);
-        assert.sameValue(Atomics.add(view, Idx, 0), 37);
-    });
+  // In-bounds boundary cases for indexing
+  testWithAtomicsInBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    view.fill(0);
+    // Atomics.store() computes an index from Idx in the same way as other
+    // Atomics operations, not quite like view[Idx].
+    Atomics.store(view, Idx, 37);
+    assert.sameValue(Atomics.add(view, Idx, 0), 37);
+  });
 }, int_views);

--- a/test/built-ins/Atomics/add/non-views.js
+++ b/test/built-ins/Atomics/add/non-views.js
@@ -10,5 +10,5 @@ features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, le
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {
-    assert.throws(TypeError, (() => Atomics.add(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.add(view, 0, 0)));
 });

--- a/test/built-ins/Atomics/add/nonshared-int-views.js
+++ b/test/built-ins/Atomics/add/nonshared-int-views.js
@@ -19,7 +19,7 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(ab);
+  var view = new View(ab);
 
-    assert.throws(TypeError, (() => Atomics.add(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.add(view, 0, 0)));
 }, int_views);

--- a/test/built-ins/Atomics/add/shared-nonint-views.js
+++ b/test/built-ins/Atomics/add/shared-nonint-views.js
@@ -14,7 +14,7 @@ var sab = new SharedArrayBuffer(1024);
 var other_views = [Uint8ClampedArray, Float32Array, Float64Array];
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(sab);
+  var view = new View(sab);
 
-    assert.throws(TypeError, (() => Atomics.add(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.add(view, 0, 0)));
 }, other_views);

--- a/test/built-ins/Atomics/and/bad-range.js
+++ b/test/built-ins/Atomics/and/bad-range.js
@@ -18,9 +18,9 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    let view = new View(sab);
-    testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        assert.throws(RangeError, () => Atomics.and(view, Idx, 10));
-    });
+  let view = new View(sab);
+  testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    assert.throws(RangeError, () => Atomics.and(view, Idx, 10));
+  });
 }, views);

--- a/test/built-ins/Atomics/and/good-views.js
+++ b/test/built-ins/Atomics/and/good-views.js
@@ -14,49 +14,49 @@ var ab = new ArrayBuffer(16);
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
 testWithTypedArrayConstructors(function(View) {
-    // Make it interesting - use non-zero byteOffsets and non-zero indexes.
+  // Make it interesting - use non-zero byteOffsets and non-zero indexes.
 
-    var view = new View(sab, 32, 20);
-    var control = new View(ab, 0, 2);
+  var view = new View(sab, 32, 20);
+  var control = new View(ab, 0, 2);
 
-    view[8] = 0x33333333;
-    control[0] = 0x33333333;
-    assert.sameValue(Atomics.and(view, 8, 0x55555555), control[0],
-                     "Result is subject to chopping");
+  view[8] = 0x33333333;
+  control[0] = 0x33333333;
+  assert.sameValue(Atomics.and(view, 8, 0x55555555), control[0],
+    "Result is subject to chopping");
 
-    control[0] = 0x11111111;
-    assert.sameValue(view[8], control[0]);
-    assert.sameValue(Atomics.and(view, 8, 0xF0F0F0F0), control[0],
-                     "Result is subject to chopping");
+  control[0] = 0x11111111;
+  assert.sameValue(view[8], control[0]);
+  assert.sameValue(Atomics.and(view, 8, 0xF0F0F0F0), control[0],
+    "Result is subject to chopping");
 
-    control[0] = 0x10101010;
-    assert.sameValue(view[8], control[0]);
+  control[0] = 0x10101010;
+  assert.sameValue(view[8], control[0]);
 
-    view[3] = -5;
-    control[0] = -5;
-    assert.sameValue(Atomics.and(view, 3, 0), control[0],
-                     "Result is negative and subject to coercion");
-    assert.sameValue(view[3], 0);
+  view[3] = -5;
+  control[0] = -5;
+  assert.sameValue(Atomics.and(view, 3, 0), control[0],
+    "Result is negative and subject to coercion");
+  assert.sameValue(view[3], 0);
 
-    control[0] = 12345;
-    view[3] = 12345;
-    assert.sameValue(Atomics.and(view, 3, 0), control[0],
-                     "Result is subjective to chopping");
-    assert.sameValue(view[3], 0);
+  control[0] = 12345;
+  view[3] = 12345;
+  assert.sameValue(Atomics.and(view, 3, 0), control[0],
+    "Result is subjective to chopping");
+  assert.sameValue(view[3], 0);
 
-    control[0] = 123456789;
-    view[3] = 123456789;
-    assert.sameValue(Atomics.and(view, 3, 0), control[0],
-                     "Result is subjective to chopping");
-    assert.sameValue(view[3], 0);
+  control[0] = 123456789;
+  view[3] = 123456789;
+  assert.sameValue(Atomics.and(view, 3, 0), control[0],
+    "Result is subjective to chopping");
+  assert.sameValue(view[3], 0);
 
-    // In-bounds boundary cases for indexing
-    testWithAtomicsInBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        view.fill(0);
-        // Atomics.store() computes an index from Idx in the same way as other
-        // Atomics operations, not quite like view[Idx].
-        Atomics.store(view, Idx, 37);
-        assert.sameValue(Atomics.and(view, Idx, 0), 37);
-    });
+  // In-bounds boundary cases for indexing
+  testWithAtomicsInBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    view.fill(0);
+    // Atomics.store() computes an index from Idx in the same way as other
+    // Atomics operations, not quite like view[Idx].
+    Atomics.store(view, Idx, 37);
+    assert.sameValue(Atomics.and(view, Idx, 0), 37);
+  });
 }, int_views);

--- a/test/built-ins/Atomics/and/non-views.js
+++ b/test/built-ins/Atomics/and/non-views.js
@@ -10,5 +10,5 @@ features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, le
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {
-    assert.throws(TypeError, (() => Atomics.and(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.and(view, 0, 0)));
 });

--- a/test/built-ins/Atomics/and/nonshared-int-views.js
+++ b/test/built-ins/Atomics/and/nonshared-int-views.js
@@ -19,7 +19,7 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(ab);
+  var view = new View(ab);
 
-    assert.throws(TypeError, (() => Atomics.and(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.and(view, 0, 0)));
 }, int_views);

--- a/test/built-ins/Atomics/and/shared-nonint-views.js
+++ b/test/built-ins/Atomics/and/shared-nonint-views.js
@@ -14,7 +14,7 @@ var sab = new SharedArrayBuffer(1024);
 var other_views = [Uint8ClampedArray, Float32Array, Float64Array];
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(sab);
+  var view = new View(sab);
 
-    assert.throws(TypeError, (() => Atomics.and(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.and(view, 0, 0)));
 }, other_views);

--- a/test/built-ins/Atomics/compareExchange/bad-range.js
+++ b/test/built-ins/Atomics/compareExchange/bad-range.js
@@ -18,9 +18,9 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    let view = new View(sab);
-    testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        assert.throws(RangeError, () => Atomics.compareExchange(view, Idx, 10, 0));
-    });
+  let view = new View(sab);
+  testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    assert.throws(RangeError, () => Atomics.compareExchange(view, Idx, 10, 0));
+  });
 }, views);

--- a/test/built-ins/Atomics/compareExchange/good-views.js
+++ b/test/built-ins/Atomics/compareExchange/good-views.js
@@ -21,54 +21,54 @@ var good_indices = [ (view) => 0/-1, // -0
                    ];
 
 testWithTypedArrayConstructors(function(View) {
-    // Make it interesting - use non-zero byteOffsets and non-zero indexes.
+  // Make it interesting - use non-zero byteOffsets and non-zero indexes.
 
-    var view = new View(sab, 32, 20);
-    var control = new View(ab, 0, 2);
+  var view = new View(sab, 32, 20);
+  var control = new View(ab, 0, 2);
 
-    // Performs the exchange
-    view[8] = 0;
-    assert.sameValue(Atomics.compareExchange(view, 8, 0, 10), 0);
-    assert.sameValue(view[8], 10);
+  // Performs the exchange
+  view[8] = 0;
+  assert.sameValue(Atomics.compareExchange(view, 8, 0, 10), 0);
+  assert.sameValue(view[8], 10);
 
-    view[8] = 0;
-    assert.sameValue(Atomics.compareExchange(view, 8, 1, 10), 0,
-                     "Does not perform the exchange");
-    assert.sameValue(view[8], 0);
+  view[8] = 0;
+  assert.sameValue(Atomics.compareExchange(view, 8, 1, 10), 0,
+    "Does not perform the exchange");
+  assert.sameValue(view[8], 0);
 
-    view[8] = 0;
-    assert.sameValue(Atomics.compareExchange(view, 8, 0, -5), 0,
-                     "Performs the exchange, coercing the value being stored");
-    control[0] = -5;
-    assert.sameValue(view[8], control[0]);
-
-
-    view[3] = -5;
-    control[0] = -5;
-    assert.sameValue(Atomics.compareExchange(view, 3, -5, 0), control[0],
-                     "Performs the exchange, coercing the value being tested");
-    assert.sameValue(view[3], 0);
+  view[8] = 0;
+  assert.sameValue(Atomics.compareExchange(view, 8, 0, -5), 0,
+    "Performs the exchange, coercing the value being stored");
+  control[0] = -5;
+  assert.sameValue(view[8], control[0]);
 
 
-    control[0] = 12345;
-    view[3] = 12345;
-    assert.sameValue(Atomics.compareExchange(view, 3, 12345, 0), control[0],
-                     "Performs the exchange, chopping the value being tested");
-    assert.sameValue(view[3], 0);
+  view[3] = -5;
+  control[0] = -5;
+  assert.sameValue(Atomics.compareExchange(view, 3, -5, 0), control[0],
+    "Performs the exchange, coercing the value being tested");
+  assert.sameValue(view[3], 0);
 
-    control[0] = 123456789;
-    view[3] = 123456789;
-    assert.sameValue(Atomics.compareExchange(view, 3, 123456789, 0), control[0],
-                     "Performs the exchange, chopping the value being tested");
-    assert.sameValue(view[3], 0);
 
-    // In-bounds boundary cases for indexing
-    testWithAtomicsInBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        view.fill(0);
-        // Atomics.store() computes an index from Idx in the same way as other
-        // Atomics operations, not quite like view[Idx].
-        Atomics.store(view, Idx, 37);
-        assert.sameValue(Atomics.compareExchange(view, Idx, 37, 0), 37);
-    });
+  control[0] = 12345;
+  view[3] = 12345;
+  assert.sameValue(Atomics.compareExchange(view, 3, 12345, 0), control[0],
+    "Performs the exchange, chopping the value being tested");
+  assert.sameValue(view[3], 0);
+
+  control[0] = 123456789;
+  view[3] = 123456789;
+  assert.sameValue(Atomics.compareExchange(view, 3, 123456789, 0), control[0],
+    "Performs the exchange, chopping the value being tested");
+  assert.sameValue(view[3], 0);
+
+  // In-bounds boundary cases for indexing
+  testWithAtomicsInBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    view.fill(0);
+    // Atomics.store() computes an index from Idx in the same way as other
+    // Atomics operations, not quite like view[Idx].
+    Atomics.store(view, Idx, 37);
+    assert.sameValue(Atomics.compareExchange(view, Idx, 37, 0), 37);
+  });
 }, int_views);

--- a/test/built-ins/Atomics/compareExchange/non-views.js
+++ b/test/built-ins/Atomics/compareExchange/non-views.js
@@ -10,5 +10,5 @@ features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, le
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {
-    assert.throws(TypeError, (() => Atomics.compareExchange(view, 0, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.compareExchange(view, 0, 0, 0)));
 });

--- a/test/built-ins/Atomics/compareExchange/nonshared-int-views.js
+++ b/test/built-ins/Atomics/compareExchange/nonshared-int-views.js
@@ -19,7 +19,7 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(ab);
+  var view = new View(ab);
 
-    assert.throws(TypeError, (() => Atomics.compareExchange(view, 0, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.compareExchange(view, 0, 0, 0)));
 }, int_views);

--- a/test/built-ins/Atomics/compareExchange/shared-nonint-views.js
+++ b/test/built-ins/Atomics/compareExchange/shared-nonint-views.js
@@ -14,7 +14,7 @@ var sab = new SharedArrayBuffer(1024);
 var other_views = [Uint8ClampedArray, Float32Array, Float64Array];
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(sab);
+  var view = new View(sab);
 
-    assert.throws(TypeError, (() => Atomics.compareExchange(view, 0, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.compareExchange(view, 0, 0, 0)));
 }, other_views);

--- a/test/built-ins/Atomics/exchange/bad-range.js
+++ b/test/built-ins/Atomics/exchange/bad-range.js
@@ -18,9 +18,9 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    let view = new View(sab);
-    testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        assert.throws(RangeError, () => Atomics.exchange(view, Idx, 10, 0));
-    });
+  let view = new View(sab);
+  testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    assert.throws(RangeError, () => Atomics.exchange(view, Idx, 10, 0));
+  });
 }, views);

--- a/test/built-ins/Atomics/exchange/good-views.js
+++ b/test/built-ins/Atomics/exchange/good-views.js
@@ -14,43 +14,43 @@ var ab = new ArrayBuffer(16);
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
 testWithTypedArrayConstructors(function(View) {
-    // Make it interesting - use non-zero byteOffsets and non-zero indexes.
+  // Make it interesting - use non-zero byteOffsets and non-zero indexes.
 
-    var view = new View(sab, 32, 20);
-    var control = new View(ab, 0, 2);
+  var view = new View(sab, 32, 20);
+  var control = new View(ab, 0, 2);
 
-    view[8] = 0;
-    assert.sameValue(Atomics.exchange(view, 8, 10), 0,
-                     "Exchange returns the value previously in the array");
-    assert.sameValue(view[8], 10);
+  view[8] = 0;
+  assert.sameValue(Atomics.exchange(view, 8, 10), 0,
+    "Exchange returns the value previously in the array");
+  assert.sameValue(view[8], 10);
 
-    assert.sameValue(Atomics.exchange(view, 8, -5), 10,
-                     "Exchange returns the value previously in the array");
-    control[0] = -5;
-    assert.sameValue(view[8], control[0]);
+  assert.sameValue(Atomics.exchange(view, 8, -5), 10,
+    "Exchange returns the value previously in the array");
+  control[0] = -5;
+  assert.sameValue(view[8], control[0]);
 
-    view[3] = -5;
-    control[0] = -5;
-    assert.sameValue(Atomics.exchange(view, 3, 0), control[0],
-                     "Result is subject to coercion");
+  view[3] = -5;
+  control[0] = -5;
+  assert.sameValue(Atomics.exchange(view, 3, 0), control[0],
+    "Result is subject to coercion");
 
-    control[0] = 12345;
-    view[3] = 12345;
-    assert.sameValue(Atomics.exchange(view, 3, 0), control[0],
-                     "Result is subject to chopping");
+  control[0] = 12345;
+  view[3] = 12345;
+  assert.sameValue(Atomics.exchange(view, 3, 0), control[0],
+    "Result is subject to chopping");
 
-    control[0] = 123456789;
-    view[3] = 123456789;
-    assert.sameValue(Atomics.exchange(view, 3, 0), control[0],
-                     "Result is subject to chopping");
+  control[0] = 123456789;
+  view[3] = 123456789;
+  assert.sameValue(Atomics.exchange(view, 3, 0), control[0],
+    "Result is subject to chopping");
 
-    // In-bounds boundary cases for indexing
-    testWithAtomicsInBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        view.fill(0);
-        // Atomics.store() computes an index from Idx in the same way as other
-        // Atomics operations, not quite like view[Idx].
-        Atomics.store(view, Idx, 37);
-        assert.sameValue(Atomics.exchange(view, Idx, 0), 37);
-    });
+  // In-bounds boundary cases for indexing
+  testWithAtomicsInBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    view.fill(0);
+    // Atomics.store() computes an index from Idx in the same way as other
+    // Atomics operations, not quite like view[Idx].
+    Atomics.store(view, Idx, 37);
+    assert.sameValue(Atomics.exchange(view, Idx, 0), 37);
+  });
 }, int_views);

--- a/test/built-ins/Atomics/exchange/non-views.js
+++ b/test/built-ins/Atomics/exchange/non-views.js
@@ -10,5 +10,5 @@ features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, le
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {
-    assert.throws(TypeError, (() => Atomics.exchange(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.exchange(view, 0, 0)));
 });

--- a/test/built-ins/Atomics/exchange/nonshared-int-views.js
+++ b/test/built-ins/Atomics/exchange/nonshared-int-views.js
@@ -19,7 +19,7 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(ab);
+  var view = new View(ab);
 
-    assert.throws(TypeError, (() => Atomics.exchange(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.exchange(view, 0, 0)));
 }, int_views);

--- a/test/built-ins/Atomics/exchange/shared-nonint-views.js
+++ b/test/built-ins/Atomics/exchange/shared-nonint-views.js
@@ -14,7 +14,7 @@ var sab = new SharedArrayBuffer(1024);
 var other_views = [Uint8ClampedArray, Float32Array, Float64Array];
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(sab);
+  var view = new View(sab);
 
-    assert.throws(TypeError, (() => Atomics.exchange(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.exchange(view, 0, 0)));
 }, other_views);

--- a/test/built-ins/Atomics/isLockFree/corner-cases.js
+++ b/test/built-ins/Atomics/isLockFree/corner-cases.js
@@ -23,8 +23,7 @@ assert.sameValue(Atomics.isLockFree(1), Atomics.isLockFree({toString: () => '1'}
 assert.sameValue(Atomics.isLockFree(3), Atomics.isLockFree({toString: () => '3'}));
 
 function hide(k, x) {
-    if (k)
-        return hide(k-3, x) + x;
-    return 0;
+  if (k)
+    return hide(k - 3, x) + x;
+  return 0;
 }
-

--- a/test/built-ins/Atomics/isLockFree/value.js
+++ b/test/built-ins/Atomics/isLockFree/value.js
@@ -13,35 +13,35 @@ var answers = [   {},    {}, false,  true, false, false, false, false,
                false, false, false, false];
 
 function testIsLockFree() {
-    var saved = {};
+  var saved = {};
 
-    // This should defeat most optimizations.
+  // This should defeat most optimizations.
 
-    for ( var i=0 ; i < sizes.length ; i++ ) {
-        var v = Atomics.isLockFree(sizes[i]);
-        var a = answers[i];
-        assert.sameValue(typeof v, 'boolean');
-        if (typeof a == 'boolean')
-            assert.sameValue(v, a);
-        else
-            saved[sizes[i]] = v;
-    }
+  for (var i = 0; i < sizes.length; i++) {
+    var v = Atomics.isLockFree(sizes[i]);
+    var a = answers[i];
+    assert.sameValue(typeof v, 'boolean');
+    if (typeof a == 'boolean')
+      assert.sameValue(v, a);
+    else
+      saved[sizes[i]] = v;
+  }
 
-    // This ought to be optimizable.  Make sure the answers are the same
-    // as for the unoptimized case.
+  // This ought to be optimizable.  Make sure the answers are the same
+  // as for the unoptimized case.
 
-    assert.sameValue(Atomics.isLockFree(1), saved[1]);
-    assert.sameValue(Atomics.isLockFree(2), saved[2]);
-    assert.sameValue(Atomics.isLockFree(3), false);
-    assert.sameValue(Atomics.isLockFree(4), true);
-    assert.sameValue(Atomics.isLockFree(5), false);
-    assert.sameValue(Atomics.isLockFree(6), false);
-    assert.sameValue(Atomics.isLockFree(7), false);
-    assert.sameValue(Atomics.isLockFree(8), false);
-    assert.sameValue(Atomics.isLockFree(9), false);
-    assert.sameValue(Atomics.isLockFree(10), false);
-    assert.sameValue(Atomics.isLockFree(11), false);
-    assert.sameValue(Atomics.isLockFree(12), false);
+  assert.sameValue(Atomics.isLockFree(1), saved[1]);
+  assert.sameValue(Atomics.isLockFree(2), saved[2]);
+  assert.sameValue(Atomics.isLockFree(3), false);
+  assert.sameValue(Atomics.isLockFree(4), true);
+  assert.sameValue(Atomics.isLockFree(5), false);
+  assert.sameValue(Atomics.isLockFree(6), false);
+  assert.sameValue(Atomics.isLockFree(7), false);
+  assert.sameValue(Atomics.isLockFree(8), false);
+  assert.sameValue(Atomics.isLockFree(9), false);
+  assert.sameValue(Atomics.isLockFree(10), false);
+  assert.sameValue(Atomics.isLockFree(11), false);
+  assert.sameValue(Atomics.isLockFree(12), false);
 }
 
 testIsLockFree();

--- a/test/built-ins/Atomics/load/bad-range.js
+++ b/test/built-ins/Atomics/load/bad-range.js
@@ -18,9 +18,9 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    let view = new View(sab);
-    testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        assert.throws(RangeError, () => Atomics.load(view, Idx));
-    });
+  let view = new View(sab);
+  testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    assert.throws(RangeError, () => Atomics.load(view, Idx));
+  });
 }, views);

--- a/test/built-ins/Atomics/load/good-views.js
+++ b/test/built-ins/Atomics/load/good-views.js
@@ -14,33 +14,33 @@ var ab = new ArrayBuffer(16);
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
 testWithTypedArrayConstructors(function(View) {
-    // Make it interesting - use non-zero byteOffsets and non-zero indexes.
+  // Make it interesting - use non-zero byteOffsets and non-zero indexes.
 
-    var view = new View(sab, 32, 20);
-    var control = new View(ab, 0, 2);
+  var view = new View(sab, 32, 20);
+  var control = new View(ab, 0, 2);
 
-    view[3] = -5;
-    control[0] = -5;
-    assert.sameValue(Atomics.load(view, 3), control[0],
-                     "Result is subject to coercion");
+  view[3] = -5;
+  control[0] = -5;
+  assert.sameValue(Atomics.load(view, 3), control[0],
+    "Result is subject to coercion");
 
-    control[0] = 12345;
-    view[3] = 12345;
-    assert.sameValue(Atomics.load(view, 3), control[0],
-                     "Result is subject to chopping");
+  control[0] = 12345;
+  view[3] = 12345;
+  assert.sameValue(Atomics.load(view, 3), control[0],
+    "Result is subject to chopping");
 
-    control[0] = 123456789;
-    view[3] = 123456789;
-    assert.sameValue(Atomics.load(view, 3), control[0],
-                    "Result is subject to chopping");
+  control[0] = 123456789;
+  view[3] = 123456789;
+  assert.sameValue(Atomics.load(view, 3), control[0],
+    "Result is subject to chopping");
 
-    // In-bounds boundary cases for indexing
-    testWithAtomicsInBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        view.fill(0);
-        // Atomics.store() computes an index from Idx in the same way as other
-        // Atomics operations, not quite like view[Idx].
-        Atomics.store(view, Idx, 37);
-        assert.sameValue(Atomics.load(view, Idx), 37);
-    });
+  // In-bounds boundary cases for indexing
+  testWithAtomicsInBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    view.fill(0);
+    // Atomics.store() computes an index from Idx in the same way as other
+    // Atomics operations, not quite like view[Idx].
+    Atomics.store(view, Idx, 37);
+    assert.sameValue(Atomics.load(view, Idx), 37);
+  });
 }, int_views);

--- a/test/built-ins/Atomics/load/non-views.js
+++ b/test/built-ins/Atomics/load/non-views.js
@@ -10,5 +10,5 @@ features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, le
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {
-    assert.throws(TypeError, (() => Atomics.load(view, 0)));
+  assert.throws(TypeError, (() => Atomics.load(view, 0)));
 });

--- a/test/built-ins/Atomics/load/nonshared-int-views.js
+++ b/test/built-ins/Atomics/load/nonshared-int-views.js
@@ -19,7 +19,7 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(ab);
+  var view = new View(ab);
 
-    assert.throws(TypeError, (() => Atomics.load(view, 0)));
+  assert.throws(TypeError, (() => Atomics.load(view, 0)));
 }, int_views);

--- a/test/built-ins/Atomics/load/shared-nonint-views.js
+++ b/test/built-ins/Atomics/load/shared-nonint-views.js
@@ -14,7 +14,7 @@ var sab = new SharedArrayBuffer(1024);
 var other_views = [Uint8ClampedArray, Float32Array, Float64Array];
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(sab);
+  var view = new View(sab);
 
-    assert.throws(TypeError, (() => Atomics.load(view, 0)));
+  assert.throws(TypeError, (() => Atomics.load(view, 0)));
 }, other_views);

--- a/test/built-ins/Atomics/or/bad-range.js
+++ b/test/built-ins/Atomics/or/bad-range.js
@@ -18,9 +18,9 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    let view = new View(sab);
-    testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        assert.throws(RangeError, () => Atomics.or(view, Idx, 10));
-    });
+  let view = new View(sab);
+  testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    assert.throws(RangeError, () => Atomics.or(view, Idx, 10));
+  });
 }, views);

--- a/test/built-ins/Atomics/or/good-views.js
+++ b/test/built-ins/Atomics/or/good-views.js
@@ -13,49 +13,49 @@ var ab = new ArrayBuffer(16);
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
 testWithTypedArrayConstructors(function(View) {
-    // Make it interesting - use non-zero byteOffsets and non-zero indexes.
+  // Make it interesting - use non-zero byteOffsets and non-zero indexes.
 
-    var view = new View(sab, 32, 20);
-    var control = new View(ab, 0, 2);
+  var view = new View(sab, 32, 20);
+  var control = new View(ab, 0, 2);
 
-    view[8] = 0x33333333;
-    control[0] = 0x33333333;
-    assert.sameValue(Atomics.or(view, 8, 0x55555555), control[0],
-                     "Result is subject to chopping");
+  view[8] = 0x33333333;
+  control[0] = 0x33333333;
+  assert.sameValue(Atomics.or(view, 8, 0x55555555), control[0],
+    "Result is subject to chopping");
 
-    control[0] = 0x77777777;
-    assert.sameValue(view[8], control[0]);
-    assert.sameValue(Atomics.or(view, 8, 0xF0F0F0F0), control[0],
-                     "Result is subject to chopping");
+  control[0] = 0x77777777;
+  assert.sameValue(view[8], control[0]);
+  assert.sameValue(Atomics.or(view, 8, 0xF0F0F0F0), control[0],
+    "Result is subject to chopping");
 
-    control[0] = 0xF7F7F7F7;
-    assert.sameValue(view[8], control[0]);
+  control[0] = 0xF7F7F7F7;
+  assert.sameValue(view[8], control[0]);
 
-    view[3] = -5;
-    control[0] = -5;
-    assert.sameValue(Atomics.or(view, 3, 0), control[0],
-                     "Result is negative and subject to coercion");
-    assert.sameValue(view[3], control[0]);
+  view[3] = -5;
+  control[0] = -5;
+  assert.sameValue(Atomics.or(view, 3, 0), control[0],
+    "Result is negative and subject to coercion");
+  assert.sameValue(view[3], control[0]);
 
-    control[0] = 12345;
-    view[3] = 12345;
-    assert.sameValue(Atomics.or(view, 3, 0), control[0],
-                     "Result is subject to chopping");
-    assert.sameValue(view[3], control[0]);
+  control[0] = 12345;
+  view[3] = 12345;
+  assert.sameValue(Atomics.or(view, 3, 0), control[0],
+    "Result is subject to chopping");
+  assert.sameValue(view[3], control[0]);
 
-    control[0] = 123456789;
-    view[3] = 123456789;
-    assert.sameValue(Atomics.or(view, 3, 0), control[0],
-                     "Result is subject to chopping");
-    assert.sameValue(view[3], control[0]);
+  control[0] = 123456789;
+  view[3] = 123456789;
+  assert.sameValue(Atomics.or(view, 3, 0), control[0],
+    "Result is subject to chopping");
+  assert.sameValue(view[3], control[0]);
 
-    // In-bounds boundary cases for indexing
-    testWithAtomicsInBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        view.fill(0);
-        // Atomics.store() computes an index from Idx in the same way as other
-        // Atomics operations, not quite like view[Idx].
-        Atomics.store(view, Idx, 37);
-        assert.sameValue(Atomics.or(view, Idx, 0), 37);
-    });
+  // In-bounds boundary cases for indexing
+  testWithAtomicsInBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    view.fill(0);
+    // Atomics.store() computes an index from Idx in the same way as other
+    // Atomics operations, not quite like view[Idx].
+    Atomics.store(view, Idx, 37);
+    assert.sameValue(Atomics.or(view, Idx, 0), 37);
+  });
 }, int_views);

--- a/test/built-ins/Atomics/or/non-views.js
+++ b/test/built-ins/Atomics/or/non-views.js
@@ -10,5 +10,5 @@ features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, le
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {
-    assert.throws(TypeError, (() => Atomics.or(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.or(view, 0, 0)));
 });

--- a/test/built-ins/Atomics/or/nonshared-int-views.js
+++ b/test/built-ins/Atomics/or/nonshared-int-views.js
@@ -19,7 +19,7 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(ab);
+  var view = new View(ab);
 
-    assert.throws(TypeError, (() => Atomics.or(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.or(view, 0, 0)));
 }, int_views);

--- a/test/built-ins/Atomics/or/shared-nonint-views.js
+++ b/test/built-ins/Atomics/or/shared-nonint-views.js
@@ -14,7 +14,7 @@ var sab = new SharedArrayBuffer(1024);
 var other_views = [Uint8ClampedArray, Float32Array, Float64Array];
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(sab);
+  var view = new View(sab);
 
-    assert.throws(TypeError, (() => Atomics.or(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.or(view, 0, 0)));
 }, other_views);

--- a/test/built-ins/Atomics/store/bad-range.js
+++ b/test/built-ins/Atomics/store/bad-range.js
@@ -18,9 +18,9 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    let view = new View(sab);
-    testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        assert.throws(RangeError, () => Atomics.store(view, Idx, 10));
-    });
+  let view = new View(sab);
+  testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    assert.throws(RangeError, () => Atomics.store(view, Idx, 10));
+  });
 }, views);

--- a/test/built-ins/Atomics/store/good-views.js
+++ b/test/built-ins/Atomics/store/good-views.js
@@ -14,43 +14,45 @@ var ab = new ArrayBuffer(16);
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
 testWithTypedArrayConstructors(function(View) {
-    // Make it interesting - use non-zero byteOffsets and non-zero indexes.
+  // Make it interesting - use non-zero byteOffsets and non-zero indexes.
 
-    var view = new View(sab, 32, 20);
-    var control = new View(ab, 0, 2);
+  var view = new View(sab, 32, 20);
+  var control = new View(ab, 0, 2);
 
-    for ( let val of [10,
-                      -5,
-                      12345,
-                      123456789,
-                      Math.PI,
-                      "33",
-                      { valueOf: () => 33 },
-                      undefined] )
-    {
-        assert.sameValue(Atomics.store(view, 3, val), ToInteger(val),
-                         "Atomics.store returns its third argument (" + val + ") converted to Integer, not the input value nor the value that was stored");
+  for (let val of [10, -5,
+      12345,
+      123456789,
+      Math.PI,
+      "33",
+      {
+        valueOf: () => 33
+      },
+      undefined
+    ])
+  {
+    assert.sameValue(Atomics.store(view, 3, val), ToInteger(val),
+      "Atomics.store returns its third argument (" + val + ") converted to Integer, not the input value nor the value that was stored");
 
-        control[0] = val;
-        assert.sameValue(view[3], control[0]);
-    }
+    control[0] = val;
+    assert.sameValue(view[3], control[0]);
+  }
 
-    // In-bounds boundary cases for indexing
-    testWithAtomicsInBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        view.fill(0);
-        Atomics.store(view, Idx, 37);
-        assert.sameValue(Atomics.load(view, Idx), 37);
-    });
+  // In-bounds boundary cases for indexing
+  testWithAtomicsInBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    view.fill(0);
+    Atomics.store(view, Idx, 37);
+    assert.sameValue(Atomics.load(view, Idx), 37);
+  });
 }, int_views);
 
 function ToInteger(v) {
-    v = +v;
-    if (isNaN(v))
-        return 0;
-    if (v == 0 || !isFinite(v))
-        return v;
-    if (v < 0)
-        return -Math.floor(Math.abs(v));
-    return Math.floor(v);
+  v = +v;
+  if (isNaN(v))
+    return 0;
+  if (v == 0 || !isFinite(v))
+    return v;
+  if (v < 0)
+    return -Math.floor(Math.abs(v));
+  return Math.floor(v);
 }

--- a/test/built-ins/Atomics/store/non-views.js
+++ b/test/built-ins/Atomics/store/non-views.js
@@ -10,5 +10,5 @@ features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, le
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {
-    assert.throws(TypeError, (() => Atomics.store(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.store(view, 0, 0)));
 });

--- a/test/built-ins/Atomics/store/nonshared-int-views.js
+++ b/test/built-ins/Atomics/store/nonshared-int-views.js
@@ -19,7 +19,7 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(ab);
+  var view = new View(ab);
 
-    assert.throws(TypeError, (() => Atomics.store(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.store(view, 0, 0)));
 }, int_views);

--- a/test/built-ins/Atomics/store/shared-nonint-views.js
+++ b/test/built-ins/Atomics/store/shared-nonint-views.js
@@ -14,7 +14,7 @@ var sab = new SharedArrayBuffer(1024);
 var other_views = [Uint8ClampedArray, Float32Array, Float64Array];
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(sab);
+  var view = new View(sab);
 
-    assert.throws(TypeError, (() => Atomics.store(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.store(view, 0, 0)));
 }, other_views);

--- a/test/built-ins/Atomics/sub/bad-range.js
+++ b/test/built-ins/Atomics/sub/bad-range.js
@@ -18,9 +18,9 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    let view = new View(sab);
-    testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        assert.throws(RangeError, () => Atomics.sub(view, Idx, 10));
-    });
+  let view = new View(sab);
+  testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    assert.throws(RangeError, () => Atomics.sub(view, Idx, 10));
+  });
 }, views);

--- a/test/built-ins/Atomics/sub/good-views.js
+++ b/test/built-ins/Atomics/sub/good-views.js
@@ -14,42 +14,42 @@ var ab = new ArrayBuffer(16);
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
 testWithTypedArrayConstructors(function(View) {
-    // Make it interesting - use non-zero byteOffsets and non-zero indexes.
+  // Make it interesting - use non-zero byteOffsets and non-zero indexes.
 
-    var view = new View(sab, 32, 20);
-    var control = new View(ab, 0, 2);
+  var view = new View(sab, 32, 20);
+  var control = new View(ab, 0, 2);
 
-    view[8] = 100;
-    assert.sameValue(Atomics.sub(view, 8, 10), 100,
-                     "Subtract positive number");
-    assert.sameValue(view[8], 90);
+  view[8] = 100;
+  assert.sameValue(Atomics.sub(view, 8, 10), 100,
+    "Subtract positive number");
+  assert.sameValue(view[8], 90);
 
-    assert.sameValue(Atomics.sub(view, 8, -5), 90,
-                     "Subtract negative number, though result remains positive");
-    assert.sameValue(view[8], 95);
+  assert.sameValue(Atomics.sub(view, 8, -5), 90,
+    "Subtract negative number, though result remains positive");
+  assert.sameValue(view[8], 95);
 
-    view[3] = -5;
-    control[0] = -5;
-    assert.sameValue(Atomics.sub(view, 3, 0), control[0],
-                     "Result is negative and subject to coercion");
+  view[3] = -5;
+  control[0] = -5;
+  assert.sameValue(Atomics.sub(view, 3, 0), control[0],
+    "Result is negative and subject to coercion");
 
-    control[0] = 12345;
-    view[3] = 12345;
-    assert.sameValue(Atomics.sub(view, 3, 0), control[0],
-                     "Result is subject to chopping");
+  control[0] = 12345;
+  view[3] = 12345;
+  assert.sameValue(Atomics.sub(view, 3, 0), control[0],
+    "Result is subject to chopping");
 
-    control[0] = 123456789;
-    view[3] = 123456789;
-    assert.sameValue(Atomics.sub(view, 3, 0), control[0],
-                     "Result is subject to chopping");
+  control[0] = 123456789;
+  view[3] = 123456789;
+  assert.sameValue(Atomics.sub(view, 3, 0), control[0],
+    "Result is subject to chopping");
 
-    // In-bounds boundary cases for indexing
-    testWithAtomicsInBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        view.fill(0);
-        // Atomics.store() computes an index from Idx in the same way as other
-        // Atomics operations, not quite like view[Idx].
-        Atomics.store(view, Idx, 37);
-        assert.sameValue(Atomics.sub(view, Idx, 0), 37);
-    });
+  // In-bounds boundary cases for indexing
+  testWithAtomicsInBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    view.fill(0);
+    // Atomics.store() computes an index from Idx in the same way as other
+    // Atomics operations, not quite like view[Idx].
+    Atomics.store(view, Idx, 37);
+    assert.sameValue(Atomics.sub(view, Idx, 0), 37);
+  });
 }, int_views);

--- a/test/built-ins/Atomics/sub/non-views.js
+++ b/test/built-ins/Atomics/sub/non-views.js
@@ -10,5 +10,5 @@ features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, le
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {
-    assert.throws(TypeError, (() => Atomics.sub(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.sub(view, 0, 0)));
 });

--- a/test/built-ins/Atomics/sub/nonshared-int-views.js
+++ b/test/built-ins/Atomics/sub/nonshared-int-views.js
@@ -19,7 +19,7 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(ab);
+  var view = new View(ab);
 
-    assert.throws(TypeError, (() => Atomics.sub(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.sub(view, 0, 0)));
 }, int_views);

--- a/test/built-ins/Atomics/sub/shared-nonint-views.js
+++ b/test/built-ins/Atomics/sub/shared-nonint-views.js
@@ -14,7 +14,7 @@ var sab = new SharedArrayBuffer(1024);
 var other_views = [Uint8ClampedArray, Float32Array, Float64Array];
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(sab);
+  var view = new View(sab);
 
-    assert.throws(TypeError, (() => Atomics.sub(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.sub(view, 0, 0)));
 }, other_views);

--- a/test/built-ins/Atomics/wait/did-timeout.js
+++ b/test/built-ins/Atomics/wait/did-timeout.js
@@ -24,11 +24,11 @@ var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 
 $262.agent.broadcast(ia.buffer);
 assert.sameValue(getReport(), "timed-out");
-assert.sameValue((getReport()|0) >= 500 - $ATOMICS_MAX_TIME_EPSILON, true);
+assert.sameValue((getReport() | 0) >= 500 - $ATOMICS_MAX_TIME_EPSILON, true);
 
 function getReport() {
-    var r;
-    while ((r = $262.agent.getReport()) == null)
-        $262.agent.sleep(100);
-    return r;
+  var r;
+  while ((r = $262.agent.getReport()) == null)
+    $262.agent.sleep(100);
+  return r;
 }

--- a/test/built-ins/Atomics/wait/good-views.js
+++ b/test/built-ins/Atomics/wait/good-views.js
@@ -47,11 +47,11 @@ assert.sameValue(getReport(), "A timed-out");
 assert.sameValue(getReport(), "B not-equal"); // Even with zero timeout
 var r;
 while ((r = getReport()) != "done")
-    assert.sameValue(r, "C not-equal");
+  assert.sameValue(r, "C not-equal");
 
 function getReport() {
-    var r;
-    while ((r = $262.agent.getReport()) == null)
-        $262.agent.sleep(100);
-    return r;
+  var r;
+  while ((r = $262.agent.getReport()) == null)
+    $262.agent.sleep(100);
+  return r;
 }

--- a/test/built-ins/Atomics/wait/nan-timeout.js
+++ b/test/built-ins/Atomics/wait/nan-timeout.js
@@ -19,14 +19,14 @@ $262.agent.receiveBroadcast(function (sab, id) {
 var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 
 $262.agent.broadcast(ia.buffer);
-$262.agent.sleep(500);                // Ample time
+$262.agent.sleep(500); // Ample time
 assert.sameValue($262.agent.getReport(), null);
 Atomics.wake(ia, 0);
 assert.sameValue(getReport(), "ok");
 
 function getReport() {
-    var r;
-    while ((r = $262.agent.getReport()) == null)
-        $262.agent.sleep(100);
-    return r;
+  var r;
+  while ((r = $262.agent.getReport()) == null)
+    $262.agent.sleep(100);
+  return r;
 }

--- a/test/built-ins/Atomics/wait/negative-timeout.js
+++ b/test/built-ins/Atomics/wait/negative-timeout.js
@@ -22,8 +22,8 @@ $262.agent.broadcast(ia.buffer);
 assert.sameValue(getReport(), "timed-out");
 
 function getReport() {
-    var r;
-    while ((r = $262.agent.getReport()) == null)
-        $262.agent.sleep(100);
-    return r;
+  var r;
+  while ((r = $262.agent.getReport()) == null)
+    $262.agent.sleep(100);
+  return r;
 }

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup.js
@@ -24,15 +24,15 @@ $262.agent.receiveBroadcast(function (sab, id) {
 var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 
 $262.agent.broadcast(ia.buffer);
-$262.agent.sleep(500);                // Give the agent a chance to wait
-Atomics.store(ia, 0, 1);              // Change the value, should not wake the agent
-$262.agent.sleep(500);                // Wait some more so that we can tell
-Atomics.wake(ia, 0);                  // Really wake it up
-assert.sameValue((getReport()|0) >= 1000 - $ATOMICS_MAX_TIME_EPSILON, true);
+$262.agent.sleep(500); // Give the agent a chance to wait
+Atomics.store(ia, 0, 1); // Change the value, should not wake the agent
+$262.agent.sleep(500); // Wait some more so that we can tell
+Atomics.wake(ia, 0); // Really wake it up
+assert.sameValue((getReport() | 0) >= 1000 - $ATOMICS_MAX_TIME_EPSILON, true);
 
 function getReport() {
-    var r;
-    while ((r = $262.agent.getReport()) == null)
-        $262.agent.sleep(100);
-    return r;
+  var r;
+  while ((r = $262.agent.getReport()) == null)
+    $262.agent.sleep(100);
+  return r;
 }

--- a/test/built-ins/Atomics/wait/non-views.js
+++ b/test/built-ins/Atomics/wait/non-views.js
@@ -10,5 +10,5 @@ features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, le
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {
-    assert.throws(TypeError, (() => Atomics.wait(view, 0, 0, 0))); // Even with zero timeout
+  assert.throws(TypeError, (() => Atomics.wait(view, 0, 0, 0))); // Even with zero timeout
 });

--- a/test/built-ins/Atomics/wait/nonshared-int-views.js
+++ b/test/built-ins/Atomics/wait/nonshared-int-views.js
@@ -19,7 +19,7 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(ab);
+  var view = new View(ab);
 
-    assert.throws(TypeError, (() => Atomics.wait(view, 0, 0, 0))); // Should fail even if waiting 0ms
+  assert.throws(TypeError, (() => Atomics.wait(view, 0, 0, 0))); // Should fail even if waiting 0ms
 }, int_views);

--- a/test/built-ins/Atomics/wait/shared-nonint-views.js
+++ b/test/built-ins/Atomics/wait/shared-nonint-views.js
@@ -15,8 +15,8 @@ var other_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Uint32Array,
                    Uint8ClampedArray, Float32Array, Float64Array];
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(sab);
+  var view = new View(sab);
 
-    // Even with timout zero this should fail
-    assert.throws(TypeError, (() => Atomics.wait(view, 0, 0, 0)));
+  // Even with timout zero this should fail
+  assert.throws(TypeError, (() => Atomics.wait(view, 0, 0, 0)));
 }, other_views);

--- a/test/built-ins/Atomics/wait/was-woken.js
+++ b/test/built-ins/Atomics/wait/was-woken.js
@@ -19,14 +19,13 @@ $262.agent.receiveBroadcast(function (sab, id) {
 var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 
 $262.agent.broadcast(ia.buffer);
-$262.agent.sleep(500);                // Give the agent a chance to wait
+$262.agent.sleep(500); // Give the agent a chance to wait
 Atomics.wake(ia, 0);
 assert.sameValue(getReport(), "ok");
 
 function getReport() {
-    var r;
-    while ((r = $262.agent.getReport()) == null)
-        $262.agent.sleep(100);
-    return r;
+  var r;
+  while ((r = $262.agent.getReport()) == null)
+    $262.agent.sleep(100);
+  return r;
 }
-

--- a/test/built-ins/Atomics/wake/good-views.js
+++ b/test/built-ins/Atomics/wake/good-views.js
@@ -20,10 +20,10 @@ assert.sameValue(Atomics.wake(view, 0, 1), 0);
 
 // In-bounds boundary cases for indexing
 testWithAtomicsInBoundsIndices(function(IdxGen) {
-    let Idx = IdxGen(view);
-    view.fill(0);
-    // Atomics.store() computes an index from Idx in the same way as other
-    // Atomics operations, not quite like view[Idx].
-    Atomics.store(view, Idx, 37);
-    assert.sameValue(Atomics.wake(view, Idx, 1), 0);
+  let Idx = IdxGen(view);
+  view.fill(0);
+  // Atomics.store() computes an index from Idx in the same way as other
+  // Atomics operations, not quite like view[Idx].
+  Atomics.store(view, Idx, 37);
+  assert.sameValue(Atomics.wake(view, Idx, 1), 0);
 });

--- a/test/built-ins/Atomics/wake/non-views.js
+++ b/test/built-ins/Atomics/wake/non-views.js
@@ -10,5 +10,5 @@ features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, le
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {
-    assert.throws(TypeError, (() => Atomics.wake(view, 0, 0))); // Even with count == 0
+  assert.throws(TypeError, (() => Atomics.wake(view, 0, 0))); // Even with count == 0
 });

--- a/test/built-ins/Atomics/wake/nonshared-int-views.js
+++ b/test/built-ins/Atomics/wake/nonshared-int-views.js
@@ -19,7 +19,7 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(ab);
+  var view = new View(ab);
 
-    assert.throws(TypeError, (() => Atomics.wake(view, 0, 0))); // Should fail even if waking zero waiters
+  assert.throws(TypeError, (() => Atomics.wake(view, 0, 0))); // Should fail even if waking zero waiters
 }, int_views);

--- a/test/built-ins/Atomics/wake/shared-nonint-views.js
+++ b/test/built-ins/Atomics/wake/shared-nonint-views.js
@@ -15,8 +15,8 @@ var other_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Uint32Array,
                    Uint8ClampedArray, Float32Array, Float64Array];
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(sab);
+  var view = new View(sab);
 
-    // Even with timout zero this should fail
-    assert.throws(TypeError, (() => Atomics.wake(view, 0, 0))); // Even with 0 to wake this should fail
+  // Even with timout zero this should fail
+  assert.throws(TypeError, (() => Atomics.wake(view, 0, 0))); // Even with 0 to wake this should fail
 }, other_views);

--- a/test/built-ins/Atomics/wake/wake-all-on-loc.js
+++ b/test/built-ins/Atomics/wake/wake-all-on-loc.js
@@ -42,7 +42,7 @@ var ia = new Int32Array(new SharedArrayBuffer(NUMELEM * Int32Array.BYTES_PER_ELE
 $262.agent.broadcast(ia.buffer);
 
 // Wait for agents to be running.
-waitUntil(ia, RUNNING, NUMAGENT+1);
+waitUntil(ia, RUNNING, NUMAGENT + 1);
 
 // Then wait some more to give the agents a fair chance to wait.  If we don't,
 // we risk sending the wakeup before agents are sleeping, and we hang.
@@ -52,26 +52,26 @@ $262.agent.sleep(500);
 assert.sameValue(Atomics.wake(ia, WAKEUP), NUMAGENT);
 
 var rs = [];
-for (var i=0; i < NUMAGENT+1; i++)
-    rs.push(getReport());
+for (var i = 0; i < NUMAGENT + 1; i++)
+  rs.push(getReport());
 rs.sort();
 
-for (var i=0; i < NUMAGENT; i++)
-    assert.sameValue(rs[i], "A ok");
+for (var i = 0; i < NUMAGENT; i++)
+  assert.sameValue(rs[i], "A ok");
 assert.sameValue(rs[NUMAGENT], "B timed-out");
 
 function getReport() {
-    var r;
-    while ((r = $262.agent.getReport()) == null)
-        $262.agent.sleep(100);
-    return r;
+  var r;
+  while ((r = $262.agent.getReport()) == null)
+    $262.agent.sleep(100);
+  return r;
 }
 
 function waitUntil(ia, k, value) {
-    var i = 0;
-    while (Atomics.load(ia, k) !== value && i < 15) {
-        $262.agent.sleep(100);
-        i++;
-    }
-    assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
+  var i = 0;
+  while (Atomics.load(ia, k) !== value && i < 15) {
+    $262.agent.sleep(100);
+    i++;
+  }
+  assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
 }

--- a/test/built-ins/Atomics/wake/wake-all.js
+++ b/test/built-ins/Atomics/wake/wake-all.js
@@ -41,7 +41,7 @@ var ia = new Int32Array(new SharedArrayBuffer(NUMELEM * Int32Array.BYTES_PER_ELE
 $262.agent.broadcast(ia.buffer);
 
 // Wait for agents to be running.
-waitUntil(ia, RUNNING, NUMAGENT+1);
+waitUntil(ia, RUNNING, NUMAGENT + 1);
 
 // Then wait some more to give the agents a fair chance to wait.  If we don't,
 // we risk sending the wakeup before agents are sleeping, and we hang.
@@ -51,26 +51,26 @@ $262.agent.sleep(500);
 assert.sameValue(Atomics.wake(ia, WAKEUP), NUMAGENT);
 
 var rs = [];
-for (var i=0; i < NUMAGENT+1; i++)
-    rs.push(getReport());
+for (var i = 0; i < NUMAGENT + 1; i++)
+  rs.push(getReport());
 rs.sort();
 
-for (var i=0; i < NUMAGENT; i++)
-    assert.sameValue(rs[i], "A ok");
+for (var i = 0; i < NUMAGENT; i++)
+  assert.sameValue(rs[i], "A ok");
 assert.sameValue(rs[NUMAGENT], "B timed-out");
 
 function getReport() {
-    var r;
-    while ((r = $262.agent.getReport()) == null)
-        $262.agent.sleep(100);
-    return r;
+  var r;
+  while ((r = $262.agent.getReport()) == null)
+    $262.agent.sleep(100);
+  return r;
 }
 
 function waitUntil(ia, k, value) {
-    var i = 0;
-    while (Atomics.load(ia, k) !== value && i < 15) {
-        $262.agent.sleep(100);
-        i++;
-    }
-    assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
+  var i = 0;
+  while (Atomics.load(ia, k) !== value && i < 15) {
+    $262.agent.sleep(100);
+    i++;
+  }
+  assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
 }

--- a/test/built-ins/Atomics/wake/wake-in-order.js
+++ b/test/built-ins/Atomics/wake/wake-in-order.js
@@ -43,29 +43,29 @@ waitUntil(ia, RUNNING, NUMAGENT);
 $262.agent.sleep(500);
 
 // Make them sleep in order 0 1 2 on ia[0]
-for ( var i=0 ; i < NUMAGENT ; i++ ) {
+for (var i = 0; i < NUMAGENT; i++) {
   Atomics.store(ia, SPIN + i, 1);
   $262.agent.sleep(500);
 }
 
 // Wake them up one at a time and check the order is 0 1 2
-for ( var i=0 ; i < NUMAGENT ; i++ ) {
+for (var i = 0; i < NUMAGENT; i++) {
   assert.sameValue(Atomics.wake(ia, WAKEUP, 1), 1);
   assert.sameValue(getReport(), i + "ok");
 }
 
 function getReport() {
-    var r;
-    while ((r = $262.agent.getReport()) == null)
-        $262.agent.sleep(100);
-    return r;
+  var r;
+  while ((r = $262.agent.getReport()) == null)
+    $262.agent.sleep(100);
+  return r;
 }
 
 function waitUntil(ia, k, value) {
-    var i = 0;
-    while (Atomics.load(ia, k) !== value && i < 15) {
-        $262.agent.sleep(100);
-        i++;
-    }
-    assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
+  var i = 0;
+  while (Atomics.load(ia, k) !== value && i < 15) {
+    $262.agent.sleep(100);
+    i++;
+  }
+  assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
 }

--- a/test/built-ins/Atomics/wake/wake-nan.js
+++ b/test/built-ins/Atomics/wake/wake-nan.js
@@ -19,13 +19,13 @@ $262.agent.receiveBroadcast(function (sab) {
 var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 
 $262.agent.broadcast(ia.buffer);
-$262.agent.sleep(500);                             // Give the agent a chance to wait
-assert.sameValue(Atomics.wake(ia, 0, NaN), 0);  // Don't actually wake it
+$262.agent.sleep(500); // Give the agent a chance to wait
+assert.sameValue(Atomics.wake(ia, 0, NaN), 0); // Don't actually wake it
 assert.sameValue(getReport(), "timed-out");
 
 function getReport() {
-    var r;
-    while ((r = $262.agent.getReport()) == null)
-        $262.agent.sleep(100);
-    return r;
+  var r;
+  while ((r = $262.agent.getReport()) == null)
+    $262.agent.sleep(100);
+  return r;
 }

--- a/test/built-ins/Atomics/wake/wake-negative.js
+++ b/test/built-ins/Atomics/wake/wake-negative.js
@@ -19,13 +19,13 @@ $262.agent.receiveBroadcast(function (sab) {
 var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 
 $262.agent.broadcast(ia.buffer);
-$262.agent.sleep(500);                             // Give the agent a chance to wait
-assert.sameValue(Atomics.wake(ia, 0, -1), 0);   // Don't actually wake it
+$262.agent.sleep(500); // Give the agent a chance to wait
+assert.sameValue(Atomics.wake(ia, 0, -1), 0); // Don't actually wake it
 assert.sameValue(getReport(), "timed-out");
 
 function getReport() {
-    var r;
-    while ((r = $262.agent.getReport()) == null)
-        $262.agent.sleep(100);
-    return r;
+  var r;
+  while ((r = $262.agent.getReport()) == null)
+    $262.agent.sleep(100);
+  return r;
 }

--- a/test/built-ins/Atomics/wake/wake-one.js
+++ b/test/built-ins/Atomics/wake/wake-one.js
@@ -45,27 +45,27 @@ assert.sameValue(Atomics.wake(ia, 0, WAKECOUNT), WAKECOUNT);
 
 // Collect and check results
 var rs = [];
-for ( var i=0; i < NUMAGENT; i++ )
-    rs.push(getReport());
+for (var i = 0; i < NUMAGENT; i++)
+  rs.push(getReport());
 rs.sort();
 
-for ( var i=0; i < WAKECOUNT; i++ )
-    assert.sameValue(rs[i], "ok");
-for ( var i=WAKECOUNT; i < NUMAGENT; i++ )
-    assert.sameValue(rs[i], "timed-out");
+for (var i = 0; i < WAKECOUNT; i++)
+  assert.sameValue(rs[i], "ok");
+for (var i = WAKECOUNT; i < NUMAGENT; i++)
+  assert.sameValue(rs[i], "timed-out");
 
 function getReport() {
-    var r;
-    while ((r = $262.agent.getReport()) == null)
-        $262.agent.sleep(100);
-    return r;
+  var r;
+  while ((r = $262.agent.getReport()) == null)
+    $262.agent.sleep(100);
+  return r;
 }
 
 function waitUntil(ia, k, value) {
-    var i = 0;
-    while (Atomics.load(ia, k) !== value && i < 15) {
-        $262.agent.sleep(100);
-        i++;
-    }
-    assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
+  var i = 0;
+  while (Atomics.load(ia, k) !== value && i < 15) {
+    $262.agent.sleep(100);
+    i++;
+  }
+  assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
 }

--- a/test/built-ins/Atomics/wake/wake-two.js
+++ b/test/built-ins/Atomics/wake/wake-two.js
@@ -46,27 +46,27 @@ assert.sameValue(Atomics.wake(ia, 0, WAKECOUNT), WAKECOUNT);
 
 // Collect and check results
 var rs = [];
-for ( var i=0; i < NUMAGENT; i++ )
-    rs.push(getReport());
+for (var i = 0; i < NUMAGENT; i++)
+  rs.push(getReport());
 rs.sort();
 
-for ( var i=0; i < WAKECOUNT; i++ )
-    assert.sameValue(rs[i], "ok");
-for ( var i=WAKECOUNT; i < NUMAGENT; i++ )
-    assert.sameValue(rs[i], "timed-out");
+for (var i = 0; i < WAKECOUNT; i++)
+  assert.sameValue(rs[i], "ok");
+for (var i = WAKECOUNT; i < NUMAGENT; i++)
+  assert.sameValue(rs[i], "timed-out");
 
 function getReport() {
-    var r;
-    while ((r = $262.agent.getReport()) == null)
-        $262.agent.sleep(100);
-    return r;
+  var r;
+  while ((r = $262.agent.getReport()) == null)
+    $262.agent.sleep(100);
+  return r;
 }
 
 function waitUntil(ia, k, value) {
-    var i = 0;
-    while (Atomics.load(ia, k) !== value && i < 15) {
-        $262.agent.sleep(100);
-        i++;
-    }
-    assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
+  var i = 0;
+  while (Atomics.load(ia, k) !== value && i < 15) {
+    $262.agent.sleep(100);
+    i++;
+  }
+  assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
 }

--- a/test/built-ins/Atomics/wake/wake-zero.js
+++ b/test/built-ins/Atomics/wake/wake-zero.js
@@ -46,27 +46,27 @@ assert.sameValue(Atomics.wake(ia, 0, WAKECOUNT), WAKECOUNT);
 
 // Collect and check results
 var rs = [];
-for ( var i=0; i < NUMAGENT; i++ )
-    rs.push(getReport());
+for (var i = 0; i < NUMAGENT; i++)
+  rs.push(getReport());
 rs.sort();
 
-for ( var i=0; i < WAKECOUNT; i++ )
-    assert.sameValue(rs[i], "ok");
-for ( var i=WAKECOUNT; i < NUMAGENT; i++ )
-    assert.sameValue(rs[i], "timed-out");
+for (var i = 0; i < WAKECOUNT; i++)
+  assert.sameValue(rs[i], "ok");
+for (var i = WAKECOUNT; i < NUMAGENT; i++)
+  assert.sameValue(rs[i], "timed-out");
 
 function getReport() {
-    var r;
-    while ((r = $262.agent.getReport()) == null)
-        $262.agent.sleep(100);
-    return r;
+  var r;
+  while ((r = $262.agent.getReport()) == null)
+    $262.agent.sleep(100);
+  return r;
 }
 
 function waitUntil(ia, k, value) {
-    var i = 0;
-    while (Atomics.load(ia, k) !== value && i < 15) {
-        $262.agent.sleep(100);
-        i++;
-    }
-    assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
+  var i = 0;
+  while (Atomics.load(ia, k) !== value && i < 15) {
+    $262.agent.sleep(100);
+    i++;
+  }
+  assert.sameValue(Atomics.load(ia, k), value, "All agents are running");
 }

--- a/test/built-ins/Atomics/xor/bad-range.js
+++ b/test/built-ins/Atomics/xor/bad-range.js
@@ -18,9 +18,9 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    let view = new View(sab);
-    testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        assert.throws(RangeError, () => Atomics.xor(view, Idx, 0));
-    });
+  let view = new View(sab);
+  testWithAtomicsOutOfBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    assert.throws(RangeError, () => Atomics.xor(view, Idx, 0));
+  });
 }, views);

--- a/test/built-ins/Atomics/xor/good-views.js
+++ b/test/built-ins/Atomics/xor/good-views.js
@@ -13,50 +13,50 @@ var ab = new ArrayBuffer(16);
 var int_views = [Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array];
 
 testWithTypedArrayConstructors(function(View) {
-    // Make it interesting - use non-zero byteOffsets and non-zero indexes.
+  // Make it interesting - use non-zero byteOffsets and non-zero indexes.
 
-    var view = new View(sab, 32, 20);
-    var control = new View(ab, 0, 2);
+  var view = new View(sab, 32, 20);
+  var control = new View(ab, 0, 2);
 
-    view[8] = 0x33333333;
-    control[0] = 0x33333333;
-    assert.sameValue(Atomics.xor(view, 8, 0x55555555), control[0],
-                     "Result is subject to chopping");
+  view[8] = 0x33333333;
+  control[0] = 0x33333333;
+  assert.sameValue(Atomics.xor(view, 8, 0x55555555), control[0],
+    "Result is subject to chopping");
 
-    control[0] = 0x66666666;
-    assert.sameValue(view[8], control[0]);
-    assert.sameValue(Atomics.xor(view, 8, 0xF0F0F0F0), control[0],
-                     "Result is subject to chopping");
+  control[0] = 0x66666666;
+  assert.sameValue(view[8], control[0]);
+  assert.sameValue(Atomics.xor(view, 8, 0xF0F0F0F0), control[0],
+    "Result is subject to chopping");
 
-    control[0] = 0x96969696;
-    assert.sameValue(view[8], control[0]);
+  control[0] = 0x96969696;
+  assert.sameValue(view[8], control[0]);
 
-    view[3] = -5;
-    control[0] = -5;
-    assert.sameValue(Atomics.xor(view, 3, 0), control[0],
-                     "Result is negative and subject to coercion");
-    assert.sameValue(view[3], control[0]);
+  view[3] = -5;
+  control[0] = -5;
+  assert.sameValue(Atomics.xor(view, 3, 0), control[0],
+    "Result is negative and subject to coercion");
+  assert.sameValue(view[3], control[0]);
 
-    control[0] = 12345;
-    view[3] = 12345;
-    assert.sameValue(Atomics.xor(view, 3, 0), control[0],
-                     "Result is subject to chopping");
-    assert.sameValue(view[3], control[0]);
+  control[0] = 12345;
+  view[3] = 12345;
+  assert.sameValue(Atomics.xor(view, 3, 0), control[0],
+    "Result is subject to chopping");
+  assert.sameValue(view[3], control[0]);
 
-    // And again
-    control[0] = 123456789;
-    view[3] = 123456789;
-    assert.sameValue(Atomics.xor(view, 3, 0), control[0],
-                     "Result is subject to chopping");
-    assert.sameValue(view[3], control[0]);
+  // And again
+  control[0] = 123456789;
+  view[3] = 123456789;
+  assert.sameValue(Atomics.xor(view, 3, 0), control[0],
+    "Result is subject to chopping");
+  assert.sameValue(view[3], control[0]);
 
-    // In-bounds boundary cases for indexing
-    testWithAtomicsInBoundsIndices(function(IdxGen) {
-        let Idx = IdxGen(view);
-        view.fill(0);
-        // Atomics.store() computes an index from Idx in the same way as other
-        // Atomics operations, not quite like view[Idx].
-        Atomics.store(view, Idx, 37);
-        assert.sameValue(Atomics.xor(view, Idx, 0), 37);
-    });
+  // In-bounds boundary cases for indexing
+  testWithAtomicsInBoundsIndices(function(IdxGen) {
+    let Idx = IdxGen(view);
+    view.fill(0);
+    // Atomics.store() computes an index from Idx in the same way as other
+    // Atomics operations, not quite like view[Idx].
+    Atomics.store(view, Idx, 37);
+    assert.sameValue(Atomics.xor(view, Idx, 0), 37);
+  });
 }, int_views);

--- a/test/built-ins/Atomics/xor/non-views.js
+++ b/test/built-ins/Atomics/xor/non-views.js
@@ -10,5 +10,5 @@ features: [SharedArrayBuffer, ArrayBuffer, DataView, Atomics, arrow-function, le
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {
-    assert.throws(TypeError, (() => Atomics.xor(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.xor(view, 0, 0)));
 });

--- a/test/built-ins/Atomics/xor/nonshared-int-views.js
+++ b/test/built-ins/Atomics/xor/nonshared-int-views.js
@@ -19,7 +19,7 @@ if (typeof BigInt !== "undefined") {
 }
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(ab);
+  var view = new View(ab);
 
-    assert.throws(TypeError, (() => Atomics.xor(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.xor(view, 0, 0)));
 }, int_views);

--- a/test/built-ins/Atomics/xor/shared-nonint-views.js
+++ b/test/built-ins/Atomics/xor/shared-nonint-views.js
@@ -14,7 +14,7 @@ var sab = new SharedArrayBuffer(1024);
 var other_views = [Uint8ClampedArray, Float32Array, Float64Array];
 
 testWithTypedArrayConstructors(function(View) {
-    var view = new View(sab);
+  var view = new View(sab);
 
-    assert.throws(TypeError, (() => Atomics.xor(view, 0, 0)));
+  assert.throws(TypeError, (() => Atomics.xor(view, 0, 0)));
 }, other_views);


### PR DESCRIPTION
@anba this takes into consideration the notes you gave here https://github.com/tc39/test262/pull/1415