### PR TITLE
Add tests for the behavior of INT32_MIN (-2147483648) as exponent

### DIFF
--- a/test/built-ins/Math/pow/int32_min-exponent.js
+++ b/test/built-ins/Math/pow/int32_min-exponent.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-applying-the-exp-operator
+description: >
+    Using -(2**31) as exponent with Math.pow should behave as expected.
+---*/
+
+const INT32_MIN = -2147483648;
+
+assert.sameValue(Math.pow(2, INT32_MIN), +0.0,
+                 "Math.pow(2, -(gonzo huge exponent > 1074)) should be +0 " +
+                 "because 2**-1074 is the smallest positive IEEE-754 number");
+
+assert.sameValue(Math.pow(1, INT32_MIN), 1,
+                 "1**-(gonzo huge exponent > 1074) should be 1");

--- a/test/language/expressions/exponentiation/int32_min-exponent.js
+++ b/test/language/expressions/exponentiation/int32_min-exponent.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2018 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-applying-the-exp-operator
+description: >
+    Using -(2**31) as exponent with the exponentiation operator should behave
+    as expected.
+---*/
+
+const INT32_MIN = -2147483648;
+
+assert.sameValue(2**INT32_MIN, +0.0,
+                 "2**-(gonzo huge exponent > 1074) should be +0 because " +
+                 "2**-1074 is the smallest positive IEEE-754 number");
+
+assert.sameValue(1**INT32_MIN, 1,
+                 "1**-(gonzo huge exponent > 1074) should be 1");


### PR DESCRIPTION
SpiderMonkey's implementation invokes signed integer overflow in this case.  It would have been nice if test262 had performed this operation and thus would have alerted us to the issue (even if, at least with the compilers we test with regularly, there might not have been an _observable_ deviation from the spec).

It's maybe a little silly having one test for operator, one for function, but this seems better for implementations that choose not to implement the behavior literally by shared function call as the spec does.