### PR TITLE
improve propertyHelper for failure messages

### DIFF
--- a/harness/propertyHelper.js
+++ b/harness/propertyHelper.js
@@ -73,7 +73,7 @@ function verifyProperty(obj, name, desc, options) {
     }
   }
 
-  assert.sameValue(failures.length, 0, failures.join('; '));
+  assert(!failures.length, failures.join('; '));
 
   if (options && options.restore) {
     Object.defineProperty(obj, name, originalDesc);


### PR DESCRIPTION
Example:
Before: _descriptor value should be 42 Expected SameValue(«1», «0») to be true_
After: _descriptor value should be 42_

---

Note that `Expected SameValue(«1», «0»)` is for the list of failures while checking the descriptor, as each error adds up to the list. The error message is confusing if the expected value is similar, e.g. 1:

> descriptor value should be 42 Expected SameValue(«1», «0») to be true
