### PR TITLE
Tests for `export * as ns from 'foo'` syntax

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -97,6 +97,10 @@ Intl.RelativeTimeFormat
 # https://github.com/tc39/proposal-global
 global
 
+# `export * as namespace from module` consensus PR
+# https://github.com/tc39/ecma262/pull/1174
+export-star-as-namespace-from-module
+
 # Standard language features
 #
 # Language features that have been included in a published version of the

--- a/test/language/module-code/early-dup-export-as-star-as.js
+++ b/test/language/module-code/early-dup-export-as-star-as.js
@@ -1,8 +1,7 @@
-// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2018 Valerie Young. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-module-semantics-static-semantics-early-errors
-es6id: 15.2.1.1
 description: >
     It is a Syntax Error if the ExportedNames of ModuleItemList contains any
     duplicate entries.
@@ -14,6 +13,6 @@ negative:
 
 throw "Test262: This statement should not be evaluated.";
 
-var x, y;
+var x;
 export { x as z };
-export { y as z };
+export * as z from "early-dup-export-as-star-as.js";

--- a/test/language/module-code/early-dup-export-as-star-as.js
+++ b/test/language/module-code/early-dup-export-as-star-as.js
@@ -5,7 +5,7 @@ esid: sec-module-semantics-static-semantics-early-errors
 description: >
     It is a Syntax Error if the ExportedNames of ModuleItemList contains any
     duplicate entries.
-flags: [module]
+flags: [module, export-star-as-namespace-from-module]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/module-code/early-dup-export-star-as-dflt.js
+++ b/test/language/module-code/early-dup-export-star-as-dflt.js
@@ -1,8 +1,7 @@
-// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2018 Valerie Young. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-module-semantics-static-semantics-early-errors
-es6id: 15.2.1.1
 description: >
     It is a Syntax Error if the ExportedNames of ModuleItemList contains any
     duplicate entries.
@@ -14,6 +13,6 @@ negative:
 
 throw "Test262: This statement should not be evaluated.";
 
-var x, y;
-export { x as z };
-export { y as z };
+var x;
+export default x;
+export * as default from 'early-dup-export-start-as-dflt.js';

--- a/test/language/module-code/early-dup-export-star-as-dflt.js
+++ b/test/language/module-code/early-dup-export-star-as-dflt.js
@@ -5,7 +5,7 @@ esid: sec-module-semantics-static-semantics-early-errors
 description: >
     It is a Syntax Error if the ExportedNames of ModuleItemList contains any
     duplicate entries.
-flags: [module]
+flags: [module, export-star-as-namespace-from-module]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/module-code/eval-rqstd-once.js
+++ b/test/language/module-code/eval-rqstd-once.js
@@ -12,7 +12,7 @@ info: |
        b. Perform ? requiredModule.ModuleEvaluation().
     [...]
 includes: [fnGlobalObject.js]
-flags: [module]
+flags: [module, export-star-as-namespace-from-module]
 ---*/
 
 import {} from './eval-rqstd-once_FIXTURE.js';

--- a/test/language/module-code/eval-rqstd-once.js
+++ b/test/language/module-code/eval-rqstd-once.js
@@ -22,7 +22,8 @@ import dflt1 from './eval-rqstd-once_FIXTURE.js';
 export {} from './eval-rqstd-once_FIXTURE.js';
 import dflt2, {} from './eval-rqstd-once_FIXTURE.js';
 export * from './eval-rqstd-once_FIXTURE.js';
-import dflt3, * as ns from './eval-rqstd-once_FIXTURE.js';
+export * as ns2 from './eval-rqstd-once_FIXTURE.js';
+import dflt3, * as ns3 from './eval-rqstd-once_FIXTURE.js';
 export default null;
 
 var global = fnGlobalObject();

--- a/test/language/module-code/eval-rqstd-order-9_FIXTURE.js
+++ b/test/language/module-code/eval-rqstd-order-9_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2018 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+Function('return this;')().test262 += '9';

--- a/test/language/module-code/eval-rqstd-order.js
+++ b/test/language/module-code/eval-rqstd-order.js
@@ -15,7 +15,7 @@ info: |
     16. Let result be the result of evaluating module.[[ECMAScriptCode]].
     [...]
 includes: [fnGlobalObject.js]
-flags: [module]
+flags: [module, export-star-as-namespace-from-module]
 ---*/
 
 assert.sameValue(fnGlobalObject().test262, '123456789');

--- a/test/language/module-code/eval-rqstd-order.js
+++ b/test/language/module-code/eval-rqstd-order.js
@@ -18,7 +18,7 @@ includes: [fnGlobalObject.js]
 flags: [module]
 ---*/
 
-assert.sameValue(fnGlobalObject().test262, '12345678');
+assert.sameValue(fnGlobalObject().test262, '123456789');
 
 import {} from './eval-rqstd-order-1_FIXTURE.js';
 
@@ -34,4 +34,6 @@ import dflt2, {} from './eval-rqstd-order-6_FIXTURE.js';
 
 export * from './eval-rqstd-order-7_FIXTURE.js';
 
-import dflt3, * as ns from './eval-rqstd-order-8_FIXTURE.js';
+import dflt3, * as ns2 from './eval-rqstd-order-8_FIXTURE.js';
+
+export * as ns3 from './eval-rqstd-order-9_FIXTURE.js';

--- a/test/language/module-code/eval-self-once.js
+++ b/test/language/module-code/eval-self-once.js
@@ -4,12 +4,21 @@
 description: Module is evaluated exactly once
 esid: sec-moduleevaluation
 info: |
+  Evaluate( ) Concrete Method
     [...]
-    4. If module.[[Evaluated]] is true, return undefined.
-    5. Set module.[[Evaluated]] to true.
+    4. Let result be InnerModuleEvaluation(module, stack, 0).
+    [...]
+
+  InnerModuleEvaluation( module, stack, index )
+    [...]
+    2. If module.[[Status]] is "evaluated", then
+      a. If module.[[EvaluationError]] is undefined, return index.
+      b. Otherwise return module.[[EvaluationError]].
+    [...]
     6. For each String required that is an element of module.[[RequestedModules]] do,
        a. Let requiredModule be ? HostResolveImportedModule(module, required).
-       b. Perform ? requiredModule.ModuleEvaluation().
+       [...]
+       c. Set index to ? InnerModuleEvaluation(requiredModule, stack, index).
     [...]
 includes: [fnGlobalObject.js]
 flags: [module]
@@ -22,6 +31,7 @@ import dflt1 from './eval-self-once.js';
 export {} from './eval-self-once.js';
 import dflt2, {} from './eval-self-once.js';
 export * from './eval-self-once.js';
+export * as ns2 from './eval-self-once.js';
 import dflt3, * as ns from './eval-self-once.js';
 export default null;
 

--- a/test/language/module-code/eval-self-once.js
+++ b/test/language/module-code/eval-self-once.js
@@ -21,7 +21,7 @@ info: |
        c. Set index to ? InnerModuleEvaluation(requiredModule, stack, index).
     [...]
 includes: [fnGlobalObject.js]
-flags: [module]
+flags: [module, export-star-as-namespace-from-module]
 ---*/
 
 import {} from './eval-self-once.js';

--- a/test/language/module-code/instn-once.js
+++ b/test/language/module-code/instn-once.js
@@ -4,18 +4,21 @@
 description: Module is instantiated exactly once
 esid: sec-moduledeclarationinstantiation
 info: |
+  Instantiate( ) Concrete Method
     [...]
-    5. If module.[[Environment]] is not undefined, return
-       NormalCompletion(empty).
-    6. Let env be NewModuleEnvironment(realm.[[GlobalEnv]]).
-    7. Set module.[[Environment]] to env.
-    8. For each String required that is an element of
-       module.[[RequestedModules]] do,
-       a. NOTE: Before instantiating a module, all of the modules it requested
-          must be available. An implementation may perform this test at any
-          time prior to this point.
-       b. Let requiredModule be ? HostResolveImportedModule(module, required).
-       c. Perform ? requiredModule.ModuleDeclarationInstantiation().
+    4. Let result be InnerModuleInstantiation(module, stack, 0).
+    [...]
+
+  InnerModuleInstantiation( module, stack, index )
+    [...]
+    2. If module.[[Status]] is "instantiating", "instantiated", or "evaluated", then
+      a. Return index.
+    3. Assert: module.[[Status]] is "uninstantiated".
+    4. Set module.[[Status]] to "instantiating".
+    [...]
+    9. For each String required that is an element of module.[[RequestedModules]], do
+      a. Let requiredModule be ? HostResolveImportedModule(module, required).
+      b. Set index to ? InnerModuleInstantiation(requiredModule, stack, index).
     [...]
 flags: [module]
 ---*/
@@ -27,6 +30,7 @@ import dflt1 from './instn-once.js';
 export {} from './instn-once.js';
 import dflt2, {} from './instn-once.js';
 export * from './instn-once.js';
+export * as ns2 from './instn-once.js';
 import dflt3, * as ns from './instn-once.js';
 export default null;
 

--- a/test/language/module-code/instn-once.js
+++ b/test/language/module-code/instn-once.js
@@ -20,7 +20,7 @@ info: |
       a. Let requiredModule be ? HostResolveImportedModule(module, required).
       b. Set index to ? InnerModuleInstantiation(requiredModule, stack, index).
     [...]
-flags: [module]
+flags: [module, export-star-as-namespace-from-module]
 ---*/
 
 import {} from './instn-once.js';

--- a/test/language/module-code/instn-resolve-empty-export.js
+++ b/test/language/module-code/instn-resolve-empty-export.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: >
-    An ExportClause without an ExportsList contributes to the list of requested
+    A NamedExport without an ExportsList contributes to the list of requested
     modules
 esid: sec-moduledeclarationinstantiation
 info: |
@@ -25,7 +25,7 @@ info: |
 
     Syntax
 
-      ExportClause:
+      NamedExport:
         { }
         { ExportsList }
         { ExportsList , }

--- a/test/language/module-code/instn-star-as-props-dflt-skip.js
+++ b/test/language/module-code/instn-star-as-props-dflt-skip.js
@@ -40,7 +40,7 @@ info: |
   c. For each element n of starNames, do
   i. If SameValue(n, "default") is false, then
   [...]
-flags: [module]
+flags: [module, export-star-as-namespace-from-module]
   ---*/
 
 import named from './instn-star-props-dflt-skip-star-as-named_FIXTURE.js';

--- a/test/language/module-code/instn-star-as-props-dflt-skip.js
+++ b/test/language/module-code/instn-star-as-props-dflt-skip.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2018 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Default exports are not included in an imported module namespace object when module exported with `* as namespace`
+esid: sec-moduledeclarationinstantiation
+info: |
+  [...]
+  4. Let result be InnerModuleInstantiation(module, stack, 0).
+  [...]
+
+  InnerModuleInstantiation( module, stack, index )
+  [...]
+  10. Perform ? ModuleDeclarationEnvironmentSetup(module).
+  [...]
+
+  ModuleDeclarationEnvironmentSetup( module )
+  [...]
+    c. If in.[[ImportName]] is "*", then
+    [...]
+    d. Else,
+      i. Let resolution be ? importedModule.ResolveExport(in.[[ImportName]], « »).
+      ii. If resolution is null or "ambiguous", throw a SyntaxError exception.
+      iii. If resolution.[[BindingName]] is "*namespace*", then
+        1. Let namespace be ? GetModuleNamespace(resolution.[[Module]]).
+    [...]
+
+  15.2.1.18 Runtime Semantics: GetModuleNamespace
+
+  [...]
+  3. If namespace is undefined, then
+  a. Let exportedNames be ? module.GetExportedNames(« »).
+  [...]
+
+  15.2.1.16.2 GetExportedNames
+
+  [...]
+  7. For each ExportEntry Record e in module.[[StarExportEntries]], do
+  [...]
+  c. For each element n of starNames, do
+  i. If SameValue(n, "default") is false, then
+  [...]
+flags: [module]
+  ---*/
+
+import named from './instn-star-props-dflt-skip-star-as-named_FIXTURE.js';
+import production from './instn-star-props-dflt-skip-star-as-prod_FIXTURE.js';
+
+assert('namedOther' in named);
+assert.sameValue(
+  'default' in named, false, 'default specified via identifier'
+);
+
+assert('productionOther' in production);
+assert.sameValue(
+  'default' in production, false, 'default specified via dedicated production'
+);

--- a/test/language/module-code/instn-star-props-dflt-skip-star-as-named-end_FIXTURE.js
+++ b/test/language/module-code/instn-star-props-dflt-skip-star-as-named-end_FIXTURE.js
@@ -1,0 +1,6 @@
+// Copyright (C) 2018 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+var x;
+export var namedOther = null;
+export { x as default };

--- a/test/language/module-code/instn-star-props-dflt-skip-star-as-named_FIXTURE.js
+++ b/test/language/module-code/instn-star-props-dflt-skip-star-as-named_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2018 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export * as named from './instn-star-props-dflt-skip-star-as-named-end_FIXTURE.js';

--- a/test/language/module-code/instn-star-props-dflt-skip-star-as-prod-end_FIXTURE.js
+++ b/test/language/module-code/instn-star-props-dflt-skip-star-as-prod-end_FIXTURE.js
@@ -1,0 +1,5 @@
+// Copyright (C) 2018 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export var productionOther = null;
+export default null;

--- a/test/language/module-code/instn-star-props-dflt-skip-star-as-prod_FIXTURE.js
+++ b/test/language/module-code/instn-star-props-dflt-skip-star-as-prod_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2018 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export * as production from './instn-star-props-dflt-skip-star-as-prod-end_FIXTURE.js';

--- a/test/language/module-code/instn-star-props-nrml-1_FIXTURE.js
+++ b/test/language/module-code/instn-star-props-nrml-1_FIXTURE.js
@@ -20,5 +20,7 @@ export { localBindingId };
 export { localBindingId as localIdName };
 export { indirectIdName } from './instn-star-props-nrml-indirect_FIXTURE.js';
 export { indirectIdName as indirectIdName2 } from './instn-star-props-nrml-indirect_FIXTURE.js';
+export * as namespaceBinding from './instn-star-props-nrml-indirect_FIXTURE.js';
 
 export * from './instn-star-props-nrml-star_FIXTURE.js';
+

--- a/test/language/module-code/instn-star-props-nrml-star_FIXTURE.js
+++ b/test/language/module-code/instn-star-props-nrml-star_FIXTURE.js
@@ -20,3 +20,4 @@ export { starBindingId };
 export { starBindingId as starIdName };
 export { starIndirectIdName } from './instn-star-props-nrml-indirect_FIXTURE.js';
 export { starIndirectIdName as starIndirectIdName2 } from './instn-star-props-nrml-indirect_FIXTURE.js';
+export * as starIndirectNamespaceBinding from './instn-star-props-nrml-indirect_FIXTURE.js';

--- a/test/language/module-code/instn-star-props-nrml.js
+++ b/test/language/module-code/instn-star-props-nrml.js
@@ -40,6 +40,7 @@ assert('localBindingId' in ns, 'localBindingId');
 assert('localIdName' in ns, 'localIdName');
 assert('indirectIdName' in ns, 'indirectIdName');
 assert('indirectIdName2' in ns, 'indirectIdName2');
+assert('namespaceBinding' in ns, 'namespaceBinding');
 
 // Export entries defined by a re-exported module
 assert('starVarDecl' in ns, 'starVarDecl');
@@ -52,8 +53,9 @@ assert('starBindingId' in ns, 'starBindingId');
 assert('starIdName' in ns, 'starIdName');
 assert('starIndirectIdName' in ns, 'starIndirectIdName');
 assert('starIndirectIdName2' in ns, 'starIndirectIdName2');
+assert('starIndirectNamespaceBinding' in ns, 'starIndirectNamespaceBinding');
 
-// Bindings that were not exported from either module
+// Bindings that were not exported from any module
 assert.sameValue('nonExportedVar1' in ns, false, 'nonExportedVar1');
 assert.sameValue('nonExportedVar2' in ns, false, 'nonExportedVar2');
 assert.sameValue('nonExportedLet1' in ns, false, 'nonExportedLet1');

--- a/test/language/module-code/instn-star-props-nrml.js
+++ b/test/language/module-code/instn-star-props-nrml.js
@@ -24,7 +24,7 @@ info: |
           iii. If resolution is not "ambiguous", append name to
                unambiguousNames.
        d. Let namespace be ModuleNamespaceCreate(module, unambiguousNames).
-flags: [module]
+flags: [module, export-star-as-namespace-from-module]
 ---*/
 
 import * as ns from './instn-star-props-nrml-1_FIXTURE.js';

--- a/test/language/module-code/namespace/internals/get-nested-namespace-dflt-skip-named-end_FIXTURE.js
+++ b/test/language/module-code/namespace/internals/get-nested-namespace-dflt-skip-named-end_FIXTURE.js
@@ -1,0 +1,6 @@
+// Copyright (C) 2018 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+var x;
+export var namedOther = null;
+export { x as default };

--- a/test/language/module-code/namespace/internals/get-nested-namespace-dflt-skip-named_FIXTURE.js
+++ b/test/language/module-code/namespace/internals/get-nested-namespace-dflt-skip-named_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2018 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export * as namedns2 from './get-nested-namespace-dflt-skip-named-end_FIXTURE.js';

--- a/test/language/module-code/namespace/internals/get-nested-namespace-dflt-skip-prod-end_FIXTURE.js
+++ b/test/language/module-code/namespace/internals/get-nested-namespace-dflt-skip-prod-end_FIXTURE.js
@@ -1,0 +1,5 @@
+// Copyright (C) 2018 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export var productionOther = null;
+export default null;

--- a/test/language/module-code/namespace/internals/get-nested-namespace-dflt-skip-prod_FIXTURE.js
+++ b/test/language/module-code/namespace/internals/get-nested-namespace-dflt-skip-prod_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2018 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export * as productionns2 from './get-nested-namespace-dflt-skip-prod-end_FIXTURE.js';

--- a/test/language/module-code/namespace/internals/get-nested-namespace-dflt-skip.js
+++ b/test/language/module-code/namespace/internals/get-nested-namespace-dflt-skip.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2018 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Default exports are not included in an imported module namespace object when a namespace object is created.
+esid: sec-module-namespace-exotic-objects-get-p-receiver
+info: |
+  [...]
+  6. Let binding be ! m.ResolveExport(P, « »).
+  7. Assert: binding is a ResolvedBinding Record.
+  8. Let targetModule be binding.[[Module]].
+  9. Assert: targetModule is not undefined.
+  10. If binding.[[BindingName]] is "*namespace*", then
+  11. Return ? GetModuleNamespace(targetModule).
+
+  Runtime Semantics: GetModuleNamespace
+  [...]
+    3. If namespace is undefined, then
+       a. Let exportedNames be ? module.GetExportedNames(« »).
+       b. Let unambiguousNames be a new empty List.
+       c. For each name that is an element of exportedNames,
+          i. Let resolution be ? module.ResolveExport(name, « », « »).
+          ii. If resolution is null, throw a SyntaxError exception.
+          iii. If resolution is not "ambiguous", append name to
+               unambiguousNames.
+       d. Let namespace be ModuleNamespaceCreate(module, unambiguousNames).
+  [...]
+flags: [module]
+  ---*/
+
+import * as namedns1 from './get-nested-namespace-dflt-skip-named_FIXTURE.js';
+import * as productionns1 from './get-nested-namespace-dflt-skip-prod_FIXTURE.js';
+
+assert('namedOther' in namedns1.namedns2);
+assert.sameValue(
+  'default' in namedns1.namedns2, false, 'default specified via identifier'
+);
+
+assert('productionOther' in productionns1.productionns2);
+assert.sameValue(
+  'default' in productionns1.productionns2, false, 'default specified via dedicated production'
+);

--- a/test/language/module-code/namespace/internals/get-nested-namespace-dflt-skip.js
+++ b/test/language/module-code/namespace/internals/get-nested-namespace-dflt-skip.js
@@ -25,8 +25,8 @@ info: |
                unambiguousNames.
        d. Let namespace be ModuleNamespaceCreate(module, unambiguousNames).
   [...]
-flags: [module]
-  ---*/
+flags: [module, export-star-as-namespace-from-module]
+---*/
 
 import * as namedns1 from './get-nested-namespace-dflt-skip-named_FIXTURE.js';
 import * as productionns1 from './get-nested-namespace-dflt-skip-prod_FIXTURE.js';

--- a/test/language/module-code/namespace/internals/get-nested-namespace-props-nrml-1_FIXTURE.js
+++ b/test/language/module-code/namespace/internals/get-nested-namespace-props-nrml-1_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2018 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export * as exportns from './get-nested-namespace-props-nrml-2_FIXTURE.js';

--- a/test/language/module-code/namespace/internals/get-nested-namespace-props-nrml-2_FIXTURE.js
+++ b/test/language/module-code/namespace/internals/get-nested-namespace-props-nrml-2_FIXTURE.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2018 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+var notExportedVar;
+let notExportedLet;
+const notExportedConst = null;
+function notExportedFunc() {}
+function* notExportedGen() {}
+class notExportedClass {}
+
+var starBindingId;
+
+export var starAsVarDecl;
+export let starAsLetDecl;
+export const starAsConstDecl = null;
+export function starAsFuncDecl() {}
+export function* starAsGenDecl() {}
+export class starAsClassDecl {}
+export { starAsBindingId };
+export { starAsBindingId as starIdName };
+export { starAsIndirectIdName } from './get-nested-namespace-props-nrml-3_FIXTURE.js';
+export { starAsIndirectIdName as starAsIndirectIdName2 } from './get-nested-namespace-props-nrml-3_FIXTURE.js';
+export * as namespaceBinding from './get-nested-namespace-props-nrml-3_FIXTURE.js';;

--- a/test/language/module-code/namespace/internals/get-nested-namespace-props-nrml-3_FIXTURE.js
+++ b/test/language/module-code/namespace/internals/get-nested-namespace-props-nrml-3_FIXTURE.js
@@ -1,0 +1,5 @@
+// Copyright (C) 2016 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export var indirectIdName;
+export var starIndirectIdName;

--- a/test/language/module-code/namespace/internals/get-nested-namespace-props-nrml.js
+++ b/test/language/module-code/namespace/internals/get-nested-namespace-props-nrml.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    Module namespace object reports properties for all ExportEntries of all
+    dependencies.
+esid: sec-moduledeclarationinstantiation
+info: |
+  [...]
+  12. For each ImportEntry Record in in module.[[ImportEntries]], do
+      a. Let importedModule be ? HostResolveImportedModule(module,
+         in.[[ModuleRequest]]).
+      b. If in.[[ImportName]] is "*", then
+         i. Let namespace be ? GetModuleNamespace(importedModule).
+  [...]
+
+  Runtime Semantics: GetModuleNamespace
+    3. If namespace is undefined, then
+       a. Let exportedNames be ? module.GetExportedNames(« »).
+       b. Let unambiguousNames be a new empty List.
+       c. For each name that is an element of exportedNames,
+          i. Let resolution be ? module.ResolveExport(name, « », « »).
+          ii. If resolution is null, throw a SyntaxError exception.
+          iii. If resolution is not "ambiguous", append name to
+               unambiguousNames.
+       d. Let namespace be ModuleNamespaceCreate(module, unambiguousNames).
+flags: [module]
+---*/
+
+import * as ns from './get-nested-namespace-props-nrml-1_FIXTURE.js';
+
+// Export entries defined by a re-exported as exportns module
+assert('starAsVarDecl' in ns.exportns, 'starssVarDecl');
+assert('starAsLetDecl' in ns.exportns, 'starSsLetDecl');
+assert('starAsConstDecl' in ns.exportns, 'starSsConstDecl');
+assert('starAsFuncDecl' in ns.exportns, 'starAsFuncDecl');
+assert('starAsGenDecl' in ns.exportns, 'starAsGenDecl');
+assert('starAsClassDecl' in ns.exportns, 'starAsClassDecl');
+assert('starAsBindingId' in ns.exportns, 'starAsBindingId');
+assert('starAsIdName' in ns.exportns, 'starAsIdName');
+assert('starAsIndirectIdName' in ns.exportns, 'starAsIndirectIdName');
+assert('starAsIndirectIdName2' in ns.exportns, 'starAsIndirectIdName2');
+assert('namespaceBinding' in ns.exportns, 'namespaceBinding');
+
+// Bindings that were not exported from any module
+assert.sameValue('nonExportedVar' in ns.exportns, false, 'nonExportedVar');
+assert.sameValue('nonExportedLet' in ns.exportns, false, 'nonExportedLet');
+assert.sameValue('nonExportedConst' in ns.exportns, false, 'nonExportedConst');
+assert.sameValue('nonExportedFunc' in ns.exportns, false, 'nonExportedFunc');
+assert.sameValue('nonExportedGen' in ns.exportns, false, 'nonExportedGen');
+assert.sameValue('nonExportedClass' in ns.exportns, false, 'nonExportedClass');

--- a/test/language/module-code/namespace/internals/get-nested-namespace-props-nrml.js
+++ b/test/language/module-code/namespace/internals/get-nested-namespace-props-nrml.js
@@ -24,7 +24,7 @@ info: |
           iii. If resolution is not "ambiguous", append name to
                unambiguousNames.
        d. Let namespace be ModuleNamespaceCreate(module, unambiguousNames).
-flags: [module]
+flags: [module, export-star-as-namespace-from-module]
 ---*/
 
 import * as ns from './get-nested-namespace-props-nrml-1_FIXTURE.js';

--- a/test/language/module-code/parse-err-export-dflt-expr.js
+++ b/test/language/module-code/parse-err-export-dflt-expr.js
@@ -7,8 +7,9 @@ esid: sec-exports
 info: |
     ExportDeclaration:
       export * FromClause;
-      export ExportClause FromClause;
-      export ExportClause;
+      export * as IdentifierName FromClause;
+      export NamedExports FromClause;
+      export NamedExports;
       export VariableStatement
       export Declaration
       export default HoistableDeclaration[Default]

--- a/test/language/module-code/parse-err-invoke-anon-fun-decl.js
+++ b/test/language/module-code/parse-err-invoke-anon-fun-decl.js
@@ -6,9 +6,10 @@ description: >
 esid: sec-exports
 info: |
     ExportDeclaration:
-      export * FromClause;
-      export ExportClause FromClause;
-      export ExportClause;
+      export * FromClause
+      export * as IdentifierName FromClause;
+      export NamedExports FromClause;
+      export NamedExports;
       export VariableStatement
       export Declaration
       export default HoistableDeclaration[Default]

--- a/test/language/module-code/parse-err-invoke-anon-gen-decl.js
+++ b/test/language/module-code/parse-err-invoke-anon-gen-decl.js
@@ -8,8 +8,9 @@ esid: sec-exports
 info: |
     ExportDeclaration:
       export * FromClause;
-      export ExportClause FromClause;
-      export ExportClause;
+      export * as IdentifierName FromClause;
+      export NamedExports FromClause;
+      export NamedExports;
       export VariableStatement
       export Declaration
       export default HoistableDeclaration[Default]

--- a/test/language/module-code/parse-err-semi-dflt-expr.js
+++ b/test/language/module-code/parse-err-semi-dflt-expr.js
@@ -8,8 +8,9 @@ esid: sec-exports
 info: |
     ExportDeclaration:
       export * FromClause;
-      export ExportClause FromClause;
-      export ExportClause;
+      export * as IdentifierName FromClause;
+      export NamedExports FromClause;
+      export NamedExports;
       export VariableStatement
       export Declaration
       export default HoistableDeclaration[Default]

--- a/test/language/module-code/parse-err-semi-export-star.js
+++ b/test/language/module-code/parse-err-semi-export-star.js
@@ -18,7 +18,7 @@ info: |
 negative:
   phase: parse
   type: SyntaxError
-flags: [module]
+flags: [module, export-star-as-namespace-from-module]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-semi-name-space-export.js
+++ b/test/language/module-code/parse-err-semi-name-space-export.js
@@ -1,8 +1,9 @@
-// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// Copyright (C) 2018 Valerie Young. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: >
-    "export *" declarations require a trailing semicolon or LineTerminator
+    "export NameSpaceExport FromClause" declarations require a trailing semicolon
+    or LineTerminator
 esid: sec-exports
 info: |
     ExportDeclaration:
@@ -23,4 +24,4 @@ flags: [module]
 
 throw "Test262: This statement should not be evaluated.";
 
-export * from './parse-err-semi-export-star.js' null;
+export * as namespace from './parse-err-semi-name-space-export.js' null;

--- a/test/language/module-code/parse-err-semi-name-space-export.js
+++ b/test/language/module-code/parse-err-semi-name-space-export.js
@@ -19,7 +19,7 @@ info: |
 negative:
   phase: parse
   type: SyntaxError
-flags: [module]
+flags: [module, export-star-as-namespace-from-module]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/parse-err-semi-named-export-from.js
+++ b/test/language/module-code/parse-err-semi-named-export-from.js
@@ -2,14 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: >
-    "export ExportClause" declarations require a trailing semicolon or
-    LineTerminator
+    "export NamedExports FromClause" declarations require a trailing semicolon
+    or LineTerminator
 esid: sec-exports
 info: |
     ExportDeclaration:
       export * FromClause;
-      export ExportClause FromClause;
-      export ExportClause;
+      export * as IdentifierName FromClause;
+      export NamedExports FromClause;
+      export NamedExports;
       export VariableStatement
       export Declaration
       export default HoistableDeclaration[Default]
@@ -23,4 +24,4 @@ flags: [module]
 
 throw "Test262: This statement should not be evaluated.";
 
-export {} null;
+export {} from './parse-err-semi-export-clause-from.js' null;

--- a/test/language/module-code/parse-err-semi-named-export.js
+++ b/test/language/module-code/parse-err-semi-named-export.js
@@ -2,14 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: >
-    "export ExportClause FromClause" declarations require a trailing semicolon
-    or LineTerminator
+    "export NamedExports" declarations require a trailing semicolon or
+    LineTerminator
 esid: sec-exports
 info: |
     ExportDeclaration:
       export * FromClause;
-      export ExportClause FromClause;
-      export ExportClause;
+      export * as IdentifierName FromClause;
+      export NamedExports FromClause;
+      export NamedExports;
       export VariableStatement
       export Declaration
       export default HoistableDeclaration[Default]
@@ -23,4 +24,4 @@ flags: [module]
 
 throw "Test262: This statement should not be evaluated.";
 
-export {} from './parse-err-semi-export-clause-from.js' null;
+export {} null;

--- a/test/language/module-code/parse-export-empty.js
+++ b/test/language/module-code/parse-export-empty.js
@@ -1,20 +1,21 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-description: An ExportClause does not require an ExportsList.
+description: A NamedExport does not require an ExportsList.
 esid: sec-parsemodule
 info: |
     ExportDeclaration:
       export * FromClause;
-      export ExportClause FromClause;
-      export ExportClause;
+      export * as IdentifierName FromClause;
+      export NamedExports FromClause;
+      export NamedExports;
       export VariableStatement
       export Declaration
       export default HoistableDeclaration[Default]
       export default ClassDeclaration[Default]
       export default [lookahead ∉ { function, class }] AssignmentExpression[In];
 
-    ExportClause:
+    NamedExports:
       { }
       { ExportsList }
       { ExportsList , }


### PR DESCRIPTION
Tests for this PR: <s>https://github.com/tc39/ecma262/pull/1005</s> 
Now this PR: https://github.com/tc39/ecma262/pull/1174

One or two more commits of tests to come.