### PR TITLE
Date.parse breathing test, time value maximum range test

### DIFF
--- a/test/built-ins/Date/parse/time-value-maximum-range.js
+++ b/test/built-ins/Date/parse/time-value-maximum-range.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2018 Andrew Paprocki. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.parse
+es6id: 20.3.3.2
+description: >
+  Date.parse return value is limited to specified time value maximum range
+info: |
+  Date.parse ( string )
+
+  parse interprets the resulting String as a date and time; it returns a
+  Number, the UTC time value corresponding to the date and time.
+
+  A Date object contains a Number indicating a particular instant in time to
+  within a millisecond. Such a Number is called a time value.
+
+  The actual range of times supported by ECMAScript Date objects is slightly
+  smaller: exactly -100,000,000 days to 100,000,000 days measured relative to
+  midnight at the beginning of 01 January, 1970 UTC. This gives a range of
+  8,640,000,000,000,000 milliseconds to either side of 01 January, 1970 UTC.
+includes: [propertyHelper.js]
+---*/
+
+const minDateStr = "-271821-04-20T00:00:00.000Z";
+const minDate = new Date(-8640000000000000);
+
+assert.sameValue(minDate.toISOString(), minDateStr, "minDateStr");
+assert.sameValue(Date.parse(minDateStr), minDate.valueOf(), "parse minDateStr");
+
+const maxDateStr = "+275760-09-13T00:00:00.000Z";
+const maxDate = new Date(8640000000000000);
+
+assert.sameValue(maxDate.toISOString(), maxDateStr, "maxDateStr");
+assert.sameValue(Date.parse(maxDateStr), maxDate.valueOf(), "parse maxDateStr");
+
+const belowRange = "-271821-04-19T23:59:59.999Z";
+const aboveRange = "+275760-09-13T00:00:00.001Z";
+
+assert.sameValue(Date.parse(belowRange), NaN, "parse below minimum time value");
+assert.sameValue(Date.parse(aboveRange), NaN, "parse above maximum time value");

--- a/test/built-ins/Date/parse/zero.js
+++ b/test/built-ins/Date/parse/zero.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2018 Andrew Paprocki. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-date.parse
+es6id: 20.3.3.2
+description: >
+  Date.parse of toString/toUTCString/toISOString of zero value is zero
+info: |
+  Date.parse ( string )
+
+  If x is any Date object whose milliseconds amount is zero within a
+  particular implementation of ECMAScript, then all of the following
+  expressions should produce the same numeric value in that
+  implementation, if all the properties referenced have their initial
+  values:
+
+  x.valueOf()
+  Date.parse(x.toString())
+  Date.parse(x.toUTCString())
+  Date.parse(x.toISOString())
+includes: [propertyHelper.js]
+---*/
+
+const zero = new Date(0);
+
+assert.sameValue(zero.valueOf(), Date.parse(zero.toString()),
+                 "Date.parse(zeroDate.toString())");
+assert.sameValue(zero.valueOf(), Date.parse(zero.toUTCString()),
+                 "Date.parse(zeroDate.toUTCString())");
+assert.sameValue(zero.valueOf(), Date.parse(zero.toISOString()),
+                 "Date.parse(zeroDate.toISOString())");


### PR DESCRIPTION
The specification directly calls out the parse identity of a `Date` `x` where `x.valueOf() === 0`. This adds a basic test for that base case and then adds an additional test for the maximum allowable *time value* range as stated in the spec.

The latter issue was raised in tc39/ecma262#1145, and currently Firefox (SpiderMonkey) is the only engine returning `NaN` for values outside of the *time value* range. This test is intended to bring the other engines in line with SM behavior.