### PR TITLE
Fix various test bugs

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -146,3 +146,4 @@ WeakSet
 # object, go here.
 
 IsHTMLDDA
+CannotSuspendMainAgent

--- a/harness/features.yml
+++ b/harness/features.yml
@@ -1,4 +1,5 @@
 typeCoercion.js: [Symbol.toPrimitive, BigInt]
 testAtomics.js: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, arrow-function, let, for-of]
+testBigIntTypedArray.js: [BigInt, TypedArray]
 testTypedArray.js: [TypedArray]
 isConstructor.js: [Reflect.construct]

--- a/harness/testBigIntTypedArray.js
+++ b/harness/testBigIntTypedArray.js
@@ -8,7 +8,7 @@ description: |
 /**
  * The %TypedArray% intrinsic constructor function.
  */
-var TypedArray = Object.getPrototypeOf(BigInt64Array);
+var TypedArray = Object.getPrototypeOf(Int8Array);
 
 /**
  * Calls the provided function for every typed array constructor.

--- a/test/built-ins/AsyncFromSyncIteratorPrototype/throw/iterator-result-unwrap-promise.js
+++ b/test/built-ins/AsyncFromSyncIteratorPrototype/throw/iterator-result-unwrap-promise.js
@@ -46,7 +46,7 @@ var obj = {
 };
 
 async function* asyncg() {
-  yield* obj;
+  return yield* obj;
 }
 
 let iter = asyncg();

--- a/test/built-ins/AsyncGeneratorFunction/invoked-as-constructor-no-arguments.js
+++ b/test/built-ins/AsyncGeneratorFunction/invoked-as-constructor-no-arguments.js
@@ -6,6 +6,7 @@ description: >
     When invoked via the constructor invocation pattern without arguments, the
     GeneratorFunction intrinsic returns a valid async generator with an empty body.
 features: [async-iteration]
+flags: [async]
 ---*/
 
 var AsyncGeneratorFunction = Object.getPrototypeOf(async function* () {}).constructor;

--- a/test/built-ins/AsyncGeneratorFunction/invoked-as-function-multiple-arguments.js
+++ b/test/built-ins/AsyncGeneratorFunction/invoked-as-function-multiple-arguments.js
@@ -8,6 +8,7 @@ description: >
     last argument evaluated as source code and whose formal parameters are
     defined by the preceeding arguments.
 features: [async-iteration]
+flags: [async]
 ---*/
 
 var AsyncGeneratorFunction = Object.getPrototypeOf(async function* () {}).constructor;

--- a/test/built-ins/AsyncGeneratorFunction/invoked-as-function-no-arguments.js
+++ b/test/built-ins/AsyncGeneratorFunction/invoked-as-function-no-arguments.js
@@ -6,6 +6,7 @@ description: >
     When invoked via the function invocation pattern without arguments, the
     AsyncGeneratorFunction intrinsic returns a valid generator with an empty body.
 features: [async-iteration]
+flags: [async]
 ---*/
 
 var AsyncGeneratorFunction = Object.getPrototypeOf(async function* () {}).constructor;

--- a/test/built-ins/Atomics/wait/cannot-suspend-throws.js
+++ b/test/built-ins/Atomics/wait/cannot-suspend-throws.js
@@ -14,7 +14,7 @@ info: |
   6. Let B be AgentCanSuspend().
   7. If B is false, throw a TypeError exception.
   ...
-features: [Atomics, SharedArrayBuffer, TypedArray]
+features: [Atomics, SharedArrayBuffer, TypedArray, CannotSuspendMainAgent]
 ---*/
 
 var sab = new SharedArrayBuffer(4);

--- a/test/built-ins/Atomics/wait/non-int32-typedarray-throws.js
+++ b/test/built-ins/Atomics/wait/non-int32-typedarray-throws.js
@@ -3,7 +3,7 @@
 
 /*---
 esid: sec-atomics.wait
-description:
+description: >
   Throws a TypeError if typedArray arg is not an Int32Array
 info: |
   Atomics.wait( typedArray, index, value, timeout )

--- a/test/built-ins/Atomics/wait/undefined-index-defaults-to-zero.js
+++ b/test/built-ins/Atomics/wait/undefined-index-defaults-to-zero.js
@@ -24,7 +24,7 @@ $262.agent.start(
   `
 $262.agent.receiveBroadcast(function (sab) { 
   var int32Array = new Int32Array(sab);
-  $262.agent.report(Atomics.wait(int32Array, undefined, 0, 10)); // undefined index => 0
+  $262.agent.report(Atomics.wait(int32Array, undefined, 0, 1000)); // undefined index => 0
   $262.agent.leaving();
 })
 `);

--- a/test/built-ins/Atomics/wait/wait-index-value-not-equal.js
+++ b/test/built-ins/Atomics/wait/wait-index-value-not-equal.js
@@ -28,11 +28,9 @@ $262.agent.start(
 $262.agent.receiveBroadcast(function (sab) {
   var int32Array = new Int32Array(sab);
     
-  $262.agent.report(Atomics.wait(int32Array, 0, 44, 100));
+  $262.agent.report(Atomics.wait(int32Array, 0, 44, 1000));
   
   $262.agent.report(Atomics.wait(int32Array, 0, 251.4, 1000));
-    
-  $262.agent.report(Atomics.wait(int32Array, 0, Infinity, 1000));
 
   $262.agent.leaving();
 })
@@ -45,7 +43,6 @@ $262.agent.broadcast(int32Array.buffer);
 $262.agent.sleep(200);
 
 
-assert.sameValue(getReport(), "not-equal");
 assert.sameValue(getReport(), "not-equal");
 assert.sameValue(getReport(), "not-equal");
 

--- a/test/built-ins/Atomics/wait/was-woken-before-timeout.js
+++ b/test/built-ins/Atomics/wait/was-woken-before-timeout.js
@@ -42,7 +42,7 @@ $262.agent.start(
   assert.sameValue(Atomics.wake(int32Array, 0), 1);
   
   assert.sameValue(getReport(), "ok");
-  assert.sameValue(sleeping < timeout, "this test assumes it won't last for more than 20 seconds");
+  assert(sleeping < timeout, "this test assumes it won't last for more than 20 seconds");
   
   function getReport() {
     var r;
@@ -52,4 +52,3 @@ $262.agent.start(
     }
     return r;
   }
-  

--- a/test/built-ins/Promise/all/iter-arg-is-string-resolve.js
+++ b/test/built-ins/Promise/all/iter-arg-is-string-resolve.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-promise.all
 description: >
-  Reject when argument is a string
+  Resolve when argument is a string
 info: |
     ...
     Let iteratorRecord be GetIterator(iterable).
@@ -23,11 +23,11 @@ flags: [async]
 ---*/
 
 try {
-  Promise.all("").then(function() {
-    $DONE();
+  Promise.all("").then(function(v) {
+    assert.sameValue(v.length, 0);
   }, function() {
     $DONE('The promise should be resolved, but was rejected');
   }).then($DONE, $DONE);
 } catch (error) {
-  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+  $DONE(`The promise should be resolved, but threw an exception: ${error.message}`);
 }

--- a/test/built-ins/Promise/all/iter-step-err-no-close.js
+++ b/test/built-ins/Promise/all/iter-step-err-no-close.js
@@ -37,7 +37,7 @@ Object.defineProperty(poisonedDone, 'done', {
 });
 Object.defineProperty(poisonedDone, 'value', {
   get: function() {
-    $DONE('The `value` property should not be accessed.');
+    $ERROR('The `value` property should not be accessed.');
   }
 });
 

--- a/test/built-ins/Promise/race/iter-arg-is-string-resolve.js
+++ b/test/built-ins/Promise/race/iter-arg-is-string-resolve.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-promise.race
 description: >
-  Reject when argument is a string
+  Resolve when argument is a string
 info: |
     ...
     Let iteratorRecord be GetIterator(iterable).
@@ -23,11 +23,11 @@ flags: [async]
 ---*/
 
 try {
-  Promise.race("").then(function() {
-    $DONE();
+  Promise.race("a").then(function(v) {
+    assert.sameValue(v, "a");
   }, function() {
     $DONE('The promise should be resolved, but was rejected');
   }).then($DONE, $DONE);
 } catch (error) {
-  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+  $DONE(`The promise should be resolved, but threw an exception: ${error.message}`);
 }

--- a/test/built-ins/TypedArray/prototype/map/return-new-typedarray-conversion-operation-consistent-nan.js
+++ b/test/built-ins/TypedArray/prototype/map/return-new-typedarray-conversion-operation-consistent-nan.js
@@ -50,7 +50,7 @@ function body(FloatArray) {
   var i = 0;
 
   var result = sample.map(function() {
-    return NaNs[i++];
+    return NaNs[i++]();
   });
 
   sampleBytes = new Uint8Array(sample.buffer);

--- a/test/harness/verifyProperty-value-error.js
+++ b/test/harness/verifyProperty-value-error.js
@@ -29,7 +29,7 @@ try {
     );
   }
 
-  if (err.message !== 'descriptor value should be 2 Expected SameValue(«1», «0») to be true') {
+  if (err.message !== 'descriptor value should be 2') {
     $ERROR('The error thrown did not define the specified message.');
   }
 }


### PR DESCRIPTION
I've changed harness/testBigIntTypedArray.js so it can be loaded in even if `BigInt64Array` is not defined. This makes it easier to process this file for SpiderMonkey's test262 importer.

Fixes #1492 