### PR TITLE
Don't compute NaN values in functions

### DIFF
--- a/harness/nans.js
+++ b/harness/nans.js
@@ -9,13 +9,13 @@ description: |
 ---*/
 
 var NaNs = [
-  () => NaN,
-  () => Number.NaN,
-  () => NaN * 0,
-  () => 0/0,
-  () => Infinity/Infinity,
-  () => -(0/0),
-  () => Math.pow(-1, 0.5),
-  () => -Math.pow(-1, 0.5),
-  () => Number("Not-a-Number"),
+  NaN,
+  Number.NaN,
+  NaN * 0,
+  0/0,
+  Infinity/Infinity,
+  -(0/0),
+  Math.pow(-1, 0.5),
+  -Math.pow(-1, 0.5),
+  Number("Not-a-Number"),
 ];

--- a/test/built-ins/Object/internals/DefineOwnProperty/nan-equivalence-define-own-property-reassign.js
+++ b/test/built-ins/Object/internals/DefineOwnProperty/nan-equivalence-define-own-property-reassign.js
@@ -57,12 +57,12 @@ for (var idx = 0; idx < len; ++idx) {
   for (var jdx = 0; jdx < len; ++jdx) {
     var a = {};
 
-    a.prop = NaNs[idx]();
-    a.prop = NaNs[jdx]();
+    a.prop = NaNs[idx];
+    a.prop = NaNs[jdx];
 
     assert(
       a.prop !== a.prop,
-      `Object property value reassigned to NaN produced by (${NaNs[idx].toString()}) results in a valid NaN`
+      `Object property value reassigned to NaN produced by (index=${idx}) results in a valid NaN`
     );
   }
 }

--- a/test/built-ins/Object/internals/DefineOwnProperty/nan-equivalence-define-own-property-reconfigure.js
+++ b/test/built-ins/Object/internals/DefineOwnProperty/nan-equivalence-define-own-property-reconfigure.js
@@ -59,17 +59,17 @@ for (var idx = 0; idx < len; ++idx) {
     var b = {};
 
     Object.defineProperty(a, "prop", {
-      value: NaNs[idx](),
+      value: NaNs[idx],
       configurable: true,
     });
 
     Object.defineProperty(a, "prop", {
-      value: NaNs[jdx](),
+      value: NaNs[jdx],
     });
 
     assert(
       a.prop !== a.prop,
-      `Object property value reconfigured to NaN produced by (${NaNs[idx].toString()}) results in a valid NaN`
+      `Object property value reconfigured to NaN produced by (index=${idx}) results in a valid NaN`
     );
   }
 }

--- a/test/built-ins/TypedArray/prototype/copyWithin/bit-precision.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/bit-precision.js
@@ -20,7 +20,7 @@ function body(FloatArray) {
   var subject = new FloatArray(NaNs.length * 2);
 
   NaNs.forEach(function(v, i) {
-    subject[i] = v();
+    subject[i] = v;
   });
 
   var originalBytes, copiedBytes;

--- a/test/built-ins/TypedArray/prototype/fill/fill-values-conversion-operations-consistent-nan.js
+++ b/test/built-ins/TypedArray/prototype/fill/fill-values-conversion-operations-consistent-nan.js
@@ -78,7 +78,7 @@ testWithTypedArrayConstructors(function(FA) {
   var controls, idx, aNaN;
 
   for (idx = 0; idx < NaNs.length; ++idx) {
-    aNaN = NaNs[idx]();
+    aNaN = NaNs[idx];
     controls = new Float32Array([aNaN, aNaN, aNaN]);
 
     samples.fill(aNaN);
@@ -89,12 +89,12 @@ testWithTypedArrayConstructors(function(FA) {
 
       assert(
         samples[i] !== samples[i],
-        `samples (${NaNs[idx].toString()}) produces a valid NaN (${precision} precision)`
+        `samples (index=${idx}) produces a valid NaN (${precision} precision)`
       );
 
       assert(
         controls[i] !== controls[i],
-        `controls (${NaNs[idx].toString()}) produces a valid NaN (${precision} precision)`
+        `controls (index=${idx}) produces a valid NaN (${precision} precision)`
       );
     }
   }

--- a/test/built-ins/TypedArray/prototype/map/return-new-typedarray-conversion-operation-consistent-nan.js
+++ b/test/built-ins/TypedArray/prototype/map/return-new-typedarray-conversion-operation-consistent-nan.js
@@ -45,12 +45,12 @@ features: [TypedArray]
 ---*/
 
 function body(FloatArray) {
-  var sample = new FloatArray(NaNs.map(n => n()));
+  var sample = new FloatArray(NaNs);
   var sampleBytes, resultBytes;
   var i = 0;
 
   var result = sample.map(function() {
-    return NaNs[i++]();
+    return NaNs[i++];
   });
 
   sampleBytes = new Uint8Array(sample.buffer);

--- a/test/built-ins/TypedArray/prototype/set/bit-precision.js
+++ b/test/built-ins/TypedArray/prototype/set/bit-precision.js
@@ -20,7 +20,7 @@ features: [TypedArray]
 ---*/
 
 function body(FA) {
-  var source = new FA(NaNs.map(n => n()));
+  var source = new FA(NaNs);
   var target = new FA(NaNs.length);
   var sourceBytes, targetBytes;
 

--- a/test/built-ins/TypedArray/prototype/slice/bit-precision.js
+++ b/test/built-ins/TypedArray/prototype/slice/bit-precision.js
@@ -25,7 +25,7 @@ features: [TypedArray]
 ---*/
 
 function body(FloatArray) {
-  var subject = new FloatArray(NaNs.map(n => n()));
+  var subject = new FloatArray(NaNs);
   var sliced, subjectBytes, slicedBytes;
 
   sliced = subject.slice();

--- a/test/built-ins/TypedArrayConstructors/ctors/object-arg/conversion-operation-consistent-nan.js
+++ b/test/built-ins/TypedArrayConstructors/ctors/object-arg/conversion-operation-consistent-nan.js
@@ -50,8 +50,8 @@ features: [TypedArray]
 ---*/
 
 function body(FloatArray) {
-  var first = new FloatArray(NaNs.map(n => n()));
-  var second = new FloatArray(NaNs.map(n => n()));
+  var first = new FloatArray(NaNs);
+  var second = new FloatArray(NaNs);
   var firstBytes = new Uint8Array(first.buffer);
   var secondBytes = new Uint8Array(second.buffer);
 

--- a/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/conversion-operation-consistent-nan.js
+++ b/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/conversion-operation-consistent-nan.js
@@ -74,7 +74,7 @@ testWithTypedArrayConstructors(function(FA) {
   var controls, idx, aNaN;
 
   for (idx = 0; idx < NaNs.length; ++idx) {
-    aNaN = NaNs[idx]();
+    aNaN = NaNs[idx];
     controls = new FA([aNaN, aNaN, aNaN]);
 
     Object.defineProperty(samples, "0", { value: aNaN });
@@ -85,12 +85,12 @@ testWithTypedArrayConstructors(function(FA) {
 
       assert(
         samples[i] !== samples[i],
-        `samples (${NaNs[idx].toString()}) produces a valid NaN (${precision} precision)`
+        `samples (index=${idx}) produces a valid NaN (${precision} precision)`
       );
 
       assert(
         controls[i] !== controls[i],
-        `controls (${NaNs[idx].toString()}) produces a valid NaN (${precision} precision)`
+        `controls (index=${idx}) produces a valid NaN (${precision} precision)`
       );
     }
   }

--- a/test/built-ins/TypedArrayConstructors/internals/Set/conversion-operation-consistent-nan.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/conversion-operation-consistent-nan.js
@@ -72,7 +72,7 @@ testWithTypedArrayConstructors(function(FA) {
   var controls, idx, aNaN;
 
   for (idx = 0; idx < NaNs.length; ++idx) {
-    aNaN = NaNs[idx]();
+    aNaN = NaNs[idx];
     controls = new FA([aNaN, aNaN, aNaN]);
 
     samples[0] = aNaN;
@@ -83,12 +83,12 @@ testWithTypedArrayConstructors(function(FA) {
 
       assert(
         samples[i] !== samples[i],
-        `samples (${NaNs[idx].toString()}) produces a valid NaN (${precision} precision)`
+        `samples (index=${idx}) produces a valid NaN (${precision} precision)`
       );
 
       assert(
         controls[i] !== controls[i],
-        `controls (${NaNs[idx].toString()}) produces a valid NaN (${precision} precision)`
+        `controls (index=${idx}) produces a valid NaN (${precision} precision)`
       );
     }
   }

--- a/test/built-ins/isNaN/return-true-nan.js
+++ b/test/built-ins/isNaN/return-true-nan.js
@@ -15,5 +15,5 @@ includes: [nans.js]
 ---*/
 
 NaNs.forEach(function(v, i) {
-  assert.sameValue(isNaN(v()), true, "value on position: " + i);
+  assert.sameValue(isNaN(v), true, "value on position: " + i);
 });

--- a/test/harness/nans.js
+++ b/test/harness/nans.js
@@ -5,20 +5,20 @@ description: >
   Including nans.js will expose:
 
   var NaNs = [
-    () => NaN,
-    () => Number.NaN,
-    () => NaN * 0,
-    () => 0/0,
-    () => Infinity/Infinity,
-    () => -(0/0),
-    () => Math.pow(-1, 0.5),
-    () => -Math.pow(-1, 0.5),
-    () => Number("Not-a-Number"),
+    NaN,
+    Number.NaN,
+    NaN * 0,
+    0/0,
+    Infinity/Infinity,
+    -(0/0),
+    Math.pow(-1, 0.5),
+    -Math.pow(-1, 0.5),
+    Number("Not-a-Number"),
   ];
 
 includes: [nans.js]
 ---*/
 
 for (var i = 0; i < NaNs.length; i++) {
-  assert.sameValue(Number.isNaN(NaNs[i]()), true, NaNs[i].toString());
+  assert.sameValue(Number.isNaN(NaNs[i]), true, "index: " + i);
 }


### PR DESCRIPTION
`function nan() { return /* expression to compute NaN */ }` may not return the same implementation-distinguishable NaN value before and after JIT compilation. As observed here: https://treeherder.mozilla.org/#/jobs?repo=try&revision=cb26ed14f1a42ae9a70b516ecc22046c3ce9c8fa