### PR TITLE
Add test for proposal-class-fields#92

### DIFF
--- a/test/language/expressions/class/constructor-this-tdz-during-initializers.js
+++ b/test/language/expressions/class/constructor-this-tdz-during-initializers.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-super-keyword-runtime-semantics-evaluation
+description: >
+    `this` is bound in the constructor of derived classes immediately before running initializers
+info: |
+    [...]
+    6. Let result be ? Construct(func, argList, newTarget).
+    [...]
+    10. Perform ? thisER.BindThisValue(result).
+    11. Perform ? InitializeInstanceFields(result, F).
+    [...]
+features: [class-fields-public]
+---*/
+
+
+var probeCtorThis;
+var thisDuringField;
+var thisFromProbe;
+var thisDuringCtor;
+
+class Base {
+  constructor() {
+    assert.throws(ReferenceError, probeCtorThis);
+  }
+}
+
+var C = class extends Base {
+  field = (thisDuringField = this, thisFromProbe = probeCtorThis());
+  constructor() {
+    probeCtorThis = () => this;
+    assert.throws(ReferenceError, probeCtorThis);
+    super();
+    thisDuringCtor = this;
+  }
+};
+
+var instance = new C();
+
+assert.sameValue(thisDuringField, instance);
+assert.sameValue(thisFromProbe, instance);
+assert.sameValue(thisDuringCtor, instance);

--- a/test/language/expressions/class/fields-run-once-on-double-super.js
+++ b/test/language/expressions/class/fields-run-once-on-double-super.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-super-keyword-runtime-semantics-evaluation
+description: >
+    when calling `super()` for a second time in a derived class, the super constructor is run twice but the field initializers are only run once
+info: |
+    [...]
+    6. Let result be ? Construct(func, argList, newTarget).
+    [...]
+    10. Perform ? thisER.BindThisValue(result).
+    11. Perform ? InitializeInstanceFields(result, F).
+    [...]
+features: [class-fields-public]
+---*/
+
+
+var baseCtorCalled = 0;
+var fieldInitCalled = 0;
+class Base {
+  constructor() {
+    ++baseCtorCalled;
+  }
+}
+
+var C = class extends Base {
+  field = ++fieldInitCalled;
+  constructor() {
+    assert.sameValue(baseCtorCalled, 0);
+    assert.sameValue(fieldInitCalled, 0);
+    super();
+    assert.sameValue(baseCtorCalled, 1);
+    assert.sameValue(fieldInitCalled, 1);
+    assert.throws(ReferenceError, () => super());
+  }
+};
+
+new C();
+
+assert.sameValue(baseCtorCalled, 2);
+assert.sameValue(fieldInitCalled, 1);


### PR DESCRIPTION
This adds a test for the change in https://github.com/tc39/proposal-class-fields/pull/92. At a glance I don't believe the previous behavior was tested (it is _very_ edge-case-y), but the important part of the change for the old-vs-new behavior in this would look like

```diff
-  field = (thisDuringField = this, assert.throws(ReferenceError, probeCtorThis));
+  field = (thisDuringField = this, thisFromProbe = probeCtorThis());
```

cc @littledan 