### PR TITLE
test BigInt toString with default radix

### DIFF
--- a/test/built-ins/BigInt/prototype/toString/default-radix.js
+++ b/test/built-ins/BigInt/prototype/toString/default-radix.js
@@ -1,0 +1,19 @@
+// Copyright 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-bigint.prototype.tostring
+description: toString with default radix
+features: [BigInt]
+---*/
+
+assert.sameValue((-100n).toString(), "-100", "(-100n).toString() === '-100'");
+assert.sameValue((0n).toString(), "0", "(0n).toString() === '0'");
+assert.sameValue((100n).toString(), "100", "(100n).toString() === '100'");
+
+assert.sameValue((-100n).toString(undefined), "-100",
+                 "(-100n).toString(undefined) === '-100'");
+assert.sameValue((0n).toString(undefined), "0",
+                 "(0n).toString(undefined) === '0'");
+assert.sameValue((100n).toString(undefined), "100",
+                 "(100n).toString(undefined) === '100'");


### PR DESCRIPTION
Add tests for BigInt.prototype.toString called with a missing or undefined radix argument