### PR TITLE
cross-realm test for BigInt.prototype.valueOf

### DIFF
--- a/test/built-ins/BigInt/prototype/valueOf/cross-realm.js
+++ b/test/built-ins/BigInt/prototype/valueOf/cross-realm.js
@@ -1,0 +1,14 @@
+// Copyright 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-bigint.prototype.valueof
+description: valueOf called with a BigInt object from another realm
+features: [BigInt, cross-realm]
+---*/
+
+var other = $262.createRealm().global;
+var wrapped = other.Object(other.BigInt(0));
+
+assert.sameValue(BigInt.prototype.valueOf.call(wrapped), 0n,
+                 "cross-realm valueOf");


### PR DESCRIPTION
Check that valueOf works on a BigInt object from another realm

This is intended to be a simple test for BigInt methods unwrapping objects from other globals correctly; there might be a better way to test this functionality.