### PR TITLE
Make parseTestRecord.py python3 compatible

### DIFF
--- a/tools/packaging/monkeyYaml.py
+++ b/tools/packaging/monkeyYaml.py
@@ -71,7 +71,7 @@ def myMultilineList(lines, value):
         leading = myLeadingSpaces(line)
         if myIsAllSpaces(line):
             pass
-        elif leading < indent:
+        elif indent is not None and leading < indent:
             lines.insert(0, line)
             break;
         else:

--- a/tools/packaging/parseTestRecord.py
+++ b/tools/packaging/parseTestRecord.py
@@ -81,7 +81,7 @@ def yamlAttrParser(testRecord, attrs, name):
     parsed = yamlLoad(body)
 
     if (parsed is None):
-        print "Failed to parse yaml in name %s"%(name)
+        print("Failed to parse yaml in name %s"%(name))
         return
 
     for key in parsed:


### PR DESCRIPTION
Two small changes to allow monkeyYaml.py and parseTestRecord.py to run under Python 3.