### PR TITLE
Remove superfluous code from negative syntax tests

### DIFF
--- a/test/language/asi/S7.9_A11_T8.js
+++ b/test/language/asi/S7.9_A11_T8.js
@@ -12,10 +12,5 @@ negative:
 
 throw "Test262: This statement should not be evaluated.";
 
-//CHECK#1
-var x = 0;
-if (false) {x = 1};
-else x = -1
-if (x !== -1) {
-  $ERROR('#1: Check If Statement for automatic semicolon insertion');
-}
+if (false) {};
+else {}

--- a/test/language/asi/S7.9_A4.js
+++ b/test/language/asi/S7.9_A4.js
@@ -18,4 +18,3 @@ try {
   1;
 } catch(e) {  
 }  
-$ERROR('#1: Check throw statement for automatic semicolon insertion');

--- a/test/language/asi/S7.9_A5.1_T1.js
+++ b/test/language/asi/S7.9_A5.1_T1.js
@@ -12,8 +12,6 @@ negative:
 
 throw "Test262: This statement should not be evaluated.";
 
-//CHECK#1
 var x = 0;
 x
 ++;
-$ERROR('#1: Check Postfix Increment Operator for automatic semicolon insertion');

--- a/test/language/asi/S7.9_A5.3_T1.js
+++ b/test/language/asi/S7.9_A5.3_T1.js
@@ -16,4 +16,3 @@ throw "Test262: This statement should not be evaluated.";
 var x = 1;
 x
 --;
-$ERROR('#1: Check Postfix Decrement Operator for automatic semicolon insertion');

--- a/test/language/module-code/early-strict-mode.js
+++ b/test/language/module-code/early-strict-mode.js
@@ -12,5 +12,4 @@ negative:
 
 throw "Test262: This statement should not be evaluated.";
 
-$ERROR('This statement should not be executed.');
 var public;

--- a/test/language/statements/break/S12.8_A8_T1.js
+++ b/test/language/statements/break/S12.8_A8_T1.js
@@ -14,19 +14,9 @@ negative:
 
 throw "Test262: This statement should not be evaluated.";
 
-var x=0,y=0;
-
 try{
-	LABEL1 : do {
-		x++;
-		throw "gonna leave it";
-		y++;
-	} while(0);
-	$ERROR('#1: throw "gonna leave it" lead to throwing exception');
 } catch(e){
 	break LABEL2;
 	LABEL2 : do {
-		x++;
-		y++;
 	} while(0);
 }

--- a/test/language/statements/break/S12.8_A8_T2.js
+++ b/test/language/statements/break/S12.8_A8_T2.js
@@ -14,19 +14,9 @@ negative:
 
 throw "Test262: This statement should not be evaluated.";
 
-var x=0,y=0;
-
 try{
-	LABEL1 : do {
-		x++;
-		throw "gonna leave it";
-		y++;
-	} while(0);
-	$ERROR('#1: throw "gonna leave it" lead to throwing exception');
 } catch(e){
 	break;
 	LABEL2 : do {
-		x++;
-		y++;
 	} while(0);
 }

--- a/test/language/statements/continue/S12.7_A8_T1.js
+++ b/test/language/statements/continue/S12.7_A8_T1.js
@@ -14,19 +14,9 @@ negative:
 
 throw "Test262: This statement should not be evaluated.";
 
-var x=0,y=0;
-
 try{
-	LABEL1 : do {
-		x++;
-		throw "gonna leave it";
-		y++;
-	} while(0);
-	$ERROR('#1: throw "gonna leave it" lead to throwing exception');
 } catch(e){
 	continue LABEL2;
 	LABEL2 : do {
-		x++;
-		y++;
 	} while(0);
 };

--- a/test/language/statements/continue/S12.7_A8_T2.js
+++ b/test/language/statements/continue/S12.7_A8_T2.js
@@ -12,19 +12,7 @@ negative:
 
 throw "Test262: This statement should not be evaluated.";
 
-var x=0,y=0;
-
 try{
-	LABEL1 : do {
-		x++;
-		throw "gonna leave it";
-		y++;
-	} while(0);
-	$ERROR('#1: throw "gonna leave it" lead to throwing exception');
 } catch(e){
 	continue;
-	LABEL2 : do {
-		x++;
-		y++;
-	} while(0);
 };


### PR DESCRIPTION
@rwaldon gh-1534 got me thinking about other places where `$ERROR` was being used unnecessarily. I'm sure there are plenty more overly-complicated "negative syntax" tests, but we'll leave those for another day.

---

Because these files contain syntax errors, the code they contain is not
intended to be executed, and the runtime semantics are therefore
irrelevant. Simplify the files by removing the unnecessary code.