### PR TITLE
Added tests for relational comparison among BigInt and Symbol

### DIFF
--- a/test/language/expressions/greater-than/bigint-and-symbol.js
+++ b/test/language/expressions/greater-than/bigint-and-symbol.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Relational comparison of BigInt and Symbol values
+esid: sec-abstract-relational-comparison
+features: [BigInt, Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+  3n > Symbol("2");
+}, "ToNumeric(rhs) throws.");
+
+assert.throws(TypeError, function() {
+  Symbol("2") > 3n;
+}, "ToNumeric(rhs) throws.");
+

--- a/test/language/expressions/greater-than/bigint-and-symbol.js
+++ b/test/language/expressions/greater-than/bigint-and-symbol.js
@@ -9,9 +9,9 @@ features: [BigInt, Symbol]
 
 assert.throws(TypeError, function() {
   3n > Symbol("2");
-}, "ToNumeric(rhs) throws.");
+}, "ToNumeric(Symbol) on RHS throws.");
 
 assert.throws(TypeError, function() {
   Symbol("2") > 3n;
-}, "ToNumeric(rhs) throws.");
+}, "ToNumeric(Symbol) on LHS throws.");
 

--- a/test/language/expressions/less-than/bigint-and-symbol.js
+++ b/test/language/expressions/less-than/bigint-and-symbol.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2018 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Relational comparison of BigInt and Symbol values
+esid: sec-abstract-relational-comparison
+features: [BigInt, Symbol]
+---*/
+
+function MyError() {}
+
+assert.throws(TypeError, function() {
+  3n < Symbol("2");
+}, "ToNumeric(rhs) throws.");
+
+assert.throws(TypeError, function() {
+  Symbol("2") < 3n;
+}, "ToNumeric(rhs) throws.");
+

--- a/test/language/expressions/less-than/bigint-and-symbol.js
+++ b/test/language/expressions/less-than/bigint-and-symbol.js
@@ -11,9 +11,9 @@ function MyError() {}
 
 assert.throws(TypeError, function() {
   3n < Symbol("2");
-}, "ToNumeric(rhs) throws.");
+}, "ToNumeric(Symbol) on RHS throws.");
 
 assert.throws(TypeError, function() {
   Symbol("2") < 3n;
-}, "ToNumeric(rhs) throws.");
+}, "ToNumeric(Symbol) on LHS throws.");
 


### PR DESCRIPTION
These tests are important too check if evaluation ordering are being respected when some of the operands are BigInt. It closes #1542