### PR TITLE
GetTemplateObject with a unique template object

### DIFF
--- a/test/language/expressions/tagged-template/template-object.js
+++ b/test/language/expressions/tagged-template/template-object.js
@@ -8,11 +8,17 @@ info: |
     defined by the GetTemplateObject abstract operation.
 includes: [propertyHelper.js]
 ---*/
-var templateObject;
+var templateObject, sameObject;
 
-(function(parameter) {
+function sameSite() {
+  tag`${Math.random()}`;
+}
+
+function tag(parameter) {
   templateObject = parameter;
-})`${1}`;
+}
+
+tag`${1}`;
 
 assert(Array.isArray(templateObject.raw), 'The template object is an array');
 
@@ -38,3 +44,13 @@ verifyNotConfigurable(templateObject.raw, '0');
 verifyNotEnumerable(templateObject.raw, 'length');
 verifyNotWritable(templateObject.raw, 'length')
 verifyNotConfigurable(templateObject.raw, 'length');
+
+sameSite();
+sameObject = templateObject;
+sameSite();
+
+assert(
+  templateObject === sameObject,
+  'Normative: Cache templates per site, rather than by contents'
+  // https://github.com/tc39/ecma262/pull/890
+);


### PR DESCRIPTION
While Firefox never behaved as such, the specifications are clear and Chrome, Safari, and Edge always respected specifications [here](https://www.ecma-international.org/ecma-262/8.0/index.html#sec-gettemplateobject):

> Each TemplateLiteral in the program code of a realm is associated with a unique template object that is used in the evaluation of tagged Templates (12.2.9.5). The template objects are frozen and the same template object is used each time a specific tagged Template is evaluated.

However, since there are no tests around that little details that has a lot of libraries built around such assumption, it's easy to break the web like [this Chrome 67 bug](https://bugs.chromium.org/p/chromium/issues/detail?id=848999) demonstrates.

Please note that behavior is so trusted that even Babel transpiler would return true after executing this code:
```js
(function(s){ return s; })`a` ===
(function(s){ return s; })`a`; // true
```

Please add this test ASAP so that NodeJS 10, as well as future versions of Chrome, can go back to be aligned with what has worked as such for at least the last 2 years.

**Thank You**.