### PR TITLE
Intl.Locale: Update expectation for empty values for collation and numberingSystem.

### DIFF
--- a/test/intl402/Locale/constructor-options-collation-invalid.js
+++ b/test/intl402/Locale/constructor-options-collation-invalid.js
@@ -18,9 +18,10 @@ features: [Intl.Locale]
 
 /*
  alphanum = (ALPHA / DIGIT)     ; letters and numbers
- collation = [(3*8alphanum) *("-" (3*8alphanum))]
+ collation = (3*8alphanum) *("-" (3*8alphanum))
 */
 const invalidCollationOptions = [
+  "",
   "a",
   "ab",
   "abcdefghi",

--- a/test/intl402/Locale/constructor-options-collation-valid.js
+++ b/test/intl402/Locale/constructor-options-collation-valid.js
@@ -37,7 +37,6 @@ features: [Intl.Locale]
 ---*/
 
 const validCollationOptions = [
-  ["", "en-u-co"],
   ["abc", "en-u-co-abc"],
   ["abcd", "en-u-co-abcd"],
   ["abcde", "en-u-co-abcde"],

--- a/test/intl402/Locale/constructor-options-numberingsystem-invalid.js
+++ b/test/intl402/Locale/constructor-options-numberingsystem-invalid.js
@@ -18,9 +18,10 @@ features: [Intl.Locale]
 
 /*
  alphanum = (ALPHA / DIGIT)     ; letters and numbers
- numberingSystem = [(3*8alphanum) *("-" (3*8alphanum))]
+ numberingSystem = (3*8alphanum) *("-" (3*8alphanum))
 */
 const invalidNumberingSystemOptions = [
+  "",
   "a",
   "ab",
   "abcdefghi",

--- a/test/intl402/Locale/constructor-options-numberingsystem-valid.js
+++ b/test/intl402/Locale/constructor-options-numberingsystem-valid.js
@@ -37,7 +37,6 @@ features: [Intl.Locale]
 ---*/
 
 const validNumberingSystemOptions = [
-  ["", "en-u-nu"],
   ["abc", "en-u-nu-abc"],
   ["abcd", "en-u-nu-abcd"],
   ["abcde", "en-u-nu-abcde"],


### PR DESCRIPTION
The spec changed in https://github.com/tc39/proposal-intl-locale/pull/47.

The tests for calendar were already correct.