### PR TITLE
Correct licensing

### DIFF
--- a/harness/atomicsHelper.js
+++ b/harness/atomicsHelper.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Ecma International.  All rights reserved.
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: |

--- a/harness/detachArrayBuffer.js
+++ b/harness/detachArrayBuffer.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Ecma International.  All rights reserved.
+// Copyright (C) 2016 the V8 project authors.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: |

--- a/harness/nans.js
+++ b/harness/nans.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Ecma International.  All rights reserved.
+// Copyright (C) 2016 the V8 project authors.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: |

--- a/harness/nativeFunctionMatcher.js
+++ b/harness/nativeFunctionMatcher.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Ecma International.  All rights reserved.
+// Copyright (C) 2016 Michael Ficarra.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: Assert _NativeFunction_ Syntax

--- a/harness/proxyTrapsHelper.js
+++ b/harness/proxyTrapsHelper.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Ecma International.  All rights reserved.
+// Copyright (C) 2016 Jordan Harband.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: |

--- a/harness/regExpUtils.js
+++ b/harness/regExpUtils.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Ecma International.  All rights reserved.
+// Copyright (C) 2017 Mathias Bynens.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: |

--- a/harness/tcoHelper.js
+++ b/harness/tcoHelper.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2015 André Bargull. All rights reserved.
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: |


### PR DESCRIPTION
In order to satisfy the project's formatting rules, license information
was inserted into a number of files where it had been mistakenly omitted
by the original contributors [1]. In many cases, the license information
did not accurately describe the contributor or the time of contribution.
Update the information according to the information provided by the
contributors at the time each file was authored:

- atomicsHelper.js - a72ee6d91275aa6524e84a9b7070103411ef2689
- detachArrayBuffer.js - 70c7375be83137015da2c5d6d29a3c40ad3cb5b1
- nans.js - b17ffc029850e3c32d51c68e0281ab7b1a4c193b
- nativeFunctionMatcher.js - 6b7cbb50350e478a543da40d02492aa8f45a792d
- proxyTrapsHelper.js d530c87b41584d47d95bb78dccf592c9c5c8f7b1
- regexpUtils.js - 44b40e083ec851cd8448d5fe4755bdfc9f0dc14c
- tcoHelper.js - 4dc81d37886f49512eb60dafe13b794af5ffeb29

[1] 4ea2931f169d4a4b5a9a4a7c731cc92bf7b3e13c

---

Caught this while reviewing [a recent change to the `test262-harness` project](https://github.com/bterlson/test262-harness/commit/df25efad8e2546f229ad5e40aa30e61443fe7292).