### PR TITLE
Make Atomics tests more resilient against intermittent failures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,8 @@ This tag is for boolean properties associated with the test.
   created procedurally using the project's test generation tool; refer to the
   section titled "Procedurally-generated tests" for more information on this
   process
+- **`CanBlockIsFalse`** - only run the test when the [[CanBlock]] property of the [Agent Record](https://tc39.github.io/ecma262/#sec-agents) executing the test file is `false`
+- **`CanBlockIsTrue`** - only run the test when the [[CanBlock]] property of the [Agent Record](https://tc39.github.io/ecma262/#sec-agents) executing the test file is `true`
 
 #### features
 **features**: [list]
@@ -170,7 +172,7 @@ Some tests require the use of language features that are not directly described 
 
 This tag identifies the section number from the portion of the ECMAScript 5.1 or ECMAScript 3 standard that is tested by this test. It was automatically generated for tests that were originally written for the ES5 (or earlier) version of the test suite and are now part of the ES6 version. You can use the es5id to discover the relevant portion of the ECMAScript standard by looking up the section number in [previous publications of the specification](https://www.ecma-international.org/publications/standards/Ecma-262-arch.htm). Unfortunately, there is no way to identify which version of ECMAScript (specifically, 3 or 5.1) without looking up the section number and deciding whether it covers the observable in the test.
 
-Read the (Test262 Technical Rationale Report)[https://github.com/tc39/test262/wiki/Test262-Technical-Rationale-Report,-October-2017#specification-reference-ids] for reasoning behind deprecation.
+Read the [Test262 Technical Rationale Report](https://github.com/tc39/test262/wiki/Test262-Technical-Rationale-Report,-October-2017#specification-reference-ids) for reasoning behind deprecation.
 
 #### es6id
 **es6id**: [es6-test-id]
@@ -179,7 +181,7 @@ Read the (Test262 Technical Rationale Report)[https://github.com/tc39/test262/wi
 
 This tag identifies the section number from the portion of the ES6 standard that is tested by this test _at the time the test was written_. The es6ids might not correspond to the correction section numbers in the ES6 (or later) specification because routine edits to the specification will change section numbering. For this reason, only the esid is required for new tests.
 
-Read the (Test262 Technical Rationale Report)[https://github.com/tc39/test262/wiki/Test262-Technical-Rationale-Report,-October-2017#specification-reference-ids] for reasoning behind deprecation.
+Read the [Test262 Technical Rationale Report](https://github.com/tc39/test262/wiki/Test262-Technical-Rationale-Report,-October-2017#specification-reference-ids) for reasoning behind deprecation.
 
 ## Test Environment
 

--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -354,6 +354,30 @@ following strings:
   test generation tool. This flag is specified for informational purposes only
   and has no bearing on how the test should be interpreted.
 
+- **`CanBlockIsFalse`** The test file should only be run when the [[CanBlock]] property of the [Agent Record](https://tc39.github.io/ecma262/#sec-agents) executing the file is `false`.
+
+ *Example*
+
+  ```js
+  /*---
+  flags: [CanBlockIsFalse]
+  ---*/
+  var i32 = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+  assert.throws(TypeError, function() { Atomics.wait(i32, 0, 0, 1000); });
+  ```
+
+- **`CanBlockIsTrue`** The test file should only be run when the [[CanBlock]] property of the [Agent Record](https://tc39.github.io/ecma262/#sec-agents) executing the file is `true`.
+
+ *Example*
+
+  ```js
+  /*---
+  flags: [CanBlockIsTrue]
+  ---*/
+  var i32 = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+  Atomics.wait(i32, 0, 0, 1000); // Sleep for one second.
+  ```
+
 ### `locale`
 
 The `locale` attribute allows tests to declare explicit information regarding locale specificity. Its value is an array of one or more valid language tags or subtags.

--- a/harness/atomicsHelper.js
+++ b/harness/atomicsHelper.js
@@ -36,19 +36,204 @@ $262.agent.MAX_TIME_EPSILON = 100;
   };
 }
 /**
- * With a given Int32Array, wait until the expected number of agents have reported themselves by
- * calling:
+ * With a given Int32Array or BigInt64Array, wait until the expected number of agents have
+ * reported themselves by calling:
  *
- *    Atomics.add(i32a, index, 1);
+ *    Atomics.add(typedArray, index, 1);
  *
- * @param {Int32Array} i32a An Int32Array with a SharedArrayBuffer
- * @param {Number} index    The index of which all agents will report.
- * @param {Number} expected The number of agents that are expected to report as active.
+ * @param {(Int32Array|BigInt64Array)} typedArray An Int32Array or BigInt64Array with a SharedArrayBuffer
+ * @param {number} index    The index of which all agents will report.
+ * @param {number} expected The number of agents that are expected to report as active.
  */
-$262.agent.waitUntil = function(i32a, index, expected) {
-  let agents = 0;
-  while ((agents = Atomics.load(i32a, index)) !== expected) {
+$262.agent.waitUntil = function(typedArray, index, expected) {
+  var agents = 0;
+  while ((agents = Atomics.load(typedArray, index)) !== expected) {
     /* nothing */
   }
-  assert.sameValue(agents, expected, `Reporting number of 'agents' equals the value of 'expected' (${expected})`);
+  assert.sameValue(agents, expected, "Reporting number of 'agents' equals the value of 'expected'");
+};
+
+/**
+ * Timeout values used throughout the Atomics tests. All timeouts are specified in milliseconds.
+ *
+ * @property {number} yield Used for `$262.agent.tryYield`. Must not be used in other functions.
+ * @property {number} small Used when agents will always timeout and `Atomics.wake` is not part
+ *                          of the test semantics. Must be larger than `$262.agent.timeouts.yield`.
+ * @property {number} long  Used when some agents may timeout and `Atomics.wake` is called on some
+ *                          agents. The agents are required to wait and this needs to be observable
+ *                          by the main thread.
+ * @property {number} huge  Used when `Atomics.wake` is called on all waiting agents. The waiting
+ *                          must not timeout. The agents are required to wait and this needs to be
+ *                          observable by the main thread. All waiting agents must be woken by the
+ *                          main thread.
+ *
+ * Usage for `$262.agent.timeouts.small`:
+ *   const WAIT_INDEX = 0;
+ *   const RUNNING = 1;
+ *   const TIMEOUT = $262.agent.timeouts.small;
+ *   const i32a = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2));
+ *
+ *   $262.agent.start(`
+ *     $262.agent.receiveBroadcast(function(sab) {
+ *       const i32a = new Int32Array(sab);
+ *       Atomics.add(i32a, ${RUNNING}, 1);
+ *
+ *       $262.agent.report(Atomics.wait(i32a, ${WAIT_INDEX}, 0, ${TIMEOUT}));
+ *
+ *       $262.agent.leaving();
+ *     });
+ *   `);
+ *   $262.agent.broadcast(i32a.buffer);
+ *
+ *   // Wait until the agent was started and then try to yield control to increase
+ *   // the likelihood the agent has called `Atomics.wait` and is now waiting.
+ *   $262.agent.waitUntil(i32a, RUNNING, 1);
+ *   $262.agent.tryYield();
+ *
+ *   // The agent is expected to time out.
+ *   assert.sameValue($262.agent.getReport(), "timed-out");
+ *
+ *
+ * Usage for `$262.agent.timeouts.long`:
+ *   const WAIT_INDEX = 0;
+ *   const RUNNING = 1;
+ *   const NUMAGENT = 2;
+ *   const TIMEOUT = $262.agent.timeouts.long;
+ *   const i32a = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2));
+ *
+ *   for (let i = 0; i < NUMAGENT; i++) {
+ *     $262.agent.start(`
+ *       $262.agent.receiveBroadcast(function(sab) {
+ *         const i32a = new Int32Array(sab);
+ *         Atomics.add(i32a, ${RUNNING}, 1);
+ *
+ *         $262.agent.report(Atomics.wait(i32a, ${WAIT_INDEX}, 0, ${TIMEOUT}));
+ *
+ *         $262.agent.leaving();
+ *       });
+ *     `);
+ *   }
+ *   $262.agent.broadcast(i32a.buffer);
+ *
+ *   // Wait until the agents were started and then try to yield control to increase
+ *   // the likelihood the agents have called `Atomics.wait` and are now waiting.
+ *   $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);
+ *   $262.agent.tryYield();
+ *
+ *   // Wake exactly one agent.
+ *   assert.sameValue(Atomics.wake(i32a, WAIT_INDEX, 1), 1);
+ *
+ *   // When it doesn't matter how many agents were woken at once, a while loop
+ *   // can be used to make the test more resilient against intermittent failures
+ *   // in case even though `tryYield` was called, the agents haven't started to
+ *   // wait.
+ *   //
+ *   // // Repeat until exactly one agent was woken.
+ *   // var woken = 0;
+ *   // while ((woken = Atomics.wake(i32a, WAIT_INDEX, 1)) !== 0) ;
+ *   // assert.sameValue(woken, 1);
+ *
+ *   // One agent was woken and the other one timed out.
+ *   const reports = [$262.agent.getReport(), $262.agent.getReport()];
+ *   assert(reports.includes("ok"));
+ *   assert(reports.includes("timed-out"));
+ *
+ *
+ * Usage for `$262.agent.timeouts.huge`:
+ *   const WAIT_INDEX = 0;
+ *   const RUNNING = 1;
+ *   const NUMAGENT = 2;
+ *   const TIMEOUT = $262.agent.timeouts.huge;
+ *   const i32a = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2));
+ *
+ *   for (let i = 0; i < NUMAGENT; i++) {
+ *     $262.agent.start(`
+ *       $262.agent.receiveBroadcast(function(sab) {
+ *         const i32a = new Int32Array(sab);
+ *         Atomics.add(i32a, ${RUNNING}, 1);
+ *
+ *         $262.agent.report(Atomics.wait(i32a, ${WAIT_INDEX}, 0, ${TIMEOUT}));
+ *
+ *         $262.agent.leaving();
+ *       });
+ *     `);
+ *   }
+ *   $262.agent.broadcast(i32a.buffer);
+ *
+ *   // Wait until the agents were started and then try to yield control to increase
+ *   // the likelihood the agents have called `Atomics.wait` and are now waiting.
+ *   $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);
+ *   $262.agent.tryYield();
+ *
+ *   // Wake all agents.
+ *   assert.sameValue(Atomics.wake(i32a, WAIT_INDEX), NUMAGENT);
+ *
+ *   // When it doesn't matter how many agents were woken at once, a while loop
+ *   // can be used to make the test more resilient against intermittent failures
+ *   // in case even though `tryYield` was called, the agents haven't started to
+ *   // wait.
+ *   //
+ *   // // Repeat until all agents were woken.
+ *   // for (var wokenCount = 0; wokenCount < NUMAGENT; ) {
+ *   //   var woken = 0;
+ *   //   while ((woken = Atomics.wake(i32a, WAIT_INDEX)) !== 0) ;
+ *   //   // Maybe perform an action on the woken agents here.
+ *   //   wokenCount += woken;
+ *   // }
+ *
+ *   // All agents were woken and none timeout.
+ *   for (var i = 0; i < NUMAGENT; i++) {
+ *     assert($262.agent.getReport(), "ok");
+ *   }
+ */
+$262.agent.timeouts = {
+  yield: 100,
+  small: 200,
+  long: 1000,
+  huge: 10000,
+};
+
+/**
+ * Try to yield control to the agent threads.
+ *
+ * Usage:
+ *   const VALUE = 0;
+ *   const RUNNING = 1;
+ *   const i32a = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2));
+ *
+ *   $262.agent.start(`
+ *     $262.agent.receiveBroadcast(function(sab) {
+ *       const i32a = new Int32Array(sab);
+ *       Atomics.add(i32a, ${RUNNING}, 1);
+ *
+ *       Atomics.store(i32a, ${VALUE}, 1);
+ *
+ *       $262.agent.leaving();
+ *     });
+ *   `);
+ *   $262.agent.broadcast(i32a.buffer);
+ *
+ *   // Wait until agent was started and then try to yield control.
+ *   $262.agent.waitUntil(i32a, RUNNING, 1);
+ *   $262.agent.tryYield();
+ *
+ *   // Note: This result is not guaranteed, but should hold in practice most of the time.
+ *   assert.sameValue(Atomics.load(i32a, VALUE), 1);
+ *
+ * The default implementation simply waits for `$262.agent.timeouts.yield` milliseconds.
+ */
+$262.agent.tryYield = function() {
+  $262.agent.sleep($262.agent.timeouts.yield);
+};
+
+/**
+ * Try to sleep the current agent for the given amount of milliseconds. It is acceptable,
+ * but not encouraged, to ignore this sleep request and directly continue execution.
+ *
+ * The default implementation calls `$262.agent.sleep(ms)`.
+ *
+ * @param {number} ms Time to sleep in milliseconds.
+ */
+$262.agent.trySleep = function(ms) {
+  $262.agent.sleep(ms);
 };

--- a/harness/features.yml
+++ b/harness/features.yml
@@ -1,6 +1,6 @@
 atomicsHelper: [Atomics]
 typeCoercion.js: [Symbol.toPrimitive, BigInt]
-testAtomics.js: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, arrow-function, let, for-of]
+testAtomics.js: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 testBigIntTypedArray.js: [BigInt, TypedArray]
 testTypedArray.js: [TypedArray]
 isConstructor.js: [Reflect.construct]

--- a/harness/testAtomics.js
+++ b/harness/testAtomics.js
@@ -15,16 +15,17 @@ description: |
  */
 function testWithAtomicsOutOfBoundsIndices(f) {
   var bad_indices = [
-    (view) => -1,
-    (view) => view.length,
-    (view) => view.length * 2,
-    (view) => Number.POSITIVE_INFINITY,
-    (view) => Number.NEGATIVE_INFINITY,
-    (view) => ({ valueOf: () => 125 }),
-    (view) => ({ toString: () => '125', valueOf: false }) // non-callable valueOf triggers invocation of toString
+    function(view) { return -1; },
+    function(view) { return view.length; },
+    function(view) { return view.length * 2; },
+    function(view) { return Number.POSITIVE_INFINITY; },
+    function(view) { return Number.NEGATIVE_INFINITY; },
+    function(view) { return { valueOf: function() { return 125; } }; },
+    function(view) { return { toString: function() { return '125'; }, valueOf: false }; }, // non-callable valueOf triggers invocation of toString
   ];
 
-  for (let IdxGen of bad_indices) {
+  for (var i = 0; i < bad_indices.length; ++i) {
+    var IdxGen = bad_indices[i];
     try {
       f(IdxGen);
     } catch (e) {
@@ -45,20 +46,21 @@ function testWithAtomicsOutOfBoundsIndices(f) {
 function testWithAtomicsInBoundsIndices(f) {
   // Most of these are eventually coerced to +0 by ToIndex.
   var good_indices = [
-    (view) => 0/-1,
-    (view) => '-0',
-    (view) => undefined,
-    (view) => NaN,
-    (view) => 0.5,
-    (view) => '0.5',
-    (view) => -0.9,
-    (view) => ({ password: 'qumquat' }),
-    (view) => view.length - 1,
-    (view) => ({ valueOf: () => 0 }),
-    (view) => ({ toString: () => '0', valueOf: false }) // non-callable valueOf triggers invocation of toString
+    function(view) { return 0/-1; },
+    function(view) { return '-0'; },
+    function(view) { return undefined; },
+    function(view) { return NaN; },
+    function(view) { return 0.5; },
+    function(view) { return '0.5'; },
+    function(view) { return -0.9; },
+    function(view) { return { password: 'qumquat' }; },
+    function(view) { return view.length - 1; },
+    function(view) { return { valueOf: function() { return 0; } }; },
+    function(view) { return { toString: function() { return '0'; }, valueOf: false }; }, // non-callable valueOf triggers invocation of toString
   ];
 
-  for (let IdxGen of good_indices) {
+  for (var i = 0; i < good_indices.length; ++i) {
+    var IdxGen = good_indices[i];
     try {
       f(IdxGen);
     } catch (e) {
@@ -94,11 +96,7 @@ function testWithAtomicsNonViewValues(f) {
     new SharedArrayBuffer(128),
     new Error('Ouch'),
     [1,1,2,3,5,8],
-    ((x) => -x),
-    new Map(),
-    new Set(),
-    new WeakMap(),
-    new WeakSet(),
+    function(x) { return -x; },
     Symbol('halleluja'),
     // TODO: Proxy?
     Object,
@@ -108,7 +106,8 @@ function testWithAtomicsNonViewValues(f) {
     Atomics
   ];
 
-  for (let nonView of values) {
+  for (var i = 0; i < values.length; ++i) {
+    var nonView = values[i];
     try {
       f(nonView);
     } catch (e) {

--- a/test/built-ins/Atomics/add/bad-range.js
+++ b/test/built-ins/Atomics/add/bad-range.js
@@ -6,7 +6,7 @@ esid: sec-atomics.add
 description: >
   Test range checking of Atomics.add on arrays that allow atomic operations
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const buffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/add/bigint/bad-range.js
+++ b/test/built-ins/Atomics/add/bigint/bad-range.js
@@ -5,7 +5,7 @@ esid: sec-atomics.add
 description: >
   Test range checking of Atomics.add on arrays that allow atomic operations
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 var buffer = new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 2);
 

--- a/test/built-ins/Atomics/add/bigint/good-views.js
+++ b/test/built-ins/Atomics/add/bigint/good-views.js
@@ -4,7 +4,7 @@
 esid: sec-atomics.add
 description: Test Atomics.add on arrays that allow atomic operations.
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 const sab = new SharedArrayBuffer(1024);
 const ab = new ArrayBuffer(16);

--- a/test/built-ins/Atomics/add/good-views.js
+++ b/test/built-ins/Atomics/add/good-views.js
@@ -5,7 +5,7 @@
 esid: sec-atomics.add
 description: Test Atomics.add on arrays that allow atomic operations.
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const sab = new SharedArrayBuffer(1024);

--- a/test/built-ins/Atomics/add/non-views.js
+++ b/test/built-ins/Atomics/add/non-views.js
@@ -6,7 +6,7 @@ esid: sec-atomics.add
 description: >
   Test Atomics.add on view values other than TypedArrays
 includes: [testAtomics.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {

--- a/test/built-ins/Atomics/and/bad-range.js
+++ b/test/built-ins/Atomics/and/bad-range.js
@@ -6,7 +6,7 @@ esid: sec-atomics.and
 description: >
   Test range checking of Atomics.and on arrays that allow atomic operations
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const buffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/and/bigint/bad-range.js
+++ b/test/built-ins/Atomics/and/bigint/bad-range.js
@@ -5,7 +5,7 @@ esid: sec-atomics.and
 description: >
   Test range checking of Atomics.and on arrays that allow atomic operations
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 const buffer = new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 2);
 

--- a/test/built-ins/Atomics/and/bigint/good-views.js
+++ b/test/built-ins/Atomics/and/bigint/good-views.js
@@ -4,7 +4,7 @@
 esid: sec-atomics.and
 description: Test Atomics.and on arrays that allow atomic operations
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 const sab = new SharedArrayBuffer(1024);
 const ab = new ArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/and/good-views.js
+++ b/test/built-ins/Atomics/and/good-views.js
@@ -5,7 +5,7 @@
 esid: sec-atomics.and
 description: Test Atomics.and on arrays that allow atomic operations
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const sab = new SharedArrayBuffer(1024);

--- a/test/built-ins/Atomics/and/non-views.js
+++ b/test/built-ins/Atomics/and/non-views.js
@@ -6,7 +6,7 @@ esid: sec-atomics.and
 description: >
   Test Atomics.and on view values other than TypedArrays
 includes: [testAtomics.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {

--- a/test/built-ins/Atomics/compareExchange/bad-range.js
+++ b/test/built-ins/Atomics/compareExchange/bad-range.js
@@ -6,7 +6,7 @@ esid: sec-atomics.compareexchange
 description: >
   Test range checking of Atomics.compareExchange on arrays that allow atomic operations
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const buffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/compareExchange/bigint/bad-range.js
+++ b/test/built-ins/Atomics/compareExchange/bigint/bad-range.js
@@ -5,7 +5,7 @@ esid: sec-atomics.compareexchange
 description: >
   Test range checking of Atomics.compareExchange on arrays that allow atomic operations
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 const buffer = new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 2);
 

--- a/test/built-ins/Atomics/compareExchange/bigint/good-views.js
+++ b/test/built-ins/Atomics/compareExchange/bigint/good-views.js
@@ -4,7 +4,7 @@
 esid: sec-atomics.compareexchange
 description: Test Atomics.compareExchange on arrays that allow atomic operations.
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 const sab = new SharedArrayBuffer(1024);
 const ab = new ArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/compareExchange/good-views.js
+++ b/test/built-ins/Atomics/compareExchange/good-views.js
@@ -5,7 +5,7 @@
 esid: sec-atomics.compareexchange
 description: Test Atomics.compareExchange on arrays that allow atomic operations.
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const sab = new SharedArrayBuffer(1024);

--- a/test/built-ins/Atomics/compareExchange/non-views.js
+++ b/test/built-ins/Atomics/compareExchange/non-views.js
@@ -6,7 +6,7 @@ esid: sec-atomics.compareexchange
 description: >
   Test Atomics.compareExchange on view values other than TypedArrays
 includes: [testAtomics.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {

--- a/test/built-ins/Atomics/exchange/bad-range.js
+++ b/test/built-ins/Atomics/exchange/bad-range.js
@@ -6,7 +6,7 @@ esid: sec-atomics.exchange
 description: >
   Test range checking of Atomics.exchange on arrays that allow atomic operations
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const buffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/exchange/bigint/bad-range.js
+++ b/test/built-ins/Atomics/exchange/bigint/bad-range.js
@@ -5,7 +5,7 @@ esid: sec-atomics.exchange
 description: >
   Test range checking of Atomics.exchange on arrays that allow atomic operations
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 var buffer = new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 2);
 

--- a/test/built-ins/Atomics/exchange/bigint/good-views.js
+++ b/test/built-ins/Atomics/exchange/bigint/good-views.js
@@ -4,7 +4,7 @@
 esid: sec-atomics.exchange
 description: Test Atomics.exchange on arrays that allow atomic operations.
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 const sab = new SharedArrayBuffer(1024);
 const ab = new ArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/exchange/good-views.js
+++ b/test/built-ins/Atomics/exchange/good-views.js
@@ -5,7 +5,7 @@
 esid: sec-atomics.exchange
 description: Test Atomics.exchange on arrays that allow atomic operations.
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const sab = new SharedArrayBuffer(1024);

--- a/test/built-ins/Atomics/exchange/non-views.js
+++ b/test/built-ins/Atomics/exchange/non-views.js
@@ -6,7 +6,7 @@ esid: sec-atomics.exchange
 description: >
   Test Atomics.exchange on view values other than TypedArrays
 includes: [testAtomics.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {

--- a/test/built-ins/Atomics/load/bad-range.js
+++ b/test/built-ins/Atomics/load/bad-range.js
@@ -6,7 +6,7 @@ esid: sec-atomics.load
 description: >
   Test range checking of Atomics.load on arrays that allow atomic operations
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 var buffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/load/bigint/bad-range.js
+++ b/test/built-ins/Atomics/load/bigint/bad-range.js
@@ -6,7 +6,7 @@ esid: sec-atomics.load
 description: >
   Test range checking of Atomics.load on arrays that allow atomic operations
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 var buffer = new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/load/bigint/good-views.js
+++ b/test/built-ins/Atomics/load/bigint/good-views.js
@@ -4,7 +4,7 @@
 esid: sec-atomics.load
 description: Test Atomics.load on arrays that allow atomic operations.
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 const sab = new SharedArrayBuffer(1024);
 const ab = new ArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/load/good-views.js
+++ b/test/built-ins/Atomics/load/good-views.js
@@ -5,7 +5,7 @@
 esid: sec-atomics.load
 description: Test Atomics.load on arrays that allow atomic operations.
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const sab = new SharedArrayBuffer(1024);

--- a/test/built-ins/Atomics/load/non-views.js
+++ b/test/built-ins/Atomics/load/non-views.js
@@ -6,7 +6,7 @@ esid: sec-atomics.load
 description: >
   Test Atomics.load on view values other than TypedArrays
 includes: [testAtomics.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {

--- a/test/built-ins/Atomics/or/bad-range.js
+++ b/test/built-ins/Atomics/or/bad-range.js
@@ -6,7 +6,7 @@ esid: sec-atomics.or
 description: >
   Test range checking of Atomics.or on arrays that allow atomic operations
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 var buffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/or/bigint/bad-range.js
+++ b/test/built-ins/Atomics/or/bigint/bad-range.js
@@ -5,7 +5,7 @@ esid: sec-atomics.or
 description: >
   Test range checking of Atomics.or on arrays that allow atomic operations
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 var buffer = new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 2);
 

--- a/test/built-ins/Atomics/or/bigint/good-views.js
+++ b/test/built-ins/Atomics/or/bigint/good-views.js
@@ -4,7 +4,7 @@
 esid: sec-atomics.or
 description: Test Atomics.or on arrays that allow atomic operations
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 const sab = new SharedArrayBuffer(1024);
 const ab = new ArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/or/good-views.js
+++ b/test/built-ins/Atomics/or/good-views.js
@@ -5,7 +5,7 @@
 esid: sec-atomics.or
 description: Test Atomics.or on arrays that allow atomic operations
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 var sab = new SharedArrayBuffer(1024);

--- a/test/built-ins/Atomics/or/non-views.js
+++ b/test/built-ins/Atomics/or/non-views.js
@@ -6,7 +6,7 @@ esid: sec-atomics.or
 description: >
   Test Atomics.or on view values other than TypedArrays
 includes: [testAtomics.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {

--- a/test/built-ins/Atomics/store/bad-range.js
+++ b/test/built-ins/Atomics/store/bad-range.js
@@ -6,7 +6,7 @@ esid: sec-atomics.store
 description: >
   Test range checking of Atomics.store on arrays that allow atomic operations
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const buffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/store/bigint/bad-range.js
+++ b/test/built-ins/Atomics/store/bigint/bad-range.js
@@ -5,7 +5,7 @@ esid: sec-atomics.store
 description: >
   Test range checking of Atomics.store on arrays that allow atomic operations
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 const buffer = new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 2);
 

--- a/test/built-ins/Atomics/store/bigint/good-views.js
+++ b/test/built-ins/Atomics/store/bigint/good-views.js
@@ -4,7 +4,7 @@
 esid: sec-atomics.store
 description: Test Atomics.store on arrays that allow atomic operations.
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 // Make it interesting - use non-zero byteOffsets and non-zero indexes.
 // In-bounds boundary cases for indexing
@@ -15,9 +15,19 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   const view = new TA(sab, 32, 20);
   const control = new TA(ab, 0, 2);
 
-  for (let val of [10n, -5n, 12345n, 123456789n, BigInt('33'), {
-    valueOf: () => 33n
-  }]) {
+  const values = [
+    10n,
+    -5n,
+    12345n,
+    123456789n,
+    BigInt('33'),
+    {
+      valueOf: function() { return 33n; }
+    }
+  ];
+
+  for (let i = 0; i < values.length; i++) {
+    let val = values[i];
     assert.sameValue(
       Atomics.store(view, 3, val),
       BigInt(val),

--- a/test/built-ins/Atomics/store/good-views.js
+++ b/test/built-ins/Atomics/store/good-views.js
@@ -5,7 +5,7 @@
 esid: sec-atomics.store
 description: Test Atomics.store on arrays that allow atomic operations.
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const sab = new SharedArrayBuffer(1024);
@@ -18,17 +18,21 @@ testWithTypedArrayConstructors(function(TA) {
   const view = new TA(sab, 32, 20);
   const control = new TA(ab, 0, 2);
 
-  for (let val of [10, -5,
-      12345,
-      123456789,
-      Math.PI,
-      "33",
-      {
-        valueOf: () => 33
-      },
-      undefined
-    ])
-  {
+  const values = [
+    10,
+    -5,
+    12345,
+    123456789,
+    Math.PI,
+    "33",
+    {
+      valueOf: function() { return 33; }
+    },
+    undefined
+  ];
+
+  for (let i = 0; i < values.length; i++) {
+    let val = values[i];
     assert.sameValue(Atomics.store(view, 3, val), ToInteger(val),
       'Atomics.store(view, 3, val) returns ToInteger(val)');
 

--- a/test/built-ins/Atomics/store/non-views.js
+++ b/test/built-ins/Atomics/store/non-views.js
@@ -6,7 +6,7 @@ esid: sec-atomics.store
 description: >
   Test Atomics.store on view values other than TypedArrays
 includes: [testAtomics.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {

--- a/test/built-ins/Atomics/sub/bad-range.js
+++ b/test/built-ins/Atomics/sub/bad-range.js
@@ -6,7 +6,7 @@ esid: sec-atomics.sub
 description: >
   Test range checking of Atomics.sub on arrays that allow atomic operations
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 var buffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/sub/bigint/bad-range.js
+++ b/test/built-ins/Atomics/sub/bigint/bad-range.js
@@ -5,7 +5,7 @@ esid: sec-atomics.sub
 description: >
   Test range checking of Atomics.sub on arrays that allow atomic operations
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 const buffer = new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 2);
 

--- a/test/built-ins/Atomics/sub/bigint/good-views.js
+++ b/test/built-ins/Atomics/sub/bigint/good-views.js
@@ -4,7 +4,7 @@
 esid: sec-atomics.sub
 description: Test Atomics.sub on arrays that allow atomic operations
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 // Make it interesting - use non-zero byteOffsets and non-zero indexes.
 // In-bounds boundary cases for indexing

--- a/test/built-ins/Atomics/sub/good-views.js
+++ b/test/built-ins/Atomics/sub/good-views.js
@@ -5,7 +5,7 @@
 esid: sec-atomics.sub
 description: Test Atomics.sub on arrays that allow atomic operations
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 var sab = new SharedArrayBuffer(1024);

--- a/test/built-ins/Atomics/sub/non-views.js
+++ b/test/built-ins/Atomics/sub/non-views.js
@@ -6,7 +6,7 @@ esid: sec-atomics.sub
 description: >
   Test Atomics.sub on view values other than TypedArrays
 includes: [testAtomics.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {

--- a/test/built-ins/Atomics/wait/bad-range.js
+++ b/test/built-ins/Atomics/wait/bad-range.js
@@ -12,7 +12,7 @@ info: |
   ...
 
 includes: [testAtomics.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const i32a = new Int32Array(

--- a/test/built-ins/Atomics/wait/bigint/bad-range.js
+++ b/test/built-ins/Atomics/wait/bigint/bad-range.js
@@ -12,7 +12,7 @@ info: |
   ...
 
 includes: [testAtomics.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const i64a = new BigInt64Array(

--- a/test/built-ins/Atomics/wait/bigint/cannot-suspend-throws.js
+++ b/test/built-ins/Atomics/wait/bigint/cannot-suspend-throws.js
@@ -16,7 +16,8 @@ info: |
 features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 flags: [CanBlockIsFalse]
 ---*/
-const i64a = new BigInt64Array(new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8));
+
+const i64a = new BigInt64Array(new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4));
 
 assert.throws(TypeError, function() {
   Atomics.wait(i64a, 0, 0n, 0);

--- a/test/built-ins/Atomics/wait/bigint/false-for-timeout.js
+++ b/test/built-ins/Atomics/wait/bigint/false-for-timeout.js
@@ -13,11 +13,11 @@ info: |
     Boolean -> If argument is true, return 1. If argument is false, return +0.
 
 features: [Atomics, BigInt, SharedArrayBuffer, Symbol, Symbol.toPrimitive, TypedArray]
-flags: [CanBlockIsFalse]
+flags: [CanBlockIsTrue]
 ---*/
 
 const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8)
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
 const valueOf = {
@@ -47,4 +47,3 @@ assert.sameValue(
   "timed-out",
   'Atomics.wait(i64a, 0, 0n, toPrimitive) returns "timed-out"'
 );
-

--- a/test/built-ins/Atomics/wait/bigint/nan-for-timeout.js
+++ b/test/built-ins/Atomics/wait/bigint/nan-for-timeout.js
@@ -17,19 +17,27 @@ includes: [atomicsHelper.js]
 features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
 
+const RUNNING = 1;
+
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i64a = new BigInt64Array(sab);
+    Atomics.add(i64a, ${RUNNING}, 1n);
+
     $262.agent.report(Atomics.wait(i64a, 0, 0n, NaN));  // NaN => +Infinity
     $262.agent.leaving();
   });
 `);
 
 const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8)
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
 $262.agent.broadcast(i64a.buffer);
-$262.agent.sleep(100);
+$262.agent.waitUntil(i64a, RUNNING, 1n);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
+
 assert.sameValue(Atomics.wake(i64a, 0), 1, 'Atomics.wake(i64a, 0) returns 1');
 assert.sameValue($262.agent.getReport(), 'ok', '$262.agent.getReport() returns "ok"');

--- a/test/built-ins/Atomics/wait/bigint/negative-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/bigint/negative-timeout-agent.js
@@ -9,20 +9,28 @@ includes: [atomicsHelper.js]
 features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
 
+const RUNNING = 1;
+
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab, id) {
     const i64a = new BigInt64Array(sab);
+    Atomics.add(i64a, ${RUNNING}, 1n);
+
     $262.agent.report(Atomics.wait(i64a, 0, 0n, -5)); // -5 => 0
     $262.agent.leaving();
   });
 `);
 
 const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8)
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
 $262.agent.broadcast(i64a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i64a, RUNNING, 1n);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
+
 assert.sameValue(
   $262.agent.getReport(),
   'timed-out',

--- a/test/built-ins/Atomics/wait/bigint/negative-timeout.js
+++ b/test/built-ins/Atomics/wait/bigint/negative-timeout.js
@@ -6,11 +6,11 @@ esid: sec-atomics.wait
 description: >
   Test that Atomics.wait times out with a negative timeout
 features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
-flags: [CanBlockIsFalse]
+flags: [CanBlockIsTrue]
 ---*/
 
 const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8)
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
 assert.sameValue(

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-and.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-and.js
@@ -5,27 +5,37 @@
 esid: sec-atomics.wait
 description: >
   Waiter does not spuriously wake on index which is subject to And operation
-includes: [testAtomics.js]
-features: [ArrayBuffer, DataView, let, arrow-function, for-of, Atomics, BigInt, SharedArrayBuffer, TypedArray]
+includes: [atomicsHelper.js]
+features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
-const TIMEOUT = 200;
+
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.small;
+
 const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8)
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i64a = new BigInt64Array(sab);
+    Atomics.add(i64a, ${RUNNING}, 1n);
+
     const before = $262.agent.monotonicNow();
     const unpark = Atomics.wait(i64a, 0, 0n, ${TIMEOUT});
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(duration);
     $262.agent.report(unpark);
     $262.agent.leaving();
   });
 `);
 
 $262.agent.broadcast(i64a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i64a, RUNNING, 1n);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 Atomics.and(i64a, 0, 1n);
 

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-compareExchange.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-compareExchange.js
@@ -5,27 +5,37 @@
 esid: sec-atomics.wait
 description: >
   Waiter does not spuriously wake on index which is subject to compareExchange operation
-includes: [testAtomics.js]
-features: [Atomics, BigInt, SharedArrayBuffer, TypedArray, ArrayBuffer, DataView, let, arrow-function, for-of]
+includes: [atomicsHelper.js]
+features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
-const TIMEOUT = 200;
+
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.small;
+
 const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8)
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i64a = new BigInt64Array(sab);
+    Atomics.add(i64a, ${RUNNING}, 1n);
+
     const before = $262.agent.monotonicNow();
     const unpark = Atomics.wait(i64a, 0, 0n, ${TIMEOUT});
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(duration);
     $262.agent.report(unpark);
     $262.agent.leaving();
   });
 `);
 
 $262.agent.broadcast(i64a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i64a, RUNNING, 1n);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 Atomics.compareExchange(i64a, 0, 0n, 1n);
 

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-exchange.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-exchange.js
@@ -5,27 +5,37 @@
 esid: sec-atomics.wait
 description: >
   Waiter does not spuriously wake on index which is subject to exchange operation
-includes: [testAtomics.js]
-features: [Atomics, BigInt, SharedArrayBuffer, TypedArray, ArrayBuffer, DataView, let, arrow-function, for-of]
+includes: [atomicsHelper.js]
+features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
-const TIMEOUT = 200;
+
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.small;
+
 const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8)
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i64a = new BigInt64Array(sab);
+    Atomics.add(i64a, ${RUNNING}, 1n);
+
     const before = $262.agent.monotonicNow();
     const unpark = Atomics.wait(i64a, 0, 0n, ${TIMEOUT});
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(duration);
     $262.agent.report(unpark);
     $262.agent.leaving();
   });
 `);
 
 $262.agent.broadcast(i64a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i64a, RUNNING, 1n);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 Atomics.exchange(i64a, 0, 1n);
 
@@ -40,4 +50,3 @@ assert.sameValue(
   '$262.agent.getReport() returns "timed-out"'
 );
 assert.sameValue(Atomics.wake(i64a, 0), 0, 'Atomics.wake(i64a, 0) returns 0');
-

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-or.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-or.js
@@ -5,27 +5,37 @@
 esid: sec-atomics.wait
 description: >
   Waiter does not spuriously wake on index which is subject to Or operation
-includes: [testAtomics.js]
-features: [Atomics, BigInt, SharedArrayBuffer, TypedArray, ArrayBuffer, DataView, let, arrow-function, for-of, Atomics, BigInt, SharedArrayBuffer, TypedArray]
+includes: [atomicsHelper.js]
+features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
-const TIMEOUT = 200;
+
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.small;
+
 const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8)
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i64a = new BigInt64Array(sab);
+    Atomics.add(i64a, ${RUNNING}, 1n);
+
     const before = $262.agent.monotonicNow();
     const unpark = Atomics.wait(i64a, 0, 0n, ${TIMEOUT});
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(duration);
     $262.agent.report(unpark);
     $262.agent.leaving();
   });
 `);
 
 $262.agent.broadcast(i64a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i64a, RUNNING, 1n);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 Atomics.or(i64a, 0, 1n);
 
@@ -40,5 +50,3 @@ assert.sameValue(
   '$262.agent.getReport() returns "timed-out"'
 );
 assert.sameValue(Atomics.wake(i64a, 0), 0, 'Atomics.wake(i64a, 0) returns 0');
-
-

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-store.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-store.js
@@ -5,27 +5,37 @@
 esid: sec-atomics.wait
 description: >
   Demonstrates that Atomics.store(...) is causing a waiting
-includes: [testAtomics.js]
-features: [Atomics, BigInt, SharedArrayBuffer, TypedArray, ArrayBuffer, DataView, let, arrow-function, for-of, Atomics, BigInt, SharedArrayBuffer, TypedArray]
+includes: [atomicsHelper.js]
+features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
-const TIMEOUT = 200;
+
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.small;
+
 const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8)
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i64a = new BigInt64Array(sab);
+    Atomics.add(i64a, ${RUNNING}, 1n);
+
     const before = $262.agent.monotonicNow();
     const unpark = Atomics.wait(i64a, 0, 0n, ${TIMEOUT});
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(duration);
     $262.agent.report(unpark);
     $262.agent.leaving();
   });
 `);
 
 $262.agent.broadcast(i64a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i64a, RUNNING, 1n);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 Atomics.store(i64a, 0, 0x111111n);
 
@@ -40,4 +50,3 @@ assert.sameValue(
   '$262.agent.getReport() returns "timed-out"'
 );
 assert.sameValue(Atomics.wake(i64a, 0), 0, 'Atomics.wake(i64a, 0) returns 0');
-

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-sub.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-sub.js
@@ -5,27 +5,37 @@
 esid: sec-atomics.wait
 description: >
   Waiter does not spuriously wake on index which is subject to Sub operation
-includes: [testAtomics.js]
-features: [Atomics, BigInt, SharedArrayBuffer, TypedArray, ArrayBuffer, DataView, let, arrow-function, for-of, Atomics, BigInt, SharedArrayBuffer, TypedArray]
+includes: [atomicsHelper.js]
+features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
-const TIMEOUT = 200;
+
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.small;
+
 const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8)
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i64a = new BigInt64Array(sab);
+    Atomics.add(i64a, ${RUNNING}, 1n);
+
     const before = $262.agent.monotonicNow();
     const unpark = Atomics.wait(i64a, 0, 0n, ${TIMEOUT});
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(duration);
     $262.agent.report(unpark);
     $262.agent.leaving();
   });
 `);
 
 $262.agent.broadcast(i64a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i64a, RUNNING, 1n);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 Atomics.sub(i64a, 0, 1n);
 

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-xor.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-xor.js
@@ -5,27 +5,37 @@
 esid: sec-atomics.wait
 description: >
   Waiter does not spuriously wake on index which is subject to xor operation
-includes: [testAtomics.js]
-features: [Atomics, BigInt, SharedArrayBuffer, TypedArray, ArrayBuffer, DataView, let, arrow-function, for-of, Atomics, BigInt, SharedArrayBuffer, TypedArray]
+includes: [atomicsHelper.js]
+features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
-const TIMEOUT = 200;
+
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.small;
+
 const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8)
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i64a = new BigInt64Array(sab);
+    Atomics.add(i64a, ${RUNNING}, 1n);
+
     const before = $262.agent.monotonicNow();
     const unpark = Atomics.wait(i64a, 0, 0n, ${TIMEOUT});
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(duration);
     $262.agent.report(unpark);
     $262.agent.leaving();
   });
 `);
 
 $262.agent.broadcast(i64a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i64a, RUNNING, 1n);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 Atomics.xor(i64a, 0, 1n);
 
@@ -40,6 +50,3 @@ assert.sameValue(
   '$262.agent.getReport() returns "timed-out"'
 );
 assert.sameValue(Atomics.wake(i64a, 0), 0, 'Atomics.wake(i64a, 0) returns 0');
-
-
-

--- a/test/built-ins/Atomics/wait/bigint/non-bigint64-typedarray-throws.js
+++ b/test/built-ins/Atomics/wait/bigint/non-bigint64-typedarray-throws.js
@@ -19,8 +19,7 @@ info: |
       a. If typeName is not "BigInt64Array",
       throw a TypeError exception.
 
-features: [Atomics, BigInt, SharedArrayBuffer, TypedArray, ArrayBuffer, DataView, let, arrow-function, for-of, Atomics, BigInt, SharedArrayBuffer, TypedArray]
-includes: [testAtomics.js, testBigIntTypedArray.js]
+features: [Atomics, BigInt, SharedArrayBuffer]
 ---*/
 
 const i64a = new BigUint64Array(
@@ -40,4 +39,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   Atomics.wait(i64a, poisoned, poisoned, poisoned);
 }, '`Atomics.wait(i64a, poisoned, poisoned, poisoned)` throws TypeError');
-

--- a/test/built-ins/Atomics/wait/bigint/null-bufferdata-throws.js
+++ b/test/built-ins/Atomics/wait/bigint/null-bufferdata-throws.js
@@ -26,7 +26,7 @@ features: [ArrayBuffer, Atomics, BigInt, TypedArray]
 ---*/
 
 const i64a = new BigInt64Array(
-  new ArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8)
+  new ArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 const poisoned = {
   valueOf: function() {

--- a/test/built-ins/Atomics/wait/bigint/out-of-range-index-throws.js
+++ b/test/built-ins/Atomics/wait/bigint/out-of-range-index-throws.js
@@ -17,7 +17,7 @@ features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
 
 const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8)
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
 const poisoned = {

--- a/test/built-ins/Atomics/wait/bigint/waiterlist-block-indexedposition-wake.js
+++ b/test/built-ins/Atomics/wait/bigint/waiterlist-block-indexedposition-wake.js
@@ -22,9 +22,13 @@ includes: [atomicsHelper.js]
 features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
 
+var NUMAGENT = 2;
+var RUNNING = 4;
+
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i64a = new BigInt64Array(sab);
+    Atomics.add(i64a, ${RUNNING}, 1n);
 
     // Wait on index 0
     $262.agent.report(Atomics.wait(i64a, 0, 0n, Infinity));
@@ -35,33 +39,37 @@ $262.agent.start(`
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i64a = new BigInt64Array(sab);
+    Atomics.add(i64a, ${RUNNING}, 1n);
 
-    // Wait on index 7
-    $262.agent.report(Atomics.wait(i64a, 7, 0n, Infinity));
+    // Wait on index 2
+    $262.agent.report(Atomics.wait(i64a, 2, 0n, Infinity));
     $262.agent.leaving();
   });
 `);
 
 const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 8)
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 5)
 );
 
 $262.agent.broadcast(i64a.buffer);
-$262.agent.sleep(10);
+
+// Wait until all agents started.
+$262.agent.waitUntil(i64a, RUNNING, BigInt(NUMAGENT));
 
 // Wake index 1, wakes nothing
 assert.sameValue(Atomics.wake(i64a, 1), 0, 'Atomics.wake(i64a, 1) returns 0');
+
 // Wake index 3, wakes nothing
 assert.sameValue(Atomics.wake(i64a, 3), 0, 'Atomics.wake(i64a, 3) returns 0');
-// Wake index 4, wakes nothing
-assert.sameValue(Atomics.wake(i64a, 4), 0, 'Atomics.wake(i64a, 4) returns 0');
-// Wake index 5, wakes nothing
-assert.sameValue(Atomics.wake(i64a, 5), 0, 'Atomics.wake(i64a, 5) returns 0');
 
-// Wake index 7, wakes 1
-assert.sameValue(Atomics.wake(i64a, 7), 1, 'Atomics.wake(i64a, 7) returns 1');
+// Wake index 2, wakes 1
+var woken = 0;
+while ((woken = Atomics.wake(i64a, 2)) === 0) ;
+assert.sameValue(woken, 1, 'Atomics.wake(i64a, 2) returns 1');
 assert.sameValue($262.agent.getReport(), 'ok', '$262.agent.getReport() returns "ok"');
 
 // Wake index 0, wakes 1
-assert.sameValue(Atomics.wake(i64a, 0), 1, 'Atomics.wake(i64a, 0) returns 1');
+var woken = 0;
+while ((woken = Atomics.wake(i64a, 0)) === 0) ;
+assert.sameValue(woken, 1, 'Atomics.wake(i64a, 0) returns 1');
 assert.sameValue($262.agent.getReport(), 'ok', '$262.agent.getReport() returns "ok"');

--- a/test/built-ins/Atomics/wait/descriptor.js
+++ b/test/built-ins/Atomics/wait/descriptor.js
@@ -13,4 +13,3 @@ verifyProperty(Atomics, 'wait', {
   writable: true,
   configurable: true,
 });
-

--- a/test/built-ins/Atomics/wait/false-for-timeout.js
+++ b/test/built-ins/Atomics/wait/false-for-timeout.js
@@ -13,7 +13,7 @@ info: |
     Boolean -> If argument is true, return 1. If argument is false, return +0.
 
 features: [Atomics, SharedArrayBuffer, Symbol, Symbol.toPrimitive, TypedArray]
-flags: [CanBlockIsFalse]
+flags: [CanBlockIsTrue]
 ---*/
 
 const i32a = new Int32Array(
@@ -47,4 +47,3 @@ assert.sameValue(
   'timed-out',
   'Atomics.wait(i32a, 0, 0, toPrimitive) returns "timed-out"'
 );
-

--- a/test/built-ins/Atomics/wait/good-views.js
+++ b/test/built-ins/Atomics/wait/good-views.js
@@ -49,13 +49,18 @@ assert.sameValue(
   'A timed-out',
   '$262.agent.getReport() returns "A timed-out"'
 );
+
 assert.sameValue(
   $262.agent.getReport(),
   'B not-equal',
   '$262.agent.getReport() returns "B not-equal"'
 );
-assert.sameValue(
-  $262.agent.getReport(),
-  'C not-equal',
-  '$262.agent.getReport() returns "C not-equal"'
-);
+
+var r;
+while ((r = $262.agent.getReport()) !== "done") {
+  assert.sameValue(
+    r,
+    'C not-equal',
+    '$262.agent.getReport() returns "C not-equal"'
+  );
+}

--- a/test/built-ins/Atomics/wait/negative-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/negative-timeout-agent.js
@@ -9,9 +9,13 @@ includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
+const RUNNING = 1;
+
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab, id) {
     var i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
+
     $262.agent.report(Atomics.wait(i32a, 0, 0, -5)); // -5 => 0
     $262.agent.leaving();
   });
@@ -22,7 +26,10 @@ const i32a = new Int32Array(
 );
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(100);
+$262.agent.waitUntil(i32a, RUNNING, 1);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 assert.sameValue(
   $262.agent.getReport(),

--- a/test/built-ins/Atomics/wait/negative-timeout.js
+++ b/test/built-ins/Atomics/wait/negative-timeout.js
@@ -6,7 +6,7 @@ esid: sec-atomics.wait
 description: >
   Test that Atomics.wait times out with a negative timeout
 features: [Atomics, SharedArrayBuffer, TypedArray]
-flags: [CanBlockIsFalse]
+flags: [CanBlockIsTrue]
 ---*/
 
 const i32a = new Int32Array(

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-no-operation.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-no-operation.js
@@ -1,10 +1,17 @@
-// Copyright (C) 2018 Rick Waldron. All rights reserved.
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 esid: sec-atomics.wait
 description: >
-  Waiter does not spuriously wake on index which is subject to Store operation
+  Test that Atomics.wait returns the right result when it timed out and that
+  the time to time out is reasonable.
+  info: |
+    17. Let awoken be Suspend(WL, W, t).
+    18. If awoken is true, then
+      a. Assert: W is not on the list of waiters in WL.
+    19. Else,
+      a.Perform RemoveWaiter(WL, W).
 includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
@@ -17,7 +24,7 @@ const i32a = new Int32Array(
 );
 
 $262.agent.start(`
-  $262.agent.receiveBroadcast(function(sab) {
+  $262.agent.receiveBroadcast(function(sab, id) {
     const i32a = new Int32Array(sab);
     Atomics.add(i32a, ${RUNNING}, 1);
 
@@ -37,7 +44,7 @@ $262.agent.waitUntil(i32a, RUNNING, 1);
 // Try to yield control to ensure the agent actually started to wait.
 $262.agent.tryYield();
 
-Atomics.store(i32a, 0, 0x111111);
+// NO OPERATION OCCURS HERE!
 
 const lapse = $262.agent.getReport();
 assert(

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-add.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-add.js
@@ -6,10 +6,12 @@ esid: sec-atomics.wait
 description: >
   Waiter does not spuriously wake on index which is subject to Add operation
 includes: [atomicsHelper.js]
-features: [ArrayBuffer, DataView, let, arrow-function, for-of, Atomics, BigInt, SharedArrayBuffer, TypedArray]
+features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
-const TIMEOUT = 200;
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.small;
+
 const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
@@ -17,23 +19,30 @@ const i32a = new Int32Array(
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
+
     const before = $262.agent.monotonicNow();
     const unpark = Atomics.wait(i32a, 0, 0, ${TIMEOUT});
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(duration);
     $262.agent.report(unpark);
     $262.agent.leaving();
   });
 `);
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i32a, RUNNING, 1);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 Atomics.add(i32a, 0, 1);
 
 const lapse = $262.agent.getReport();
 assert(
   lapse >= TIMEOUT,
-  'The result of `(lapse >= TIMEOUT)` is true (The result of `(lapse >= TIMEOUT)` is true)'
+  'The result of `(lapse >= TIMEOUT)` is true'
 );
 assert.sameValue(
   $262.agent.getReport(),
@@ -41,5 +50,3 @@ assert.sameValue(
   '$262.agent.getReport() returns "timed-out"'
 );
 assert.sameValue(Atomics.wake(i32a, 0), 0, 'Atomics.wake(i32a, 0) returns 0');
-
-

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-and.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-and.js
@@ -9,7 +9,9 @@ includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
-const TIMEOUT = 200;
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.small;
+
 const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
@@ -17,23 +19,30 @@ const i32a = new Int32Array(
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
+
     const before = $262.agent.monotonicNow();
     const unpark = Atomics.wait(i32a, 0, 0, ${TIMEOUT});
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(duration);
     $262.agent.report(unpark);
     $262.agent.leaving();
   });
 `);
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i32a, RUNNING, 1);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 Atomics.and(i32a, 0, 1);
 
 const lapse = $262.agent.getReport();
 assert(
   lapse >= TIMEOUT,
-  'The result of `(lapse >= TIMEOUT)` is true (The result of `(lapse >= TIMEOUT)` is true)'
+  'The result of `(lapse >= TIMEOUT)` is true'
 );
 assert.sameValue(
   $262.agent.getReport(),
@@ -41,5 +50,3 @@ assert.sameValue(
   '$262.agent.getReport() returns "timed-out"'
 );
 assert.sameValue(Atomics.wake(i32a, 0), 0, 'Atomics.wake(i32a, 0) returns 0');
-
-

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-compareExchange.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-compareExchange.js
@@ -9,7 +9,9 @@ includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
-const TIMEOUT = 200;
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.small;
+
 const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
@@ -17,23 +19,30 @@ const i32a = new Int32Array(
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
+
     const before = $262.agent.monotonicNow();
     const unpark = Atomics.wait(i32a, 0, 0, ${TIMEOUT});
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(duration);
     $262.agent.report(unpark);
     $262.agent.leaving();
   });
 `);
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i32a, RUNNING, 1);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 Atomics.compareExchange(i32a, 0, 0, 1);
 
 const lapse = $262.agent.getReport();
 assert(
   lapse >= TIMEOUT,
-  'The result of `(lapse >= TIMEOUT)` is true (The result of `(lapse >= TIMEOUT)` is true)'
+  'The result of `(lapse >= TIMEOUT)` is true'
 );
 assert.sameValue(
   $262.agent.getReport(),

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-exchange.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-exchange.js
@@ -9,7 +9,9 @@ includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
-const TIMEOUT = 200;
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.small;
+
 const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
@@ -17,23 +19,30 @@ const i32a = new Int32Array(
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
+
     const before = $262.agent.monotonicNow();
     const unpark = Atomics.wait(i32a, 0, 0, ${TIMEOUT});
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(duration);
     $262.agent.report(unpark);
     $262.agent.leaving();
   });
 `);
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i32a, RUNNING, 1);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 Atomics.exchange(i32a, 0, 1);
 
 const lapse = $262.agent.getReport();
 assert(
   lapse >= TIMEOUT,
-  'The result of `(lapse >= TIMEOUT)` is true (The result of `(lapse >= TIMEOUT)` is true)'
+  'The result of `(lapse >= TIMEOUT)` is true'
 );
 assert.sameValue(
   $262.agent.getReport(),
@@ -41,4 +50,3 @@ assert.sameValue(
   '$262.agent.getReport() returns "timed-out"'
 );
 assert.sameValue(Atomics.wake(i32a, 0), 0, 'Atomics.wake(i32a, 0) returns 0');
-

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-or.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-or.js
@@ -9,7 +9,9 @@ includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
-const TIMEOUT = 200;
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.small;
+
 const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
@@ -17,23 +19,30 @@ const i32a = new Int32Array(
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
+
     const before = $262.agent.monotonicNow();
     const unpark = Atomics.wait(i32a, 0, 0, ${TIMEOUT});
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(duration);
     $262.agent.report(unpark);
     $262.agent.leaving();
   });
 `);
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i32a, RUNNING, 1);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 Atomics.or(i32a, 0, 1);
 
 const lapse = $262.agent.getReport();
 assert(
   lapse >= TIMEOUT,
-  'The result of `(lapse >= TIMEOUT)` is true (The result of `(lapse >= TIMEOUT)` is true)'
+  'The result of `(lapse >= TIMEOUT)` is true'
 );
 assert.sameValue(
   $262.agent.getReport(),
@@ -41,5 +50,3 @@ assert.sameValue(
   '$262.agent.getReport() returns "timed-out"'
 );
 assert.sameValue(Atomics.wake(i32a, 0), 0, 'Atomics.wake(i32a, 0) returns 0');
-
-

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-sub.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-sub.js
@@ -9,7 +9,9 @@ includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
-const TIMEOUT = 200;
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.small;
+
 const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
@@ -17,23 +19,30 @@ const i32a = new Int32Array(
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
+
     const before = $262.agent.monotonicNow();
     const unpark = Atomics.wait(i32a, 0, 0, ${TIMEOUT});
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(duration);
     $262.agent.report(unpark);
     $262.agent.leaving();
   });
 `);
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i32a, RUNNING, 1);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 Atomics.sub(i32a, 0, 1);
 
 const lapse = $262.agent.getReport();
 assert(
   lapse >= TIMEOUT,
-  'The result of `(lapse >= TIMEOUT)` is true (The result of `(lapse >= TIMEOUT)` is true)'
+  'The result of `(lapse >= TIMEOUT)` is true'
 );
 assert.sameValue(
   $262.agent.getReport(),

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-xor.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-xor.js
@@ -9,7 +9,9 @@ includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
-const TIMEOUT = 200;
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.small;
+
 const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
@@ -17,23 +19,30 @@ const i32a = new Int32Array(
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
+
     const before = $262.agent.monotonicNow();
     const unpark = Atomics.wait(i32a, 0, 0, ${TIMEOUT});
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(duration);
     $262.agent.report(unpark);
     $262.agent.leaving();
   });
 `);
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(10);
+$262.agent.waitUntil(i32a, RUNNING, 1);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 Atomics.xor(i32a, 0, 1);
 
 const lapse = $262.agent.getReport();
 assert(
   lapse >= TIMEOUT,
-  'The result of `(lapse >= TIMEOUT)` is true (The result of `(lapse >= TIMEOUT)` is true)'
+  'The result of `(lapse >= TIMEOUT)` is true'
 );
 assert.sameValue(
   $262.agent.getReport(),
@@ -41,6 +50,3 @@ assert.sameValue(
   '$262.agent.getReport() returns "timed-out"'
 );
 assert.sameValue(Atomics.wake(i32a, 0), 0, 'Atomics.wake(i32a, 0) returns 0');
-
-
-

--- a/test/built-ins/Atomics/wait/null-for-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/null-for-timeout-agent.js
@@ -16,6 +16,8 @@ includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
+const RUNNING = 1;
+
 $262.agent.start(`
   const valueOf = {
     valueOf: function() {
@@ -31,11 +33,18 @@ $262.agent.start(`
 
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
+
     const before = $262.agent.monotonicNow();
-    $262.agent.report(Atomics.wait(i32a, 0, 0, null));
-    $262.agent.report(Atomics.wait(i32a, 0, 0, valueOf));
-    $262.agent.report(Atomics.wait(i32a, 0, 0, toPrimitive));
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const status1 = Atomics.wait(i32a, 0, 0, null);
+    const status2 = Atomics.wait(i32a, 0, 0, valueOf);
+    const status3 = Atomics.wait(i32a, 0, 0, toPrimitive);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(status1);
+    $262.agent.report(status2);
+    $262.agent.report(status3);
+    $262.agent.report(duration);
     $262.agent.leaving();
   });
 `);
@@ -45,7 +54,10 @@ const i32a = new Int32Array(
 );
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(150);
+$262.agent.waitUntil(i32a, RUNNING, 1);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 assert.sameValue(
   $262.agent.getReport(),
@@ -65,9 +77,8 @@ assert.sameValue(
 
 const lapse = $262.agent.getReport();
 
-assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (The result of `(lapse >= 0)` is true (timeout should be a min of 0ms))');
+assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (timeout should be a min of 0ms)');
 
-assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $262.agent.MAX_TIME_EPSILON))');
+assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $262.agent.MAX_TIME_EPSILON)');
 
 assert.sameValue(Atomics.wake(i32a, 0), 0, 'Atomics.wake(i32a, 0) returns 0');
-

--- a/test/built-ins/Atomics/wait/null-for-timeout.js
+++ b/test/built-ins/Atomics/wait/null-for-timeout.js
@@ -13,7 +13,7 @@ info: |
     Null -> Return +0.
 
 features: [Atomics, SharedArrayBuffer, Symbol, Symbol.toPrimitive, TypedArray]
-flags: [CanBlockIsFalse]
+flags: [CanBlockIsTrue]
 ---*/
 
 const i32a = new Int32Array(
@@ -47,4 +47,3 @@ assert.sameValue(
   "timed-out",
   'Atomics.wait(i32a, 0, 0, toPrimitive) returns "timed-out"'
 );
-

--- a/test/built-ins/Atomics/wait/object-for-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/object-for-timeout-agent.js
@@ -15,6 +15,9 @@ info: |
 includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
+
+const RUNNING = 1;
+
 $262.agent.start(`
   const valueOf = {
     valueOf: function() {
@@ -36,11 +39,18 @@ $262.agent.start(`
 
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
+
     const before = $262.agent.monotonicNow();
-    $262.agent.report(Atomics.wait(i32a, 0, 0, valueOf));
-    $262.agent.report(Atomics.wait(i32a, 0, 0, toString));
-    $262.agent.report(Atomics.wait(i32a, 0, 0, toPrimitive));
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const status1 = Atomics.wait(i32a, 0, 0, valueOf);
+    const status2 = Atomics.wait(i32a, 0, 0, toString);
+    const status3 = Atomics.wait(i32a, 0, 0, toPrimitive);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(status1);
+    $262.agent.report(status2);
+    $262.agent.report(status3);
+    $262.agent.report(duration);
     $262.agent.leaving();
   });
 `);
@@ -50,7 +60,10 @@ const i32a = new Int32Array(
 );
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(150);
+$262.agent.waitUntil(i32a, RUNNING, 1);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 assert.sameValue(
   $262.agent.getReport(),
@@ -70,9 +83,8 @@ assert.sameValue(
 
 const lapse = $262.agent.getReport();
 
-assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (The result of `(lapse >= 0)` is true (timeout should be a min of 0ms))');
+assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (timeout should be a min of 0ms)');
 
-assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $$262.agent.MAX_TIME_EPSILON))');
+assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $$262.agent.MAX_TIME_EPSILON)');
 
 assert.sameValue(Atomics.wake(i32a, 0), 0, 'Atomics.wake(i32a, 0) returns 0');
-

--- a/test/built-ins/Atomics/wait/object-for-timeout.js
+++ b/test/built-ins/Atomics/wait/object-for-timeout.js
@@ -17,7 +17,7 @@ info: |
 
 includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, Symbol, Symbol.toPrimitive, TypedArray]
-flags: [CanBlockIsFalse]
+flags: [CanBlockIsTrue]
 ---*/
 
 const i32a = new Int32Array(

--- a/test/built-ins/Atomics/wait/symbol-for-timeout-throws-agent.js
+++ b/test/built-ins/Atomics/wait/symbol-for-timeout-throws-agent.js
@@ -15,21 +15,33 @@ info: |
 includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, Symbol, Symbol.toPrimitive, TypedArray]
 ---*/
+
+const RUNNING = 1;
+
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
+
+    let status1 = "";
+    let status2 = "";
+
     const start = $262.agent.monotonicNow();
     try {
       Atomics.wait(i32a, 0, 0, Symbol("1"));
     } catch (error) {
-      $262.agent.report('Symbol("1")');
+      status1 = 'Symbol("1")';
     }
     try {
       Atomics.wait(i32a, 0, 0, Symbol("2"));
     } catch (error) {
-      $262.agent.report('Symbol("2")');
+      status2 = 'Symbol("2")';
     }
-    $262.agent.report($262.agent.monotonicNow() - start);
+    const duration = $262.agent.monotonicNow() - start;
+
+    $262.agent.report(status1);
+    $262.agent.report(status2);
+    $262.agent.report(duration);
     $262.agent.leaving();
   });
 `);
@@ -39,7 +51,10 @@ const i32a = new Int32Array(
 );
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(150);
+$262.agent.waitUntil(i32a, RUNNING, 1);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 assert.sameValue(
   $262.agent.getReport(),
@@ -54,7 +69,7 @@ assert.sameValue(
 
 const lapse = $262.agent.getReport();
 
-assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (The result of `(lapse >= 0)` is true (timeout should be a min of 0ms))');
-assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $$262.agent.MAX_TIME_EPSILON))');
+assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (timeout should be a min of 0ms)');
+assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $$262.agent.MAX_TIME_EPSILON)');
 
 assert.sameValue(Atomics.wake(i32a, 0), 0, 'Atomics.wake(i32a, 0) returns 0');

--- a/test/built-ins/Atomics/wait/symbol-for-value-throws-agent.js
+++ b/test/built-ins/Atomics/wait/symbol-for-value-throws-agent.js
@@ -20,6 +20,8 @@ includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, Symbol, Symbol.toPrimitive, TypedArray]
 ---*/
 
+const RUNNING = 1;
+
 $262.agent.start(`
   const poisonedValueOf = {
     valueOf: function() {
@@ -35,18 +37,27 @@ $262.agent.start(`
 
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
+
+    let status1 = "";
+    let status2 = "";
+
     const before = $262.agent.monotonicNow();
     try {
       Atomics.wait(i32a, 0, Symbol("1"), poisonedValueOf);
     } catch (error) {
-      $262.agent.report('Symbol("1")');
+      status1 = 'Symbol("1")';
     }
     try {
       Atomics.wait(i32a, 0, Symbol("2"), poisonedToPrimitive);
     } catch (error) {
-      $262.agent.report('Symbol("2")');
+      status2 = 'Symbol("2")';
     }
-    $262.agent.report($262.agent.monotonicNow() - before);
+    const duration = $262.agent.monotonicNow() - before;
+
+    $262.agent.report(status1);
+    $262.agent.report(status2);
+    $262.agent.report(duration);
     $262.agent.leaving();
   });
 `);
@@ -56,7 +67,10 @@ const i32a = new Int32Array(
 );
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(150);
+$262.agent.waitUntil(i32a, RUNNING, 1);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 assert.sameValue(
   $262.agent.getReport(),
@@ -71,7 +85,7 @@ assert.sameValue(
 
 const lapse = $262.agent.getReport();
 
-assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (The result of `(lapse >= 0)` is true (timeout should be a min of 0ms))');
-assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $$262.agent.MAX_TIME_EPSILON))');
+assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (timeout should be a min of 0ms)');
+assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $$262.agent.MAX_TIME_EPSILON)');
 
 assert.sameValue(Atomics.wake(i32a, 0), 0, 'Atomics.wake(i32a, 0) returns 0');

--- a/test/built-ins/Atomics/wait/symbol-for-value-throws.js
+++ b/test/built-ins/Atomics/wait/symbol-for-value-throws.js
@@ -50,4 +50,3 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   Atomics.wait(i32a, 0, Symbol("foo"), poisonedToPrimitive);
 }, '`Atomics.wait(i32a, 0, Symbol("foo"), poisonedToPrimitive)` throws TypeError');
-

--- a/test/built-ins/Atomics/wait/true-for-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/true-for-timeout-agent.js
@@ -16,6 +16,8 @@ includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
+const RUNNING = 1;
+
 $262.agent.start(`
   const valueOf = {
     valueOf: function() {
@@ -31,11 +33,18 @@ $262.agent.start(`
 
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
+
     const start = $262.agent.monotonicNow();
-    $262.agent.report(Atomics.wait(i32a, 0, 0, true));
-    $262.agent.report(Atomics.wait(i32a, 0, 0, valueOf));
-    $262.agent.report(Atomics.wait(i32a, 0, 0, toPrimitive));
-    $262.agent.report($262.agent.monotonicNow() - start);
+    const status1 = Atomics.wait(i32a, 0, 0, true);
+    const status2 = Atomics.wait(i32a, 0, 0, valueOf);
+    const status3 = Atomics.wait(i32a, 0, 0, toPrimitive);
+    const duration = $262.agent.monotonicNow() - start;
+
+    $262.agent.report(status1);
+    $262.agent.report(status2);
+    $262.agent.report(status3);
+    $262.agent.report(duration);
     $262.agent.leaving();
   });
 `);
@@ -45,7 +54,10 @@ const i32a = new Int32Array(
 );
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(150);
+$262.agent.waitUntil(i32a, RUNNING, 1);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 assert.sameValue(
   $262.agent.getReport(),
@@ -65,9 +77,8 @@ assert.sameValue(
 
 const lapse = $262.agent.getReport();
 
-assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (The result of `(lapse >= 0)` is true (timeout should be a min of 0ms))');
+assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (timeout should be a min of 0ms)');
 
-assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $$262.agent.MAX_TIME_EPSILON))');
+assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $$262.agent.MAX_TIME_EPSILON)');
 
 assert.sameValue(Atomics.wake(i32a, 0), 0, 'Atomics.wake(i32a, 0) returns 0');
-

--- a/test/built-ins/Atomics/wait/true-for-timeout.js
+++ b/test/built-ins/Atomics/wait/true-for-timeout.js
@@ -13,7 +13,7 @@ info: |
     Boolean -> If argument is true, return 1. If argument is false, return +0.
 
 features: [Atomics, SharedArrayBuffer, Symbol, Symbol.toPrimitive, TypedArray]
-flags: [CanBlockIsFalse]
+flags: [CanBlockIsTrue]
 ---*/
 
 const i32a = new Int32Array(
@@ -47,4 +47,3 @@ assert.sameValue(
   'timed-out',
   'Atomics.wait(i32a, 0, 0, toPrimitive) returns "timed-out"'
 );
-

--- a/test/built-ins/Atomics/wait/undefined-for-timeout.js
+++ b/test/built-ins/Atomics/wait/undefined-for-timeout.js
@@ -25,8 +25,9 @@ const WAKECOUNT = 2;  // Total number of agents to wake up
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     var i32a = new Int32Array(sab);
-    // undefined => NaN => +Infinity
     Atomics.add(i32a, ${RUNNING}, 1);
+
+    // undefined => NaN => +Infinity
     $262.agent.report("A " + Atomics.wait(i32a, 0, 0, undefined));
     $262.agent.leaving();
   });
@@ -35,8 +36,9 @@ $262.agent.start(`
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     var i32a = new Int32Array(sab);
-    // undefined timeout arg => NaN => +Infinity
     Atomics.add(i32a, ${RUNNING}, 1);
+
+    // undefined timeout arg => NaN => +Infinity
     $262.agent.report("B " + Atomics.wait(i32a, 0, 0));
     $262.agent.leaving();
   });
@@ -48,6 +50,9 @@ const i32a = new Int32Array(
 
 $262.agent.broadcast(i32a.buffer);
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
 
 assert.sameValue(
   Atomics.wake(i32a, WAIT_INDEX, WAKECOUNT),

--- a/test/built-ins/Atomics/wait/waiterlist-block-indexedposition-wake.js
+++ b/test/built-ins/Atomics/wait/waiterlist-block-indexedposition-wake.js
@@ -22,9 +22,13 @@ includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
+var NUMAGENT = 2;
+var RUNNING = 4;
+
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
 
     // Wait on index 0
     $262.agent.report(Atomics.wait(i32a, 0, 0, Infinity));
@@ -35,6 +39,7 @@ $262.agent.start(`
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
+    Atomics.add(i32a, ${RUNNING}, 1);
 
     // Wait on index 2
     $262.agent.report(Atomics.wait(i32a, 2, 0, Infinity));
@@ -43,21 +48,28 @@ $262.agent.start(`
 `);
 
 const i32a = new Int32Array(
-  new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
+  new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 5)
 );
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(10);
+
+// Wait until all agents started.
+$262.agent.waitUntil(i32a, RUNNING, NUMAGENT);
 
 // Wake index 1, wakes nothing
 assert.sameValue(Atomics.wake(i32a, 1), 0, 'Atomics.wake(i32a, 1) returns 0');
+
 // Wake index 3, wakes nothing
 assert.sameValue(Atomics.wake(i32a, 3), 0, 'Atomics.wake(i32a, 3) returns 0');
 
 // Wake index 2, wakes 1
-assert.sameValue(Atomics.wake(i32a, 2), 1, 'Atomics.wake(i32a, 2) returns 1');
+var woken = 0;
+while ((woken = Atomics.wake(i32a, 2)) === 0) ;
+assert.sameValue(woken, 1, 'Atomics.wake(i32a, 2) returns 1');
 assert.sameValue($262.agent.getReport(), 'ok', '$262.agent.getReport() returns "ok"');
 
 // Wake index 0, wakes 1
-assert.sameValue(Atomics.wake(i32a, 0), 1, 'Atomics.wake(i32a, 0) returns 1');
+var woken = 0;
+while ((woken = Atomics.wake(i32a, 0)) === 0) ;
+assert.sameValue(woken, 1, 'Atomics.wake(i32a, 0) returns 1');
 assert.sameValue($262.agent.getReport(), 'ok', '$262.agent.getReport() returns "ok"');

--- a/test/built-ins/Atomics/wake/bad-range.js
+++ b/test/built-ins/Atomics/wake/bad-range.js
@@ -11,8 +11,8 @@ info: |
   1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray, true).
   ..
 
-includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+includes: [testAtomics.js]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const i32a = new Int32Array(

--- a/test/built-ins/Atomics/wake/bigint/bad-range.js
+++ b/test/built-ins/Atomics/wake/bigint/bad-range.js
@@ -12,7 +12,7 @@ info: |
   ..
 
 includes: [testAtomics.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 const i64a = new BigInt64Array(

--- a/test/built-ins/Atomics/wake/bigint/wake-all-on-loc.js
+++ b/test/built-ins/Atomics/wake/bigint/wake-all-on-loc.js
@@ -13,14 +13,21 @@ features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 const WAIT_INDEX = 0;             // Waiters on this will be woken
 const WAIT_FAKE = 1;              // Waiters on this will not be woken
 const RUNNING = 2;                // Accounting of live agents
+const WAKE_INDEX = 3;             // Accounting for too early timeouts
 const NUMAGENT = 3;
+const TIMEOUT_AGENT_MESSAGES = 2; // Number of messages for the timeout agent
 const BUFFER_SIZE = 4;
+
+// Long timeout to ensure the agent doesn't timeout before the main agent calls
+// `Atomics.wake`.
+const TIMEOUT = $262.agent.timeouts.long;
 
 for (var i = 0; i < NUMAGENT; i++) {
   $262.agent.start(`
     $262.agent.receiveBroadcast(function(sab) {
       const i64a = new BigInt64Array(sab);
       Atomics.add(i64a, ${RUNNING}, 1n);
+
       $262.agent.report("A " + Atomics.wait(i64a, ${WAIT_INDEX}, 0n));
       $262.agent.leaving();
     });
@@ -31,8 +38,17 @@ $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i64a = new BigInt64Array(sab);
     Atomics.add(i64a, ${RUNNING}, 1n);
+
     // This will always time out.
-    $262.agent.report("B " + Atomics.wait(i64a, ${WAIT_FAKE}, 0n, 10));
+    $262.agent.report("B " + Atomics.wait(i64a, ${WAIT_FAKE}, 0n, ${TIMEOUT}));
+
+    // If this value is not 1n, then the agent timeout before the main agent
+    // called Atomics.wake.
+    const result = Atomics.load(i64a, ${WAKE_INDEX}) === 1n
+                   ? "timeout after Atomics.wake"
+                   : "timeout before Atomics.wake";
+    $262.agent.report("W " + result);
+
     $262.agent.leaving();
   });
 `);
@@ -40,24 +56,27 @@ $262.agent.start(`
 const i64a = new BigInt64Array(
   new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
 );
+
 $262.agent.broadcast(i64a.buffer);
 
 // Wait for agents to be running.
-$262.agent.waitUntil(i64a, RUNNING, BigInt(BUFFER_SIZE));
+$262.agent.waitUntil(i64a, RUNNING, BigInt(NUMAGENT + 1));
 
-// Then wait some more to give the agents a fair chance to wait.  If we don't,
-// we risk sending the wakeup before agents are sleeping, and we hang.
-$262.agent.sleep(50);
+// Try to yield control to ensure the agent actually started to wait. If we
+// don't, we risk sending the wakeup before agents are sleeping, and we hang.
+$262.agent.tryYield();
 
 // Wake all waiting on WAIT_INDEX, should be 3 always, they won't time out.
 assert.sameValue(
   Atomics.wake(i64a, WAIT_INDEX),
   NUMAGENT,
-  'Atomics.wake(i64a, WAIT_INDEX) returns the value of `NUMAGENT` (3)'
+  'Atomics.wake(i64a, WAIT_INDEX) returns the value of `NUMAGENT`'
 );
 
-var reports = [];
-for (var i = 0; i < NUMAGENT + 1; i++) {
+Atomics.store(i64a, WAKE_INDEX, 1n);
+
+const reports = [];
+for (var i = 0; i < NUMAGENT  + TIMEOUT_AGENT_MESSAGES; i++) {
   reports.push($262.agent.getReport());
 }
 reports.sort();
@@ -66,4 +85,5 @@ for (var i = 0; i < NUMAGENT; i++) {
   assert.sameValue(reports[i], 'A ok', 'The value of reports[i] is "A ok"');
 }
 assert.sameValue(reports[NUMAGENT], 'B timed-out', 'The value of reports[NUMAGENT] is "B timed-out"');
-
+assert.sameValue(reports[NUMAGENT + 1], "W timeout after Atomics.wake",
+                 'The value of reports[NUMAGENT + 1] is "W timeout after Atomics.wake"');

--- a/test/built-ins/Atomics/wake/count-defaults-to-infinity-missing.js
+++ b/test/built-ins/Atomics/wake/count-defaults-to-infinity-missing.js
@@ -16,61 +16,43 @@ includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
-const RUNNING = 0
-const WAIT_INDEX = 1; // Index all agents are waiting on
+const RUNNING = 0; // Index to notify agent has started.
+const WAIT_INDEX = 1; // Index all agents are waiting on.
+const BUFFER_SIZE = 2;
+
 const NUMAGENT = 4; // Total number of agents started
-const BUFFER_SIZE = 5; // Index all agents are waiting on
 
-$262.agent.start(`
-  $262.agent.receiveBroadcast(function(sab) {
-    const i32a = new Int32Array(sab);
-    Atomics.add(i32a, ${RUNNING}, 1);
-    $262.agent.report("A " + Atomics.wait(i32a, ${WAIT_INDEX}, 0, 50));
-    $262.agent.leaving();
-  });
-`);
+for (var i = 0; i < NUMAGENT; i++) {
+  $262.agent.start(`
+    $262.agent.receiveBroadcast(function(sab) {
+      const i32a = new Int32Array(sab);
+      Atomics.add(i32a, ${RUNNING}, 1);
 
-$262.agent.start(`
-  $262.agent.receiveBroadcast(function(sab) {
-    const i32a = new Int32Array(sab);
-    Atomics.add(i32a, ${RUNNING}, 1);
-    $262.agent.report("B " + Atomics.wait(i32a, ${WAIT_INDEX}, 0, 50));
-    $262.agent.leaving();
-  });
-`);
+      // Wait until restarted by main thread.
+      var status = Atomics.wait(i32a, ${WAIT_INDEX}, 0);
 
-$262.agent.start(`
-  $262.agent.receiveBroadcast(function(sab) {
-    const i32a = new Int32Array(sab);
-    Atomics.add(i32a, ${RUNNING}, 1);
-    $262.agent.report("C " + Atomics.wait(i32a, ${WAIT_INDEX}, 0, 50));
-    $262.agent.leaving();
-  });
-`);
-
-$262.agent.start(`
-  $262.agent.receiveBroadcast(function(sab) {
-    const i32a = new Int32Array(sab);
-    Atomics.add(i32a, ${RUNNING}, 1);
-    $262.agent.report("D " + Atomics.wait(i32a, ${WAIT_INDEX}, 0, 50));
-    $262.agent.leaving();
-  });
-`);
+      // Report wait status and then exit the agent.
+      var name = String.fromCharCode(0x41 + ${i}); // "A", "B", "C", or "D"
+      $262.agent.report(name + " " + status);
+      $262.agent.leaving();
+    });
+  `);
+}
 
 const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
 );
 
 $262.agent.broadcast(i32a.buffer);
-
-// Wait for agents to be running.
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);
 
-assert.sameValue(
-  Atomics.wake(i32a, WAIT_INDEX /*, count missing */),
-  NUMAGENT,
-  'Atomics.wake(i32a, WAIT_INDEX /*, count missing */) returns the value of `NUMAGENT` (4)'
-);
+// An agent may have been interrupted between reporting its initial report
+// and the `Atomics.wait` call. Try to yield control to ensure the agent
+// actually started to wait.
+$262.agent.tryYield();
+
+assert.sameValue(Atomics.wake(i32a, WAIT_INDEX /*, count missing */), NUMAGENT,
+                 'Atomics.wake(i32a, WAIT_INDEX /*, count missing */) returns the value of `NUMAGENT`');
 
 const reports = [];
 for (var i = 0; i < NUMAGENT; i++) {

--- a/test/built-ins/Atomics/wake/non-views.js
+++ b/test/built-ins/Atomics/wake/non-views.js
@@ -6,7 +6,7 @@ esid: sec-atomics.wake
 description: >
   Test Atomics.wake on view values other than TypedArrays
 includes: [testAtomics.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 testWithAtomicsNonViewValues(function(nonView) {

--- a/test/built-ins/Atomics/wake/undefined-index-defaults-to-zero.js
+++ b/test/built-ins/Atomics/wake/undefined-index-defaults-to-zero.js
@@ -22,42 +22,52 @@ includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
-$262.agent.start(`
-  $262.agent.receiveBroadcast(function(sab) {
-    const i32a = new Int32Array(sab);
-    $262.agent.report(Atomics.wait(i32a, 0, 0, 200));
-    $262.agent.leaving();
-  });
-`);
+var WAIT_INDEX = 0;
+var RUNNING = 1;
 
-$262.agent.start(`
-  $262.agent.receiveBroadcast(function(sab) {
-    const i32a = new Int32Array(sab);
-    $262.agent.report(Atomics.wait(i32a, 0, 0, 200));
-    $262.agent.leaving();
-  });
-`);
+var NUMAGENT = 2;
+
+for (var i = 0; i < NUMAGENT; i++) {
+  $262.agent.start(`
+    $262.agent.receiveBroadcast(function(sab) {
+      const i32a = new Int32Array(sab);
+
+      // Notify main thread that the agent was started.
+      Atomics.add(i32a, ${RUNNING}, 1);
+
+      // Wait until restarted by main thread.
+      var status = Atomics.wait(i32a, ${WAIT_INDEX}, 0);
+
+      // Report wait status.
+      $262.agent.report(status);
+
+      $262.agent.leaving();
+    });
+  `);
+}
 
 const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(100); // halfway through timeout
 
-// wake at index 0, undefined => 0
-assert.sameValue(
-  Atomics.wake(i32a, undefined, 1),
-  1,
-  'Atomics.wake(i32a, undefined, 1) returns 1'
-);
+// Wait until both agents started.
+$262.agent.waitUntil(i32a, RUNNING, NUMAGENT);
+
+// Try to yield control to ensure the agents actually started to wait.
+$262.agent.tryYield();
+
+// Wake at index 0, undefined => 0.
+var woken = 0;
+while ((woken = Atomics.wake(i32a, undefined, 1)) === 0) ;
+assert.sameValue(woken, 1, 'Atomics.wake(i32a, undefined, 1) returns 1');
+
 assert.sameValue($262.agent.getReport(), 'ok', '$262.agent.getReport() returns "ok"');
 
+// Wake again at index 0, default => 0.
+var woken = 0;
+while ((woken = Atomics.wake(i32a, /*, default values used */)) === 0) ;
+assert.sameValue(woken, 1, 'Atomics.wake(i32a /*, default values used */) returns 1');
 
-// wake again at index 0, default => 0
-assert.sameValue(
-  Atomics.wake(i32a /*, default values used */),
-  1,
-  'Atomics.wake(i32a /*, default values used */) returns 1'
-);
 assert.sameValue($262.agent.getReport(), 'ok', '$262.agent.getReport() returns "ok"');

--- a/test/built-ins/Atomics/wake/wake-all-on-loc.js
+++ b/test/built-ins/Atomics/wake/wake-all-on-loc.js
@@ -13,14 +13,21 @@ features: [Atomics, SharedArrayBuffer, TypedArray]
 const WAIT_INDEX = 0;             // Waiters on this will be woken
 const WAIT_FAKE = 1;              // Waiters on this will not be woken
 const RUNNING = 2;                // Accounting of live agents
+const WAKE_INDEX = 3;             // Accounting for too early timeouts
 const NUMAGENT = 3;
+const TIMEOUT_AGENT_MESSAGES = 2; // Number of messages for the timeout agent
 const BUFFER_SIZE = 4;
+
+// Long timeout to ensure the agent doesn't timeout before the main agent calls
+// `Atomics.wake`.
+const TIMEOUT = $262.agent.timeouts.long;
 
 for (var i = 0; i < NUMAGENT; i++) {
   $262.agent.start(`
     $262.agent.receiveBroadcast(function(sab) {
       const i32a = new Int32Array(sab);
       Atomics.add(i32a, ${RUNNING}, 1);
+
       $262.agent.report("A " + Atomics.wait(i32a, ${WAIT_INDEX}, 0));
       $262.agent.leaving();
     });
@@ -31,8 +38,17 @@ $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
     Atomics.add(i32a, ${RUNNING}, 1);
+
     // This will always time out.
-    $262.agent.report("B " + Atomics.wait(i32a, ${WAIT_FAKE}, 0, 10));
+    $262.agent.report("B " + Atomics.wait(i32a, ${WAIT_FAKE}, 0, ${TIMEOUT}));
+
+    // If this value is not 1, then the agent timeout before the main agent
+    // called Atomics.wake.
+    const result = Atomics.load(i32a, ${WAKE_INDEX}) === 1
+                   ? "timeout after Atomics.wake"
+                   : "timeout before Atomics.wake";
+    $262.agent.report("W " + result);
+
     $262.agent.leaving();
   });
 `);
@@ -44,21 +60,23 @@ const i32a = new Int32Array(
 $262.agent.broadcast(i32a.buffer);
 
 // Wait for agents to be running.
-$262.agent.waitUntil(i32a, RUNNING, BUFFER_SIZE);
+$262.agent.waitUntil(i32a, RUNNING, NUMAGENT + 1);
 
-// Then wait some more to give the agents a fair chance to wait.  If we don't,
-// we risk sending the wakeup before agents are sleeping, and we hang.
-$262.agent.sleep(50);
+// Try to yield control to ensure the agent actually started to wait. If we
+// don't, we risk sending the wakeup before agents are sleeping, and we hang.
+$262.agent.tryYield();
 
 // Wake all waiting on WAIT_INDEX, should be 3 always, they won't time out.
 assert.sameValue(
   Atomics.wake(i32a, WAIT_INDEX),
   NUMAGENT,
-  'Atomics.wake(i32a, WAIT_INDEX) returns the value of `NUMAGENT` (3)'
+  'Atomics.wake(i32a, WAIT_INDEX) returns the value of `NUMAGENT`'
 );
 
+Atomics.store(i32a, WAKE_INDEX, 1);
+
 const reports = [];
-for (var i = 0; i < NUMAGENT + 1; i++) {
+for (var i = 0; i < NUMAGENT + TIMEOUT_AGENT_MESSAGES; i++) {
   reports.push($262.agent.getReport());
 }
 reports.sort();
@@ -67,3 +85,5 @@ for (var i = 0; i < NUMAGENT; i++) {
   assert.sameValue(reports[i], "A ok", 'The value of reports[i] is "A ok"');
 }
 assert.sameValue(reports[NUMAGENT], "B timed-out", 'The value of reports[NUMAGENT] is "B timed-out"');
+assert.sameValue(reports[NUMAGENT + 1], "W timeout after Atomics.wake",
+                 'The value of reports[NUMAGENT + 1] is "W timeout after Atomics.wake"');

--- a/test/built-ins/Atomics/wake/wake-all.js
+++ b/test/built-ins/Atomics/wake/wake-all.js
@@ -10,8 +10,7 @@ features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
 const WAIT_INDEX = 0;             // Waiters on this will be woken
-const WAIT_FAKE = 1;              // Waiters on this will not be woken
-const RUNNING = 2;                // Accounting of live agents
+const RUNNING = 1;                // Accounting of live agents
 const NUMAGENT = 3;
 const BUFFER_SIZE = 4;
 
@@ -20,21 +19,12 @@ for (var i = 0; i < NUMAGENT; i++) {
     $262.agent.receiveBroadcast(function(sab) {
       const i32a = new Int32Array(sab);
       Atomics.add(i32a, ${RUNNING}, 1);
+
       $262.agent.report("A " + Atomics.wait(i32a, ${WAIT_INDEX}, 0));
       $262.agent.leaving();
     });
   `);
 }
-
-$262.agent.start(`
-  $262.agent.receiveBroadcast(function(sab) {
-    const i32a = new Int32Array(sab);
-    Atomics.add(i32a, ${RUNNING}, 1);
-    // This will always time out.
-    $262.agent.report("B " + Atomics.wait(i32a, ${WAIT_FAKE}, 0, 10));
-    $262.agent.leaving();
-  });
-`);
 
 const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
@@ -43,26 +33,19 @@ const i32a = new Int32Array(
 $262.agent.broadcast(i32a.buffer);
 
 // Wait for agents to be running.
-$262.agent.waitUntil(i32a, RUNNING, NUMAGENT + 1);
+$262.agent.waitUntil(i32a, RUNNING, NUMAGENT);
 
-// Then wait some more to give the agents a fair chance to wait.  If we don't,
-// we risk sending the wakeup before agents are sleeping, and we hang.
-$262.agent.sleep(50);
+// Try to yield control to ensure the agent actually started to wait. If we
+// don't, we risk sending the wakeup before agents are sleeping, and we hang.
+$262.agent.tryYield();
 
 // Wake all waiting on WAIT_INDEX, should be 3 always, they won't time out.
 assert.sameValue(
   Atomics.wake(i32a, WAIT_INDEX),
   NUMAGENT,
-  'Atomics.wake(i32a, WAIT_INDEX) returns the value of `NUMAGENT` (3)'
+  'Atomics.wake(i32a, WAIT_INDEX) returns the value of `NUMAGENT`'
 );
 
-const reports = [];
-for (var i = 0; i < NUMAGENT + 1; i++) {
-  reports.push($262.agent.getReport());
-}
-reports.sort();
-
 for (var i = 0; i < NUMAGENT; i++) {
-  assert.sameValue(reports[i], 'A ok', 'The value of reports[i] is "A ok"');
+  assert.sameValue($262.agent.getReport(), 'A ok', 'The value of reports[i] is "A ok"');
 }
-assert.sameValue(reports[NUMAGENT], 'B timed-out', 'The value of reports[NUMAGENT] is "B timed-out"');

--- a/test/built-ins/Atomics/wake/wake-in-order-one-time.js
+++ b/test/built-ins/Atomics/wake/wake-in-order-one-time.js
@@ -24,12 +24,15 @@ for (var i = 0; i < NUMAGENT; i++) {
     $262.agent.receiveBroadcast(function(sab) {
       const i32a = new Int32Array(sab);
       Atomics.add(i32a, ${RUNNING}, 1);
+
       while (Atomics.load(i32a, ${SPIN + i}) === 0) {
         /* nothing */
       }
+
       $262.agent.report(${i});
       Atomics.wait(i32a, ${WAIT_INDEX}, 0);
       $262.agent.report(${i});
+
       $262.agent.leaving();
     });
   `);
@@ -44,53 +47,30 @@ $262.agent.broadcast(i32a.buffer);
 // Wait for agents to be running.
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);
 
-// Sleep to allow the agents a fair chance to wait. If we don't,
-// we risk sending the wakeup before agents are sleeping, and we hang.
-$262.agent.sleep(50);
-
 var waiterlist = [];
-assert.sameValue(
-  Atomics.store(i32a, SPIN + 0, 1),
-  1,
-  'Atomics.store(i32a, SPIN + 0, 1) returns 1'
-);
-waiterlist.push($262.agent.getReport());
+for (var i = 0; i < NUMAGENT; i++) {
+  assert.sameValue(
+    Atomics.store(i32a, SPIN + i, 1),
+    1,
+    `Atomics.store(i32a, SPIN + ${i}, 1) returns 1`
+  );
 
-assert.sameValue(
-  Atomics.store(i32a, SPIN + 1, 1),
-  1,
-  'Atomics.store(i32a, SPIN + 1, 1) returns 1'
-);
-waiterlist.push($262.agent.getReport());
+  waiterlist.push($262.agent.getReport());
 
-assert.sameValue(
-  Atomics.store(i32a, SPIN + 2, 1),
-  1,
-  'Atomics.store(i32a, SPIN + 2, 1) returns 1'
-);
-waiterlist.push($262.agent.getReport());
+  // Try to yield control to ensure the agent actually started to wait.
+  $262.agent.tryYield();
+}
 
 var notified = [];
-assert.sameValue(
-  Atomics.wake(i32a, WAIT_INDEX, 1),
-  1,
-  'Atomics.wake(i32a, WAIT_INDEX, 1) returns 1'
-);
-notified.push($262.agent.getReport());
+for (var i = 0; i < NUMAGENT; i++) {
+  assert.sameValue(
+    Atomics.wake(i32a, WAIT_INDEX, 1),
+    1,
+    `Atomics.wake(i32a, WAIT_INDEX, 1) returns 1 (${i})`
+  );
 
-assert.sameValue(
-  Atomics.wake(i32a, WAIT_INDEX, 1),
-  1,
-  'Atomics.wake(i32a, WAIT_INDEX, 1) returns 1'
-);
-notified.push($262.agent.getReport());
-
-assert.sameValue(
-  Atomics.wake(i32a, WAIT_INDEX, 1),
-  1,
-  'Atomics.wake(i32a, WAIT_INDEX, 1) returns 1'
-);
-notified.push($262.agent.getReport());
+  notified.push($262.agent.getReport());
+}
 
 assert.sameValue(
   notified.join(''),

--- a/test/built-ins/Atomics/wake/wake-in-order.js
+++ b/test/built-ins/Atomics/wake/wake-in-order.js
@@ -19,83 +19,61 @@ const BUFFER_SIZE = RUNNING + 1;
 // them go into a wait, thus controlling the waiting order.  Then we wake them
 // one by one and observe the wakeup order.
 
-for (var attempt = 0; attempt < 10; attempt++) {
-  for (var i = 0; i < NUMAGENT; i++) {
-    $262.agent.start(`
-      $262.agent.receiveBroadcast(function(sab) {
-        const i32a = new Int32Array(sab);
-        Atomics.add(i32a, ${RUNNING}, 1);
-        while (Atomics.load(i32a, ${SPIN + i}) === 0) {
-          /* nothing */
-        }
-        $262.agent.report(${i});
-        Atomics.wait(i32a, ${WAIT_INDEX}, 0);
-        $262.agent.report(${i});
-        $262.agent.leaving();
-      });
-    `);
-  }
+for (var i = 0; i < NUMAGENT; i++) {
+  $262.agent.start(`
+    $262.agent.receiveBroadcast(function(sab) {
+      const i32a = new Int32Array(sab);
+      Atomics.add(i32a, ${RUNNING}, 1);
 
-  const i32a = new Int32Array(
-    new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
-  );
+      while (Atomics.load(i32a, ${SPIN + i}) === 0) {
+        /* nothing */
+      }
 
-  $262.agent.broadcast(i32a.buffer);
+      $262.agent.report(${i});
+      Atomics.wait(i32a, ${WAIT_INDEX}, 0);
+      $262.agent.report(${i});
 
-  // Wait for agents to be running.
-  $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);
-
-  // Sleep to allow the agents a fair chance to wait. If we don't,
-  // we risk sending the wakeup before agents are sleeping, and we hang.
-  $262.agent.sleep(50);
-
-  var waiterlist = [];
-  assert.sameValue(
-    Atomics.store(i32a, SPIN + 0, 1),
-    1,
-    'Atomics.store(i32a, SPIN + 0, 1) returns 1'
-  );
-  waiterlist.push($262.agent.getReport());
-
-  assert.sameValue(
-    Atomics.store(i32a, SPIN + 1, 1),
-    1,
-    'Atomics.store(i32a, SPIN + 1, 1) returns 1'
-  );
-  waiterlist.push($262.agent.getReport());
-
-  assert.sameValue(
-    Atomics.store(i32a, SPIN + 2, 1),
-    1,
-    'Atomics.store(i32a, SPIN + 2, 1) returns 1'
-  );
-  waiterlist.push($262.agent.getReport());
-
-  var notified = [];
-  assert.sameValue(
-    Atomics.wake(i32a, WAIT_INDEX, 1),
-    1,
-    'Atomics.wake(i32a, WAIT_INDEX, 1) returns 1'
-  );
-  notified.push($262.agent.getReport());
-
-  assert.sameValue(
-    Atomics.wake(i32a, WAIT_INDEX, 1),
-    1,
-    'Atomics.wake(i32a, WAIT_INDEX, 1) returns 1'
-  );
-  notified.push($262.agent.getReport());
-
-  assert.sameValue(
-    Atomics.wake(i32a, WAIT_INDEX, 1),
-    1,
-    'Atomics.wake(i32a, WAIT_INDEX, 1) returns 1'
-  );
-  notified.push($262.agent.getReport());
-
-  assert.sameValue(
-    notified.join(''),
-    waiterlist.join(''),
-    'notified.join(\'\') returns waiterlist.join(\'\')'
-  );
+      $262.agent.leaving();
+    });
+  `);
 }
+
+const i32a = new Int32Array(
+  new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
+);
+
+$262.agent.broadcast(i32a.buffer);
+
+// Wait for agents to be running.
+$262.agent.waitUntil(i32a, RUNNING, NUMAGENT);
+
+var waiterlist = [];
+for (var i = 0; i < NUMAGENT; i++) {
+  assert.sameValue(
+    Atomics.store(i32a, SPIN + i, 1),
+    1,
+    `Atomics.store(i32a, SPIN + ${i}, 1) returns 1`
+  );
+
+  waiterlist.push($262.agent.getReport());
+
+  // Try to yield control to ensure the agent actually started to wait.
+  $262.agent.tryYield();
+}
+
+var notified = [];
+for (var i = 0; i < NUMAGENT; i++) {
+  assert.sameValue(
+    Atomics.wake(i32a, WAIT_INDEX, 1),
+    1,
+    `Atomics.wake(i32a, WAIT_INDEX, 1) returns 1 (${i})`
+  );
+
+  notified.push($262.agent.getReport());
+}
+
+assert.sameValue(
+  notified.join(''),
+  waiterlist.join(''),
+  'notified.join(\'\') returns waiterlist.join(\'\')'
+);

--- a/test/built-ins/Atomics/wake/wake-nan.js
+++ b/test/built-ins/Atomics/wake/wake-nan.js
@@ -5,14 +5,19 @@
 esid: sec-atomics.wake
 description: >
   Test that Atomics.wake wakes zero waiters if the count is NaN
-includes: [atomicsHelper.js,testAtomics.js]
-features: [ArrayBuffer, DataView, let, arrow-function, for-of, Atomics, BigInt, SharedArrayBuffer, TypedArray]
+includes: [atomicsHelper.js]
+features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
+
+const RUNNING = 1;
+const TIMEOUT = $262.agent.timeouts.long;
 
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i32a = new Int32Array(sab);
-    $262.agent.report(Atomics.wait(i32a, 0, 0, 200)); // We will timeout eventually
+    Atomics.add(i32a, ${RUNNING}, 1);
+
+    $262.agent.report(Atomics.wait(i32a, 0, 0, ${TIMEOUT})); // We will timeout eventually
     $262.agent.leaving();
   });
 `);
@@ -22,9 +27,14 @@ const i32a = new Int32Array(
 );
 
 $262.agent.broadcast(i32a.buffer);
-$262.agent.sleep(10); // Give the agent a chance to wait
+$262.agent.waitUntil(i32a, RUNNING, 1);
+
+// Try to yield control to ensure the agent actually started to wait.
+$262.agent.tryYield();
+
 assert.sameValue(Atomics.wake(i32a, 0, NaN), 0, 'Atomics.wake(i32a, 0, NaN) returns 0');
 
-// Sleep past the timeout
-$262.agent.sleep(300);
+// Try to sleep past the timeout.
+$262.agent.trySleep(TIMEOUT);
+
 assert.sameValue($262.agent.getReport(), 'timed-out', '$262.agent.getReport() returns "timed-out"');

--- a/test/built-ins/Atomics/xor/bad-range.js
+++ b/test/built-ins/Atomics/xor/bad-range.js
@@ -6,7 +6,7 @@ esid: sec-atomics.xor
 description: >
   Test range checking of Atomics.xor on arrays that allow atomic operations
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 var sab = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/xor/bigint/bad-range.js
+++ b/test/built-ins/Atomics/xor/bigint/bad-range.js
@@ -6,7 +6,7 @@ esid: sec-atomics.xor
 description: >
   Test range checking of Atomics.xor on arrays that allow atomic operations
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 var buffer = new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 2);

--- a/test/built-ins/Atomics/xor/bigint/good-views.js
+++ b/test/built-ins/Atomics/xor/bigint/good-views.js
@@ -4,7 +4,7 @@
 esid: sec-atomics.xor
 description: Test Atomics.xor on arrays that allow atomic operations
 includes: [testAtomics.js, testBigIntTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, BigInt, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, BigInt, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 // Make it interesting - use non-zero byteOffsets and non-zero indexes.
 // And again

--- a/test/built-ins/Atomics/xor/good-views.js
+++ b/test/built-ins/Atomics/xor/good-views.js
@@ -5,7 +5,7 @@
 esid: sec-atomics.xor
 description: Test Atomics.xor on arrays that allow atomic operations
 includes: [testAtomics.js, testTypedArray.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer, TypedArray]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 var sab = new SharedArrayBuffer(1024);

--- a/test/built-ins/Atomics/xor/non-views.js
+++ b/test/built-ins/Atomics/xor/non-views.js
@@ -6,7 +6,7 @@ esid: sec-atomics.xor
 description: >
   Test Atomics.xor on view values other than TypedArrays
 includes: [testAtomics.js]
-features: [ArrayBuffer, arrow-function, Atomics, DataView, for-of, let, SharedArrayBuffer]
+features: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, TypedArray]
 ---*/
 
 testWithAtomicsNonViewValues(function(view) {


### PR DESCRIPTION
Also fixes multiple issues and bugs in various Atomics tests.

CONTRIBUTING.md and INTERPRETING.md:
- Add missing description for `CanBlockIsFalse` flag and also introduce `CanBlockIsTrue` flag which is needed for some tests (see below).

harness/atomicsHelper.js:
- Updated `$262.agent.waitUntil` to clarify it can also be called with BigInt64Array objects.
- Added `$262.agent.timeouts` constants to unify the various, inconsistently used timeouts in the Atomics tests. Each timeout constant has a brief description and a usage example to clarify when it should or should not be used. The default values were tested in SpiderMonkey (locally and CI) under various system load levels and should hopefully also be valid for other engines. 
- Added `$262.agent.tryYield` to yield control from the main thread. The default implementation simply calls `$262.agent.sleep`, but test262 hosts could theoretically provide a different implementation.
- Added `$262.agent.trySleep` to replace direct calls to `$262.agent.sleep` from the main thread. Motivation for this function: Some test262 hosts (like browsers) may be able to pause and sleep on the main thread, so they could provide their implementation for `trySleep` which performs a busy-wait or something do nothing.

harness/testAtomics.js:
- Replace `let`, `arrow-functions`, and `for-of` loops to avoid creating extremely long `features` lists in tests using this helper. Removed `Map`, `WeakMap`, `Set`, and `WeakSet` (these weren't even listed in features.yaml) for the same reason and added the missing `Symbol` entry for this file to features.yaml.
- Updated all files including "harness/testAtomics.js" to match the new feature requirements.


test/built-ins/Atomics/store/good-views.js and test/built-ins/Atomics/store/bigint/good-views.js:
- Replace `arrow-functions` and `for-of` loops with ES5 alternatives.


test/built-ins/Atomics/wait/bigint/*.js and test/built-ins/Atomics/wake/bigint/*.js
- Some tests were using `BigInt64Array.BYTES_PER_ELEMENT * 8` for the SharedArrayBuffer length, but their non-BigInt counterparts are using `Int32Array.BYTES_PER_ELEMENT * 4`. For consistency and to make it easier to compare the BigInt against the non-BigInt versions, I've changed it to `BigInt64Array.BYTES_PER_ELEMENT * 4`.
- Also aligned formatting and statement placement when they differed between the non-BigInt and the BigInt version of a test file. (I've diffed some of the non-BigInt and BigInt files against each other and different formatting was a nuisance.)

Test files using `$262.agent.monotonicNow()`:
- Moved `$262.agent.report()` calls outside of the block of code measured `$262.agent.monotonicNow()` to avoid measuring how long it takes to execute `$262.agent.report()`. 
- Without this change some tests failed intermittently in certain test configurations in SpiderMonkey. For example with the flags `--ion-eager -- ion-offthread-compile=off` which forces early Ion compilation on the main thread. The `$262.agent.report()` implementation in the SpiderMonkey test262 host embedding uses a for-loop which was forcefully Ion compiled under these settings. And because Ion compilation can take some time, the test case ran longer than `$262.agent.MAX_TIME_EPSILON` which lead to intermittent failures.

Test files using `CanBlockIsFalse` / `CanBlockIsTrue`:
- Some of these tests actually expected that the main thread can wait and [[CanBlock]] is `true` for the agent record executing the test. Therefore I've added a new `CanBlockIsTrue` flag and replaced the flags where needed.

test/built-ins/Atomics/wait/**/*.js and test/built-ins/Atomics/wake/**/*.js:
- Use an atomic counter `RUNNING` in more tests to have better control when a worker agent was actually started.
- Replace the various `$262.agent.sleep(/* Sleep X ms to ensure worker actually sleeps */)` calls with the new `$262.agent.tryYield()` function. This `X` was sometimes as low as 10 milliseconds, which is definitely too short for CI systems under heavy load (observed by intermittent CI failures for SpiderMonkey) and sometimes as high as 500 milliseconds, which is probably much longer than needed even when the system is under heavy load. 
- Removed duplicate strings in assertion messages, presumably from copy-pasting the messages between different files.
- Removed extra empty lines at the end of multiple files.

test/built-ins/Atomics/wake/bad-range.js, test/built-ins/Atomics/wake/bigint/bad-range.js, and test/built-ins/Atomics/wait/bigint/non-bigint64-typedarray-throws.js:
- Removed unnecessary `features` and `includes` from this file.

test/built-ins/Atomics/wait/waiterlist-order-of-operations-is-fifo.js and test/built-ins/Atomics/wait/bigint/waiterlist-order-of-operations-is-fifo.js:
- The test was actually broken and didn't test what it said it does. This probably explains #1530.
- The test wants to ensure the waiterlist is implemented as a FIFO structure. This requires that the waiting agents all wait on the same index position, because the waiterlists are defined by each index. But if the agents wait on different indices, each agent is inserted into a different FIFO structure and therefore we can't observe any FIFO ordering between the agents when they're woken up.
- All this requires a bit of synchronization between the main agent and the waiting agent, I hope the added comments help to review these changes.

test/built-ins/Atomics/wait/good-views.js:
- The agent sends multiple reports to the main agent, but only the first one was read.
- This error was introduced during previous refactorings. I've changed it to back to use a while-loop as used in the first version of this file.

test/built-ins/Atomics/wait/no-spurious-wakeup-no-operation.js:
- Only the BigInt version of this test was present, copied it so we also get code coverage for the non-BigInt case.

test/built-ins/Atomics/wait/waiterlist-block-indexedposition-wake.js:
- Added extra while loops to avoid intermittent failures when the agent worker haven't started to wait.
- This should help to avoid some of the intermittent failures we saw for SpiderMonkey.

test/built-ins/Atomics/wake/wake-all-on-loc.js and test/built-ins/Atomics/wake/bigint/wake-all-on-loc.js:
- This test was also no longer after previous refactoring sessions.
- The "B" agent only waited for 10 milliseconds, which made it likely that it already timed out before the main agent was able to call `Atomics.wake`, which in turn rendered the test useless, because the test case wants to ensure that `Atomics.wake` cannot wake "B". But if "B" was already timed out, it can trivially not be woken by `Atomics.wake`.
- Added some safety measure to catch the case when "B" timed out before `Atomics.wake` was called and made it a test error if that happens.

test/built-ins/Atomics/wake/count-defaults-to-infinity-missing.js, test/built-ins/Atomics/wake/count-defaults-to-infinity-undefined.js, and test/built-ins/Atomics/wake/undefined-index-defaults-to-zero.js:
- Changed the `$262.agent.start()` calls to use a for-loop to avoid code duplication.
- (Forgot to undo the code formatting around `assert.sameValue`, still need to change it back.)
- Also more while-loops around `Atomics.wake`.
- These changes should fix #1529 and #1566.

test/built-ins/Atomics/wake/wake-all.js:
- Removed "B" worker agent.
- Without this removal the test case would be exactly equal to test/built-ins/Atomics/wake/wake-all-on-loc.js.

test/built-ins/Atomics/wake/wake-in-order-one-time.js:
- Add for-loops to avoid code duplication and make the test more readable.
- Make the `Atomics.wake` assertion messages unique by adding the current loop counter.
- Add `$262.agent.tryYield()` to give the worker agents enough time to actually start waiting.

test/built-ins/Atomics/wake/wake-in-order.js:
- Removed the outer loop `attempt < 10` because it uses `$262.agent` in a way currently not required to work. And which actually also doesn't work in SpiderMonkey's implementation of `$262.agent`.
- According to INTERPRETING.md `$262.agent.broadcast()` broadcasts its message to all agents ever started by `$262.agent.start()` and then blocks until all agents received the broadcast. It is not required that the agents started by the first `$262.agent.broadcast()` call will all be disabled/destroyed/whatever when the second `$262.agent.broadcast()` call occurs, which then means the second `$262.agent.broadcast()` call still tries to reach the agents started in the first loop iteration, but these may no longer accept broadcasts and therefore won't acknowledge they've received the broadcast. Which then means the second `$262.agent.broadcast()` call waits forever.




