### PR TITLE
Update expectation for Intl.RelativeTimeFormat.prototype[@@toStringTag].

### DIFF
--- a/test/intl402/RelativeTimeFormat/prototype/toStringTag/toString.js
+++ b/test/intl402/RelativeTimeFormat/prototype/toStringTag/toString.js
@@ -1,0 +1,16 @@
+// Copyright 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.RelativeTimeFormat.prototype-@@tostringtag
+description: >
+    Checks Object.prototype.toString with Intl.RelativeTimeFormat objects.
+info: |
+    Intl.RelativeTimeFormat.prototype[ @@toStringTag ]
+
+    The initial value of the @@toStringTag property is the string value "Intl.RelativeTimeFormat".
+features: [Intl.RelativeTimeFormat]
+---*/
+
+assert.sameValue(Object.prototype.toString.call(Intl.RelativeTimeFormat.prototype), "[object Intl.RelativeTimeFormat]");
+assert.sameValue(Object.prototype.toString.call(new Intl.RelativeTimeFormat("en")), "[object Intl.RelativeTimeFormat]");

--- a/test/intl402/RelativeTimeFormat/prototype/toStringTag/toStringTag.js
+++ b/test/intl402/RelativeTimeFormat/prototype/toStringTag/toStringTag.js
@@ -8,7 +8,7 @@ description: >
 info: |
     Intl.RelativeTimeFormat.prototype[ @@toStringTag ]
 
-    The initial value of the @@toStringTag property is the string value "Object".
+    The initial value of the @@toStringTag property is the string value "Intl.RelativeTimeFormat".
 
     This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
 includes: [propertyHelper.js]
@@ -16,7 +16,7 @@ features: [Intl.RelativeTimeFormat, Symbol.toStringTag]
 ---*/
 
 verifyProperty(Intl.RelativeTimeFormat.prototype, Symbol.toStringTag, {
-  value: "Object",
+  value: "Intl.RelativeTimeFormat",
   writable: false,
   enumerable: false,
   configurable: true


### PR DESCRIPTION
The specification changed in https://github.com/tc39/proposal-intl-relative-time/pull/77.