### PR TITLE
Relax linting rules for `esid` metadata

### DIFF
--- a/tools/lint/lib/checks/esid.py
+++ b/tools/lint/lib/checks/esid.py
@@ -8,7 +8,12 @@ class CheckEsid(Check):
     def __init__(self):
         #self.es5idRegex = re.compile(r"^S?(B|\d+)(\.\d+)+(-(\d+|[a-z]|i+))*(_A\d(\.\d+)?(_T\d(\.\d+)?)?)?$")
         self.es6idRegex = re.compile(r"^(S?(B|\d+)(\.\d+)+(((_A\d\.\d)?_T?\d)|[ _]S\d+(\.[a-z])*)?(, |$))+")
-        self.esidRegex = re.compile(r"^(pending|(prod|sec|sup)-[-_A-Za-z0-9.%@]+)$")
+        # Simpliiied version of the WhatWG URL specification for fragment
+        # parsing
+        # https://url.spec.whatwg.org/#fragment-state
+        self.esidRegex = re.compile(
+            u"^[a-z0-9!$&'()*+,\-./:;=?@_~\u00a0-\U0010fffd]+$", re.IGNORECASE
+        )
 
     def run(self, name, meta, source):
         if not meta:

--- a/tools/lint/test/fixtures/esid_invalid.js
+++ b/tools/lint/test/fixtures/esid_invalid.js
@@ -1,0 +1,10 @@
+ESID
+^ expected errors | v input
+// Copyright (C) 2018 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: something withaspace
+description: Minimal test
+---*/
+
+function f() {}

--- a/tools/lint/test/fixtures/valid_esid_alternate.js
+++ b/tools/lint/test/fixtures/valid_esid_alternate.js
@@ -1,0 +1,9 @@
+^ expected errors | v input
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: use-strict-directive!@$&*()_+
+description: Minimal test
+---*/
+
+function f() {}


### PR DESCRIPTION
The document fragments used by the ECMAScript specification do not
conform to any particular pattern beyond the grammar defined by the URL
standard [1]. Relax the linting rule to enforce a simplified version of
that grammar.

[1] https://url.spec.whatwg.org/#fragment-state