### PR TITLE
arguments / eval with prefix / postfix in strict code should raise early ReferenceError instead of SyntaxError

### DIFF
--- a/test/language/expressions/postfix-decrement/11.3.2-2-1-s.js
+++ b/test/language/expressions/postfix-decrement/11.3.2-2-1-s.js
@@ -4,14 +4,14 @@
 /*---
 es5id: 11.3.2-2-1-s
 description: >
-    Strict Mode - SyntaxError is thrown if the identifier 'arguments'
+    Strict Mode - ReferenceError is thrown if the identifier 'arguments'
     appear as a PostfixExpression(arguments--)
 flags: [onlyStrict]
 ---*/
 
 function testcase() {
         var blah = arguments;
-        assert.throws(SyntaxError, function() {
+        assert.throws(ReferenceError, function() {
             eval("arguments--;");
         });
         assert.sameValue(blah, arguments, 'blah');

--- a/test/language/expressions/postfix-decrement/11.3.2-2-2-s.js
+++ b/test/language/expressions/postfix-decrement/11.3.2-2-2-s.js
@@ -4,13 +4,13 @@
 /*---
 es5id: 11.3.2-2-2-s
 description: >
-    Strict Mode - SyntaxError is thrown if the identifier 'eval'
+    Strict Mode - ReferenceError is thrown if the identifier 'eval'
     appear as a PostfixExpression(eval--)
 flags: [onlyStrict]
 ---*/
 
         var blah = eval;
-assert.throws(SyntaxError, function() {
+assert.throws(ReferenceError, function() {
             eval("eval--;");
 });
 assert.sameValue(blah, eval, 'blah');

--- a/test/language/expressions/postfix-increment/11.3.1-2-1-s.js
+++ b/test/language/expressions/postfix-increment/11.3.1-2-1-s.js
@@ -4,14 +4,14 @@
 /*---
 es5id: 11.3.1-2-1-s
 description: >
-    Strict Mode - SyntaxError is thrown if the identifier 'arguments'
+    Strict Mode - ReferenceError is thrown if the identifier 'arguments'
     appear as a PostfixExpression(arguments++)
 flags: [onlyStrict]
 ---*/
 
 function testcase() {
         var blah = arguments;
-        assert.throws(SyntaxError, function() {
+        assert.throws(ReferenceError, function() {
             eval("arguments++;");
         });
         assert.sameValue(blah, arguments, 'blah');

--- a/test/language/expressions/postfix-increment/11.3.1-2-1gs.js
+++ b/test/language/expressions/postfix-increment/11.3.1-2-1gs.js
@@ -4,11 +4,11 @@
 /*---
 es5id: 11.3.1-2-1gs
 description: >
-    Strict Mode - SyntaxError is throw if the identifier arguments
+    Strict Mode - ReferenceError is throw if the identifier arguments
     appear as a PostfixExpression(arguments++)
 negative:
   phase: parse
-  type: SyntaxError
+  type: ReferenceError
 flags: [onlyStrict]
 ---*/
 

--- a/test/language/expressions/postfix-increment/11.3.1-2-2-s.js
+++ b/test/language/expressions/postfix-increment/11.3.1-2-2-s.js
@@ -4,13 +4,13 @@
 /*---
 es5id: 11.3.1-2-2-s
 description: >
-    Strict Mode - SyntaxError is thrown if the identifier 'eval'
+    Strict Mode - ReferenceError is thrown if the identifier 'eval'
     appear as a PostfixExpression(eval++)
 flags: [onlyStrict]
 ---*/
 
         var blah = eval;
-assert.throws(SyntaxError, function() {
+assert.throws(ReferenceError, function() {
             eval("eval++;");
 });
 assert.sameValue(blah, eval, 'blah');

--- a/test/language/expressions/prefix-decrement/11.4.5-2-1-s.js
+++ b/test/language/expressions/prefix-decrement/11.4.5-2-1-s.js
@@ -3,12 +3,12 @@
 
 /*---
 es5id: 11.4.5-2-1-s
-description: Strict Mode - SyntaxError is thrown for --eval
+description: Strict Mode - ReferenceError is thrown for --eval
 flags: [onlyStrict]
 ---*/
 
         var blah = eval;
-assert.throws(SyntaxError, function() {
+assert.throws(ReferenceError, function() {
             eval("--eval;");
 });
 assert.sameValue(blah, eval, 'blah');

--- a/test/language/expressions/prefix-decrement/11.4.5-2-2-s.js
+++ b/test/language/expressions/prefix-decrement/11.4.5-2-2-s.js
@@ -3,13 +3,13 @@
 
 /*---
 es5id: 11.4.5-2-2-s
-description: Strict Mode - SyntaxError is thrown for --arguments
+description: Strict Mode - ReferenceError is thrown for --arguments
 flags: [onlyStrict]
 ---*/
 
 function testcase() {
         var blah = arguments;
-        assert.throws(SyntaxError, function() {
+        assert.throws(ReferenceError, function() {
             eval("--arguments;");
         });
         assert.sameValue(blah, arguments, 'blah');

--- a/test/language/expressions/prefix-decrement/11.4.5-2-2gs.js
+++ b/test/language/expressions/prefix-decrement/11.4.5-2-2gs.js
@@ -4,11 +4,11 @@
 /*---
 es5id: 11.4.5-2-2gs
 description: >
-    Strict Mode - SyntaxError is throw if the UnaryExpression operated
+    Strict Mode - ReferenceError is throw if the UnaryExpression operated
     upon by a Prefix Decrement operator(--arguments)
 negative:
   phase: parse
-  type: SyntaxError
+  type: ReferenceError
 flags: [onlyStrict]
 ---*/
 

--- a/test/language/expressions/prefix-increment/11.4.4-2-1-s.js
+++ b/test/language/expressions/prefix-increment/11.4.4-2-1-s.js
@@ -3,12 +3,12 @@
 
 /*---
 es5id: 11.4.4-2-1-s
-description: Strict Mode - SyntaxError is thrown for ++eval
+description: Strict Mode - ReferenceError is thrown for ++eval
 flags: [onlyStrict]
 ---*/
 
         var blah = eval;
-assert.throws(SyntaxError, function() {
+assert.throws(ReferenceError, function() {
             eval("++eval;");
 });
 assert.sameValue(blah, eval, 'blah');

--- a/test/language/expressions/prefix-increment/11.4.4-2-2-s.js
+++ b/test/language/expressions/prefix-increment/11.4.4-2-2-s.js
@@ -3,13 +3,13 @@
 
 /*---
 es5id: 11.4.4-2-2-s
-description: Strict Mode - SyntaxError is thrown for ++arguments
+description: Strict Mode - ReferenceError is thrown for ++arguments
 flags: [onlyStrict]
 ---*/
 
 function testcase() {
         var blah = arguments;
-        assert.throws(SyntaxError, function() {
+        assert.throws(ReferenceError, function() {
             eval("++arguments;");
         });
         assert.sameValue(blah, arguments, 'blah');


### PR DESCRIPTION
According to the latest spec[1,2], we should throw early ReferenceError if IsValidSimpleAssignmentTarget for `expr++`'s and `++expr`'s `expr` is false.
However, our tests expect SyntaxError now. This patch fixes it to align these tests to the latest spec.

1: https://tc39.github.io/ecma262/#sec-update-expressions-static-semantics-early-errors
2: https://tc39.github.io/ecma262/#sec-identifiers-static-semantics-isvalidsimpleassignmenttarget