### PR TITLE
Add a missing Reflect feature flag

### DIFF
--- a/test/built-ins/Proxy/deleteProperty/boolean-trap-result-boolean-true.js
+++ b/test/built-ins/Proxy/deleteProperty/boolean-trap-result-boolean-true.js
@@ -6,6 +6,7 @@ description: >
     [[Delete]] (P)
 
     The result is a Boolean value.
+features: [Reflect]
 ---*/
 
 var p = new Proxy({}, {


### PR DESCRIPTION
`built-ins/Proxy/deleteProperty/boolean-trap-result-boolean-true.js` was missing a feature flag for the Reflect library.