### PR TITLE
Make Proxy/ownKeys tests ES5-parsable

### DIFF
--- a/test/built-ins/Proxy/ownKeys/return-duplicate-entries-throws.js
+++ b/test/built-ins/Proxy/ownKeys/return-duplicate-entries-throws.js
@@ -12,7 +12,7 @@ info: |
 ---*/
 
 var p = new Proxy({}, {
-  ownKeys() {
+  ownKeys: function() {
     return ["a", "a"];
   }
 });

--- a/test/built-ins/Proxy/ownKeys/return-duplicate-symbol-entries-throws.js
+++ b/test/built-ins/Proxy/ownKeys/return-duplicate-symbol-entries-throws.js
@@ -14,7 +14,7 @@ features: [Symbol]
 
 var s = Symbol();
 var p = new Proxy({}, {
-  ownKeys() {
+  ownKeys: function() {
     return [s, s];
   }
 });

--- a/test/built-ins/Proxy/ownKeys/return-type-throws-array.js
+++ b/test/built-ins/Proxy/ownKeys/return-type-throws-array.js
@@ -24,7 +24,7 @@ info: |
 ---*/
 
 var p = new Proxy({}, {
-  ownKeys() {
+  ownKeys: function() {
     return [
       []
     ];

--- a/test/built-ins/Proxy/ownKeys/return-type-throws-boolean.js
+++ b/test/built-ins/Proxy/ownKeys/return-type-throws-boolean.js
@@ -24,7 +24,7 @@ info: |
 ---*/
 
 var p = new Proxy({}, {
-  ownKeys() {
+  ownKeys: function() {
     return [true];
   }
 });

--- a/test/built-ins/Proxy/ownKeys/return-type-throws-null.js
+++ b/test/built-ins/Proxy/ownKeys/return-type-throws-null.js
@@ -24,7 +24,7 @@ info: |
 ---*/
 
 var p = new Proxy({}, {
-  ownKeys() {
+  ownKeys: function() {
     return [null];
   }
 });

--- a/test/built-ins/Proxy/ownKeys/return-type-throws-number.js
+++ b/test/built-ins/Proxy/ownKeys/return-type-throws-number.js
@@ -24,7 +24,7 @@ info: |
 ---*/
 
 var p = new Proxy({}, {
-  ownKeys() {
+  ownKeys: function() {
     return [1];
   }
 });

--- a/test/built-ins/Proxy/ownKeys/return-type-throws-object.js
+++ b/test/built-ins/Proxy/ownKeys/return-type-throws-object.js
@@ -24,7 +24,7 @@ info: |
 ---*/
 
 var p = new Proxy({}, {
-  ownKeys() {
+  ownKeys: function() {
     return [{}];
   }
 });

--- a/test/built-ins/Proxy/ownKeys/return-type-throws-undefined.js
+++ b/test/built-ins/Proxy/ownKeys/return-type-throws-undefined.js
@@ -24,7 +24,7 @@ info: |
 ---*/
 
 var p = new Proxy({}, {
-  ownKeys() {
+  ownKeys: function() {
     return [undefined];
   }
 });


### PR DESCRIPTION
All other Proxy tests use the syntax `attr: function() {...}` for defining traps, ownKeys was unique in using the shorthand syntax `attr() {..}`. Change to longhand syntax for back-compat for partial implementations.