### PR TITLE
Added a legal part types test

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/formatToParts/main.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/main.js
@@ -38,3 +38,39 @@ compareFTPtoFormat(['ar'], {
   day: 'numeric',
   year: '2-digit'
 }, Date.now());
+
+const actualPartTypes = new Intl.DateTimeFormat('en-us', {
+    weekday: 'long',
+    era: 'long',
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    hour12: true,
+    timeZone: 'UTC',
+    timeZoneName: 'long'
+}).formatToParts(Date.UTC(2012, 11, 17, 3, 0, 42))
+  .map(function (part) { return part.type; });
+
+const legalPartTypes = [
+  "weekday",
+  "era",
+  "year",
+  "month",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "literal",
+  "dayPeriod",
+  "timeZoneName"
+];
+
+actualPartTypes.forEach(
+  function (type) {
+    assert(
+      legalPartTypes.indexOf(type) !== -1,
+      type + " is not a legal type");
+  });


### PR DESCRIPTION
Chrome uses dayperiod while the specification says dayPeriod. :(
https://crbug.com/865351
This should prevent such mistakes in the future.


I am surprised such a basic test was not added until now... Is there a reason, or am I simply bad at searching?