### PR TITLE
Add feature flags for `new.target`

### DIFF
--- a/src/class-fields/eval-err-contains-newtarget.case
+++ b/src/class-fields/eval-err-contains-newtarget.case
@@ -16,7 +16,7 @@ info: |
   ScriptBody:StatementList
 
     It is a Syntax Error if StatementList Contains NewTarget.
-features: [class, class-fields-public]
+features: [class, class-fields-public, new.target]
 template: initializer-eval-newtarget
 ---*/
 

--- a/test/built-ins/Proxy/construct/trap-is-null.js
+++ b/test/built-ins/Proxy/construct/trap-is-null.js
@@ -21,7 +21,7 @@ info: |
     ...
     3. If func is either undefined or null, return undefined.
     ...
-features: [Proxy, Reflect, Reflect.construct]
+features: [Proxy, Reflect, Reflect.construct, new.target]
 ---*/
 
 var calls = 0;

--- a/test/built-ins/Proxy/construct/trap-is-undefined-no-property.js
+++ b/test/built-ins/Proxy/construct/trap-is-undefined-no-property.js
@@ -10,7 +10,7 @@ info: |
 
     7. If trap is undefined, then
         b. Return Construct(target, argumentsList, newTarget).
-features: [Proxy, Reflect, Reflect.construct]
+features: [Proxy, Reflect, Reflect.construct, new.target]
 ---*/
 
 var calls = 0;

--- a/test/built-ins/Proxy/construct/trap-is-undefined.js
+++ b/test/built-ins/Proxy/construct/trap-is-undefined.js
@@ -21,7 +21,7 @@ info: |
     ...
     3. If func is either undefined or null, return undefined.
     ...
-features: [Proxy, Reflect, Reflect.construct]
+features: [Proxy, Reflect, Reflect.construct, new.target]
 ---*/
 
 var calls = 0;

--- a/test/language/eval-code/direct/new.target-arrow.js
+++ b/test/language/eval-code/direct/new.target-arrow.js
@@ -11,7 +11,7 @@ info: |
     code containing NewTarget is eval code that is being processed by a direct
     eval that is contained in function code that is not the function code of an
     ArrowFunction.
-features: [arrow-function]
+features: [arrow-function, new.target]
 ---*/
 
 var caught;

--- a/test/language/eval-code/direct/new.target-fn.js
+++ b/test/language/eval-code/direct/new.target-fn.js
@@ -11,7 +11,7 @@ info: |
     code containing NewTarget is eval code that is being processed by a direct
     eval that is contained in function code that is not the function code of an
     ArrowFunction.
-features: [arrow-function]
+features: [new.target]
 ---*/
 
 var newTarget = null;

--- a/test/language/eval-code/direct/new.target.js
+++ b/test/language/eval-code/direct/new.target.js
@@ -9,6 +9,7 @@ info: |
     code containing NewTarget is eval code that is being processed by a direct
     eval that is contained in function code that is not the function code of an
     ArrowFunction.
+features: [new.target]
 ---*/
 
 var caught;

--- a/test/language/eval-code/indirect/new.target.js
+++ b/test/language/eval-code/indirect/new.target.js
@@ -10,6 +10,7 @@ info: |
     code containing NewTarget is eval code that is being processed by a direct
     eval that is contained in function code that is not the function code of an
     ArrowFunction.
+features: [new.target]
 ---*/
 
 var caught;

--- a/test/language/expressions/arrow-function/lexical-new.target-closure-returned.js
+++ b/test/language/expressions/arrow-function/lexical-new.target-closure-returned.js
@@ -14,6 +14,7 @@ description: >
     The non-normative note elaborates on the "scope" argument:
 
     An ArrowFunction does not define local bindings for arguments, super, this, or new.target. Any reference to arguments, super, or this within an ArrowFunction must resolve to a binding in a lexically enclosing environment. Typically this will be the Function Environment of an immediately enclosing function. Even though an ArrowFunction may contain references to super, the function object created in step 4 is not made into a method by performing MakeMethod. An ArrowFunction that references super is always contained within a non-ArrowFunction and the necessary state to implement super is accessible via the scope that is captured by the function object of the ArrowFunction.
+features: [new.target]
 ---*/
 
 function F() {

--- a/test/language/expressions/arrow-function/lexical-new.target.js
+++ b/test/language/expressions/arrow-function/lexical-new.target.js
@@ -14,6 +14,7 @@ description: >
     The non-normative note elaborates on the "scope" argument:
 
     An ArrowFunction does not define local bindings for arguments, super, this, or new.target. Any reference to arguments, super, or this within an ArrowFunction must resolve to a binding in a lexically enclosing environment. Typically this will be the Function Environment of an immediately enclosing function. Even though an ArrowFunction may contain references to super, the function object created in step 4 is not made into a method by performing MakeMethod. An ArrowFunction that references super is always contained within a non-ArrowFunction and the necessary state to implement super is accessible via the scope that is captured by the function object of the ArrowFunction.
+features: [new.target]
 ---*/
 
 var functionInvocationCount = 0;

--- a/test/language/expressions/assignment/target-cover-newtarget.js
+++ b/test/language/expressions/assignment/target-cover-newtarget.js
@@ -21,6 +21,7 @@ info: |
 negative:
   phase: parse
   type: ReferenceError
+features: [new.target]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/expressions/assignment/target-newtarget.js
+++ b/test/language/expressions/assignment/target-newtarget.js
@@ -21,6 +21,7 @@ info: |
 negative:
   phase: parse
   type: ReferenceError
+features: [new.target]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/expressions/new.target/value-via-call.js
+++ b/test/language/expressions/new.target/value-via-call.js
@@ -9,6 +9,7 @@ info: |
 
   [...]
   8. Return ? EvaluateDirectCall(func, thisValue, Arguments, tailCall).
+features: [new.target]
 ---*/
 
 var newTarget = null;

--- a/test/language/expressions/new.target/value-via-fpapply.js
+++ b/test/language/expressions/new.target/value-via-fpapply.js
@@ -7,6 +7,7 @@ description: Value when invoked via `Function.prototype.apply`
 info: |
   [...]
   5. Return ? Call(func, thisArg, argList).
+features: [new.target]
 ---*/
 
 var newTarget = null;

--- a/test/language/expressions/new.target/value-via-fpcall.js
+++ b/test/language/expressions/new.target/value-via-fpcall.js
@@ -7,6 +7,7 @@ description: Value when invoked via `Function.prototype.call`
 info: |
   [...]
   5. Return ? Call(func, thisArg, argList).
+features: [new.target]
 ---*/
 
 var newTarget = null;

--- a/test/language/expressions/new.target/value-via-member.js
+++ b/test/language/expressions/new.target/value-via-member.js
@@ -18,6 +18,7 @@ info: |
 
   1. Let exprRef be the result of evaluating Expression.
   2. Return ? GetValue(exprRef).
+features: [new.target]
 ---*/
 
 var newTarget = null;

--- a/test/language/expressions/new.target/value-via-new.js
+++ b/test/language/expressions/new.target/value-via-new.js
@@ -21,6 +21,7 @@ info: |
   7.3.13 Construct (F [ , argumentsList [ , newTarget ]])
 
   1. If newTarget was not passed, let newTarget be F.
+features: [new.target]
 ---*/
 
 var newTarget = null;

--- a/test/language/expressions/new.target/value-via-reflect-apply.js
+++ b/test/language/expressions/new.target/value-via-reflect-apply.js
@@ -7,7 +7,7 @@ description: Value when invoked via `Reflect.apply`
 info: |
   [...]
   5. Return ? Call(target, thisArgument, args).
-features: [Reflect]
+features: [Reflect, new.target]
 ---*/
 
 var newTarget = null;

--- a/test/language/expressions/new.target/value-via-reflect-construct.js
+++ b/test/language/expressions/new.target/value-via-reflect-construct.js
@@ -9,7 +9,7 @@ info: |
   2. If newTarget is not present, let newTarget be target.
   [...]
   5. Return ? Construct(target, args, newTarget).
-features: [Reflect]
+features: [Reflect, new.target]
 ---*/
 
 var customNewTarget = function() {};

--- a/test/language/expressions/new.target/value-via-super-call.js
+++ b/test/language/expressions/new.target/value-via-super-call.js
@@ -11,7 +11,7 @@ info: |
   [...]
   6. Let result be ? Construct(func, argList, newTarget).
   [...]
-features: [class]
+features: [class, new.target]
 ---*/
 
 var baseNewTarget, parentNewTarget;

--- a/test/language/expressions/new.target/value-via-super-property.js
+++ b/test/language/expressions/new.target/value-via-super-property.js
@@ -11,7 +11,7 @@ info: |
   [...]
   6. Let result be ? Construct(func, argList, newTarget).
   [...]
-features: [class]
+features: [class, new.target]
 ---*/
 
 var newTarget = null;

--- a/test/language/expressions/new.target/value-via-tagged-template.js
+++ b/test/language/expressions/new.target/value-via-tagged-template.js
@@ -9,7 +9,7 @@ info: |
 
    [...]
    4. Return ? EvaluateCall(tagRef, TemplateLiteral, tailCall).
-features: [template]
+features: [template, new.target]
 ---*/
 
 var newTarget = null;

--- a/test/language/expressions/postfix-decrement/target-cover-newtarget.js
+++ b/test/language/expressions/postfix-decrement/target-cover-newtarget.js
@@ -22,6 +22,7 @@ info: |
 negative:
   phase: parse
   type: ReferenceError
+features: [new.target]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/expressions/postfix-decrement/target-newtarget.js
+++ b/test/language/expressions/postfix-decrement/target-newtarget.js
@@ -22,6 +22,7 @@ info: |
 negative:
   phase: parse
   type: ReferenceError
+features: [new.target]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/expressions/postfix-increment/target-cover-newtarget.js
+++ b/test/language/expressions/postfix-increment/target-cover-newtarget.js
@@ -22,6 +22,7 @@ info: |
 negative:
   phase: parse
   type: ReferenceError
+features: [new.target]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/expressions/postfix-increment/target-newtarget.js
+++ b/test/language/expressions/postfix-increment/target-newtarget.js
@@ -22,6 +22,7 @@ info: |
 negative:
   phase: parse
   type: ReferenceError
+features: [new.target]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/expressions/prefix-decrement/target-cover-newtarget.js
+++ b/test/language/expressions/prefix-decrement/target-cover-newtarget.js
@@ -22,6 +22,7 @@ info: |
 negative:
   phase: parse
   type: ReferenceError
+features: [new.target]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/expressions/prefix-decrement/target-newtarget.js
+++ b/test/language/expressions/prefix-decrement/target-newtarget.js
@@ -22,6 +22,7 @@ info: |
 negative:
   phase: parse
   type: ReferenceError
+features: [new.target]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/expressions/prefix-increment/target-cover-newtarget.js
+++ b/test/language/expressions/prefix-increment/target-cover-newtarget.js
@@ -22,6 +22,7 @@ info: |
 negative:
   phase: parse
   type: ReferenceError
+features: [new.target]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/expressions/prefix-increment/target-newtarget.js
+++ b/test/language/expressions/prefix-increment/target-newtarget.js
@@ -22,6 +22,7 @@ info: |
 negative:
   phase: parse
   type: ReferenceError
+features: [new.target]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/expressions/super/call-construct-invocation.js
+++ b/test/language/expressions/super/call-construct-invocation.js
@@ -8,7 +8,7 @@ info: |
   [...]
   6. Let result be ? Construct(func, argList, newTarget).
   [...]
-features: [class, Reflect]
+features: [class, Reflect, new.target]
 ---*/
 
 var expectedNewTarget = function() {};

--- a/test/language/global-code/new.target-arrow.js
+++ b/test/language/global-code/new.target-arrow.js
@@ -24,7 +24,7 @@ info: |
   NOTE Normally, Contains does not look inside most function forms. However,
        Contains is used to detect new.target, this, and super usage within an
        ArrowFunction.
-features: [arrow-function]
+features: [arrow-function, new.target]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/global-code/new.target.js
+++ b/test/language/global-code/new.target.js
@@ -12,6 +12,7 @@ info: |
 negative: 
   phase: parse
   type: SyntaxError
+features: [new.target]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";

--- a/test/language/module-code/early-new-target.js
+++ b/test/language/module-code/early-new-target.js
@@ -8,6 +8,7 @@ flags: [module]
 negative:
   phase: parse
   type: SyntaxError
+features: [new.target]
 ---*/
 
 throw "Test262: This statement should not be evaluated.";


### PR DESCRIPTION
Add feature flags for `new.target`

Commit additionally removes the `arrow-function` feature for
test/language/eval-code/direct/new.target-fn.js as it is not testing
arrow-functions, but they are mentioned in the preamble.