### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "00228d3ccc",
-  "targetRevisionAtLastExport": "4314e2cab",
+  "sourceRevisionAtLastExport": "5895364ed5",
+  "targetRevisionAtLastExport": "df1fc484e",
   "curatedFiles": {}
 }

--- a/implementation-contributed/javascriptcore/stress/array-profile-should-record-copy-on-write.js
+++ b/implementation-contributed/javascriptcore/stress/array-profile-should-record-copy-on-write.js
@@ -1,0 +1,39 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test1(array)
+{
+    for (var i = 0; i < 5; ++i) {
+        array[0] = array[0] + 1;
+    }
+    return array;
+}
+noInline(test1);
+
+function test2(array)
+{
+    for (var i = 0; i < 5; ++i) {
+        array[0] = array[0] + 1;
+    }
+    return array;
+}
+noInline(test2);
+
+function test3(array)
+{
+    for (var i = 0; i < 5; ++i) {
+        array[0] = array[0] + 1;
+    }
+    return array;
+}
+noInline(test3);
+
+for (var i = 0; i < 1e5; ++i) {
+    shouldBe(String(test1([0, 1, 2, 3, 4])), `5,1,2,3,4`);
+    shouldBe(String(test2([0.1, 1.1, 2.1, 3.1, 4.1])), `5.1,1.1,2.1,3.1,4.1`);
+    shouldBe(String(test3(['C', 'o', 'c', 'o', 'a'])), `C11111,o,c,o,a`);
+}


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[00228d3ccc](https://github.com///github/blob/00228d3ccc) in JavaScriptCore and all changes made since [4314e2cab](../blob/4314e2cab) in
test262.













### 1 New File Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/array-profile-should-record-copy-on-write.js](../blob/javascriptcore-test262-automation-export-4314e2cab/implementation-contributed/javascriptcore/stress/array-profile-should-record-copy-on-write.js)