### PR TITLE
Intl.RelativeTimeFormat: Test for grouping in long numbers.

### DIFF
--- a/test/intl402/RelativeTimeFormat/prototype/format/en-us-numeric-always.js
+++ b/test/intl402/RelativeTimeFormat/prototype/format/en-us-numeric-always.js
@@ -24,7 +24,7 @@ const rtf = new Intl.RelativeTimeFormat("en-US");
 assert.sameValue(typeof rtf.format, "function", "format should be supported");
 
 for (const unit of units) {
-  // Note https://github.com/tc39/proposal-intl-relative-time/issues/80
+  assert.sameValue(rtf.format(1000, unit), `in 1,000 ${unit}s`);
   assert.sameValue(rtf.format(10, unit), `in 10 ${unit}s`);
   assert.sameValue(rtf.format(2, unit), `in 2 ${unit}s`);
   assert.sameValue(rtf.format(1, unit), `in 1 ${unit}`);
@@ -33,4 +33,5 @@ for (const unit of units) {
   assert.sameValue(rtf.format(-1, unit), `1 ${unit} ago`);
   assert.sameValue(rtf.format(-2, unit), `2 ${unit}s ago`);
   assert.sameValue(rtf.format(-10, unit), `10 ${unit}s ago`);
+  assert.sameValue(rtf.format(-1000, unit), `1,000 ${unit}s ago`);
 }

--- a/test/intl402/RelativeTimeFormat/prototype/format/en-us-numeric-auto.js
+++ b/test/intl402/RelativeTimeFormat/prototype/format/en-us-numeric-auto.js
@@ -56,7 +56,8 @@ for (const unit of units) {
   const expected = unit in exceptions
     ? [exceptions[unit]["1"], exceptions[unit]["0"], exceptions[unit]["0"], exceptions[unit]["-1"]]
     : [`in 1 ${unit}`, `in 0 ${unit}s`, `0 ${unit}s ago`, `1 ${unit} ago`];
-  // Note https://github.com/tc39/proposal-intl-relative-time/issues/80
+
+  assert.sameValue(rtf.format(1000, unit), `in 1,000 ${unit}s`);
   assert.sameValue(rtf.format(10, unit), `in 10 ${unit}s`);
   assert.sameValue(rtf.format(2, unit), `in 2 ${unit}s`);
   assert.sameValue(rtf.format(1, unit), expected[0]);
@@ -65,4 +66,5 @@ for (const unit of units) {
   assert.sameValue(rtf.format(-1, unit), expected[3]);
   assert.sameValue(rtf.format(-2, unit), `2 ${unit}s ago`);
   assert.sameValue(rtf.format(-10, unit), `10 ${unit}s ago`);
+  assert.sameValue(rtf.format(-1000, unit), `1,000 ${unit}s ago`);
 }

--- a/test/intl402/RelativeTimeFormat/prototype/formatToParts/en-us-numeric-always.js
+++ b/test/intl402/RelativeTimeFormat/prototype/formatToParts/en-us-numeric-always.js
@@ -34,7 +34,12 @@ const rtf = new Intl.RelativeTimeFormat("en-US");
 assert.sameValue(typeof rtf.formatToParts, "function", "formatToParts should be supported");
 
 for (const unit of units) {
-  // Note https://github.com/tc39/proposal-intl-relative-time/issues/80
+  verifyFormatParts(rtf.formatToParts(1000, unit), [
+    { "type": "literal", "value": "in " },
+    { "type": "integer", "value": "1,000", "unit": unit },
+    { "type": "literal", "value": ` ${unit}s` },
+  ], `formatToParts(1000, ${unit})`);
+
   verifyFormatParts(rtf.formatToParts(10, unit), [
     { "type": "literal", "value": "in " },
     { "type": "integer", "value": "10", "unit": unit },
@@ -78,4 +83,9 @@ for (const unit of units) {
     { "type": "integer", "value": "10", "unit": unit },
     { "type": "literal", "value": ` ${unit}s ago` },
   ], `formatToParts(-10, ${unit})`);
+
+  verifyFormatParts(rtf.formatToParts(-1000, unit), [
+    { "type": "integer", "value": "1,000", "unit": unit },
+    { "type": "literal", "value": ` ${unit}s ago` },
+  ], `formatToParts(-1000, ${unit})`);
 }

--- a/test/intl402/RelativeTimeFormat/prototype/formatToParts/en-us-numeric-auto.js
+++ b/test/intl402/RelativeTimeFormat/prototype/formatToParts/en-us-numeric-auto.js
@@ -72,17 +72,12 @@ const rtf = new Intl.RelativeTimeFormat("en-US", { "numeric": "auto" });
 assert.sameValue(typeof rtf.formatToParts, "function", "formatToParts should be supported");
 
 for (const unit of units) {
-  // Note https://github.com/tc39/proposal-intl-relative-time/issues/80
-  /*
-  assert.sameValue(rtf.formatToParts(10, unit), `in 10 ${unit}s`);
-  assert.sameValue(rtf.formatToParts(2, unit), `in 2 ${unit}s`);
-  assert.sameValue(rtf.formatToParts(1, unit), expected[0]);
-  assert.sameValue(rtf.formatToParts(0, unit), expected[1]);
-  assert.sameValue(rtf.formatToParts(-0, unit), expected[2]);
-  assert.sameValue(rtf.formatToParts(-1, unit), expected[3]);
-  assert.sameValue(rtf.formatToParts(-2, unit), `2 ${unit}s ago`);
-  assert.sameValue(rtf.formatToParts(-10, unit), `10 ${unit}s ago`);
-*/
+  verifyFormatParts(rtf.formatToParts(1000, unit), [
+    { "type": "literal", "value": "in " },
+    { "type": "integer", "value": "1,000", "unit": unit },
+    { "type": "literal", "value": ` ${unit}s` },
+  ], `formatToParts(1000, ${unit})`);
+
   verifyFormatParts(rtf.formatToParts(10, unit), [
     { "type": "literal", "value": "in " },
     { "type": "integer", "value": "10", "unit": unit },
@@ -126,4 +121,9 @@ for (const unit of units) {
     { "type": "integer", "value": "10", "unit": unit },
     { "type": "literal", "value": ` ${unit}s ago` },
   ], `formatToParts(-10, ${unit})`);
+
+  verifyFormatParts(rtf.formatToParts(-1000, unit), [
+    { "type": "integer", "value": "1,000", "unit": unit },
+    { "type": "literal", "value": ` ${unit}s ago` },
+  ], `formatToParts(-1000, ${unit})`);
 }


### PR DESCRIPTION
The specification was changed to remove the useGrouping option in
<https://github.com/tc39/proposal-intl-relative-time/pull/81>.

The change to remove the minimumIntegerDigits option in that PR was already
taken into account; this commit also removes the reference to the issue.

This also removes some commented-out code that was left in by accident.