### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "b69d88687a",
-  "targetRevisionAtLastExport": "93b2865ca",
+  "sourceRevisionAtLastExport": "3454cfdb5a",
+  "targetRevisionAtLastExport": "1804b1343",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/date-utc-optional.js
+++ b/implementation-contributed/javascriptcore/stress/date-utc-optional.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+for (var i = 0; i < 1e5; ++i) {
+    shouldBe(Number.isNaN(Date.UTC()), true);
+    shouldBe(Date.UTC(2018), 1514764800000);
+    shouldBe(Date.UTC(2018, 1), 1517443200000);
+    shouldBe(Date.UTC(2018, 1, 2), 1517529600000);
+    shouldBe(Date.UTC(2018, 1, 2, 3), 1517540400000);
+    shouldBe(Date.UTC(2018, 1, 2, 3, 4), 1517540640000);
+    shouldBe(Date.UTC(2018, 1, 2, 3, 4, 5), 1517540645000);
+    shouldBe(Date.UTC(2018, 1, 2, 3, 4, 5, 6), 1517540645006);
+    shouldBe(Date.UTC(2018, 1, 2, 3, 4, 5, 6, 7), 1517540645006);
+}


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[b69d88687a](https://github.com///github/blob/b69d88687a) in JavaScriptCore and all changes made since [93b2865ca](../blob/93b2865ca) in
test262.













### 1 New File Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/date-utc-optional.js](../blob/javascriptcore-test262-automation-export-93b2865ca/implementation-contributed/javascriptcore/stress/date-utc-optional.js)