### PR TITLE
Object.fromEntries: add basic tests

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -7,6 +7,10 @@
 #
 # https://github.com/tc39/process-document
 
+# Object.fromEntries
+# https://github.com/tc39/proposal-object-from-entries
+Object.fromEntries
+
 # BigInt
 # https://github.com/tc39/proposal-bigint
 BigInt

--- a/test/built-ins/Object/fromEntries/empty-iterable.js
+++ b/test/built-ins/Object/fromEntries/empty-iterable.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: When given an empty list, makes an empty object.
+esid: sec-object.fromentries
+features: [Object.fromEntries]
+---*/
+
+var result = Object.fromEntries([]);
+assert.sameValue(Object.keys(result).length, 0);

--- a/test/built-ins/Object/fromEntries/evaluation-order.js
+++ b/test/built-ins/Object/fromEntries/evaluation-order.js
@@ -1,0 +1,74 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Evaluation order is iterator.next(), get '0', get '1', toPropertyKey, repeat.
+esid: sec-object.fromentries
+includes: [compareArray.js]
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+var effects = [];
+
+function makeEntry(label) {
+  return {
+    get '0'() {
+      effects.push('access property "0" of ' + label + ' entry');
+      return {
+        toString: function() {
+          effects.push('toString of ' + label + ' key');
+          return label + ' key';
+        },
+      };
+    },
+    get '1'() {
+      effects.push('access property "1" of ' + label + ' entry');
+      return label + ' value';
+    },
+  };
+}
+
+var iterable = {
+  [Symbol.iterator]: function() {
+    effects.push('get Symbol.iterator');
+    var count = 0;
+    return {
+      next: function() {
+        effects.push('next ' + count);
+        if (count === 0) {
+          ++count;
+          return {
+            done: false,
+            value: makeEntry('first', 'first key', 'first value'),
+          };
+        } else if (count === 1) {
+          ++count;
+          return {
+            done: false,
+            value: makeEntry('second', 'second key', 'second value'),
+          };
+        } else {
+          return {
+            done: true,
+          };
+        }
+      },
+    };
+  },
+};
+
+var result = Object.fromEntries(iterable);
+assert.compareArray(effects, [
+  'get Symbol.iterator',
+  'next 0',
+  'access property "0" of first entry',
+  'access property "1" of first entry',
+  'toString of first key',
+  'next 1',
+  'access property "0" of second entry',
+  'access property "1" of second entry',
+  'toString of second key',
+  'next 2',
+], 'Object.fromEntries evaluation order');
+assert.sameValue(result['first key'], 'first value');
+assert.sameValue(result['second key'], 'second value');

--- a/test/built-ins/Object/fromEntries/iterator-closed-for-null-entry.js.js
+++ b/test/built-ins/Object/fromEntries/iterator-closed-for-null-entry.js.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Closes iterators when they return entries which are null.
+esid: sec-object.fromentries
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+var returned = false;
+var iterable = {
+  [Symbol.iterator]: function() {
+    var advanced = false;
+    return {
+      next: function() {
+        if (advanced) {
+          throw new Test262Error('should only advance once');
+        }
+        advanced = true;
+        return {
+          done: false,
+          value: 'null',
+        };
+      },
+      return: function() {
+        if (returned) {
+          throw new Test262Error('should only return once');
+        }
+        returned = true;
+      },
+    };
+  },
+};
+
+assert.throws(TypeError, function() {
+  Object.fromEntries(iterable);
+});
+
+assert(returned, 'iterator should be closed when entry is null');

--- a/test/built-ins/Object/fromEntries/iterator-closed-for-string-entry.js.js
+++ b/test/built-ins/Object/fromEntries/iterator-closed-for-string-entry.js.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Closes iterators when they return entries which are strings.
+esid: sec-object.fromentries
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+var returned = false;
+var iterable = {
+  [Symbol.iterator]: function() {
+    var advanced = false;
+    return {
+      next: function() {
+        if (advanced) {
+          throw new Test262Error('should only advance once');
+        }
+        advanced = true;
+        return {
+          done: false,
+          value: 'ab',
+        };
+      },
+      return: function() {
+        if (returned) {
+          throw new Test262Error('should only return once');
+        }
+        returned = true;
+      },
+    };
+  },
+};
+
+assert.throws(TypeError, function() {
+  Object.fromEntries(iterable);
+});
+
+assert(returned, 'iterator should be closed when entry is a string');

--- a/test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-accessor.js
+++ b/test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-accessor.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Closes iterators when accessing an entry's properties throws.
+esid: sec-object.fromentries
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+function DummyError() {}
+
+var returned = false;
+var iterable = {
+  [Symbol.iterator]: function() {
+    var advanced = false;
+    return {
+      next: function() {
+        if (advanced) {
+          throw new Test262Error('should only advance once');
+        }
+        advanced = true;
+        return {
+          done: false,
+          value: {
+            get '0'() {
+              throw new DummyError();
+            },
+          },
+        };
+      },
+      return: function() {
+        if (returned) {
+          throw new Test262Error('should only return once');
+        }
+        returned = true;
+      },
+    };
+  },
+};
+
+assert.throws(DummyError, function() {
+  Object.fromEntries(iterable);
+});
+
+assert(returned, 'iterator should be closed when entry property access throws');

--- a/test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-key-tostring.js
+++ b/test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-key-tostring.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Closes iterators when toString on a key throws.
+esid: sec-object.fromentries
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+function DummyError() {}
+
+var returned = false;
+var iterable = {
+  [Symbol.iterator]: function() {
+    var advanced = false;
+    return {
+      next: function() {
+        if (advanced) {
+          throw new Test262Error('should only advance once');
+        }
+        advanced = true;
+        return {
+          done: false,
+          value: {
+            0: {
+              toString: function() {
+                throw new DummyError();
+              },
+            },
+          },
+        };
+      },
+      return: function() {
+        if (returned) {
+          throw new Test262Error('should only return once');
+        }
+        returned = true;
+      },
+    };
+  },
+};
+
+assert.throws(DummyError, function() {
+  Object.fromEntries(iterable);
+});
+
+assert(returned, 'iterator should be closed when key toString throws');

--- a/test/built-ins/Object/fromEntries/iterator-not-closed-for-next-returning-non-object.js
+++ b/test/built-ins/Object/fromEntries/iterator-not-closed-for-next-returning-non-object.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Does not close iterators with a `next` method which returns a non-object.
+esid: sec-object.fromentries
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+var iterable = {
+  [Symbol.iterator]: function() {
+    return {
+      next: function() {
+        return null;
+      },
+      return: function() {
+        throw new Test262Error('should not call return');
+      },
+    };
+  },
+};
+
+assert.throws(TypeError, function() {
+  Object.fromEntries(iterable);
+});

--- a/test/built-ins/Object/fromEntries/iterator-not-closed-for-throwing-done-accessor.js
+++ b/test/built-ins/Object/fromEntries/iterator-not-closed-for-throwing-done-accessor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Does not close iterators with a `done` accessor which throws.
+esid: sec-object.fromentries
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+function DummyError() {}
+
+var returned = false;
+var iterable = {
+  [Symbol.iterator]: function() {
+    return {
+      next: function() {
+        return {
+          get done() {
+            throw new DummyError();
+          },
+        };
+      },
+      return: function() {
+        throw new Test262Error('should not call return');
+      },
+    };
+  },
+};
+
+assert.throws(DummyError, function() {
+  Object.fromEntries(iterable);
+});

--- a/test/built-ins/Object/fromEntries/iterator-not-closed-for-throwing-next.js
+++ b/test/built-ins/Object/fromEntries/iterator-not-closed-for-throwing-next.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Does not close iterators with a `next` method which throws.
+esid: sec-object.fromentries
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+function DummyError() {}
+
+var iterable = {
+  [Symbol.iterator]: function() {
+    return {
+      next: function() {
+        throw new DummyError();
+      },
+      return: function() {
+        throw new Test262Error('should not call return');
+      },
+    };
+  },
+};
+
+assert.throws(DummyError, function() {
+  Object.fromEntries(iterable);
+});

--- a/test/built-ins/Object/fromEntries/iterator-not-closed-for-uncallable-next.js
+++ b/test/built-ins/Object/fromEntries/iterator-not-closed-for-uncallable-next.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Does not close iterators with an uncallable `next` property.
+esid: sec-object.fromentries
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+var iterable = {
+  [Symbol.iterator]: function() {
+    return {
+      next: null,
+      return: function() {
+        throw new Test262Error('should not call return');
+      },
+    };
+  },
+};
+
+assert.throws(TypeError, function() {
+  Object.fromEntries(iterable);
+});

--- a/test/built-ins/Object/fromEntries/key-order.js
+++ b/test/built-ins/Object/fromEntries/key-order.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Key enumeration order of result objects matches the order of entries in the iterable.
+esid: sec-object.fromentries
+includes: [compareArray.js]
+features: [Object.fromEntries]
+---*/
+
+var entries = [
+  ['z', 1],
+  ['y', 2],
+  ['x', 3],
+  ['y', 4],
+];
+
+var result = Object.fromEntries(entries);
+assert.sameValue(result['z'], 1);
+assert.sameValue(result['y'], 4);
+assert.sameValue(result['x'], 3);
+assert.compareArray(Object.keys(result), ['z', 'y', 'x']);

--- a/test/built-ins/Object/fromEntries/length.js
+++ b/test/built-ins/Object/fromEntries/length.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Object.fromEntries.length is 1.
+esid: sec-object.fromentries
+includes: [propertyHelper.js]
+features: [Object.fromEntries]
+---*/
+
+assert.sameValue(Object.fromEntries.length, 1);
+
+verifyNotEnumerable(Object.fromEntries, "length");
+verifyNotWritable(Object.fromEntries, "length");
+verifyConfigurable(Object.fromEntries, "length");

--- a/test/built-ins/Object/fromEntries/name.js
+++ b/test/built-ins/Object/fromEntries/name.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Object.fromEntries.name is "fromEntries".
+esid: sec-object.fromentries
+includes: [propertyHelper.js]
+features: [Object.fromEntries]
+---*/
+
+assert.sameValue(Object.fromEntries.name, "fromEntries");
+
+verifyNotEnumerable(Object.fromEntries, "name");
+verifyNotWritable(Object.fromEntries, "name");
+verifyConfigurable(Object.fromEntries, "name");

--- a/test/built-ins/Object/fromEntries/prototype.js
+++ b/test/built-ins/Object/fromEntries/prototype.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Created objects inherit from Object.prototype.
+esid: sec-object.fromentries
+features: [Object.fromEntries]
+---*/
+
+var result = Object.fromEntries([]);
+assert.sameValue(Object.getPrototypeOf(result), Object.prototype);

--- a/test/built-ins/Object/fromEntries/requires-argument.js
+++ b/test/built-ins/Object/fromEntries/requires-argument.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Throws when called without an argument.
+esid: sec-object.fromentries
+features: [Object.fromEntries]
+---*/
+
+assert.throws(TypeError, function() {
+  Object.fromEntries();
+});

--- a/test/built-ins/Object/fromEntries/simple-properties.js
+++ b/test/built-ins/Object/fromEntries/simple-properties.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Creates data properties which are enumerable, writable, and configurable.
+esid: sec-object.fromentries
+includes: [propertyHelper.js]
+features: [Object.fromEntries]
+---*/
+
+var result = Object.fromEntries([['key', 'value']]);
+verifyEnumerable(result, 'key');
+verifyWritable(result, 'key');
+verifyConfigurable(result, 'key');

--- a/test/built-ins/Object/fromEntries/string-entry-object-succeeds.js
+++ b/test/built-ins/Object/fromEntries/string-entry-object-succeeds.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Succeeds when an entry object is a boxed string.
+esid: sec-object.fromentries
+features: [Object.fromEntries]
+---*/
+
+var result = Object.fromEntries([Object('ab')]);
+assert.sameValue(result['a'], 'b');

--- a/test/built-ins/Object/fromEntries/string-entry-primitive-throws.js
+++ b/test/built-ins/Object/fromEntries/string-entry-primitive-throws.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Throws when an entry object is a primitive string.
+esid: sec-object.fromentries
+features: [Object.fromEntries]
+---*/
+
+assert.throws(TypeError, function() {
+  Object.fromEntries(['ab']);
+});

--- a/test/built-ins/Object/fromEntries/supports-symbols.js
+++ b/test/built-ins/Object/fromEntries/supports-symbols.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Allows symbol keys.
+esid: sec-object.fromentries
+features: [Symbol, Object.fromEntries]
+---*/
+
+var key = Symbol();
+var result = Object.fromEntries([[key, 'value']]);
+assert.sameValue(result[key], 'value');

--- a/test/built-ins/Object/fromEntries/to-property-key.js
+++ b/test/built-ins/Object/fromEntries/to-property-key.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Coerces keys to strings using ToPropertyKey.
+esid: sec-object.fromentries
+features: [Symbol.toPrimitive, Object.fromEntries]
+---*/
+
+var key = {
+  [Symbol.toPrimitive]: function(hint) {
+    assert.sameValue(hint, 'string');
+    return 'key';
+  },
+};
+var result = Object.fromEntries([[key, 'value']]);
+assert.sameValue(result.key, 'value');

--- a/test/built-ins/Object/fromEntries/uses-define-semantics.js
+++ b/test/built-ins/Object/fromEntries/uses-define-semantics.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Uses [[DefineOwnProperty]] rather than [[Set]].
+esid: sec-object.fromentries
+features: [Object.fromEntries]
+---*/
+
+Object.defineProperty(Object.prototype, 'property', {
+  get: function() {
+    throw new Test262Error('should not trigger getter on Object.prototype');
+  },
+  set: function() {
+    throw new Test262Error('should not trigger setter on Object.prototype');
+  },
+});
+
+var result = Object.fromEntries([['property', 'value']]);
+assert.sameValue(result['property'], 'value', '');

--- a/test/built-ins/Object/fromEntries/uses-keys-not-iterator.js
+++ b/test/built-ins/Object/fromEntries/uses-keys-not-iterator.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Reads properties rather than iterating.
+esid: sec-object.fromentries
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+var iterable = {
+  [Symbol.iterator]: function() {
+    var count = 0;
+    return {
+      next: function() {
+        if (count === 0) {
+          ++count;
+          return {
+            done: false,
+            value: {
+              '0': 'first key',
+              '1': 'first value',
+              get [Symbol.iterator]() {
+                throw new Test262Error('Object.fromEntries should not access Symbol.iterator on entry objects');
+              },
+            },
+          };
+        } else if (count === 1) {
+          ++count;
+          Array.prototype[Symbol.iterator] = function() {
+            throw new Test262Error('Object.fromEntries should not access Symbol.iterator on entry arrays');
+          };
+          return {
+            done: false,
+            value: ['second key', 'second value'],
+          };
+        } else {
+          return {
+            done: true,
+          };
+        }
+      },
+    };
+  },
+};
+
+var result = Object.fromEntries(iterable);
+assert.sameValue(result['first key'], 'first value');
+assert.sameValue(result['second key'], 'second value');


### PR DESCRIPTION
See https://github.com/tc39/proposal-object-from-entries. This proposal is stage 3, so these tests should be good to merge.

The [reference implementation](https://github.com/tc39/proposal-object-from-entries/blob/2ccf4e528b441d8da308b76f7db465edcb6803a6/polyfill.js) passes all of these tests.

cc @ljharb