### PR TITLE
Add test for private accessor methods

### DIFF
--- a/src/accessor-names/default/cls-private-decl-inst.template
+++ b/src/accessor-names/default/cls-private-decl-inst.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/class/accessor-name-inst-
+name: Class declaration, instance method
+esid: sec-runtime-semantics-classdefinitionevaluation
+es6id: 14.5.14
+info: |
+  [...]
+  21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+         i. Let status be the result of performing PropertyDefinitionEvaluation
+            for m with arguments proto and false.
+---*/
+
+var stringSet;
+
+class C {
+  get /*{ declareWith }*/() { return 'get string'; }
+  set /*{ declareWith }*/(param) { stringSet = param; }
+}
+
+assert.sameValue(C.prototype[/*{ referenceWith }*/], 'get string');
+
+C.prototype[/*{ referenceWith }*/] = 'set string';
+assert.sameValue(stringSet, 'set string');

--- a/src/accessor-names/default/cls-private-decl-inst.template
+++ b/src/accessor-names/default/cls-private-decl-inst.template
@@ -29,15 +29,15 @@ class C {
   set #/*{ declareWith }*/(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#/*{ referenceWith }*/;
+    return this[#/*{ referenceWith }*/];
   }
 
   setPrivateReference(value) {
-    this.#/*{ referenceWith }*/ = value;
+    this[#/*{ referenceWith }*/] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/src/accessor-names/default/cls-private-decl-inst.template
+++ b/src/accessor-names/default/cls-private-decl-inst.template
@@ -1,26 +1,45 @@
-// Copyright (C) 2017 Mike Pennisi. All rights reserved.
+// Copyright (C) 2018 Katie Broida. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-path: language/statements/class/accessor-name-inst-
-name: Class declaration, instance method
-esid: sec-runtime-semantics-classdefinitionevaluation
-es6id: 14.5.14
+path: language/statements/class/private-accessor-name-inst-
+name: Class declaration, private instance method
+esid: #prod-MethodDefinition
 info: |
   [...]
-  21. For each ClassElement m in order from methods
-      a. If IsStatic of m is false, then
-         i. Let status be the result of performing PropertyDefinitionEvaluation
-            for m with arguments proto and false.
+  MethodDefinition[Yield, Await]:
+      PropertyNameClassElementName [?Yield, ?Await](
+        UniqueFormalParameters [~Yield, ~Await] ) {
+        FunctionBody [~Yield, ~Await] }
+      AsyncMethod[?Yield, ?Await]
+        get PropertyName ClassElementName [?Yield, ?Await] (){
+          FunctionBody [~Yield, ~Await] }
+        set PropertyNameClassElementName [?Yield, ?Await] (
+          PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+      AsyncMethod [Yield, Await]:
+        async [no LineTerminator here] PropertyName
+          ClassElementName[?Yield, ?Await](
+          UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
 ---*/
 
 var stringSet;
 
 class C {
-  get /*{ declareWith }*/() { return 'get string'; }
-  set /*{ declareWith }*/(param) { stringSet = param; }
-}
+  get #/*{ declareWith }*/() { return 'get string'; }
+  set #/*{ declareWith }*/(param) { stringSet = param; }
 
-assert.sameValue(C.prototype[/*{ referenceWith }*/], 'get string');
+  getPrivateReference() {
+    return this.#/*{ referenceWith }*/;
+  }
 
-C.prototype[/*{ referenceWith }*/] = 'set string';
+  setPrivateReference(value) {
+    this.#/*{ referenceWith }*/ = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
 assert.sameValue(stringSet, 'set string');

--- a/src/accessor-names/default/cls-private-decl-static.template
+++ b/src/accessor-names/default/cls-private-decl-static.template
@@ -1,0 +1,46 @@
+// Copyright (C) 2018 Katie Broida. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/statements/class/private-accessor-name-static-
+name: Class declaration, static method
+esid: #prod-MethodDefinition
+info: |
+  [...]
+  MethodDefinition[Yield, Await]:
+      PropertyNameClassElementName [?Yield, ?Await](
+        UniqueFormalParameters [~Yield, ~Await] ) {
+        FunctionBody [~Yield, ~Await] }
+      AsyncMethod[?Yield, ?Await]
+        get PropertyName ClassElementName [?Yield, ?Await] (){
+          FunctionBody [~Yield, ~Await] }
+        set PropertyNameClassElementName [?Yield, ?Await] (
+          PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+      AsyncMethod [Yield, Await]:
+        async [no LineTerminator here] PropertyName
+          ClassElementName[?Yield, ?Await](
+          UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+---*/
+
+var stringSet;
+
+class C {
+  static get #/*{ declareWith }*/() { return 'get string'; }
+  static set #/*{ declareWith }*/(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#/*{ referenceWith }*/;
+  }
+
+  static setPrivateReference(value) {
+    this.#/*{ referenceWith }*/ = value;
+  }
+}
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/src/accessor-names/default/cls-private-decl-static.template
+++ b/src/accessor-names/default/cls-private-decl-static.template
@@ -29,11 +29,11 @@ class C {
   static set #/*{ declareWith }*/(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#/*{ referenceWith }*/;
+    return this[#/*{ referenceWith }*/];
   }
 
   static setPrivateReference(value) {
-    this.#/*{ referenceWith }*/ = value;
+    this[#/*{ referenceWith }*/] = value;
   }
 }
 

--- a/src/accessor-names/default/cls-private-decl-static.template
+++ b/src/accessor-names/default/cls-private-decl-static.template
@@ -37,10 +37,8 @@ class C {
   }
 }
 
-var inst = C();
+assert.sameValue(C.getPrivateReference(), 'get string');
 
-assert.sameValue(inst.getPrivateReference(), 'get string');
-
-inst.setPrivateReference('set string');
+C.setPrivateReference('set string');
 assert.sameValue(stringSet, 'set string');
 

--- a/src/accessor-names/default/cls-private-expr-inst.template
+++ b/src/accessor-names/default/cls-private-expr-inst.template
@@ -1,0 +1,45 @@
+// Copyright (C) 2018 Katie Broida. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/class/private-accessor-name-inst-
+name: Class expression, instance private method
+esid: #prod-MethodDefinition
+info: |
+  [...]
+    MethodDefinition[Yield, Await]:
+      PropertyNameClassElementName [?Yield, ?Await](
+        UniqueFormalParameters [~Yield, ~Await] ) {
+        FunctionBody [~Yield, ~Await] }
+      AsyncMethod[?Yield, ?Await]
+        get PropertyName ClassElementName [?Yield, ?Await] (){
+          FunctionBody [~Yield, ~Await] }
+        set PropertyNameClassElementName [?Yield, ?Await] ( 
+          PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+      AsyncMethod [Yield, Await]:
+        async [no LineTerminator here] PropertyName
+          ClassElementName[?Yield, ?Await](
+          UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+---*/
+
+var stringSet;
+
+var C = class {
+  get #/*{ declareWith }*/() { return 'get string'; }
+  set #/*{ declareWith }*/(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#/*{ referenceWith }*/;
+  }
+
+  setPrivateReference(value) {
+    this.#/*{ referenceWith }*/ = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/src/accessor-names/default/cls-private-expr-inst.template
+++ b/src/accessor-names/default/cls-private-expr-inst.template
@@ -29,15 +29,15 @@ var C = class {
   set #/*{ declareWith }*/(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#/*{ referenceWith }*/;
+    return this[#/*{ referenceWith }*/];
   }
 
   setPrivateReference(value) {
-    this.#/*{ referenceWith }*/ = value;
+    this[#/*{ referenceWith }*/] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/src/accessor-names/default/cls-private-expr-inst.template
+++ b/src/accessor-names/default/cls-private-expr-inst.template
@@ -13,7 +13,7 @@ info: |
       AsyncMethod[?Yield, ?Await]
         get PropertyName ClassElementName [?Yield, ?Await] (){
           FunctionBody [~Yield, ~Await] }
-        set PropertyNameClassElementName [?Yield, ?Await] ( 
+        set PropertyNameClassElementName [?Yield, ?Await] (
           PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
       AsyncMethod [Yield, Await]:
         async [no LineTerminator here] PropertyName

--- a/src/accessor-names/default/cls-private-expr-static.template
+++ b/src/accessor-names/default/cls-private-expr-static.template
@@ -1,0 +1,45 @@
+// Copyright (C) 2018 Katie Broida. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: language/expressions/class/private-accessor-name-static-
+name: Class expression, static private method
+esid: #prod-MethodDefinition
+info: |
+  [...]
+  MethodDefinition[Yield, Await]:
+      PropertyNameClassElementName [?Yield, ?Await](
+        UniqueFormalParameters [~Yield, ~Await] ) {
+        FunctionBody [~Yield, ~Await] }
+      AsyncMethod[?Yield, ?Await]
+        get PropertyName ClassElementName [?Yield, ?Await] (){
+          FunctionBody [~Yield, ~Await] }
+        set PropertyNameClassElementName [?Yield, ?Await] ( 
+          PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+      AsyncMethod [Yield, Await]:
+        async [no LineTerminator here] PropertyName
+          ClassElementName[?Yield, ?Await](
+          UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #/*{ declareWith }*/() { return 'get string'; }
+  static set #/*{ declareWith }*/(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#/*{ referenceWith }*/;
+  }
+
+  static setPrivateReference(value) {
+    this.#/*{ referenceWith }*/ = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/src/accessor-names/default/cls-private-expr-static.template
+++ b/src/accessor-names/default/cls-private-expr-static.template
@@ -37,9 +37,8 @@ var C = class {
   }
 };
 
-var inst = C();
 
-assert.sameValue(inst.getPrivateReference(), 'get string');
+assert.sameValue(C.getPrivateReference(), 'get string');
 
-inst.setPrivateReference('set string');
+C.setPrivateReference('set string');
 assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-computed.js
+++ b/test/language/expressions/class/private-accessor-name-inst-computed.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (AssignmentExpression) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+var _;
+
+
+var stringSet;
+
+var C = class {
+  get #[_ = 'str' + 'ing']() { return 'get string'; }
+  set #[_ = 'str' + 'ing'](param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'string';
+  }
+
+  setPrivateReference(value) {
+    this.#'string' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-computed.js
+++ b/test/language/expressions/class/private-accessor-name-inst-computed.js
@@ -41,15 +41,15 @@ var C = class {
   set #[_ = 'str' + 'ing'](param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'string';
+    return this[#'string'];
   }
 
   setPrivateReference(value) {
-    this.#'string' = value;
+    this[#'string'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-numeric-binary.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-numeric-binary.js
@@ -39,15 +39,15 @@ var C = class {
   set #0b10(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'2';
+    return this[#'2'];
   }
 
   setPrivateReference(value) {
-    this.#'2' = value;
+    this[#'2'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-numeric-binary.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-numeric-binary.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-binary.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in binary notation) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get #0b10() { return 'get string'; }
+  set #0b10(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'2';
+  }
+
+  setPrivateReference(value) {
+    this.#'2' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-literal-numeric-exponent.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-numeric-exponent.js
@@ -39,15 +39,15 @@ var C = class {
   set #1E+9(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'1000000000';
+    return this[#'1000000000'];
   }
 
   setPrivateReference(value) {
-    this.#'1000000000' = value;
+    this[#'1000000000'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-numeric-exponent.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-numeric-exponent.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-exponent.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in exponent notation) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get #1E+9() { return 'get string'; }
+  set #1E+9(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'1000000000';
+  }
+
+  setPrivateReference(value) {
+    this.#'1000000000' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-literal-numeric-hex.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-numeric-hex.js
@@ -39,15 +39,15 @@ var C = class {
   set #0x10(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'16';
+    return this[#'16'];
   }
 
   setPrivateReference(value) {
-    this.#'16' = value;
+    this[#'16'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-numeric-hex.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-numeric-hex.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-hex.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in hexadecimal notation) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get #0x10() { return 'get string'; }
+  set #0x10(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'16';
+  }
+
+  setPrivateReference(value) {
+    this.#'16' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-literal-numeric-leading-decimal.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-numeric-leading-decimal.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-leading-decimal.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal with leading decimal point) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get #.1() { return 'get string'; }
+  set #.1(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'0.1';
+  }
+
+  setPrivateReference(value) {
+    this.#'0.1' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-literal-numeric-leading-decimal.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-numeric-leading-decimal.js
@@ -39,15 +39,15 @@ var C = class {
   set #.1(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'0.1';
+    return this[#'0.1'];
   }
 
   setPrivateReference(value) {
-    this.#'0.1' = value;
+    this[#'0.1'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-numeric-non-canonical.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-numeric-non-canonical.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-non-canonical.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal with non-canonical representation) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get #0.0000001() { return 'get string'; }
+  set #0.0000001(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'1e-7';
+  }
+
+  setPrivateReference(value) {
+    this.#'1e-7' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-literal-numeric-non-canonical.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-numeric-non-canonical.js
@@ -39,15 +39,15 @@ var C = class {
   set #0.0000001(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'1e-7';
+    return this[#'1e-7'];
   }
 
   setPrivateReference(value) {
-    this.#'1e-7' = value;
+    this[#'1e-7'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-numeric-octal.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-numeric-octal.js
@@ -39,15 +39,15 @@ var C = class {
   set #0o10(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'8';
+    return this[#'8'];
   }
 
   setPrivateReference(value) {
-    this.#'8' = value;
+    this[#'8'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-numeric-octal.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-numeric-octal.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-octal.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in octal notation) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get #0o10() { return 'get string'; }
+  set #0o10(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'8';
+  }
+
+  setPrivateReference(value) {
+    this.#'8' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-literal-numeric-zero.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-numeric-zero.js
@@ -39,15 +39,15 @@ var C = class {
   set #0(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'0';
+    return this[#'0'];
   }
 
   setPrivateReference(value) {
-    this.#'0' = value;
+    this[#'0'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-numeric-zero.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-numeric-zero.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-zero.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal zero) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get #0() { return 'get string'; }
+  set #0(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'0';
+  }
+
+  setPrivateReference(value) {
+    this.#'0' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-literal-string-char-escape.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-string-char-escape.js
@@ -39,15 +39,15 @@ var C = class {
   set #'character\tescape'(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'character	escape';
+    return this[#'character	escape'];
   }
 
   setPrivateReference(value) {
-    this.#'character	escape' = value;
+    this[#'character	escape'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-string-char-escape.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-string-char-escape.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-char-escape.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (string literal containing a character escape sequence) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get #'character\tescape'() { return 'get string'; }
+  set #'character\tescape'(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'character	escape';
+  }
+
+  setPrivateReference(value) {
+    this.#'character	escape' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-literal-string-double-quote.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-string-double-quote.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-double-quote.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (string literal using double quotes) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get #"doubleQuote"() { return 'get string'; }
+  set #"doubleQuote"(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#"doubleQuote";
+  }
+
+  setPrivateReference(value) {
+    this.#"doubleQuote" = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-literal-string-double-quote.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-string-double-quote.js
@@ -39,15 +39,15 @@ var C = class {
   set #"doubleQuote"(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#"doubleQuote";
+    return this[#"doubleQuote"];
   }
 
   setPrivateReference(value) {
-    this.#"doubleQuote" = value;
+    this[#"doubleQuote"] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-string-empty.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-string-empty.js
@@ -39,15 +39,15 @@ var C = class {
   set #''(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'';
+    return this[#''];
   }
 
   setPrivateReference(value) {
-    this.#'' = value;
+    this[#''] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-string-empty.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-string-empty.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-empty.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (string literal, the empty string) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get #''() { return 'get string'; }
+  set #''(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'';
+  }
+
+  setPrivateReference(value) {
+    this.#'' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-literal-string-hex-escape.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-string-hex-escape.js
@@ -39,15 +39,15 @@ var C = class {
   set #'hex\x45scape'(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'hexEscape';
+    return this[#'hexEscape'];
   }
 
   setPrivateReference(value) {
-    this.#'hexEscape' = value;
+    this[#'hexEscape'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-string-hex-escape.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-string-hex-escape.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-hex-escape.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (string literal containing a hexadecimal escape sequence) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get #'hex\x45scape'() { return 'get string'; }
+  set #'hex\x45scape'(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'hexEscape';
+  }
+
+  setPrivateReference(value) {
+    this.#'hexEscape' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-literal-string-line-continuation.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-string-line-continuation.js
@@ -41,15 +41,15 @@ Continuation'() { return 'get string'; }
 Continuation'(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'lineContinuation';
+    return this[#'lineContinuation'];
   }
 
   setPrivateReference(value) {
-    this.#'lineContinuation' = value;
+    this[#'lineContinuation'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-string-line-continuation.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-string-line-continuation.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-line-continuation.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (string literal containing LineContinuation) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get #'line\
+Continuation'() { return 'get string'; }
+  set #'line\
+Continuation'(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'lineContinuation';
+  }
+
+  setPrivateReference(value) {
+    this.#'lineContinuation' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-literal-string-single-quote.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-string-single-quote.js
@@ -39,15 +39,15 @@ var C = class {
   set #'singleQuote'(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'singleQuote';
+    return this[#'singleQuote'];
   }
 
   setPrivateReference(value) {
-    this.#'singleQuote' = value;
+    this[#'singleQuote'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-string-single-quote.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-string-single-quote.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-single-quote.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (string literal using single quotes) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get #'singleQuote'() { return 'get string'; }
+  set #'singleQuote'(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'singleQuote';
+  }
+
+  setPrivateReference(value) {
+    this.#'singleQuote' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-inst-literal-string-unicode-escape.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-string-unicode-escape.js
@@ -39,15 +39,15 @@ var C = class {
   set #'unicod\u{000065}Escape'(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'unicodeEscape';
+    return this[#'unicodeEscape'];
   }
 
   setPrivateReference(value) {
-    this.#'unicodeEscape' = value;
+    this[#'unicodeEscape'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/expressions/class/private-accessor-name-inst-literal-string-unicode-escape.js
+++ b/test/language/expressions/class/private-accessor-name-inst-literal-string-unicode-escape.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-unicode-escape.case
+// - src/accessor-names/default/cls-private-expr-inst.template
+/*---
+description: Computed values as accessor property names (string literal containing a Unicode escape sequence) (Class expression, instance private method)
+flags: [generated]
+info: |
+    [...]
+      MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  get #'unicod\u{000065}Escape'() { return 'get string'; }
+  set #'unicod\u{000065}Escape'(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'unicodeEscape';
+  }
+
+  setPrivateReference(value) {
+    this.#'unicodeEscape' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-computed.js
+++ b/test/language/expressions/class/private-accessor-name-static-computed.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (AssignmentExpression) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+var _;
+
+
+var stringSet;
+
+var C = class {
+  static get #[_ = 'str' + 'ing']() { return 'get string'; }
+  static set #[_ = 'str' + 'ing'](param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'string';
+  }
+
+  static setPrivateReference(value) {
+    this.#'string' = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-literal-numeric-binary.js
+++ b/test/language/expressions/class/private-accessor-name-static-literal-numeric-binary.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-binary.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in binary notation) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #0b10() { return 'get string'; }
+  static set #0b10(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'2';
+  }
+
+  static setPrivateReference(value) {
+    this.#'2' = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-literal-numeric-exponent.js
+++ b/test/language/expressions/class/private-accessor-name-static-literal-numeric-exponent.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-exponent.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in exponent notation) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #1E+9() { return 'get string'; }
+  static set #1E+9(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'1000000000';
+  }
+
+  static setPrivateReference(value) {
+    this.#'1000000000' = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-literal-numeric-hex.js
+++ b/test/language/expressions/class/private-accessor-name-static-literal-numeric-hex.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-hex.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in hexadecimal notation) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #0x10() { return 'get string'; }
+  static set #0x10(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'16';
+  }
+
+  static setPrivateReference(value) {
+    this.#'16' = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-literal-numeric-leading-decimal.js
+++ b/test/language/expressions/class/private-accessor-name-static-literal-numeric-leading-decimal.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-leading-decimal.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (numeric literal with leading decimal point) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #.1() { return 'get string'; }
+  static set #.1(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'0.1';
+  }
+
+  static setPrivateReference(value) {
+    this.#'0.1' = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-literal-numeric-non-canonical.js
+++ b/test/language/expressions/class/private-accessor-name-static-literal-numeric-non-canonical.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-non-canonical.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (numeric literal with non-canonical representation) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #0.0000001() { return 'get string'; }
+  static set #0.0000001(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'1e-7';
+  }
+
+  static setPrivateReference(value) {
+    this.#'1e-7' = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-literal-numeric-octal.js
+++ b/test/language/expressions/class/private-accessor-name-static-literal-numeric-octal.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-octal.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in octal notation) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #0o10() { return 'get string'; }
+  static set #0o10(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'8';
+  }
+
+  static setPrivateReference(value) {
+    this.#'8' = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-literal-numeric-zero.js
+++ b/test/language/expressions/class/private-accessor-name-static-literal-numeric-zero.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-zero.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (numeric literal zero) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #0() { return 'get string'; }
+  static set #0(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'0';
+  }
+
+  static setPrivateReference(value) {
+    this.#'0' = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-literal-string-char-escape.js
+++ b/test/language/expressions/class/private-accessor-name-static-literal-string-char-escape.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-char-escape.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (string literal containing a character escape sequence) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #'character\tescape'() { return 'get string'; }
+  static set #'character\tescape'(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'character	escape';
+  }
+
+  static setPrivateReference(value) {
+    this.#'character	escape' = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-literal-string-double-quote.js
+++ b/test/language/expressions/class/private-accessor-name-static-literal-string-double-quote.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-double-quote.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (string literal using double quotes) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #"doubleQuote"() { return 'get string'; }
+  static set #"doubleQuote"(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#"doubleQuote";
+  }
+
+  static setPrivateReference(value) {
+    this.#"doubleQuote" = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-literal-string-empty.js
+++ b/test/language/expressions/class/private-accessor-name-static-literal-string-empty.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-empty.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (string literal, the empty string) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #''() { return 'get string'; }
+  static set #''(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'';
+  }
+
+  static setPrivateReference(value) {
+    this.#'' = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-literal-string-hex-escape.js
+++ b/test/language/expressions/class/private-accessor-name-static-literal-string-hex-escape.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-hex-escape.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (string literal containing a hexadecimal escape sequence) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #'hex\x45scape'() { return 'get string'; }
+  static set #'hex\x45scape'(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'hexEscape';
+  }
+
+  static setPrivateReference(value) {
+    this.#'hexEscape' = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-literal-string-line-continuation.js
+++ b/test/language/expressions/class/private-accessor-name-static-literal-string-line-continuation.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-line-continuation.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (string literal containing LineContinuation) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #'line\
+Continuation'() { return 'get string'; }
+  static set #'line\
+Continuation'(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'lineContinuation';
+  }
+
+  static setPrivateReference(value) {
+    this.#'lineContinuation' = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-literal-string-single-quote.js
+++ b/test/language/expressions/class/private-accessor-name-static-literal-string-single-quote.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-single-quote.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (string literal using single quotes) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #'singleQuote'() { return 'get string'; }
+  static set #'singleQuote'(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'singleQuote';
+  }
+
+  static setPrivateReference(value) {
+    this.#'singleQuote' = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/expressions/class/private-accessor-name-static-literal-string-unicode-escape.js
+++ b/test/language/expressions/class/private-accessor-name-static-literal-string-unicode-escape.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-unicode-escape.case
+// - src/accessor-names/default/cls-private-expr-static.template
+/*---
+description: Computed values as accessor property names (string literal containing a Unicode escape sequence) (Class expression, static private method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] ( 
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+var C = class {
+  static get #'unicod\u{000065}Escape'() { return 'get string'; }
+  static set #'unicod\u{000065}Escape'(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'unicodeEscape';
+  }
+
+  static setPrivateReference(value) {
+    this.#'unicodeEscape' = value;
+  }
+};
+
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-computed.js
+++ b/test/language/statements/class/private-accessor-name-inst-computed.js
@@ -41,15 +41,15 @@ class C {
   set #[_ = 'str' + 'ing'](param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'string';
+    return this[#'string'];
   }
 
   setPrivateReference(value) {
-    this.#'string' = value;
+    this[#'string'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-computed.js
+++ b/test/language/statements/class/private-accessor-name-inst-computed.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (AssignmentExpression) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+var _;
+
+
+var stringSet;
+
+class C {
+  get #[_ = 'str' + 'ing']() { return 'get string'; }
+  set #[_ = 'str' + 'ing'](param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'string';
+  }
+
+  setPrivateReference(value) {
+    this.#'string' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-literal-numeric-binary.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-numeric-binary.js
@@ -39,15 +39,15 @@ class C {
   set #0b10(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'2';
+    return this[#'2'];
   }
 
   setPrivateReference(value) {
-    this.#'2' = value;
+    this[#'2'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-literal-numeric-binary.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-numeric-binary.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-binary.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in binary notation) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get #0b10() { return 'get string'; }
+  set #0b10(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'2';
+  }
+
+  setPrivateReference(value) {
+    this.#'2' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-literal-numeric-exponent.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-numeric-exponent.js
@@ -39,15 +39,15 @@ class C {
   set #1E+9(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'1000000000';
+    return this[#'1000000000'];
   }
 
   setPrivateReference(value) {
-    this.#'1000000000' = value;
+    this[#'1000000000'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-literal-numeric-exponent.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-numeric-exponent.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-exponent.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in exponent notation) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get #1E+9() { return 'get string'; }
+  set #1E+9(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'1000000000';
+  }
+
+  setPrivateReference(value) {
+    this.#'1000000000' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-literal-numeric-hex.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-numeric-hex.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-hex.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in hexadecimal notation) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get #0x10() { return 'get string'; }
+  set #0x10(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'16';
+  }
+
+  setPrivateReference(value) {
+    this.#'16' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-literal-numeric-hex.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-numeric-hex.js
@@ -39,15 +39,15 @@ class C {
   set #0x10(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'16';
+    return this[#'16'];
   }
 
   setPrivateReference(value) {
-    this.#'16' = value;
+    this[#'16'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-literal-numeric-leading-decimal.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-numeric-leading-decimal.js
@@ -39,15 +39,15 @@ class C {
   set #.1(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'0.1';
+    return this[#'0.1'];
   }
 
   setPrivateReference(value) {
-    this.#'0.1' = value;
+    this[#'0.1'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-literal-numeric-leading-decimal.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-numeric-leading-decimal.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-leading-decimal.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal with leading decimal point) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get #.1() { return 'get string'; }
+  set #.1(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'0.1';
+  }
+
+  setPrivateReference(value) {
+    this.#'0.1' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-literal-numeric-non-canonical.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-numeric-non-canonical.js
@@ -39,15 +39,15 @@ class C {
   set #0.0000001(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'1e-7';
+    return this[#'1e-7'];
   }
 
   setPrivateReference(value) {
-    this.#'1e-7' = value;
+    this[#'1e-7'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-literal-numeric-non-canonical.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-numeric-non-canonical.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-non-canonical.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal with non-canonical representation) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get #0.0000001() { return 'get string'; }
+  set #0.0000001(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'1e-7';
+  }
+
+  setPrivateReference(value) {
+    this.#'1e-7' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-literal-numeric-octal.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-numeric-octal.js
@@ -39,15 +39,15 @@ class C {
   set #0o10(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'8';
+    return this[#'8'];
   }
 
   setPrivateReference(value) {
-    this.#'8' = value;
+    this[#'8'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-literal-numeric-octal.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-numeric-octal.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-octal.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal in octal notation) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get #0o10() { return 'get string'; }
+  set #0o10(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'8';
+  }
+
+  setPrivateReference(value) {
+    this.#'8' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-literal-numeric-zero.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-numeric-zero.js
@@ -39,15 +39,15 @@ class C {
   set #0(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'0';
+    return this[#'0'];
   }
 
   setPrivateReference(value) {
-    this.#'0' = value;
+    this[#'0'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-literal-numeric-zero.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-numeric-zero.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-zero.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (numeric literal zero) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get #0() { return 'get string'; }
+  set #0(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'0';
+  }
+
+  setPrivateReference(value) {
+    this.#'0' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-literal-string-char-escape.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-string-char-escape.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-char-escape.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (string literal containing a character escape sequence) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get #'character\tescape'() { return 'get string'; }
+  set #'character\tescape'(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'character	escape';
+  }
+
+  setPrivateReference(value) {
+    this.#'character	escape' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-literal-string-char-escape.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-string-char-escape.js
@@ -39,15 +39,15 @@ class C {
   set #'character\tescape'(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'character	escape';
+    return this[#'character	escape'];
   }
 
   setPrivateReference(value) {
-    this.#'character	escape' = value;
+    this[#'character	escape'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-literal-string-double-quote.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-string-double-quote.js
@@ -39,15 +39,15 @@ class C {
   set #"doubleQuote"(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#"doubleQuote";
+    return this[#"doubleQuote"];
   }
 
   setPrivateReference(value) {
-    this.#"doubleQuote" = value;
+    this[#"doubleQuote"] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-literal-string-double-quote.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-string-double-quote.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-double-quote.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (string literal using double quotes) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get #"doubleQuote"() { return 'get string'; }
+  set #"doubleQuote"(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#"doubleQuote";
+  }
+
+  setPrivateReference(value) {
+    this.#"doubleQuote" = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-literal-string-empty.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-string-empty.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-empty.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (string literal, the empty string) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get #''() { return 'get string'; }
+  set #''(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'';
+  }
+
+  setPrivateReference(value) {
+    this.#'' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-literal-string-empty.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-string-empty.js
@@ -39,15 +39,15 @@ class C {
   set #''(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'';
+    return this[#''];
   }
 
   setPrivateReference(value) {
-    this.#'' = value;
+    this[#''] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-literal-string-hex-escape.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-string-hex-escape.js
@@ -39,15 +39,15 @@ class C {
   set #'hex\x45scape'(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'hexEscape';
+    return this[#'hexEscape'];
   }
 
   setPrivateReference(value) {
-    this.#'hexEscape' = value;
+    this[#'hexEscape'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-literal-string-hex-escape.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-string-hex-escape.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-hex-escape.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (string literal containing a hexadecimal escape sequence) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get #'hex\x45scape'() { return 'get string'; }
+  set #'hex\x45scape'(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'hexEscape';
+  }
+
+  setPrivateReference(value) {
+    this.#'hexEscape' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-literal-string-line-continuation.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-string-line-continuation.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-line-continuation.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (string literal containing LineContinuation) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get #'line\
+Continuation'() { return 'get string'; }
+  set #'line\
+Continuation'(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'lineContinuation';
+  }
+
+  setPrivateReference(value) {
+    this.#'lineContinuation' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-literal-string-line-continuation.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-string-line-continuation.js
@@ -41,15 +41,15 @@ Continuation'() { return 'get string'; }
 Continuation'(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'lineContinuation';
+    return this[#'lineContinuation'];
   }
 
   setPrivateReference(value) {
-    this.#'lineContinuation' = value;
+    this[#'lineContinuation'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-literal-string-single-quote.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-string-single-quote.js
@@ -39,15 +39,15 @@ class C {
   set #'singleQuote'(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'singleQuote';
+    return this[#'singleQuote'];
   }
 
   setPrivateReference(value) {
-    this.#'singleQuote' = value;
+    this[#'singleQuote'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-literal-string-single-quote.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-string-single-quote.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-single-quote.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (string literal using single quotes) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get #'singleQuote'() { return 'get string'; }
+  set #'singleQuote'(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'singleQuote';
+  }
+
+  setPrivateReference(value) {
+    this.#'singleQuote' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-inst-literal-string-unicode-escape.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-string-unicode-escape.js
@@ -39,15 +39,15 @@ class C {
   set #'unicod\u{000065}Escape'(param) { stringSet = param; }
 
   getPrivateReference() {
-    return this.#'unicodeEscape';
+    return this[#'unicodeEscape'];
   }
 
   setPrivateReference(value) {
-    this.#'unicodeEscape' = value;
+    this[#'unicodeEscape'] = value;
   }
 };
 
-var inst = C();
+var inst = new C();
 
 assert.sameValue(inst.getPrivateReference(), 'get string');
 

--- a/test/language/statements/class/private-accessor-name-inst-literal-string-unicode-escape.js
+++ b/test/language/statements/class/private-accessor-name-inst-literal-string-unicode-escape.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-unicode-escape.case
+// - src/accessor-names/default/cls-private-decl-inst.template
+/*---
+description: Computed values as accessor property names (string literal containing a Unicode escape sequence) (Class declaration, private instance method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  get #'unicod\u{000065}Escape'() { return 'get string'; }
+  set #'unicod\u{000065}Escape'(param) { stringSet = param; }
+
+  getPrivateReference() {
+    return this.#'unicodeEscape';
+  }
+
+  setPrivateReference(value) {
+    this.#'unicodeEscape' = value;
+  }
+};
+
+var inst = C();
+
+assert.sameValue(inst.getPrivateReference(), 'get string');
+
+inst.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');

--- a/test/language/statements/class/private-accessor-name-static-computed.js
+++ b/test/language/statements/class/private-accessor-name-static-computed.js
@@ -41,11 +41,11 @@ class C {
   static set #[_ = 'str' + 'ing'](param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#'string';
+    return this[#'string'];
   }
 
   static setPrivateReference(value) {
-    this.#'string' = value;
+    this[#'string'] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-computed.js
+++ b/test/language/statements/class/private-accessor-name-static-computed.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/computed.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (AssignmentExpression) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+var _;
+
+
+var stringSet;
+
+class C {
+  static get #[_ = 'str' + 'ing']() { return 'get string'; }
+  static set #[_ = 'str' + 'ing'](param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'string';
+  }
+
+  static setPrivateReference(value) {
+    this.#'string' = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/test/language/statements/class/private-accessor-name-static-literal-numeric-binary.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-numeric-binary.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-binary.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in binary notation) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get #0b10() { return 'get string'; }
+  static set #0b10(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'2';
+  }
+
+  static setPrivateReference(value) {
+    this.#'2' = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/test/language/statements/class/private-accessor-name-static-literal-numeric-binary.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-numeric-binary.js
@@ -39,11 +39,11 @@ class C {
   static set #0b10(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#'2';
+    return this[#'2'];
   }
 
   static setPrivateReference(value) {
-    this.#'2' = value;
+    this[#'2'] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-literal-numeric-exponent.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-numeric-exponent.js
@@ -39,11 +39,11 @@ class C {
   static set #1E+9(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#'1000000000';
+    return this[#'1000000000'];
   }
 
   static setPrivateReference(value) {
-    this.#'1000000000' = value;
+    this[#'1000000000'] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-literal-numeric-exponent.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-numeric-exponent.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-exponent.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in exponent notation) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get #1E+9() { return 'get string'; }
+  static set #1E+9(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'1000000000';
+  }
+
+  static setPrivateReference(value) {
+    this.#'1000000000' = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/test/language/statements/class/private-accessor-name-static-literal-numeric-hex.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-numeric-hex.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-hex.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in hexadecimal notation) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get #0x10() { return 'get string'; }
+  static set #0x10(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'16';
+  }
+
+  static setPrivateReference(value) {
+    this.#'16' = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/test/language/statements/class/private-accessor-name-static-literal-numeric-hex.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-numeric-hex.js
@@ -39,11 +39,11 @@ class C {
   static set #0x10(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#'16';
+    return this[#'16'];
   }
 
   static setPrivateReference(value) {
-    this.#'16' = value;
+    this[#'16'] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-literal-numeric-leading-decimal.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-numeric-leading-decimal.js
@@ -39,11 +39,11 @@ class C {
   static set #.1(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#'0.1';
+    return this[#'0.1'];
   }
 
   static setPrivateReference(value) {
-    this.#'0.1' = value;
+    this[#'0.1'] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-literal-numeric-leading-decimal.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-numeric-leading-decimal.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-leading-decimal.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (numeric literal with leading decimal point) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get #.1() { return 'get string'; }
+  static set #.1(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'0.1';
+  }
+
+  static setPrivateReference(value) {
+    this.#'0.1' = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/test/language/statements/class/private-accessor-name-static-literal-numeric-non-canonical.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-numeric-non-canonical.js
@@ -39,11 +39,11 @@ class C {
   static set #0.0000001(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#'1e-7';
+    return this[#'1e-7'];
   }
 
   static setPrivateReference(value) {
-    this.#'1e-7' = value;
+    this[#'1e-7'] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-literal-numeric-non-canonical.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-numeric-non-canonical.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-non-canonical.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (numeric literal with non-canonical representation) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get #0.0000001() { return 'get string'; }
+  static set #0.0000001(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'1e-7';
+  }
+
+  static setPrivateReference(value) {
+    this.#'1e-7' = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/test/language/statements/class/private-accessor-name-static-literal-numeric-octal.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-numeric-octal.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-octal.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (numeric literal in octal notation) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get #0o10() { return 'get string'; }
+  static set #0o10(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'8';
+  }
+
+  static setPrivateReference(value) {
+    this.#'8' = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/test/language/statements/class/private-accessor-name-static-literal-numeric-octal.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-numeric-octal.js
@@ -39,11 +39,11 @@ class C {
   static set #0o10(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#'8';
+    return this[#'8'];
   }
 
   static setPrivateReference(value) {
-    this.#'8' = value;
+    this[#'8'] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-literal-numeric-zero.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-numeric-zero.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-numeric-zero.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (numeric literal zero) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get #0() { return 'get string'; }
+  static set #0(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'0';
+  }
+
+  static setPrivateReference(value) {
+    this.#'0' = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/test/language/statements/class/private-accessor-name-static-literal-numeric-zero.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-numeric-zero.js
@@ -39,11 +39,11 @@ class C {
   static set #0(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#'0';
+    return this[#'0'];
   }
 
   static setPrivateReference(value) {
-    this.#'0' = value;
+    this[#'0'] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-literal-string-char-escape.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-string-char-escape.js
@@ -39,11 +39,11 @@ class C {
   static set #'character\tescape'(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#'character	escape';
+    return this[#'character	escape'];
   }
 
   static setPrivateReference(value) {
-    this.#'character	escape' = value;
+    this[#'character	escape'] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-literal-string-char-escape.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-string-char-escape.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-char-escape.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (string literal containing a character escape sequence) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get #'character\tescape'() { return 'get string'; }
+  static set #'character\tescape'(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'character	escape';
+  }
+
+  static setPrivateReference(value) {
+    this.#'character	escape' = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/test/language/statements/class/private-accessor-name-static-literal-string-double-quote.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-string-double-quote.js
@@ -39,11 +39,11 @@ class C {
   static set #"doubleQuote"(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#"doubleQuote";
+    return this[#"doubleQuote"];
   }
 
   static setPrivateReference(value) {
-    this.#"doubleQuote" = value;
+    this[#"doubleQuote"] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-literal-string-double-quote.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-string-double-quote.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-double-quote.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (string literal using double quotes) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get #"doubleQuote"() { return 'get string'; }
+  static set #"doubleQuote"(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#"doubleQuote";
+  }
+
+  static setPrivateReference(value) {
+    this.#"doubleQuote" = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/test/language/statements/class/private-accessor-name-static-literal-string-empty.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-string-empty.js
@@ -39,11 +39,11 @@ class C {
   static set #''(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#'';
+    return this[#''];
   }
 
   static setPrivateReference(value) {
-    this.#'' = value;
+    this[#''] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-literal-string-empty.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-string-empty.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-empty.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (string literal, the empty string) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get #''() { return 'get string'; }
+  static set #''(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'';
+  }
+
+  static setPrivateReference(value) {
+    this.#'' = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/test/language/statements/class/private-accessor-name-static-literal-string-hex-escape.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-string-hex-escape.js
@@ -39,11 +39,11 @@ class C {
   static set #'hex\x45scape'(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#'hexEscape';
+    return this[#'hexEscape'];
   }
 
   static setPrivateReference(value) {
-    this.#'hexEscape' = value;
+    this[#'hexEscape'] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-literal-string-hex-escape.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-string-hex-escape.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-hex-escape.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (string literal containing a hexadecimal escape sequence) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get #'hex\x45scape'() { return 'get string'; }
+  static set #'hex\x45scape'(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'hexEscape';
+  }
+
+  static setPrivateReference(value) {
+    this.#'hexEscape' = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/test/language/statements/class/private-accessor-name-static-literal-string-line-continuation.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-string-line-continuation.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-line-continuation.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (string literal containing LineContinuation) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get #'line\
+Continuation'() { return 'get string'; }
+  static set #'line\
+Continuation'(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'lineContinuation';
+  }
+
+  static setPrivateReference(value) {
+    this.#'lineContinuation' = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/test/language/statements/class/private-accessor-name-static-literal-string-line-continuation.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-string-line-continuation.js
@@ -41,11 +41,11 @@ Continuation'() { return 'get string'; }
 Continuation'(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#'lineContinuation';
+    return this[#'lineContinuation'];
   }
 
   static setPrivateReference(value) {
-    this.#'lineContinuation' = value;
+    this[#'lineContinuation'] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-literal-string-single-quote.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-string-single-quote.js
@@ -39,11 +39,11 @@ class C {
   static set #'singleQuote'(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#'singleQuote';
+    return this[#'singleQuote'];
   }
 
   static setPrivateReference(value) {
-    this.#'singleQuote' = value;
+    this[#'singleQuote'] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-literal-string-single-quote.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-string-single-quote.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-single-quote.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (string literal using single quotes) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get #'singleQuote'() { return 'get string'; }
+  static set #'singleQuote'(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'singleQuote';
+  }
+
+  static setPrivateReference(value) {
+    this.#'singleQuote' = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+

--- a/test/language/statements/class/private-accessor-name-static-literal-string-unicode-escape.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-string-unicode-escape.js
@@ -39,11 +39,11 @@ class C {
   static set #'unicod\u{000065}Escape'(param) { stringSet = param; }
 
   static getPrivateReference() {
-    return this.#'unicodeEscape';
+    return this[#'unicodeEscape'];
   }
 
   static setPrivateReference(value) {
-    this.#'unicodeEscape' = value;
+    this[#'unicodeEscape'] = value;
   }
 }
 

--- a/test/language/statements/class/private-accessor-name-static-literal-string-unicode-escape.js
+++ b/test/language/statements/class/private-accessor-name-static-literal-string-unicode-escape.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/accessor-names/literal-string-unicode-escape.case
+// - src/accessor-names/default/cls-private-decl-static.template
+/*---
+description: Computed values as accessor property names (string literal containing a Unicode escape sequence) (Class declaration, static method)
+flags: [generated]
+info: |
+    [...]
+    MethodDefinition[Yield, Await]:
+        PropertyNameClassElementName [?Yield, ?Await](
+          UniqueFormalParameters [~Yield, ~Await] ) {
+          FunctionBody [~Yield, ~Await] }
+        AsyncMethod[?Yield, ?Await]
+          get PropertyName ClassElementName [?Yield, ?Await] (){
+            FunctionBody [~Yield, ~Await] }
+          set PropertyNameClassElementName [?Yield, ?Await] (
+            PropertySetParameterList ) { FunctionBody [~Yield, ~Await] }
+        AsyncMethod [Yield, Await]:
+          async [no LineTerminator here] PropertyName
+            ClassElementName[?Yield, ?Await](
+            UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
+
+
+    12.2.6.7 Runtime Semantics: Evaluation
+
+    [...]
+
+    ComputedPropertyName : [ AssignmentExpression ]
+
+    1. Let exprValue be the result of evaluating AssignmentExpression.
+    2. Let propName be ? GetValue(exprValue).
+    3. Return ? ToPropertyKey(propName).
+---*/
+
+var stringSet;
+
+class C {
+  static get #'unicod\u{000065}Escape'() { return 'get string'; }
+  static set #'unicod\u{000065}Escape'(param) { stringSet = param; }
+
+  static getPrivateReference() {
+    return this.#'unicodeEscape';
+  }
+
+  static setPrivateReference(value) {
+    this.#'unicodeEscape' = value;
+  }
+}
+
+assert.sameValue(C.getPrivateReference(), 'get string');
+
+C.setPrivateReference('set string');
+assert.sameValue(stringSet, 'set string');
+


### PR DESCRIPTION
This PR adds templates  and generated tests for the [proposed private methods and getter/setters for JavaScript classes](https://github.com/tc39/proposal-private-methods). One issue I ran into is that single quotes are being included in generated accessor names, like in this example in `private-accessor-name-inst-computed.js`:

```
getPrivateReference() {
    return this[#'string'];
  }

setPrivateReference(value) {
    this[#'string'] = value;
}
```

One solution I was picturing was adding new variables in the case files for something like `privateDeclareWith` and `privateReferenceWith` and add the hash sign to the accessor name string there. Does that make sense or should I change this elsewhere?