### PR TITLE
Remove requirement that ToNumber(value) completes in less than $262.agent.MAX_TIME_EPSILON

### DIFF
--- a/harness/atomicsHelper.js
+++ b/harness/atomicsHelper.js
@@ -6,13 +6,6 @@ description: >
 ---*/
 
 /**
- * The amount of slack allowed for testing time-related Atomics methods (i.e. wait and notify).
- * The absolute value of the difference of the observed time and the expected time must
- * be epsilon-close.
- */
-$262.agent.MAX_TIME_EPSILON = 100;
-
-/**
  * @return {String} A report sent from an agent.
  */
 {

--- a/test/built-ins/Atomics/wait/bigint/false-for-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/bigint/false-for-timeout-agent.js
@@ -35,16 +35,13 @@ $262.agent.start(`
     const i64a = new BigInt64Array(sab);
     Atomics.add(i64a, ${RUNNING}, 1n);
 
-    const before = $262.agent.monotonicNow();
     const status1 = Atomics.wait(i64a, 0, 0n, false);
     const status2 = Atomics.wait(i64a, 0, 0n, valueOf);
     const status3 = Atomics.wait(i64a, 0, 0n, toPrimitive);
-    const duration = $262.agent.monotonicNow() - before;
 
     $262.agent.report(status1);
     $262.agent.report(status2);
     $262.agent.report(status3);
-    $262.agent.report(duration);
     $262.agent.leaving();
   });
 `);
@@ -74,11 +71,5 @@ assert.sameValue(
   'timed-out',
   '$262.agent.getReport() returns "timed-out"'
 );
-
-const lapse = $262.agent.getReport();
-
-assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (timeout should be a min of 0ms)');
-
-assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true');
 
 assert.sameValue(Atomics.notify(i64a, 0), 0, 'Atomics.notify(i64a, 0) returns 0');

--- a/test/built-ins/Atomics/wait/false-for-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/false-for-timeout-agent.js
@@ -35,16 +35,13 @@ $262.agent.start(`
     const i32a = new Int32Array(sab);
     Atomics.add(i32a, ${RUNNING}, 1);
 
-    const before = $262.agent.monotonicNow();
     const status1 = Atomics.wait(i32a, 0, 0, false);
     const status2 = Atomics.wait(i32a, 0, 0, valueOf);
     const status3 = Atomics.wait(i32a, 0, 0, toPrimitive);
-    const duration = $262.agent.monotonicNow() - before;
 
     $262.agent.report(status1);
     $262.agent.report(status2);
     $262.agent.report(status3);
-    $262.agent.report(duration);
     $262.agent.leaving();
   });
 `);
@@ -74,11 +71,5 @@ assert.sameValue(
   'timed-out',
   '$262.agent.getReport() returns "timed-out"'
 );
-
-const lapse = $262.agent.getReport();
-
-assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (timeout should be a min of 0ms)');
-
-assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true');
 
 assert.sameValue(Atomics.notify(i32a, 0), 0, 'Atomics.notify(i32a, 0) returns 0');

--- a/test/built-ins/Atomics/wait/null-for-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/null-for-timeout-agent.js
@@ -35,16 +35,13 @@ $262.agent.start(`
     const i32a = new Int32Array(sab);
     Atomics.add(i32a, ${RUNNING}, 1);
 
-    const before = $262.agent.monotonicNow();
     const status1 = Atomics.wait(i32a, 0, 0, null);
     const status2 = Atomics.wait(i32a, 0, 0, valueOf);
     const status3 = Atomics.wait(i32a, 0, 0, toPrimitive);
-    const duration = $262.agent.monotonicNow() - before;
 
     $262.agent.report(status1);
     $262.agent.report(status2);
     $262.agent.report(status3);
-    $262.agent.report(duration);
     $262.agent.leaving();
   });
 `);
@@ -74,11 +71,5 @@ assert.sameValue(
   'timed-out',
   '$262.agent.getReport() returns "timed-out"'
 );
-
-const lapse = $262.agent.getReport();
-
-assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (timeout should be a min of 0ms)');
-
-assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $262.agent.MAX_TIME_EPSILON)');
 
 assert.sameValue(Atomics.notify(i32a, 0), 0, 'Atomics.notify(i32a, 0) returns 0');

--- a/test/built-ins/Atomics/wait/object-for-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/object-for-timeout-agent.js
@@ -41,16 +41,13 @@ $262.agent.start(`
     const i32a = new Int32Array(sab);
     Atomics.add(i32a, ${RUNNING}, 1);
 
-    const before = $262.agent.monotonicNow();
     const status1 = Atomics.wait(i32a, 0, 0, valueOf);
     const status2 = Atomics.wait(i32a, 0, 0, toString);
     const status3 = Atomics.wait(i32a, 0, 0, toPrimitive);
-    const duration = $262.agent.monotonicNow() - before;
 
     $262.agent.report(status1);
     $262.agent.report(status2);
     $262.agent.report(status3);
-    $262.agent.report(duration);
     $262.agent.leaving();
   });
 `);
@@ -80,11 +77,5 @@ assert.sameValue(
   'timed-out',
   '$262.agent.getReport() returns "timed-out"'
 );
-
-const lapse = $262.agent.getReport();
-
-assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (timeout should be a min of 0ms)');
-
-assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $$262.agent.MAX_TIME_EPSILON)');
 
 assert.sameValue(Atomics.notify(i32a, 0), 0, 'Atomics.notify(i32a, 0) returns 0');

--- a/test/built-ins/Atomics/wait/poisoned-object-for-timeout-throws-agent.js
+++ b/test/built-ins/Atomics/wait/poisoned-object-for-timeout-throws-agent.js
@@ -38,7 +38,6 @@ $262.agent.start(`
     let status1 = "";
     let status2 = "";
 
-    const start = $262.agent.monotonicNow();
     try {
       Atomics.wait(i32a, 0, 0, poisonedValueOf);
     } catch (error) {
@@ -49,11 +48,9 @@ $262.agent.start(`
     } catch (error) {
       status2 = "poisonedToPrimitive";
     }
-    const duration = $262.agent.monotonicNow() - start;
 
     $262.agent.report(status1);
     $262.agent.report(status2);
-    $262.agent.report(duration);
     $262.agent.leaving();
   });
 `);
@@ -78,11 +75,5 @@ assert.sameValue(
   'poisonedToPrimitive',
   '$262.agent.getReport() returns "poisonedToPrimitive"'
 );
-
-const lapse = $262.agent.getReport();
-
-assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (timeout should be a min of 0ms)');
-
-assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $$262.agent.MAX_TIME_EPSILON)');
 
 assert.sameValue(Atomics.notify(i32a, 0), 0, 'Atomics.notify(i32a, 0) returns 0');

--- a/test/built-ins/Atomics/wait/symbol-for-index-throws-agent.js
+++ b/test/built-ins/Atomics/wait/symbol-for-index-throws-agent.js
@@ -51,7 +51,6 @@ $262.agent.start(`
     let status1 = "";
     let status2 = "";
 
-    const start = $262.agent.monotonicNow();
     try {
       Atomics.wait(i32a, Symbol("1"), poisonedValueOf, poisonedValueOf);
     } catch (error) {
@@ -62,11 +61,9 @@ $262.agent.start(`
     } catch (error) {
       status2 = 'Symbol("2")';
     }
-    const duration = $262.agent.monotonicNow() - start;
 
     $262.agent.report(status1);
     $262.agent.report(status2);
-    $262.agent.report(duration);
     $262.agent.leaving();
   });
 `);
@@ -91,10 +88,5 @@ assert.sameValue(
   'Symbol("2")',
   '$262.agent.getReport() returns "Symbol("2")"'
 );
-
-const lapse = $262.agent.getReport();
-
-assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (The result of `(lapse >= 0)` is true (timeout should be a min of 0ms))');
-assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $$262.agent.MAX_TIME_EPSILON))');
 
 assert.sameValue(Atomics.notify(i32a, 0), 0, 'Atomics.notify(i32a, 0) returns 0');

--- a/test/built-ins/Atomics/wait/symbol-for-timeout-throws-agent.js
+++ b/test/built-ins/Atomics/wait/symbol-for-timeout-throws-agent.js
@@ -26,7 +26,6 @@ $262.agent.start(`
     let status1 = "";
     let status2 = "";
 
-    const start = $262.agent.monotonicNow();
     try {
       Atomics.wait(i32a, 0, 0, Symbol("1"));
     } catch (error) {
@@ -37,11 +36,9 @@ $262.agent.start(`
     } catch (error) {
       status2 = 'Symbol("2")';
     }
-    const duration = $262.agent.monotonicNow() - start;
 
     $262.agent.report(status1);
     $262.agent.report(status2);
-    $262.agent.report(duration);
     $262.agent.leaving();
   });
 `);
@@ -66,10 +63,5 @@ assert.sameValue(
   'Symbol("2")',
   '$262.agent.getReport() returns "Symbol("2")"'
 );
-
-const lapse = $262.agent.getReport();
-
-assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (timeout should be a min of 0ms)');
-assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $$262.agent.MAX_TIME_EPSILON)');
 
 assert.sameValue(Atomics.notify(i32a, 0), 0, 'Atomics.notify(i32a, 0) returns 0');

--- a/test/built-ins/Atomics/wait/symbol-for-value-throws-agent.js
+++ b/test/built-ins/Atomics/wait/symbol-for-value-throws-agent.js
@@ -42,7 +42,6 @@ $262.agent.start(`
     let status1 = "";
     let status2 = "";
 
-    const before = $262.agent.monotonicNow();
     try {
       Atomics.wait(i32a, 0, Symbol("1"), poisonedValueOf);
     } catch (error) {
@@ -53,11 +52,9 @@ $262.agent.start(`
     } catch (error) {
       status2 = 'Symbol("2")';
     }
-    const duration = $262.agent.monotonicNow() - before;
 
     $262.agent.report(status1);
     $262.agent.report(status2);
-    $262.agent.report(duration);
     $262.agent.leaving();
   });
 `);
@@ -82,10 +79,5 @@ assert.sameValue(
   'Symbol("2")',
   '$262.agent.getReport() returns "Symbol("2")"'
 );
-
-const lapse = $262.agent.getReport();
-
-assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (timeout should be a min of 0ms)');
-assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $$262.agent.MAX_TIME_EPSILON)');
 
 assert.sameValue(Atomics.notify(i32a, 0), 0, 'Atomics.notify(i32a, 0) returns 0');

--- a/test/built-ins/Atomics/wait/true-for-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/true-for-timeout-agent.js
@@ -35,16 +35,13 @@ $262.agent.start(`
     const i32a = new Int32Array(sab);
     Atomics.add(i32a, ${RUNNING}, 1);
 
-    const start = $262.agent.monotonicNow();
     const status1 = Atomics.wait(i32a, 0, 0, true);
     const status2 = Atomics.wait(i32a, 0, 0, valueOf);
     const status3 = Atomics.wait(i32a, 0, 0, toPrimitive);
-    const duration = $262.agent.monotonicNow() - start;
 
     $262.agent.report(status1);
     $262.agent.report(status2);
     $262.agent.report(status3);
-    $262.agent.report(duration);
     $262.agent.leaving();
   });
 `);
@@ -74,11 +71,5 @@ assert.sameValue(
   'timed-out',
   '$262.agent.getReport() returns "timed-out"'
 );
-
-const lapse = $262.agent.getReport();
-
-assert(lapse >= 0, 'The result of `(lapse >= 0)` is true (timeout should be a min of 0ms)');
-
-assert(lapse <= $262.agent.MAX_TIME_EPSILON, 'The result of `(lapse <= $262.agent.MAX_TIME_EPSILON)` is true (timeout should be a max of $$262.agent.MAX_TIME_EPSILON)');
 
 assert.sameValue(Atomics.notify(i32a, 0), 0, 'Atomics.notify(i32a, 0) returns 0');


### PR DESCRIPTION
$262.agent.MAX_TIME_EPSILON was intended to be used for callers like `Atomics.wait(typedArray, indexNumber, valueNumber, timeoutNumber)` where all parameters with the `Number` suffix denote values which are already Number values. It should not be used for `Atomics.wait(typedArray, indexObject, valueObject, timeoutObject)` where all parameters with the `Object` suffix denote values which are Object values, because in that case we'd require that `ToNumber(objectValue)` (potentially invoked multiple times) completes in less than 100 milliseconds (the default value for MAX_TIME_EPSILON).

Also removes $262.agent.MAX_TIME_EPSILON because it is now no longer used.