### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "3454cfdb5a",
-  "targetRevisionAtLastExport": "1804b1343",
+  "sourceRevisionAtLastExport": "ffc7368147",
+  "targetRevisionAtLastExport": "ac84caea5",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/cfa-expected-values-must-set-clobbered-to-false.js
+++ b/implementation-contributed/javascriptcore/stress/cfa-expected-values-must-set-clobbered-to-false.js
@@ -1,0 +1,38 @@
+//@ runDefault("--useFTLJIT=0", "--useConcurrentJIT=false")
+
+let num = 150;
+
+function foo(comp, o, b) {
+    let sum = o.f;
+    if (b)
+        OSRExit();
+    for (let i = 0; i < comp; ++i) {
+        sum += o.f;
+    }
+    return sum;
+}
+noInline(foo);
+
+let o = {f:25};
+let o2 = {f:25, g:44};
+o2.f = 45;
+o2.f = 45;
+o2.f = 45;
+o2.f = 45;
+let comp = {
+    valueOf() { return num; }
+}
+
+foo(comp, o2, true);
+foo(comp, o2, true);
+for (let i = 0; i < 500; ++i) {
+    foo(comp, o2, false);
+}
+
+let o3 = {g:24, f:73};
+num = 10000000;
+let result = foo(comp, o3, false);
+
+if (result !== (num + 1)*73) {
+    throw new Error("Bad: " + result);
+}


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[3454cfdb5a](https://github.com///github/blob/3454cfdb5a) in JavaScriptCore and all changes made since [1804b1343](../blob/1804b1343) in
test262.













### 1 New File Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/cfa-expected-values-must-set-clobbered-to-false.js](../blob/javascriptcore-test262-automation-export-1804b1343/implementation-contributed/javascriptcore/stress/cfa-expected-values-must-set-clobbered-to-false.js)