### PR TITLE
Array.prototype.{flat,flatMap} property access count

### DIFF
--- a/test/built-ins/Array/prototype/flat/proxy-access-count.js
+++ b/test/built-ins/Array/prototype/flat/proxy-access-count.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2018 Richard Lawrence. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.flat
+description: >
+    properties are accessed correct number of times by .flat
+features: [Array.prototype.flat]
+includes: [compareArray.js]
+---*/
+
+
+const getCalls = [], hasCalls = [];
+const handler = {
+  get : function (t, p, r) { getCalls.push(p); return Reflect.get(t, p, r); },
+  has : function (t, p, r) { hasCalls.push(p); return Reflect.has(t, p, r); }
+}
+
+const tier2 = new Proxy([4, 3], handler);
+const tier1 = new Proxy([2, [3, [4, 2], 2], 5, tier2, 6], handler);
+
+Array.prototype.flat.call(tier1, 3);
+
+assert.compareArray(getCalls, ["length", "constructor", "0", "1", "2", "3", "length", "0", "1", "4"], 'getProperty by .flat should occur exactly once per property and once for length and constructor');
+assert.compareArray(hasCalls, ["0", "1", "2", "3", "0", "1", "4"], 'hasProperty by .flat should occur exactly once per property');

--- a/test/built-ins/Array/prototype/flatMap/proxy-access-count.js
+++ b/test/built-ins/Array/prototype/flatMap/proxy-access-count.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2018 Richard Lawrence. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.flatMap
+description: >
+    properties are accessed correct number of times by .flatMap
+features: [Array.prototype.flat]
+includes: [compareArray.js]
+---*/
+
+
+const getCalls = [], hasCalls = [];
+const handler = {
+  get : function (t, p, r) { getCalls.push(p); return Reflect.get(t, p, r); },
+  has : function (t, p, r) { hasCalls.push(p); return Reflect.has(t, p, r); }
+}
+
+const tier2 = new Proxy([4, 3], handler);
+const tier1 = new Proxy([2, [3, 4, 2, 2], 5, tier2, 6], handler);
+
+Array.prototype.flatMap.call(tier1, function(a){ return a; });
+
+assert.compareArray(getCalls, ["length", "constructor", "0", "1", "2", "3", "length", "0", "1", "4"], 'getProperty by .flatMap should occur exactly once per property and once for length and constructor');
+assert.compareArray(hasCalls, ["0", "1", "2", "3", "0", "1", "4"], 'hasProperty by .flatMap should occur exactly once per property');


### PR DESCRIPTION
Tests for the number of has/get property accesses that occur when using Array.prototype.flat/flatMap.

@ljharb asked me to submit these after my initial implementation of flat and flatMap for chakracore was wrong on this point.

(I haven't signed a CLA here yet so assume I'll need to do that before this is merged)
EDIT: I have now completed a CLA