### PR TITLE
TypedArray.prototype.sort: check result of compareFn is immediately converted ToNumber

### DIFF
--- a/test/built-ins/TypedArray/prototype/sort/sort-tonumber.js
+++ b/test/built-ins/TypedArray/prototype/sort/sort-tonumber.js
@@ -12,7 +12,7 @@ info: |
     b. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
     ...
   ...
-includes: [testTypedArray.js]
+includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 
@@ -21,19 +21,17 @@ testWithTypedArrayConstructors(function(TA) {
   var ab = ta.buffer;
 
   var called = false;
-  try {
+  assert.throws(TypeError, function() {
     ta.sort(function(a, b) {
       // IsDetachedBuffer is checked right after calling comparefn.
       // So, detach the ArrayBuffer to cause sort to throw, to make sure we're actually calling ToNumber immediately (as spec'd)
       // (a possible bug is to wait until the result is inspected to call ToNumber, rather than immediately)
-      detachArrayBuffer(ab);
+      $DETACHBUFFER(ab);
       return {
         [Symbol.toPrimitive]() { called = true; }
       };
     });
-  } catch (e) { }
+  });
 
   assert.sameValue(true, called);
-})
-
-reportCompare(0, 0);
+});

--- a/test/built-ins/TypedArray/prototype/sort/sort-tonumber.js
+++ b/test/built-ins/TypedArray/prototype/sort/sort-tonumber.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2018 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.sort
+description: The result of compareFn is immediately passed through ToNumber
+info: |
+  22.2.3.26 %TypedArray%.prototype.sort ( comparefn )
+
+  ...
+  2. If comparefn is not undefined, then
+    a. Let v be ? ToNumber(? Call(comparefn, undefined, « x, y »)).
+    b. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+    ...
+  ...
+includes: [testTypedArray.js]
+features: [TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var ta = new TA(4);
+  var ab = ta.buffer;
+
+  var called = false;
+  try {
+    ta.sort(function(a, b) {
+      // IsDetachedBuffer is checked right after calling comparefn.
+      // So, detach the ArrayBuffer to cause sort to throw, to make sure we're actually calling ToNumber immediately (as spec'd)
+      // (a possible bug is to wait until the result is inspected to call ToNumber, rather than immediately)
+      detachArrayBuffer(ab);
+      return {
+        [Symbol.toPrimitive]() { called = true; }
+      };
+    });
+  } catch (e) { }
+
+  assert.sameValue(true, called);
+})
+
+reportCompare(0, 0);


### PR DESCRIPTION
This was originally a [bug in spidermonkey](https://bugzilla.mozilla.org/show_bug.cgi?id=1456973).

In it, the result of comparefn was only ran through `ToNumber` upon comparing it to -1/0/1, which has an observable difference in behavior (as this test indicates).