### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "ce279990f8",
-  "targetRevisionAtLastExport": "170f4cbbb",
+  "sourceRevisionAtLastExport": "3ced8564a6",
+  "targetRevisionAtLastExport": "f8c62a49f",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/regress-189185.js
+++ b/implementation-contributed/javascriptcore/stress/regress-189185.js
@@ -1,4 +1,5 @@
 //@ runDefault
+//@ skip if $architecture == "x86"
 // This passes if it does not crash.
 new WebAssembly.CompileError({
     valueOf() {

--- a/implementation-contributed/javascriptcore/stress/regress-189292.js
+++ b/implementation-contributed/javascriptcore/stress/regress-189292.js
@@ -1,0 +1,18 @@
+//@ runDefault
+
+function assert(a, b) {
+    if (a != b)
+        throw "FAIL";
+}
+
+function test(script) {
+    try {
+        eval(script);
+    } catch (e) {
+        return e;
+    }
+}
+
+assert(test("class C1 { async constructor() { } }"), "SyntaxError: Cannot declare an async method named 'constructor'.");
+assert(test("class C1 { *constructor() { } }"), "SyntaxError: Cannot declare a generator function named 'constructor'.");
+assert(test("class C1 { async *constructor() { } }"), "SyntaxError: Cannot declare an async generator method named 'constructor'.");


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[ce279990f8](https://github.com///github/blob/ce279990f8) in JavaScriptCore and all changes made since [170f4cbbb](../blob/170f4cbbb) in
test262.



### 1 File Updated From JavaScriptCore

These files have been modified in JavaScriptCore.

 - [implementation-contributed/javascriptcore/stress/regress-189185.js](../blob/javascriptcore-test262-automation-export-170f4cbbb/implementation-contributed/javascriptcore/stress/regress-189185.js)









### 1 New File Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/regress-189292.js](../blob/javascriptcore-test262-automation-export-170f4cbbb/implementation-contributed/javascriptcore/stress/regress-189292.js)