### PR TITLE
Assert extensibility of dataview objects

### DIFF
--- a/implementation-contributed/javascriptcore/stress/regress-189186.js
+++ b/implementation-contributed/javascriptcore/stress/regress-189186.js
@@ -1,4 +1,0 @@
-//@ runDefault
-// This test passes if it does not crash.
-let x = new DataView(new ArrayBuffer(1));
-Object.defineProperty(x, 'foo', {});

--- a/test/built-ins/DataView/instance-extensibility-sab.js
+++ b/test/built-ins/DataView/instance-extensibility-sab.js
@@ -28,9 +28,27 @@ info: |
   5. Set the [[Extensible]] internal slot of obj to true.
   ...
 features: [SharedArrayBuffer]
+includes: [propertyHelper.js]
 ---*/
 
 var buffer = new SharedArrayBuffer(8);
 var sample = new DataView(buffer, 0);
 
 assert(Object.isExtensible(sample));
+
+Object.defineProperty(sample, 'baz', {});
+assert(sample.hasOwnProperty('baz'), 'confirms extensibility adding a new property');
+
+Object.defineProperty(sample, 'foo', {
+  value: 'bar',
+  writable: true,
+  configurable: true,
+  enumerable: false,
+});
+
+verifyProperty(sample, 'foo', {
+  value: 'bar',
+  writable: true,
+  configurable: true,
+  enumerable: false,
+});

--- a/test/built-ins/DataView/instance-extensibility.js
+++ b/test/built-ins/DataView/instance-extensibility.js
@@ -26,9 +26,27 @@ info: |
   ...
   5. Set the [[Extensible]] internal slot of obj to true.
   ...
+includes: [propertyHelper.js]
 ---*/
 
 var buffer = new ArrayBuffer(8);
 var sample = new DataView(buffer, 0);
 
 assert(Object.isExtensible(sample));
+
+Object.defineProperty(sample, 'baz', {});
+assert(sample.hasOwnProperty('baz'), 'confirms extensibility adding a new property');
+
+Object.defineProperty(sample, 'foo', {
+  value: 'bar',
+  writable: true,
+  configurable: true,
+  enumerable: false,
+});
+
+verifyProperty(sample, 'foo', {
+  value: 'bar',
+  writable: true,
+  configurable: true,
+  enumerable: false,
+});


### PR DESCRIPTION
This adds assertions to confirm extensibility of dataview objects, based on the contributed test from JSC.

See implementation-contributed/javascriptcore/stress/regress-189186.js 