### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "3ced8564a6",
-  "targetRevisionAtLastExport": "f8c62a49f",
+  "sourceRevisionAtLastExport": "a2f7b0c562",
+  "targetRevisionAtLastExport": "5594c916b",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/regress-189124.js
+++ b/implementation-contributed/javascriptcore/stress/regress-189124.js
@@ -1,0 +1,31 @@
+//@ runDefault("--jitPolicyScale=0")
+
+function makeTmp() {
+    let tmp = {a: 1};
+    gc();
+    tmp.__proto__ = {};
+    return tmp;
+}
+
+function foo(tmp, obj) {
+    for (let k in tmp) {
+        tmp.__proto__ = {};
+        gc();
+        obj.__proto__ = {};
+
+        var result = obj[k];
+        return result;
+    }
+}
+
+foo(makeTmp(), {});
+
+let memory = new Uint32Array(100);
+memory[0] = 0x1234;
+
+let fooResult = foo(makeTmp(), memory);
+var result = $vm.value(fooResult);
+
+if (result != "Undefined")
+    throw "FAIL";
+

--- a/implementation-contributed/javascriptcore/stress/regress-189185.js
+++ b/implementation-contributed/javascriptcore/stress/regress-189185.js
@@ -1,5 +1,5 @@
-//@ runDefault
 //@ skip if $architecture == "x86"
+//@ runDefault
 // This passes if it does not crash.
 new WebAssembly.CompileError({
     valueOf() {

--- a/implementation-contributed/javascriptcore/stress/symbol-description.js
+++ b/implementation-contributed/javascriptcore/stress/symbol-description.js
@@ -1,0 +1,95 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+var s0 = Symbol("Cocoa");
+var s1 = Symbol("Cappuccino");
+var s2 = Symbol("");
+var s3 = Symbol();
+
+shouldBe(s0.description, "Cocoa");
+shouldBe(s0.toString(), "Symbol(Cocoa)");
+shouldBe(s1.description, "Cappuccino");
+shouldBe(s1.toString(), "Symbol(Cappuccino)");
+shouldBe(s2.description, "");
+shouldBe(s2.toString(), "Symbol()");
+shouldBe(s3.description, undefined);
+shouldBe(s3.toString(), "Symbol()");
+
+var o0 = Object(s0);
+var o1 = Object(s1);
+var o2 = Object(s2);
+var o3 = Object(s3);
+
+shouldBe(o0.description, "Cocoa");
+shouldBe(o0.toString(), "Symbol(Cocoa)");
+shouldBe(o1.description, "Cappuccino");
+shouldBe(o1.toString(), "Symbol(Cappuccino)");
+shouldBe(o2.description, "");
+shouldBe(o2.toString(), "Symbol()");
+shouldBe(o3.description, undefined);
+shouldBe(o3.toString(), "Symbol()");
+
+var descriptor = Object.getOwnPropertyDescriptor(Symbol.prototype, "description");
+shouldBe(descriptor.enumerable, false);
+shouldBe(descriptor.configurable, true);
+shouldBe(descriptor.set, undefined);
+shouldBe(typeof descriptor.get, "function");
+
+shouldThrow(() => {
+    "use strict";
+    s0.description = "Matcha";
+}, `TypeError: Attempted to assign to readonly property.`);
+shouldThrow(() => {
+    "use strict";
+    o0.description = "Matcha";
+}, `TypeError: Attempted to assign to readonly property.`);
+
+shouldThrow(() => {
+    descriptor.get.call({});
+}, `TypeError: Symbol.prototype.description requires that |this| be a symbol or a symbol object`);
+
+shouldThrow(() => {
+    descriptor.get.call(null);
+}, `TypeError: Symbol.prototype.description requires that |this| be a symbol or a symbol object`);
+
+shouldThrow(() => {
+    descriptor.get.call(undefined);
+}, `TypeError: Symbol.prototype.description requires that |this| be a symbol or a symbol object`);
+
+shouldThrow(() => {
+    descriptor.get.call(42);
+}, `TypeError: Symbol.prototype.description requires that |this| be a symbol or a symbol object`);
+
+shouldThrow(() => {
+    descriptor.get.call("Hello");
+}, `TypeError: Symbol.prototype.description requires that |this| be a symbol or a symbol object`);
+
+shouldThrow(() => {
+    descriptor.get.call(42.195);
+}, `TypeError: Symbol.prototype.description requires that |this| be a symbol or a symbol object`);
+
+shouldThrow(() => {
+    descriptor.get.call(false);
+}, `TypeError: Symbol.prototype.description requires that |this| be a symbol or a symbol object`);
+
+shouldBe(descriptor.get.call(s0), "Cocoa");
+shouldBe(descriptor.get.call(o0), "Cocoa");
+o0.__proto__ = {};
+shouldBe(descriptor.get.call(o0), "Cocoa");


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[3ced8564a6](https://github.com///github/blob/3ced8564a6) in JavaScriptCore and all changes made since [f8c62a49f](../blob/f8c62a49f) in
test262.



### 2 Files Updated From JavaScriptCore

These files have been modified in JavaScriptCore.

 - [implementation-contributed/javascriptcore/stress/regress-189185.js](../blob/javascriptcore-test262-automation-export-f8c62a49f/implementation-contributed/javascriptcore/stress/regress-189185.js)
 - [implementation-contributed/javascriptcore/stress/symbol-description.js](../blob/javascriptcore-test262-automation-export-f8c62a49f/implementation-contributed/javascriptcore/stress/symbol-description.js)









### 1 New File Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/regress-189124.js](../blob/javascriptcore-test262-automation-export-f8c62a49f/implementation-contributed/javascriptcore/stress/regress-189124.js)