### PR TITLE
Intl: Add tests for subclassing Locale, ListFormat and RelativeTimeFormat.

### DIFF
--- a/test/intl402/ListFormat/constructor/constructor/subclassing.js
+++ b/test/intl402/ListFormat/constructor/constructor/subclassing.js
@@ -1,0 +1,39 @@
+// Copyright 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.ListFormat
+description: Checks that ListFormat can be subclassed.
+info: |
+    Intl.ListFormat ( [ locales [ , options ] ] )
+
+    2. Let listFormat be ? OrdinaryCreateFromConstructor(NewTarget, "%ListFormatPrototype%", « [[InitializedListFormat]], [[Locale]], [[Type]], [[Style]] »).
+
+features: [Intl.ListFormat]
+---*/
+
+class CustomListFormat extends Intl.ListFormat {
+  constructor(locales, options) {
+    super(locales, options);
+    this.isCustom = true;
+  }
+}
+
+const locale = "de";
+const argument = ["foo", "bar"];
+
+const real_lf = new Intl.ListFormat(locale);
+assert.sameValue(real_lf.isCustom, undefined, "Custom property");
+
+const custom_lf = new CustomListFormat(locale);
+assert.sameValue(custom_lf.isCustom, true, "Custom property");
+
+assert.sameValue(custom_lf.format(argument),
+                 real_lf.format(argument),
+                 "Direct call");
+
+assert.sameValue(Intl.ListFormat.prototype.format.call(custom_lf, argument),
+                 Intl.ListFormat.prototype.format.call(real_lf, argument),
+                 "Indirect call");
+
+assert.sameValue(Object.getPrototypeOf(custom_lf), CustomListFormat.prototype, "Prototype");

--- a/test/intl402/Locale/subclassing.js
+++ b/test/intl402/Locale/subclassing.js
@@ -1,0 +1,26 @@
+// Copyright 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale
+description: Checks that Locale can be subclassed.
+info: |
+    Intl.Locale( tag [, options] )
+
+    6. Let locale be ? OrdinaryCreateFromConstructor(NewTarget, %LocalePrototype%, internalSlotsList).
+
+features: [Intl.Locale]
+---*/
+
+class CustomLocale extends Intl.Locale {
+  constructor(locales, options) {
+    super(locales, options);
+    this.isCustom = true;
+  }
+}
+
+var locale = new CustomLocale("de");
+assert.sameValue(locale.isCustom, true, "Custom property");
+assert.sameValue(locale.toString(), "de", "Direct call");
+assert.sameValue(Intl.Locale.prototype.toString.call(locale), "de", "Indirect call");
+assert.sameValue(Object.getPrototypeOf(locale), CustomLocale.prototype, "Prototype");

--- a/test/intl402/RelativeTimeFormat/constructor/constructor/subclassing.js
+++ b/test/intl402/RelativeTimeFormat/constructor/constructor/subclassing.js
@@ -1,0 +1,40 @@
+// Copyright 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.RelativeTimeFormat
+description: Checks that RelativeTimeFormat can be subclassed.
+info: |
+    Intl.RelativeTimeFormat ( [ locales [ , options ] ] )
+
+    2. Let relativeTimeFormat be ! OrdinaryCreateFromConstructor(NewTarget, "%RelativeTimeFormatPrototype%", « [[InitializedRelativeTimeFormat]] »).
+
+features: [Intl.RelativeTimeFormat]
+---*/
+
+class CustomRelativeTimeFormat extends Intl.RelativeTimeFormat {
+  constructor(locales, options) {
+    super(locales, options);
+    this.isCustom = true;
+  }
+}
+
+const locale = "de";
+const value = 7;
+const unit = "day";
+
+const real_rtf = new Intl.RelativeTimeFormat(locale);
+assert.sameValue(real_rtf.isCustom, undefined, "Custom property");
+
+const custom_rtf = new CustomRelativeTimeFormat(locale);
+assert.sameValue(custom_rtf.isCustom, true, "Custom property");
+
+assert.sameValue(custom_rtf.format(value, unit),
+                 real_rtf.format(value, unit),
+                 "Direct call");
+
+assert.sameValue(Intl.RelativeTimeFormat.prototype.format.call(custom_rtf, value, unit),
+                 Intl.RelativeTimeFormat.prototype.format.call(real_rtf, value, unit),
+                 "Indirect call");
+
+assert.sameValue(Object.getPrototypeOf(custom_rtf), CustomRelativeTimeFormat.prototype, "Prototype");


### PR DESCRIPTION
Fixes #1705.