### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "8a73712b6a",
-  "targetRevisionAtLastExport": "8e73aadc2",
+  "sourceRevisionAtLastExport": "a7577363f7",
+  "targetRevisionAtLastExport": "1f7948aa7",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1643,6 +1643,8 @@
     "/stress/yield-named-variable.js": "DELETED_IN_TARGET",
     "/stress/yield-out-of-generator.js": "DELETED_IN_TARGET",
     "/stress/yield-reserved-word.js": "DELETED_IN_TARGET",
-    "/stress/yield-star-throw-continue.js": "DELETED_IN_TARGET"
+    "/stress/yield-star-throw-continue.js": "DELETED_IN_TARGET",
+    "/stress/regress-189186.js": "DELETED_IN_TARGET",
+    "/stress/regress-189292.js": "DELETED_IN_TARGET"
   }
 }

--- a/implementation-contributed/javascriptcore/modules/different-view.js
+++ b/implementation-contributed/javascriptcore/modules/different-view.js
@@ -1,7 +1,5 @@
-import { shouldBe, shouldThrow } from "./resources/assert.js"
+import { shouldBe } from "./resources/assert.js"
 
-shouldThrow(() => {
-    loadModule('./different-view/main.js');
-}, `SyntaxError: Importing binding name 'A' cannot be resolved due to ambiguous multiple bindings.`);
-
-
+import('./different-view/main.js').then($vm.abort, function (error) {
+    shouldBe(String(error), `SyntaxError: Importing binding name 'A' cannot be resolved due to ambiguous multiple bindings.`);
+}).catch($vm.abort);

--- a/implementation-contributed/javascriptcore/modules/fallback-ambiguous.js
+++ b/implementation-contributed/javascriptcore/modules/fallback-ambiguous.js
@@ -6,7 +6,8 @@
 //        |      |
 //        v      @
 //       (B)
-import { shouldThrow } from "./resources/assert.js"
-shouldThrow(() => {
-    loadModule("./fallback-ambiguous/main.js");
-}, `SyntaxError: Indirectly exported binding name 'A' cannot be resolved due to ambiguous multiple bindings.`);
+import { shouldBe } from "./resources/assert.js"
+
+import('./fallback-ambiguous/main.js').then($vm.abort, function (error) {
+    shouldBe(String(error), `SyntaxError: Indirectly exported binding name 'A' cannot be resolved due to ambiguous multiple bindings.`);
+}).catch($vm.abort);

--- a/implementation-contributed/javascriptcore/modules/import-error.js
+++ b/implementation-contributed/javascriptcore/modules/import-error.js
@@ -1,13 +1,16 @@
-import { shouldBe, shouldThrow } from "./resources/assert.js"
+import { shouldBe } from "./resources/assert.js"
 
-shouldThrow(() => {
-    loadModule('./import-error/import-not-found.js');
-}, `SyntaxError: Importing binding name 'B' is not found.`);
-
-shouldThrow(() => {
-    loadModule('./import-error/import-ambiguous.js');
-}, `SyntaxError: Importing binding name 'B' cannot be resolved due to ambiguous multiple bindings.`);
-
-shouldThrow(() => {
-    loadModule('./import-error/import-default-from-star.js');
-}, `SyntaxError: Importing binding name 'default' cannot be resolved by star export entries.`);
+Promise.all([
+    import('./import-error/import-not-found.js')
+        .then($vm.abort, function (error) {
+            shouldBe(String(error), `SyntaxError: Importing binding name 'B' is not found.`);
+        }).catch($vm.abort),
+    import('./import-error/import-ambiguous.js')
+        .then($vm.abort, function (error) {
+            shouldBe(String(error), `SyntaxError: Importing binding name 'B' cannot be resolved due to ambiguous multiple bindings.`);
+        }).catch($vm.abort),
+    import('./import-error/import-default-from-star.js')
+        .then($vm.abort, function (error) {
+            shouldBe(String(error), `SyntaxError: Importing binding name 'default' cannot be resolved by star export entries.`);
+        }).catch($vm.abort),
+]).catch($vm.abort);

--- a/implementation-contributed/javascriptcore/modules/indirect-export-error.js
+++ b/implementation-contributed/javascriptcore/modules/indirect-export-error.js
@@ -1,13 +1,17 @@
-import { shouldBe, shouldThrow } from "./resources/assert.js"
+import { shouldBe } from "./resources/assert.js"
 
-shouldThrow(() => {
-    loadModule('./indirect-export-error/indirect-export-not-found.js');
-}, `SyntaxError: Indirectly exported binding name 'B' is not found.`);
 
-shouldThrow(() => {
-    loadModule('./indirect-export-error/indirect-export-ambiguous.js');
-}, `SyntaxError: Indirectly exported binding name 'B' cannot be resolved due to ambiguous multiple bindings.`);
-
-shouldThrow(() => {
-    loadModule('./indirect-export-error/indirect-export-default.js');
-}, `SyntaxError: Indirectly exported binding name 'default' cannot be resolved by star export entries.`);
+Promise.all([
+    import('./indirect-export-error/indirect-export-not-found.js')
+        .then($vm.abort, function (error) {
+            shouldBe(String(error), `SyntaxError: Indirectly exported binding name 'B' is not found.`);
+        }).catch($vm.abort),
+    import('./indirect-export-error/indirect-export-ambiguous.js')
+        .then($vm.abort, function (error) {
+            shouldBe(String(error), `SyntaxError: Indirectly exported binding name 'B' cannot be resolved due to ambiguous multiple bindings.`);
+        }).catch($vm.abort),
+    import('./indirect-export-error/indirect-export-default.js')
+        .then($vm.abort, function (error) {
+            shouldBe(String(error), `SyntaxError: Indirectly exported binding name 'default' cannot be resolved by star export entries.`);
+        }).catch($vm.abort),
+]).catch($vm.abort);

--- a/implementation-contributed/javascriptcore/modules/namespace-error.js
+++ b/implementation-contributed/javascriptcore/modules/namespace-error.js
@@ -1,5 +1,5 @@
-import { shouldThrow } from "./resources/assert.js"
+import { shouldBe } from "./resources/assert.js"
 
-shouldThrow(() => {
-    loadModule('./namespace-error/namespace-local-error-should-hide-global-ambiguity.js');
-}, `SyntaxError: Indirectly exported binding name 'default' cannot be resolved by star export entries.`);
+import('./namespace-error/namespace-local-error-should-hide-global-ambiguity.js').then($vm.abort, function (error) {
+    shouldBe(String(error), `SyntaxError: Indirectly exported binding name 'default' cannot be resolved by star export entries.`);
+}).catch($vm.abort);


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[8a73712b6a](https://github.com///github/blob/8a73712b6a) in JavaScriptCore and all changes made since [8e73aadc2](../blob/8e73aadc2) in
test262.


### 2 Files Classified as Fully Curated

These files will be ignored in future imports.

 - [implementation-contributed/javascriptcore/stress/regress-189186.js](../blob/javascriptcore-test262-automation-export-8e73aadc2/implementation-contributed/javascriptcore/stress/regress-189186.js)
 - [implementation-contributed/javascriptcore/stress/regress-189292.js](../blob/javascriptcore-test262-automation-export-8e73aadc2/implementation-contributed/javascriptcore/stress/regress-189292.js)
### 5 Files Updated From JavaScriptCore

These files have been modified in JavaScriptCore.

 - [implementation-contributed/javascriptcore/modules/different-view.js](../blob/javascriptcore-test262-automation-export-8e73aadc2/implementation-contributed/javascriptcore/modules/different-view.js)
 - [implementation-contributed/javascriptcore/modules/fallback-ambiguous.js](../blob/javascriptcore-test262-automation-export-8e73aadc2/implementation-contributed/javascriptcore/modules/fallback-ambiguous.js)
 - [implementation-contributed/javascriptcore/modules/import-error.js](../blob/javascriptcore-test262-automation-export-8e73aadc2/implementation-contributed/javascriptcore/modules/import-error.js)
 - [implementation-contributed/javascriptcore/modules/indirect-export-error.js](../blob/javascriptcore-test262-automation-export-8e73aadc2/implementation-contributed/javascriptcore/modules/indirect-export-error.js)
 - [implementation-contributed/javascriptcore/modules/namespace-error.js](../blob/javascriptcore-test262-automation-export-8e73aadc2/implementation-contributed/javascriptcore/modules/namespace-error.js)